### PR TITLE
fix(eval): improve IRR convergence with Brent's method fallback

### DIFF
--- a/crates/formualizer-eval/src/builtins/financial/tvm.rs
+++ b/crates/formualizer-eval/src/builtins/financial/tvm.rs
@@ -1088,6 +1088,178 @@ impl Function for NominalFn {
     }
 }
 
+/// Compute NPV at a given rate.
+fn irr_npv(cashflows: &[f64], rate: f64) -> f64 {
+    let mut npv = 0.0;
+    for (i, &cf) in cashflows.iter().enumerate() {
+        npv += cf / (1.0 + rate).powi(i as i32);
+    }
+    npv
+}
+
+/// Compute NPV and its derivative w.r.t. rate.
+fn irr_npv_deriv(cashflows: &[f64], rate: f64) -> (f64, f64) {
+    let mut npv = 0.0;
+    let mut d_npv = 0.0;
+    for (i, &cf) in cashflows.iter().enumerate() {
+        let factor = (1.0 + rate).powi(i as i32);
+        npv += cf / factor;
+        if i > 0 {
+            d_npv -= (i as f64) * cf / (factor * (1.0 + rate));
+        }
+    }
+    (npv, d_npv)
+}
+
+/// Solve for IRR using Newton-Raphson with Brent's method fallback.
+///
+/// Strategy:
+/// 1. Try Newton-Raphson from the user's guess (fast when it works).
+/// 2. If Newton diverges, bracket the root by scanning probe points,
+///    then use Brent's method (superlinear convergence with guaranteed
+///    bracketing) to find the root precisely.
+fn irr_solve(cashflows: &[f64], guess: f64) -> Option<f64> {
+    const MAX_NR: usize = 100;
+    const MAX_BRENT: usize = 200;
+    const TOL: f64 = 1e-12;
+    const MACH_EPS: f64 = f64::EPSILON;
+
+    // --- Phase 1: Newton-Raphson from the given guess ---
+    let mut rate = guess;
+    for _ in 0..MAX_NR {
+        let (npv, d_npv) = irr_npv_deriv(cashflows, rate);
+        if d_npv.abs() < TOL {
+            break; // flat derivative, fall through to Brent
+        }
+        let new_rate = rate - npv / d_npv;
+        // Accept if converged and rate > -1 (pole at -1)
+        if (new_rate - rate).abs() < TOL && new_rate > -1.0 {
+            return Some(new_rate);
+        }
+        // If Newton shoots below -1 or to NaN/Inf, bail out
+        if new_rate <= -1.0 || !new_rate.is_finite() {
+            break;
+        }
+        rate = new_rate;
+    }
+
+    // --- Phase 2: Bracket the root, then apply Brent's method ---
+    // Search for a sign change in NPV across a wide range of rates.
+    let probes: &[f64] = &[
+        -0.99, -0.9, -0.5, -0.1, -0.01, 0.0, 0.001, 0.005, 0.01, 0.02, 0.05, 0.1, 0.15, 0.2, 0.3,
+        0.5, 1.0, 2.0, 5.0, 10.0,
+    ];
+    let mut lo = f64::NAN;
+    let mut hi = f64::NAN;
+    let mut npv_lo = f64::NAN;
+
+    for &r in probes {
+        let npv = irr_npv(cashflows, r);
+        if !npv.is_finite() {
+            continue;
+        }
+        if lo.is_nan() {
+            lo = r;
+            npv_lo = npv;
+            continue;
+        }
+        if npv_lo * npv < 0.0 {
+            hi = r;
+            break;
+        }
+        lo = r;
+        npv_lo = npv;
+    }
+
+    if hi.is_nan() {
+        return None; // no sign change found — no real IRR
+    }
+
+    // Brent's method (following scipy's brentq / Brent's zeroin algorithm).
+    // Combines inverse quadratic interpolation, secant, and bisection.
+    // xpre/xcur maintain the bracket; xblk is the contrapoint.
+    let mut xpre = lo;
+    let mut xcur = hi;
+    let mut fpre = irr_npv(cashflows, xpre);
+    let mut fcur = irr_npv(cashflows, xcur);
+
+    if fpre == 0.0 {
+        return Some(xpre);
+    }
+    if fcur == 0.0 {
+        return Some(xcur);
+    }
+
+    let mut xblk = 0.0;
+    let mut fblk = 0.0;
+    let mut spre = 0.0;
+    let mut scur = 0.0;
+
+    for _ in 0..MAX_BRENT {
+        // If xpre and xcur bracket the root, reset the contrapoint
+        if fpre * fcur < 0.0 {
+            xblk = xpre;
+            fblk = fpre;
+            spre = xcur - xpre;
+            scur = spre;
+        }
+
+        // Ensure xcur is the best approximation (|fcur| <= |fblk|)
+        if fblk.abs() < fcur.abs() {
+            xpre = xcur;
+            xcur = xblk;
+            xblk = xpre;
+            fpre = fcur;
+            fcur = fblk;
+            fblk = fpre;
+        }
+
+        let delta = (MACH_EPS * xcur.abs() + 0.5 * TOL).max(MACH_EPS);
+        let sbis = (xblk - xcur) * 0.5;
+
+        if fcur == 0.0 || sbis.abs() < delta {
+            return Some(xcur);
+        }
+
+        if spre.abs() >= delta && fcur.abs() < fpre.abs() {
+            // Try interpolation
+            let stry = if (xpre - xblk).abs() < MACH_EPS {
+                // Secant step
+                -fcur * (xcur - xpre) / (fcur - fpre)
+            } else {
+                // Inverse quadratic interpolation
+                let dpre = (fpre - fcur) / (xpre - xcur);
+                let dblk = (fblk - fcur) / (xblk - xcur);
+                -fcur * (fblk * dblk - fpre * dpre) / (dblk * dpre * (fblk - fpre))
+            };
+
+            // Accept if step is small enough
+            if 2.0 * stry.abs() < spre.abs().min(3.0 * sbis.abs() - delta) {
+                spre = scur;
+                scur = stry;
+            } else {
+                spre = sbis;
+                scur = sbis;
+            }
+        } else {
+            // Bisection
+            spre = sbis;
+            scur = sbis;
+        }
+
+        xpre = xcur;
+        fpre = fcur;
+
+        if scur.abs() > delta {
+            xcur += scur;
+        } else {
+            xcur += if sbis > 0.0 { delta } else { -delta };
+        }
+        fcur = irr_npv(cashflows, xcur);
+    }
+    Some(xcur)
+}
+
 /// Calculates periodic internal rate of return for regularly spaced cash flows.
 ///
 /// The function iteratively finds the per-period rate where discounted cash flows sum to zero.
