### PR TITLE
feat: implement Excel space (intersection) operator

### DIFF
--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -383,16 +383,25 @@ impl<'a> Interpreter<'a> {
                             }
                         };
                     }
-                    // Fallback: element-wise multiplication.
-                    let left = self
-                        .evaluate_arena_ast(*left_id, data_store, sheet_registry)?
-                        .into_literal();
-                    let right = self
-                        .evaluate_arena_ast(*right_id, data_store, sheet_registry)?
-                        .into_literal();
-                    return self
-                        .numeric_binary(left, right, |a, b| a * b)
-                        .map(crate::traits::CalcValue::Scalar);
+                    // Fallback: element-wise multiplication for array
+                    // operands only (SUMPRODUCT idiom).
+                    let l_cv = self
+                        .evaluate_arena_ast(*left_id, data_store, sheet_registry)?;
+                    let r_cv = self
+                        .evaluate_arena_ast(*right_id, data_store, sheet_registry)?;
+                    let is_array = matches!(&l_cv, crate::traits::CalcValue::Scalar(LiteralValue::Array(_)))
+                        || matches!(&r_cv, crate::traits::CalcValue::Scalar(LiteralValue::Array(_)));
+                    if is_array {
+                        let left = l_cv.into_literal();
+                        let right = r_cv.into_literal();
+                        return self
+                            .numeric_binary(left, right, |a, b| a * b)
+                            .map(crate::traits::CalcValue::Scalar);
+                    }
+                    return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                        ExcelError::new(ExcelErrorKind::Null)
+                            .with_message("Intersection operands are not references or arrays"),
+                    )));
                 }
 
                 let left = self
@@ -948,8 +957,6 @@ impl<'a> Interpreter<'a> {
 
         if op == " " {
             // Intersection operator: try reference intersection first.
-            // For array operands (e.g. in SUMPRODUCT), fall back to
-            // element-wise multiplication.
             match (
                 self.evaluate_ast_as_reference(left),
                 self.evaluate_ast_as_reference(right),
@@ -963,9 +970,23 @@ impl<'a> Interpreter<'a> {
                     };
                 }
                 _ => {
-                    let l_val = self.evaluate_ast(left)?.into_literal();
-                    let r_val = self.evaluate_ast(right)?.into_literal();
-                    return self.numeric_binary(l_val, r_val, |a, b| a * b);
+                    // Fallback: element-wise multiplication for array
+                    // operands (SUMPRODUCT idiom).  Only multiply when at
+                    // least one side is an array; scalar-scalar intersection
+                    // is not valid Excel and should return #NULL!.
+                    let l_cv = self.evaluate_ast(left)?;
+                    let r_cv = self.evaluate_ast(right)?;
+                    let is_array = matches!(&l_cv, crate::traits::CalcValue::Scalar(LiteralValue::Array(_)))
+                        || matches!(&r_cv, crate::traits::CalcValue::Scalar(LiteralValue::Array(_)));
+                    if is_array {
+                        let l_val = l_cv.into_literal();
+                        let r_val = r_cv.into_literal();
+                        return self.numeric_binary(l_val, r_val, |a, b| a * b);
+                    }
+                    return Ok(LiteralValue::Error(
+                        ExcelError::new(ExcelErrorKind::Null)
+                            .with_message("Intersection operands are not references or arrays"),
+                    ));
                 }
             }
         }

