### PR TITLE
fix(eval): add min_args arity check to prevent panic on too-few arguments

### DIFF
--- a/crates/formualizer-eval/src/args.rs
+++ b/crates/formualizer-eval/src/args.rs
@@ -86,6 +86,11 @@ pub struct PreparedArgs<'a> {
 #[derive(Default)]
 pub struct ValidationOptions {
     pub warn_only: bool,
+    /// Minimum number of arguments the function requires.  When non-zero,
+    /// `validate_and_prepare` rejects calls with fewer arguments before any
+    /// per-argument validation runs, preventing out-of-bounds panics in
+    /// `eval` implementations.
+    pub min_args: usize,
 }
 
 // Legacy adapter removed in clean break.
@@ -178,6 +183,19 @@ pub fn validate_and_prepare<'a, 'b>(
     schema: &[ArgSchema],
     options: ValidationOptions,
 ) -> Result<PreparedArgs<'a>, ExcelError> {
+    // Minimum arity — reject too-few arguments before per-arg validation so
+    // that individual `eval` implementations cannot panic on indexing.
+    if options.min_args > 0 && args.len() < options.min_args {
+        if options.warn_only {
+            return Ok(PreparedArgs { items: Vec::new() });
+        }
+        return Err(ExcelError::new(ExcelErrorKind::Value).with_message(format!(
+            "Too few arguments: expected at least {}, got {}",
+            options.min_args,
+            args.len()
+        )));
+    }
+
     // Arity: simple rule – if schema.len() == 1, allow variadic repetition; else match up to schema.len()
     if schema.is_empty() {
         return Ok(PreparedArgs { items: Vec::new() });

--- a/crates/formualizer-eval/src/builtins/math/numeric.rs
+++ b/crates/formualizer-eval/src/builtins/math/numeric.rs
@@ -3420,4 +3420,78 @@ mod tests_numeric {
             .into_literal();
         assert_eq!(out_arabic, LiteralValue::Number(499.0));
     }
+
+    // ── Too-few-arguments: must not panic ────────────────────────────────
+
+    #[test]
+    fn round_one_arg_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(RoundFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "ROUND").unwrap();
+        let n = lit(LiteralValue::Number(2.5));
+        let result = f
+            .dispatch(
+                &[ArgumentHandle::new(&n, &ctx)],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn rounddown_one_arg_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(RoundDownFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "ROUNDDOWN").unwrap();
+        let n = lit(LiteralValue::Number(1.9));
+        let result = f
+            .dispatch(
+                &[ArgumentHandle::new(&n, &ctx)],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn abs_zero_args_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(AbsFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "ABS").unwrap();
+        let result = f
+            .dispatch(&[], &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn mod_one_arg_returns_error_not_panic() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(ModFn));
+        let ctx = interp(&wb);
+        let f = ctx.context.get_function("", "MOD").unwrap();
+        let n = lit(LiteralValue::Number(10.0));
+        let result = f
+            .dispatch(
+                &[ArgumentHandle::new(&n, &ctx)],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(result, LiteralValue::Error(_)),
+            "Expected an error, got {result:?}"
+        );
+    }
 }

--- a/crates/formualizer-eval/src/function.rs
+++ b/crates/formualizer-eval/src/function.rs
@@ -151,13 +151,18 @@ pub trait Function: Send + Sync + 'static {
         args: &'c [crate::traits::ArgumentHandle<'a, 'b>],
         ctx: &dyn crate::traits::FunctionContext<'b>,
     ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
-        // Central argument validation
+        // Central argument validation (includes min-arity check)
         {
             use crate::args::{ValidationOptions, validate_and_prepare};
             let schema = self.arg_schema();
-            if let Err(e) =
-                validate_and_prepare(args, schema, ValidationOptions { warn_only: false })
-            {
+            if let Err(e) = validate_and_prepare(
+                args,
+                schema,
+                ValidationOptions {
+                    warn_only: false,
+                    min_args: self.min_args(),
+                },
+            ) {
                 return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
             }
         }

--- a/crates/formualizer-eval/src/tests/validator.rs
+++ b/crates/formualizer-eval/src/tests/validator.rs
@@ -27,7 +27,14 @@ fn validator_enforces_min_args_and_max_when_not_variadic() {
     let schema = vec![s];
 
     // Too many args → #VALUE! is enforced in dispatch, not in validator; validator should accept
-    let res = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false });
+    let res = validate_and_prepare(
+        &args,
+        &schema,
+        ValidationOptions {
+            warn_only: false,
+            ..Default::default()
+        },
+    );
     assert!(
         res.is_ok(),
         "validator should not enforce max; dispatch enforces max"
@@ -48,7 +55,15 @@ fn schema_scalar_allows_scalar_in_range_position_fallback() {
     s.shape = ShapeKind::Range; // function expects a range, but we provide a scalar
     let schema = vec![s];
 
-    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false }).unwrap();
+    let out = validate_and_prepare(
+        &args,
+        &schema,
+        ValidationOptions {
+            warn_only: false,
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert_eq!(out.items.len(), 1);
     match &out.items[0] {
         crate::args::PreparedArg::Value(v) => assert_eq!(v.as_ref(), &LiteralValue::Number(6.0)),
@@ -69,7 +84,15 @@ fn number_lenient_text_coercion_accepts_numeric_text() {
     let s = ArgSchema::number_lenient_scalar();
     let schema = vec![s];
 
-    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false }).unwrap();
+    let out = validate_and_prepare(
+        &args,
+        &schema,
+        ValidationOptions {
+            warn_only: false,
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert_eq!(out.items.len(), 1);
     // After Milestone 7: scalar values are coerced per schema. Expect a Number(42.0).
     match &out.items[0] {
@@ -98,7 +121,15 @@ fn by_ref_accepts_ast_reference() {
     s.by_ref = true;
     let schema = vec![s];
 
-    let out = validate_and_prepare(&args, &schema, ValidationOptions { warn_only: false }).unwrap();
+    let out = validate_and_prepare(
+        &args,
+        &schema,
+        ValidationOptions {
+            warn_only: false,
+            ..Default::default()
+        },
+    )
+    .unwrap();
     assert_eq!(out.items.len(), 1);
     match &out.items[0] {
         crate::args::PreparedArg::Reference(r) => match r {


### PR DESCRIPTION
## Summary

Functions like ROUND (`min_args=2`) could panic with index-out-of-bounds when called with fewer arguments than expected, because per-argument validation only checks declared schema positions.

Adds a `min_args` field to `ValidationOptions` and checks it at the start of `validate_and_prepare`, before any per-argument validation runs. The `dispatch` method now passes `self.min_args()` automatically.

This prevents mutex-poisoning panics in the evaluation engine when formulas have missing arguments.

## Test plan

- [x] 4 new tests: ROUND(1 arg), ROUNDDOWN(1 arg), ABS(0 args), MOD(1 arg) — all return errors instead of panicking
- [x] Updated existing `ValidationOptions` literals in validator.rs
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)