@@ -1200,39 +1372,12 @@ impl Function for IrrFn {
             0.1
         };
 
-        // Newton-Raphson iteration to find IRR
-        let mut rate = guess;
-        const MAX_ITER: i32 = 100;
-        const EPSILON: f64 = 1e-10;
-
-        for _ in 0..MAX_ITER {
-            let mut npv = 0.0;
-            let mut d_npv = 0.0;
-
-            for (i, &cf) in cashflows.iter().enumerate() {
-                let factor = (1.0 + rate).powi(i as i32);
-                npv += cf / factor;
-                if i > 0 {
-                    d_npv -= (i as f64) * cf / (factor * (1.0 + rate));
-                }
-            }
-
-            if d_npv.abs() < EPSILON {
-                return Ok(CalcValue::Scalar(
-                    LiteralValue::Error(ExcelError::new_num()),
-                ));
-            }
-
-            let new_rate = rate - npv / d_npv;
-            if (new_rate - rate).abs() < EPSILON {
-                return Ok(CalcValue::Scalar(LiteralValue::Number(new_rate)));
-            }
-            rate = new_rate;
+        match irr_solve(&cashflows, guess) {
+            Some(rate) => Ok(CalcValue::Scalar(LiteralValue::Number(rate))),
+            None => Ok(CalcValue::Scalar(
+                LiteralValue::Error(ExcelError::new_num()),
+            )),
         }
-
-        Ok(CalcValue::Scalar(
-            LiteralValue::Error(ExcelError::new_num()),
-        ))
     }
 }
 

--- a/tests/formula_tests/financial.json
+++ b/tests/formula_tests/financial.json
@@ -75,6 +75,86 @@
       "result": 4000,
       "result_type": "int",
       "description": "double declining balance"