--- a/crates/formualizer-eval/src/reference.rs
+++ b/crates/formualizer-eval/src/reference.rs
@@ -185,16 +185,30 @@ pub fn combine_references(
 /// Compute the intersection of two references (Excel space operator).
 /// Returns the overlapping rectangular region, or `#NULL!` if the ranges
 /// do not share any cells.
+/// Sentinel value representing an open-ended bound (full-row or full-column).
+const OPEN_BOUND: u32 = u32::MAX;
+
+/// Compute the intersection of two references (Excel space operator).
+/// Returns the overlapping rectangular region, or `#NULL!` if the ranges
+/// do not share any cells.
+///
+/// Handles reversed ranges (e.g. `A5:A1`), full-row (`1:3`), and
+/// full-column (`A:C`) references.  Treats `None` sheet qualifiers as
+/// compatible with any named sheet (unqualified ≈ current sheet).
 pub fn intersect_references(
     a: &ReferenceType,
     b: &ReferenceType,
 ) -> Result<ReferenceType, ExcelError> {
-    // Reuse the same SheetBounds helper shape as combine_references.
-    fn to_isect_bounds(r: &ReferenceType) -> Option<(Option<String>, (u32, u32, u32, u32))> {
+    /// Bounds are (sheet, row_start, col_start, row_end, col_end) with
+    /// `None` row/col bounds mapped to 0 / OPEN_BOUND.  The bools track
+    /// whether row/col were originally open-ended.
+    type Bounds = (Option<String>, u32, u32, u32, u32, bool, bool);
+
+    fn to_isect_bounds(r: &ReferenceType) -> Option<Bounds> {
         match r {
             ReferenceType::Cell {
                 sheet, row, col, ..
-            } => Some((sheet.clone(), (*row, *col, *row, *col))),
+            } => Some((sheet.clone(), *row, *col, *row, *col, false, false)),
             ReferenceType::Range {
                 sheet,
                 start_row,
@@ -203,30 +217,51 @@ pub fn intersect_references(
                 end_col,
                 ..
             } => {
-                // Treat None bounds as sheet extents so full-row (1:1) and
-                // full-column (A:A) ranges participate in intersections.
+                let row_open = start_row.is_none() || end_row.is_none();
+                let col_open = start_col.is_none() || end_col.is_none();
                 let sr = start_row.unwrap_or(0);
                 let sc = start_col.unwrap_or(0);
-                let er = end_row.unwrap_or(u32::MAX);
-                let ec = end_col.unwrap_or(u32::MAX);
-                Some((sheet.clone(), (sr, sc, er, ec)))
+                let er = end_row.unwrap_or(OPEN_BOUND);
+                let ec = end_col.unwrap_or(OPEN_BOUND);
+                // Normalize reversed ranges (e.g. A5:A1 → A1:A5).
+                Some((
+                    sheet.clone(),
+                    sr.min(er),
+                    sc.min(ec),
+                    sr.max(er),
+                    sc.max(ec),
+                    row_open,
+                    col_open,
+                ))
             }
             _ => None,
         }
     }
 
-    let (sheet_a, (a_sr, a_sc, a_er, a_ec)) = to_isect_bounds(a).ok_or_else(|| {
-        ExcelError::new(ExcelErrorKind::Null).with_message("Unsupported reference for intersection")
-    })?;
-    let (sheet_b, (b_sr, b_sc, b_er, b_ec)) = to_isect_bounds(b).ok_or_else(|| {
-        ExcelError::new(ExcelErrorKind::Null).with_message("Unsupported reference for intersection")
-    })?;
+    let (sheet_a, a_sr, a_sc, a_er, a_ec, a_row_open, a_col_open) =
+        to_isect_bounds(a).ok_or_else(|| {
+            ExcelError::new(ExcelErrorKind::Null)
+                .with_message("Unsupported reference for intersection")
+        })?;
+    let (sheet_b, b_sr, b_sc, b_er, b_ec, b_row_open, b_col_open) =
+        to_isect_bounds(b).ok_or_else(|| {
+            ExcelError::new(ExcelErrorKind::Null)
+                .with_message("Unsupported reference for intersection")
+        })?;
 
-    if sheet_a != sheet_b {
-        return Err(
-            ExcelError::new(ExcelErrorKind::Null).with_message("Intersection across sheets")
-        );
-    }
+    // Sheets must match.  Treat unqualified (None) as compatible with any
+    // named sheet so `A1:A3 Sheet1!A2:A4` works on Sheet1.
+    let result_sheet = match (&sheet_a, &sheet_b) {
+        (None, _) => sheet_b.clone(),
+        (_, None) => sheet_a.clone(),
+        (Some(sa), Some(sb)) if sa == sb => sheet_a.clone(),
+        _ => {
+            return Err(
+                ExcelError::new(ExcelErrorKind::Null)
+                    .with_message("Intersection across sheets"),
+            )
+        }
+    };
 
     let sr = a_sr.max(b_sr);
     let sc = a_sc.max(b_sc);
@@ -235,13 +270,18 @@ pub fn intersect_references(
 
     if sr > er || sc > ec {
         return Err(
-            ExcelError::new(ExcelErrorKind::Null).with_message("Ranges do not intersect")
+            ExcelError::new(ExcelErrorKind::Null).with_message("Ranges do not intersect"),
         );
     }
 
-    if sr == er && sc == ec {
+    // If the result is still open-ended on an axis (both inputs were
+    // open on that axis), preserve `None` bounds.
+    let row_open = a_row_open && b_row_open;
+    let col_open = a_col_open && b_col_open;
+
+    if !row_open && !col_open && sr == er && sc == ec {
         Ok(ReferenceType::Cell {
-            sheet: sheet_a,
+            sheet: result_sheet,
             row: sr,
             col: sc,
             row_abs: false,
@@ -249,11 +289,19 @@ pub fn intersect_references(
         })
     } else {
         Ok(ReferenceType::Range {
-            sheet: sheet_a,
-            start_row: Some(sr),
-            start_col: Some(sc),
-            end_row: Some(er),
-            end_col: Some(ec),
+            sheet: result_sheet,
+            start_row: if row_open && sr == 0 { None } else { Some(sr) },
+            start_col: if col_open && sc == 0 { None } else { Some(sc) },
+            end_row: if row_open && er == OPEN_BOUND {
+                None
+            } else {
+                Some(er)
+            },
+            end_col: if col_open && ec == OPEN_BOUND {
+                None
+            } else {
+                Some(ec)
+            },
             start_row_abs: false,
             start_col_abs: false,
             end_row_abs: false,

--- a/crates/formualizer-eval/src/tests/interpreter.rs
+++ b/crates/formualizer-eval/src/tests/interpreter.rs
@@ -717,10 +717,14 @@ mod tests {
     }
 
     #[test]
-    fn implicit_intersection_juxtaposed_parens_multiplies() {
-        // (2)*(3) via implicit intersection should yield 6
+    fn implicit_intersection_scalar_returns_null() {
+        // Scalar-scalar intersection is not valid — should return #NULL!
+        // (only array operands get implicit multiplication).
         let wb = TestWorkbook::new();
         let result = evaluate_formula("=(2)(3)", &wb).unwrap();
-        assert_eq!(result, LiteralValue::Number(6.0));
+        match result {
+            LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Null),
+            other => panic!("Expected #NULL! error, got {:?}", other),
+        }
     }
 }

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1973,6 +1973,23 @@ fn is_value_ending(tt: TokenType, st: TokenSubType) -> bool {
     )
 }
 
+/// Check if a token can begin a new value expression.  Only `Paren/Open` is
+/// included for the implicit-insertion pass — `Func/Open`, `Operand`, and
+/// `OpPrefix` are excluded to avoid inventing multiplication for cases like
+/// `1(A1)`, `A1 SUM(...)`, or `50%-A1` which are not valid Excel patterns.
+fn is_paren_starting(_tt: TokenType, _st: TokenSubType) -> bool {
+    matches!((_tt, _st), (TokenType::Paren, TokenSubType::Open))
+}
+
+/// Check if a token can end a value expression on the "closing" side only.
+fn is_paren_ending(_tt: TokenType, _st: TokenSubType) -> bool {
+    matches!(
+        (_tt, _st),
+        (TokenType::Paren, TokenSubType::Close)
+            | (TokenType::Func, TokenSubType::Close)
+    )
+}
+
 fn is_value_starting(tt: TokenType, st: TokenSubType) -> bool {
     matches!(
         (tt, st),
@@ -1985,6 +2002,9 @@ fn is_value_starting(tt: TokenType, st: TokenSubType) -> bool {
 
 /// Promote significant whitespace tokens to `OpInfix` (intersection operator)
 /// and drop insignificant whitespace.  Works on the legacy `Token` vec.
+///
+/// Multi-character whitespace (e.g. `"  "`, `"\n"`) is normalized to a single
+/// `" "` value so precedence lookup is consistent across all entry points.
 fn promote_intersection_tokens(tokens: &mut Vec<Token>) {
     let len = tokens.len();
     for i in 0..len {
@@ -2019,6 +2039,9 @@ fn promote_intersection_tokens(tokens: &mut Vec<Token>) {
 /// Promote significant whitespace spans to `OpInfix` and drop insignificant
 /// whitespace.  Works on the span-based token stream used by `SpanParser` and
 /// `BatchParser`.
+///
+/// Multi-character whitespace spans are collapsed to a single-char slice
+/// (`start..start+1`) so that `span_value()` always returns exactly `" "`.
 fn promote_intersection_spans(spans: &mut Vec<crate::tokenizer::TokenSpan>) {
     let len = spans.len();
     for i in 0..len {
@@ -2044,29 +2067,32 @@ fn promote_intersection_spans(spans: &mut Vec<crate::tokenizer::TokenSpan>) {
         if dominated {
             spans[i].token_type = TokenType::OpInfix;
             spans[i].subtype = TokenSubType::None;
-            // Keep start/end pointing at the whitespace in the source so
+            // Collapse multi-char whitespace to exactly one space char so
             // span_value() returns " " for precedence lookup.
+            spans[i].end = spans[i].start + 1;
         }
     }
     spans.retain(|t| t.token_type != TokenType::Whitespace);
 }
 
-/// Insert synthetic intersection operators for implicit intersection, where a
-/// value-ending token is directly adjacent to a value-starting token with no
-/// operator between them.  E.g. `(A1:A10>50)(B1:B10>25)`.
+/// Insert synthetic intersection operators for implicit intersection between
+/// juxtaposed parenthesized expressions, e.g. `(A1:A10>50)(B1:B10>25)`.
+///
+/// Only triggers for `Paren/Close` or `Func/Close` followed by `Paren/Open`
+/// to avoid inventing multiplication for unintended cases like `1(A1)` or
+/// `A1 SUM(...)`.
 ///
 /// Must be called *after* whitespace promotion so that all insignificant
 /// whitespace has already been removed.
 fn insert_implicit_intersection_spans(
     spans: &mut Vec<crate::tokenizer::TokenSpan>,
-    _source: &str,
 ) {
     let mut i = 0;
     while i + 1 < spans.len() {
         let cur = &spans[i];
         let nxt = &spans[i + 1];
-        if is_value_ending(cur.token_type, cur.subtype)
-            && is_value_starting(nxt.token_type, nxt.subtype)
+        if is_paren_ending(cur.token_type, cur.subtype)
+            && is_paren_starting(nxt.token_type, nxt.subtype)
         {
             // Insert a zero-width OpInfix " " between cur and nxt.
             let boundary = cur.end;
@@ -2092,8 +2118,8 @@ fn insert_implicit_intersection_tokens(tokens: &mut Vec<Token>) {
     while i + 1 < tokens.len() {
         let cur = &tokens[i];
         let nxt = &tokens[i + 1];
-        if is_value_ending(cur.token_type, cur.subtype)
-            && is_value_starting(nxt.token_type, nxt.subtype)
+        if is_paren_ending(cur.token_type, cur.subtype)
+            && is_paren_starting(nxt.token_type, nxt.subtype)
         {
             let boundary = cur.end;
             tokens.insert(
@@ -2686,7 +2712,9 @@ impl<'a> SpanParser<'a> {
         };
 
         match op {
-            ":" | " " | "," => Some((8, Associativity::Left)),
+            ":" => Some((10, Associativity::Left)),
+            " " => Some((9, Associativity::Left)),
+            "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
             "^" => Some((6, Associativity::Right)),
             "u" => Some((5, Associativity::Right)),
@@ -3138,7 +3166,7 @@ pub fn parse_with_dialect<T: AsRef<str>>(
 ) -> Result<ASTNode, ParserError> {
     let mut spans = crate::tokenizer::tokenize_spans_with_dialect(formula.as_ref(), dialect)?;
     promote_intersection_spans(&mut spans);
-    insert_implicit_intersection_spans(&mut spans, formula.as_ref());
+    insert_implicit_intersection_spans(&mut spans);
     let mut parser = SpanParser::new(formula.as_ref(), &spans, dialect);
     parser.parse()
 }
@@ -3167,7 +3195,7 @@ where
 {
     let mut spans = crate::tokenizer::tokenize_spans_with_dialect(formula.as_ref(), dialect)?;
     promote_intersection_spans(&mut spans);
-    insert_implicit_intersection_spans(&mut spans, formula.as_ref());
+    insert_implicit_intersection_spans(&mut spans);
     let mut parser =
         SpanParser::new(formula.as_ref(), &spans, dialect).with_volatility_classifier(classifier);
     parser.parse()
@@ -3197,7 +3225,7 @@ impl BatchParser {
             let mut spans = crate::tokenizer::tokenize_spans_with_dialect(formula, self.dialect)?;
             if !self.include_whitespace {
                 promote_intersection_spans(&mut spans);
-                insert_implicit_intersection_spans(&mut spans, formula);
+                insert_implicit_intersection_spans(&mut spans);
             }
 
             let spans: Arc<[crate::tokenizer::TokenSpan]> = Arc::from(spans.into_boxed_slice());

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -2148,4 +2148,37 @@ mod intersection_operator_tests {
             panic!("Expected BinaryOp for table intersection, got {:?}", ast.node_type);
         }
     }
+
+    #[test]
+    fn test_double_space_intersection_via_public_parse() {
+        // Double-space and newline-containing whitespace must also produce " "
+        // via the public parse() which uses SpanParser.
+        let ast = crate::parser::parse("=SUM(A1:A10  B1:B10)").unwrap();
+        if let ASTNodeType::Function { name, args } = &ast.node_type {
+            assert_eq!(name, "SUM");
+            assert_eq!(args.len(), 1);
+            if let ASTNodeType::BinaryOp { op, .. } = &args[0].node_type {
+                assert_eq!(op, " ", "multi-space should normalize to single space op");
+            } else {
+                panic!("Expected BinaryOp");
+            }
+        } else {
+            panic!("Expected Function");
+        }
+    }
+
+    #[test]
+    fn test_precedence_colon_tighter_than_space() {
+        // =A1:B2 C2:D3 should parse as (A1:B2) ISECT (C2:D3)
+        // The tokenizer produces range references as single operand tokens,
+        // so both sides are Reference nodes, not BinaryOp(":").
+        let ast = parse_formula("=A1:B2 C2:D3").unwrap();
+        if let ASTNodeType::BinaryOp { op, left, right } = &ast.node_type {
+            assert_eq!(op, " ");
+            assert!(matches!(&left.node_type, ASTNodeType::Reference { .. }));
+            assert!(matches!(&right.node_type, ASTNodeType::Reference { .. }));
+        } else {
+            panic!("Expected intersection BinaryOp, got {:?}", ast.node_type);
+        }
+    }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -255,7 +255,9 @@ impl Token {
         //   &
         //   comparisons
         match op {
-            ":" | " " | "," => Some((8, Associativity::Left)),
+            ":" => Some((10, Associativity::Left)),
+            " " => Some((9, Associativity::Left)),
+            "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
             "^" => Some((6, Associativity::Right)),
             "u" => Some((5, Associativity::Right)),


### PR DESCRIPTION
## Summary
- Implements the Excel space operator (intersection) and implicit multiplication for SUMPRODUCT-style formulas
- The parser previously discarded all whitespace tokens, causing `ParserError` for valid formulas like `=SUM(A1:A10 B1:B10)`, `=SUMPRODUCT((A1>50)(B1>25))`, and `=SUMPRODUCT((A1="x") (B1:B10))`
- Adds a pre-processing step that promotes significant whitespace to `OpInfix` operators, and inserts synthetic intersection operators for juxtaposed value tokens
- Evaluator handles `" "` as range intersection (returning `#NULL!` for non-overlapping ranges) or element-wise multiplication (SUMPRODUCT idiom)

## Test plan
- [x] All 143 parser tests pass (138 existing + 5 new intersection tests)
- [x] All 867 eval tests pass (1 pre-existing failure in `type_codes_basic` unrelated)
- [ ] Manual verification with real-world XLSX files that previously triggered ParserError
- [ ] Integration test via newton-be spreadsheet ingestion pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)