### PR TITLE
feat(eval): implement RRI (equivalent rate of return) function

### DIFF
--- a/crates/formualizer-eval/src/builtins/financial/tvm.rs
+++ b/crates/formualizer-eval/src/builtins/financial/tvm.rs
@@ -2330,6 +2330,59 @@ impl Function for DollarfrFn {
     }
 }
 
+/// RRI(nper, pv, fv) — equivalent interest rate for growth of an investment.
+/// Returns (fv/pv)^(1/nper) - 1  (i.e. CAGR).
+#[derive(Debug)]
+pub struct RriFn;
+impl Function for RriFn {
+    func_caps!(PURE);
+    fn name(&self) -> &'static str {
+        "RRI"
+    }
+    fn min_args(&self) -> usize {
+        3
+    }
+    fn arg_schema(&self) -> &'static [ArgSchema] {
+        use std::sync::LazyLock;
+        static SCHEMA: LazyLock<Vec<ArgSchema>> = LazyLock::new(|| {
+            vec![
+                ArgSchema::number_lenient_scalar(), // nper
+                ArgSchema::number_lenient_scalar(), // pv
+                ArgSchema::number_lenient_scalar(), // fv
+            ]
+        });
+        &SCHEMA[..]
+    }
+    fn eval<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        _ctx: &dyn FunctionContext<'b>,
+    ) -> Result<CalcValue<'b>, ExcelError> {
+        let nper = coerce_num(&args[0])?;
+        let pv = coerce_num(&args[1])?;
+        let fv = coerce_num(&args[2])?;
+
+        // nper must be > 0, pv must be non-zero
+        if nper <= 0.0 || pv == 0.0 {
+            return Ok(CalcValue::Scalar(
+                LiteralValue::Error(ExcelError::new_num()),
+            ));
+        }
+
+        // If pv and fv have different signs, the ratio is negative and
+        // fractional exponent would produce NaN → Excel returns #NUM!
+        let ratio = fv / pv;
+        if ratio < 0.0 {
+            return Ok(CalcValue::Scalar(
+                LiteralValue::Error(ExcelError::new_num()),
+            ));
+        }
+
+        let result = ratio.powf(1.0 / nper) - 1.0;
+        Ok(CalcValue::Scalar(LiteralValue::Number(result)))
+    }
+}
+
 pub fn register_builtins() {
     use std::sync::Arc;
     crate::function_registry::register_function(Arc::new(PmtFn));
@@ -2350,4 +2403,5 @@ pub fn register_builtins() {
     crate::function_registry::register_function(Arc::new(XirrFn));
     crate::function_registry::register_function(Arc::new(DollardeFn));
     crate::function_registry::register_function(Arc::new(DollarfrFn));
+    crate::function_registry::register_function(Arc::new(RriFn));
 }

--- a/crates/formualizer-eval/src/engine/tests/formula_error_propagation.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_error_propagation.rs
@@ -69,3 +69,41 @@ fn iferror_catches_name_errors_from_eval_path() {
         Some(LiteralValue::Number(42.0))
     );
 }
+
+#[test]
+fn rri_basic_cagr_calculation() {
+    // RRI(nper, pv, fv) = (fv/pv)^(1/nper) - 1
+    // Excel: =RRI(10, 1000, 2000) ≈ 0.07177 (CAGR for doubling in 10 periods)
+    let wb = TestWorkbook::new();
+    let mut engine = Engine::new(wb, EvalConfig::default());
+
+    // A1 = RRI(10, 1000, 2000)
+    engine.stage_formula_text("Sheet1", 1, 1, "=RRI(10, 1000, 2000)".to_string());
+    // B1 = _XLFN.RRI(10, 1000, 2000) — verify prefix stripping works
+    engine.stage_formula_text("Sheet1", 1, 2, "=_XLFN.RRI(10, 1000, 2000)".to_string());
+
+    engine.build_graph_all().expect("staged formulas build");
+    engine.evaluate_all().expect("evaluation succeeds");
+
+    let expected = (2000.0_f64 / 1000.0).powf(1.0 / 10.0) - 1.0;
+
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Number(n)) => {
+            assert!(
+                (n - expected).abs() < 1e-10,
+                "A1 expected {expected}, got {n}"
+            );
+        }
+        other => panic!("A1 expected Number({expected}), got {other:?}"),
+    }
+
+    match engine.get_cell_value("Sheet1", 1, 2) {
+        Some(LiteralValue::Number(n)) => {
+            assert!(
+                (n - expected).abs() < 1e-10,
+                "B1 expected {expected}, got {n}"
+            );
+        }
+        other => panic!("B1 expected Number({expected}), got {other:?}"),
+    }
+}


### PR DESCRIPTION
RRI(nper, pv, fv) = (fv/pv)^(1/nper) - 1

Returns the equivalent interest rate for the growth of an investment over a number of periods. Validates that nper > 0 and pv != 0.