+    },
+    {
+      "formula": "=IRR({-1000, 400, 400, 400, 400})",
+      "result": 0.21862269609834224,
+      "result_type": "float",
+      "description": "IRR simple annual cash flows"
+    },
+    {
+      "formula": "=IRR({-1000, 400, 400, 400, 400}, 0.5)",
+      "result": 0.21862269609834224,
+      "result_type": "float",
+      "description": "IRR with explicit guess far from root"
+    },
+    {
+      "formula": "=IRR({-100, 30, 40, 50, 60})",
+      "result": 0.24888335662407088,
+      "result_type": "float",
+      "description": "IRR basic investment"
+    },
+    {
+      "formula": "=IRR({-10000, 2750, 4250, 3250, 2750})",
+      "result": 0.11541278310055848,
+      "result_type": "float",
+      "description": "IRR moderate return (scipy brentq reference)"
+    },
+    {
+      "formula": "=IRR(A1:BI1)",
+      "result": 0.014896916887517,
+      "result_type": "float",
+      "description": "IRR small monthly rate (~1.5%) — 61 cash flows (scipy: 1.489691688751711e-02)",
+      "context": {
+        "A1": -5000000,
+        "B1": 70000, "C1": 70000, "D1": 70000, "E1": 70000, "F1": 70000,
+        "G1": 70000, "H1": 70000, "I1": 70000, "J1": 70000, "K1": 70000,
+        "L1": 70000, "M1": 70000, "N1": 70000, "O1": 70000, "P1": 70000,
+        "Q1": 70000, "R1": 70000, "S1": 70000, "T1": 70000, "U1": 70000,
+        "V1": 70000, "W1": 70000, "X1": 70000, "Y1": 70000, "Z1": 70000,
+        "AA1": 70000, "AB1": 70000, "AC1": 70000, "AD1": 70000, "AE1": 70000,
+        "AF1": 70000, "AG1": 70000, "AH1": 70000, "AI1": 70000, "AJ1": 70000,
+        "AK1": 70000, "AL1": 70000, "AM1": 70000, "AN1": 70000, "AO1": 70000,
+        "AP1": 70000, "AQ1": 70000, "AR1": 70000, "AS1": 70000, "AT1": 70000,
+        "AU1": 70000, "AV1": 70000, "AW1": 70000, "AX1": 70000, "AY1": 70000,
+        "AZ1": 70000, "BA1": 70000, "BB1": 70000, "BC1": 70000, "BD1": 70000,
+        "BE1": 70000, "BF1": 70000, "BG1": 70000, "BH1": 70000,
+        "BI1": 5500000
+      }
+    },
+    {
+      "formula": "=IRR(A1:BJ1)",
+      "result": -0.005669715548890,
+      "result_type": "float",
+      "description": "IRR negative return — 62 cash flows (scipy: -5.669715548889694e-03)",
+      "context": {
+        "A1": -1000000,
+        "B1": 10000, "C1": 10000, "D1": 10000, "E1": 10000, "F1": 10000,
+        "G1": 10000, "H1": 10000, "I1": 10000, "J1": 10000, "K1": 10000,
+        "L1": 10000, "M1": 10000, "N1": 10000, "O1": 10000, "P1": 10000,
+        "Q1": 10000, "R1": 10000, "S1": 10000, "T1": 10000, "U1": 10000,
+        "V1": 10000, "W1": 10000, "X1": 10000, "Y1": 10000, "Z1": 10000,
+        "AA1": 10000, "AB1": 10000, "AC1": 10000, "AD1": 10000, "AE1": 10000,
+        "AF1": 10000, "AG1": 10000, "AH1": 10000, "AI1": 10000, "AJ1": 10000,
+        "AK1": 10000, "AL1": 10000, "AM1": 10000, "AN1": 10000, "AO1": 10000,
+        "AP1": 10000, "AQ1": 10000, "AR1": 10000, "AS1": 10000, "AT1": 10000,
+        "AU1": 10000, "AV1": 10000, "AW1": 10000, "AX1": 10000, "AY1": 10000,
+        "AZ1": 10000, "BA1": 10000, "BB1": 10000, "BC1": 10000, "BD1": 10000,
+        "BE1": 10000, "BF1": 10000, "BG1": 10000, "BH1": 10000, "BI1": 10000,
+        "BJ1": 200000
+      }
+    },
+    {
+      "formula": "=IRR({-500000, 100000, 100000, 100000, 100000, 100000, 100000})",
+      "result": 0.05471792502353683,
+      "result_type": "float",
+      "description": "IRR break-even (scipy brentq reference)"
+    },
+    {
+      "formula": "=IRR({100, -100, -100})",
+      "result": 0.6180339887498949,
+      "result_type": "float",
+      "description": "IRR with positive initial cash flow (golden ratio root)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replace the simple Newton-Raphson IRR solver with a two-phase approach:
1. Try Newton-Raphson from the user's guess (fast when it works)
2. If Newton diverges, bracket the root by scanning probe points, then use Brent's method for guaranteed convergence

This fixes IRR returning `#NUM!` for cash flow patterns where Newton-Raphson oscillates or diverges (e.g., large loan amortizations with small monthly rates, negative-return investments).

## Test plan

- [x] 8 new IRR test cases including 61/62-cashflow edge cases validated against scipy `brentq`
- [x] `cargo test -p formualizer-eval run_formula_test_suite` — 556 passed, 3 failed (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)