### PR TITLE
Add test workflow for Python wheel builds and fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -426,7 +426,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-latest
             target: x86_64
           - runner: macos-latest
             target: aarch64

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-latest
             target: x86_64
           - runner: macos-latest
             target: aarch64


### PR DESCRIPTION
- Split build-wheels into per-OS jobs (linux, musllinux, windows, macos)
- Fix aarch64 builds by removing hardcoded interpreter paths
- Add musllinux (Alpine) wheel builds
- Split macOS into native x86_64/aarch64 runners (replaces universal2)
- Switch PyPI publish to uv with --check-url for idempotency
- Add artifact attestation for supply chain security
- Bump action versions (checkout@v6, setup-python@v6, upload-artifact@v6)
- Add test-release.yml workflow_dispatch for validating builds without publishing