### PR TITLE
Heal pending symbolic formula names

### DIFF
--- a/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
@@ -1,7 +1,7 @@
 use super::*;
 use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
 
-// Type alias for complex return type (local to analysis).
+// Type alias for complex return types (local to analysis).
 type ExtractDependenciesResult = Result<
     (
         Vec<VertexId>,
@@ -12,6 +12,23 @@ type ExtractDependenciesResult = Result<
     ExcelError,
 >;
 
+type ExtractDependenciesWithPendingNamesResult = Result<
+    (
+        Vec<VertexId>,
+        Vec<SharedRangeRef<'static>>,
+        Vec<CellRef>,
+        Vec<VertexId>,
+        Vec<String>,
+    ),
+    ExcelError,
+>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnresolvedNamePolicy {
+    Error,
+    Collect,
+}
+
 impl DependencyGraph {
     // Helper methods for formula analysis / dependency extraction.
 
@@ -20,10 +37,30 @@ impl DependencyGraph {
         ast: &ASTNode,
         current_sheet_id: SheetId,
     ) -> ExtractDependenciesResult {
+        let (dependencies, ranges, placeholders, named_dependencies, _pending_names) =
+            self.extract_dependencies_inner(ast, current_sheet_id, UnresolvedNamePolicy::Error)?;
+        Ok((dependencies, ranges, placeholders, named_dependencies))
+    }
+
+    pub(super) fn extract_dependencies_with_pending_names(
+        &mut self,
+        ast: &ASTNode,
+        current_sheet_id: SheetId,
+    ) -> ExtractDependenciesWithPendingNamesResult {
+        self.extract_dependencies_inner(ast, current_sheet_id, UnresolvedNamePolicy::Collect)
+    }
+
+    fn extract_dependencies_inner(
+        &mut self,
+        ast: &ASTNode,
+        current_sheet_id: SheetId,
+        unresolved_name_policy: UnresolvedNamePolicy,
+    ) -> ExtractDependenciesWithPendingNamesResult {
         let mut dependencies = FxHashSet::default();
         let mut range_dependencies: Vec<SharedRangeRef<'static>> = Vec::new();
         let mut created_placeholders = Vec::new();
         let mut named_dependencies = Vec::new();
+        let mut unresolved_names = FxHashSet::default();
         let mut local_scopes: Vec<FxHashSet<String>> = Vec::new();
         self.extract_dependencies_recursive(
             ast,
@@ -32,7 +69,9 @@ impl DependencyGraph {
             &mut range_dependencies,
             &mut created_placeholders,
             &mut named_dependencies,
+            &mut unresolved_names,
             &mut local_scopes,
+            unresolved_name_policy,
         )?;
 
         // Deduplicate range references.
@@ -46,11 +85,15 @@ impl DependencyGraph {
         named_dependencies.sort_unstable_by_key(|v| v.0);
         named_dependencies.dedup_by_key(|v| v.0);
 
+        let mut unresolved_names: Vec<String> = unresolved_names.into_iter().collect();
+        unresolved_names.sort();
+
         Ok((
             dependencies.into_iter().collect(),
             deduped_ranges,
             created_placeholders,
             named_dependencies,
+            unresolved_names,
         ))
     }
 
@@ -62,7 +105,9 @@ impl DependencyGraph {
         range_dependencies: &mut Vec<SharedRangeRef<'static>>,
         created_placeholders: &mut Vec<CellRef>,
         named_dependencies: &mut Vec<VertexId>,
+        unresolved_names: &mut FxHashSet<String>,
         local_scopes: &mut Vec<FxHashSet<String>>,
+        unresolved_name_policy: UnresolvedNamePolicy,
     ) -> Result<(), ExcelError> {
         match &ast.node_type {
             ASTNodeType::Reference { reference, .. } => match reference {
@@ -186,8 +231,15 @@ impl DependencyGraph {
                     } else if let Some(source) = self.resolve_source_scalar_entry(name) {
                         dependencies.insert(source.vertex);
                     } else {
-                        return Err(ExcelError::new(ExcelErrorKind::Name)
-                            .with_message(format!("Undefined name: {name}")));
+                        match unresolved_name_policy {
+                            UnresolvedNamePolicy::Error => {
+                                return Err(ExcelError::new(ExcelErrorKind::Name)
+                                    .with_message(format!("Undefined name: {name}")));
+                            }
+                            UnresolvedNamePolicy::Collect => {
+                                unresolved_names.insert(name.to_string());
+                            }
+                        }
                     }
                 }
                 ReferenceType::Table(tref) => {
@@ -209,7 +261,9 @@ impl DependencyGraph {
                     range_dependencies,
                     created_placeholders,
                     named_dependencies,
+                    unresolved_names,
                     local_scopes,
+                    unresolved_name_policy,
                 )?;
                 self.extract_dependencies_recursive(
                     right,
@@ -218,7 +272,9 @@ impl DependencyGraph {
                     range_dependencies,
                     created_placeholders,
                     named_dependencies,
+                    unresolved_names,
                     local_scopes,
+                    unresolved_name_policy,
                 )?;
             }
             ASTNodeType::UnaryOp { expr, .. } => {
@@ -229,7 +285,9 @@ impl DependencyGraph {
                     range_dependencies,
                     created_placeholders,
                     named_dependencies,
+                    unresolved_names,
                     local_scopes,
+                    unresolved_name_policy,
                 )?;
             }
             ASTNodeType::Function { name, args } => {
@@ -245,7 +303,9 @@ impl DependencyGraph {
                                 range_dependencies,
                                 created_placeholders,
                                 named_dependencies,
+                                unresolved_names,
                                 local_scopes,
+                                unresolved_name_policy,
                             )?;
 
                             if let ASTNodeType::Reference {
@@ -265,7 +325,9 @@ impl DependencyGraph {
                             range_dependencies,
                             created_placeholders,
                             named_dependencies,
+                            unresolved_names,
                             local_scopes,
+                            unresolved_name_policy,
                         )?;
 
                         local_scopes.pop();
@@ -278,7 +340,9 @@ impl DependencyGraph {
                                 range_dependencies,
                                 created_placeholders,
                                 named_dependencies,
+                                unresolved_names,
                                 local_scopes,
+                                unresolved_name_policy,
                             )?;
                         }
                     }
@@ -302,7 +366,9 @@ impl DependencyGraph {
                             range_dependencies,
                             created_placeholders,
                             named_dependencies,
+                            unresolved_names,
                             local_scopes,
+                            unresolved_name_policy,
                         )?;
                         local_scopes.pop();
                     }
@@ -315,7 +381,9 @@ impl DependencyGraph {
                             range_dependencies,
                             created_placeholders,
                             named_dependencies,
+                            unresolved_names,
                             local_scopes,
+                            unresolved_name_policy,
                         )?;
                     }
                 }
@@ -330,7 +398,9 @@ impl DependencyGraph {
                             range_dependencies,
                             created_placeholders,
                             named_dependencies,
+                            unresolved_names,
                             local_scopes,
+                            unresolved_name_policy,
                         )?;
                     }
                 }

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -187,8 +187,15 @@ pub struct DependencyGraph {
     /// Lookup for name vertex -> (scope, name) to avoid map scans
     name_vertex_lookup: FxHashMap<VertexId, (NameScope, String)>,
 
-    /// Pending formula vertices referencing names not yet defined
-    pending_name_links: FxHashMap<String, Vec<(SheetId, VertexId)>>,
+    /// Pending formula vertices referencing unresolved bare symbolic names.
+    ///
+    /// Keys are normalized through `name_lookup_key(...)` so workbook names and
+    /// source scalars can both wake the same waiting formulas when a symbol appears.
+    pending_name_links: FxHashMap<String, FxHashSet<(SheetId, VertexId)>>,
+
+    /// Reverse mapping used to clear stale pending-name registrations when a
+    /// formula is edited, overwritten with a value, or otherwise rebuilt.
+    vertex_to_pending_names: FxHashMap<VertexId, FxHashSet<String>>,
 
     // Native workbook tables (ListObjects)
     tables: FxHashMap<String, tables::TableEntry>,
@@ -574,6 +581,7 @@ impl DependencyGraph {
             vertex_to_names: FxHashMap::default(),
             name_vertex_lookup: FxHashMap::default(),
             pending_name_links: FxHashMap::default(),
+            vertex_to_pending_names: FxHashMap::default(),
             tables: FxHashMap::default(),
             tables_lookup: FxHashMap::default(),
             table_vertex_lookup: FxHashMap::default(),
@@ -747,6 +755,8 @@ impl DependencyGraph {
 
             if is_formula {
                 self.remove_dependent_edges(existing_id);
+                self.detach_vertex_from_names(existing_id);
+                self.clear_pending_name_references(existing_id);
                 self.vertex_formulas.remove(&existing_id);
             }
 
@@ -815,6 +825,15 @@ impl DependencyGraph {
         let addr = CellRef::new(sheet_id, coord);
         if let Some(&existing_id) = self.cell_to_vertex.get(&addr) {
             // Overwrite existing value vertex only (ignore formulas in bulk path)
+            if matches!(
+                self.store.kind(existing_id),
+                VertexKind::FormulaScalar | VertexKind::FormulaArray
+            ) {
+                self.remove_dependent_edges(existing_id);
+                self.detach_vertex_from_names(existing_id);
+                self.clear_pending_name_references(existing_id);
+                self.vertex_formulas.remove(&existing_id);
+            }
             if self.value_cache_enabled {
                 let value_ref = self.data_store.store_value(value);
                 self.vertex_values.insert(existing_id, value_ref);
@@ -871,6 +890,15 @@ impl DependencyGraph {
             let coord = Coord::from_excel(row, col, true, true);
             let addr = CellRef::new(sheet_id, coord);
             if !assume_new && let Some(&existing_id) = self.cell_to_vertex.get(&addr) {
+                if matches!(
+                    self.store.kind(existing_id),
+                    VertexKind::FormulaScalar | VertexKind::FormulaArray
+                ) {
+                    self.remove_dependent_edges(existing_id);
+                    self.detach_vertex_from_names(existing_id);
+                    self.clear_pending_name_references(existing_id);
+                    self.vertex_formulas.remove(&existing_id);
+                }
                 if self.value_cache_enabled {
                     let value_ref = self.data_store.store_value(value);
                     self.vertex_values.insert(existing_id, value_ref);
@@ -979,7 +1007,8 @@ impl DependencyGraph {
             new_range_dependencies,
             mut created_placeholders,
             named_dependencies,
-        ) = self.extract_dependencies(&ast, sheet_id)?;
+            unresolved_names,
+        ) = self.extract_dependencies_with_pending_names(&ast, sheet_id)?;
         if let (true, Some(t)) = (dbg, t_dep0) {
             let elapsed = t.elapsed().as_millis();
             // Only log if over threshold or sampled
@@ -1035,6 +1064,7 @@ impl DependencyGraph {
         // Remove old dependencies first
         self.remove_dependent_edges(addr_vertex_id);
         self.detach_vertex_from_names(addr_vertex_id);
+        self.clear_pending_name_references(addr_vertex_id);
 
         // Update vertex properties
         self.store
@@ -1052,6 +1082,9 @@ impl DependencyGraph {
 
         if !named_dependencies.is_empty() {
             self.attach_vertex_to_names(addr_vertex_id, &named_dependencies);
+        }
+        for unresolved_name in &unresolved_names {
+            self.record_pending_name_reference(sheet_id, unresolved_name, addr_vertex_id);
         }
 
         if let (true, Some(t)) = (dbg, t0) {
@@ -2956,18 +2989,24 @@ impl DependencyGraph {
     pub(crate) fn rebuild_formula_dependencies(&mut self, vertex_id: VertexId, ast: &ASTNode) {
         let sheet_id = self.store.sheet_id(vertex_id);
 
-        // Remove old dependency and name links first.
+        // Remove old dependency, name, and pending-name links first.
         self.remove_dependent_edges(vertex_id);
         self.detach_vertex_from_names(vertex_id);
+        self.clear_pending_name_references(vertex_id);
 
-        let (new_dependencies, new_range_dependencies, _created_placeholders, named_dependencies) =
-            match self.extract_dependencies(ast, sheet_id) {
-                Ok(v) => v,
-                Err(_) => {
-                    self.mark_as_ref_error(vertex_id);
-                    return;
-                }
-            };
+        let (
+            new_dependencies,
+            new_range_dependencies,
+            _created_placeholders,
+            named_dependencies,
+            unresolved_names,
+        ) = match self.extract_dependencies_with_pending_names(ast, sheet_id) {
+            Ok(v) => v,
+            Err(_) => {
+                self.mark_as_ref_error(vertex_id);
+                return;
+            }
+        };
 
         // Self-reference / name-cycle safety parity with set_cell_formula.
         if new_dependencies.contains(&vertex_id) {
@@ -2989,6 +3028,9 @@ impl DependencyGraph {
 
         if !named_dependencies.is_empty() {
             self.attach_vertex_to_names(vertex_id, &named_dependencies);
+        }
+        for unresolved_name in &unresolved_names {
+            self.record_pending_name_reference(sheet_id, unresolved_name, vertex_id);
         }
 
         self.add_dependent_edges(vertex_id, &new_dependencies);

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -224,7 +224,7 @@ impl DependencyGraph {
         }
 
         self.name_vertex_lookup.insert(vertex_id, (scope, key));
-        self.resolve_pending_name_references(scope, name, vertex_id);
+        self.resolve_pending_name_references(scope, name);
 
         Ok(())
     }
@@ -495,34 +495,49 @@ impl DependencyGraph {
     ) {
         let key = self.name_lookup_key(name);
         self.pending_name_links
-            .entry(key)
+            .entry(key.clone())
             .or_default()
-            .push((sheet_id, formula_vertex));
+            .insert((sheet_id, formula_vertex));
+        self.vertex_to_pending_names
+            .entry(formula_vertex)
+            .or_default()
+            .insert(key);
     }
 
-    fn resolve_pending_name_references(
-        &mut self,
-        scope: NameScope,
-        name: &str,
-        named_vertex: VertexId,
-    ) {
+    pub(crate) fn clear_pending_name_references(&mut self, formula_vertex: VertexId) {
+        let Some(keys) = self.vertex_to_pending_names.remove(&formula_vertex) else {
+            return;
+        };
+
+        for key in keys {
+            let mut remove_key = false;
+            if let Some(entries) = self.pending_name_links.get_mut(&key) {
+                entries.retain(|(_, vertex_id)| *vertex_id != formula_vertex);
+                remove_key = entries.is_empty();
+            }
+            if remove_key {
+                self.pending_name_links.remove(&key);
+            }
+        }
+    }
+
+    pub(super) fn resolve_pending_name_references(&mut self, scope: NameScope, name: &str) {
         let key = self.name_lookup_key(name);
-        if let Some(mut entries) = self.pending_name_links.remove(&key) {
-            let mut remaining: Vec<(SheetId, VertexId)> = Vec::new();
-            for (sheet_id, formula_vertex) in entries.drain(..) {
+        if let Some(entries) = self.pending_name_links.remove(&key) {
+            for (sheet_id, formula_vertex) in entries {
                 let attach = match scope {
                     NameScope::Workbook => true,
                     NameScope::Sheet(expected) => expected == sheet_id,
                 };
                 if attach {
-                    self.add_dependent_edges(formula_vertex, &[named_vertex]);
-                    self.attach_vertex_to_names(formula_vertex, &[named_vertex]);
+                    if let Some(ast) = self.get_formula(formula_vertex) {
+                        self.rebuild_formula_dependencies(formula_vertex, &ast);
+                    } else {
+                        self.clear_pending_name_references(formula_vertex);
+                    }
                 } else {
-                    remaining.push((sheet_id, formula_vertex));
+                    self.record_pending_name_reference(sheet_id, name, formula_vertex);
                 }
-            }
-            if !remaining.is_empty() {
-                self.pending_name_links.insert(key, remaining);
             }
         }
     }

--- a/crates/formualizer-eval/src/engine/graph/sheets.rs
+++ b/crates/formualizer-eval/src/engine/graph/sheets.rs
@@ -143,6 +143,7 @@ impl DependencyGraph {
                 index.remove_vertex(coord, vertex_id);
             }
 
+            self.clear_pending_name_references(vertex_id);
             self.vertex_formulas.remove(&vertex_id);
             self.vertex_values.remove(&vertex_id);
 

--- a/crates/formualizer-eval/src/engine/graph/sources.rs
+++ b/crates/formualizer-eval/src/engine/graph/sources.rs
@@ -1,5 +1,6 @@
 use crate::SheetId;
 use crate::engine::graph::DependencyGraph;
+use crate::engine::named_range::NameScope;
 use crate::engine::vertex::{VertexId, VertexKind};
 use formualizer_common::{Coord as AbsCoord, ExcelError, ExcelErrorKind};
 
@@ -73,6 +74,7 @@ impl DependencyGraph {
             version,
         };
         self.source_scalars.insert(name.to_string(), entry);
+        self.resolve_pending_name_references(NameScope::Workbook, name);
         Ok(())
     }
 

--- a/crates/formualizer-eval/src/engine/tests/let_lambda.rs
+++ b/crates/formualizer-eval/src/engine/tests/let_lambda.rs
@@ -175,16 +175,20 @@ fn lambda_param_shadowing_and_capture_snapshot_engine() {
 fn let_undefined_symbol_and_non_invoked_lambda_errors_engine() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
 
-    let err = engine
+    engine
         .set_cell_formula("Sheet1", 7, 1, parse("=LET(x,y,y,2,x)").unwrap())
-        .expect_err("undefined y should fail ingest");
-    assert_eq!(err.kind, ExcelErrorKind::Name);
+        .unwrap();
 
     engine
         .set_cell_formula("Sheet1", 7, 2, parse("=LET(f,LAMBDA(x,x+1),f)").unwrap())
         .unwrap();
 
     engine.evaluate_all().unwrap();
+
+    match engine.get_cell_value("Sheet1", 7, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected #NAME?, got {other:?}"),
+    }
 
     match engine.get_cell_value("Sheet1", 7, 2) {
         Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Calc),

--- a/crates/formualizer-eval/src/engine/tests/named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/named_ranges.rs
@@ -990,15 +990,270 @@ fn test_duplicate_name_error() {
 }
 
 #[test]
-fn test_undefined_name_error() {
-    let mut graph = DependencyGraph::new();
+fn test_undefined_name_evaluates_to_name_and_heals() {
+    let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
 
-    // Try to use undefined name in formula
-    let ast = parse("=UndefinedName*2").unwrap();
-    let result = graph.set_cell_formula("Sheet1", 1, 1, ast);
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=UndefinedName*2").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
 
-    assert!(result.is_err());
-    assert!(matches!(result.unwrap_err().kind, ExcelErrorKind::Name));
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected #NAME? for unresolved symbol, got {other:?}"),
+    }
+
+    engine
+        .define_name(
+            "UndefinedName",
+            NamedDefinition::Literal(LiteralValue::Number(5.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(10.0))
+    );
+}
+
+#[test]
+fn pending_workbook_name_heal_tracks_future_updates() {
+    let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=Foo+1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected #NAME? before healing, got {other:?}"),
+    }
+
+    engine
+        .define_name(
+            "Foo",
+            NamedDefinition::Literal(LiteralValue::Number(10.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(11.0))
+    );
+
+    engine
+        .update_name(
+            "Foo",
+            NamedDefinition::Literal(LiteralValue::Number(20.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(21.0))
+    );
+}
+
+#[test]
+fn pending_name_heal_is_case_insensitive_by_default() {
+    let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=foo+1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected unresolved lower-case symbol to yield #NAME?, got {other:?}"),
+    }
+
+    engine
+        .define_name(
+            "Foo",
+            NamedDefinition::Literal(LiteralValue::Number(3.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(4.0))
+    );
+}
+
+#[test]
+fn pending_sheet_scoped_name_heals_only_same_sheet() {
+    let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
+    let sheet1 = engine.sheet_id_mut("Sheet1");
+    engine.add_sheet("Sheet2").unwrap();
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=LocalX").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet2", 1, 1, parse("=LocalX").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    engine
+        .define_name(
+            "LocalX",
+            NamedDefinition::Literal(LiteralValue::Number(7.0)),
+            NameScope::Sheet(sheet1),
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(7.0))
+    );
+    match engine.get_cell_value("Sheet2", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected Sheet2 formula to remain unresolved, got {other:?}"),
+    }
+}
+
+#[test]
+fn pending_formula_edit_clears_stale_name_intent() {
+    let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=Foo").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=Bar").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    engine
+        .define_name(
+            "Foo",
+            NamedDefinition::Literal(LiteralValue::Number(10.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected formula to keep waiting on Bar, got {other:?}"),
+    }
+
+    engine
+        .define_name(
+            "Bar",
+            NamedDefinition::Literal(LiteralValue::Number(20.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(20.0))
+    );
+}
+
+#[test]
+fn pending_formula_overwrite_with_value_clears_stale_name_intent() {
+    let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=Foo").unwrap())
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(42.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    engine
+        .define_name(
+            "Foo",
+            NamedDefinition::Literal(LiteralValue::Number(10.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(42.0))
+    );
+}
+
+#[test]
+fn pending_mixed_and_multi_name_formulas_heal_incrementally() {
+    let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
+
+    engine
+        .define_name(
+            "Known",
+            NamedDefinition::Literal(LiteralValue::Number(2.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=Known+Missing").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=Foo+Bar").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected mixed formula to start unresolved, got {other:?}"),
+    }
+    match engine.get_cell_value("Sheet1", 1, 2) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected double-missing formula to start unresolved, got {other:?}"),
+    }
+
+    engine
+        .define_name(
+            "Missing",
+            NamedDefinition::Literal(LiteralValue::Number(5.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .define_name(
+            "Foo",
+            NamedDefinition::Literal(LiteralValue::Number(10.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(7.0))
+    );
+    match engine.get_cell_value("Sheet1", 1, 2) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected Foo+Bar to remain unresolved until Bar exists, got {other:?}"),
+    }
+
+    engine
+        .define_name(
+            "Bar",
+            NamedDefinition::Literal(LiteralValue::Number(3.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(13.0))
+    );
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/sources.rs
+++ b/crates/formualizer-eval/src/engine/tests/sources.rs
@@ -188,16 +188,56 @@ impl Resolver for SourceCtx {}
 impl EvaluationContext for SourceCtx {}
 
 #[test]
-fn undeclared_source_is_name_error() {
+fn undeclared_source_symbol_is_stored_and_evaluates_to_name_error() {
     let ctx = SourceCtx::default();
     let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
     engine.add_sheet("Sheet1").unwrap();
 
     let ast = formualizer_parse::parser::parse("=Foo").unwrap();
-    let err = engine
-        .set_cell_formula("Sheet1", 1, 1, ast)
-        .expect_err("undeclared source should be a hard error");
-    assert_eq!(err.kind, ExcelErrorKind::Name);
+    engine.set_cell_formula("Sheet1", 1, 1, ast).unwrap();
+    engine.evaluate_all().unwrap();
+
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected #NAME? for unresolved source-like symbol, got {other:?}"),
+    }
+}
+
+#[test]
+fn defining_source_scalar_heals_pending_formula_symbol() {
+    let ctx = SourceCtx::default();
+    ctx.set_scalar("Foo", LiteralValue::Number(9.0));
+
+    let mut engine: Engine<_> = Engine::new(ctx.clone(), EvalConfig::default());
+    engine.add_sheet("Sheet1").unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            1,
+            formualizer_parse::parser::parse("=Foo+1").unwrap(),
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    match engine.get_cell_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Name),
+        other => panic!("expected pending symbol to start unresolved, got {other:?}"),
+    }
+
+    engine.define_source_scalar("Foo", Some(1)).unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(10.0))
+    );
+
+    ctx.set_scalar("Foo", LiteralValue::Number(12.0));
+    engine.invalidate_source("Foo").unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(13.0))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements pending symbolic-name healing for interactive formulas on current `main`.

Before this change, formulas like `=Foo+1` failed at set-time if `Foo` was not yet defined.
After this change, those formulas:
- store successfully
- evaluate to `#NAME?` while unresolved
- automatically heal when the symbol later appears via:
  - `define_name(...)`
  - `define_source_scalar(...)`

## Design

This intentionally keeps the current specialized sheet-healing path intact.

Instead of reviving PR #29's broader generalized rescue approach, this change:
- reuses the canonical dependency rebuild path
- adds bidirectional pending-symbol tracking for stale-entry cleanup
- supports interactive formulas without adding a second dependency-resolution pipeline

## Implementation details

- add lenient dependency extraction for unresolved bare symbolic names
- record unresolved symbols in pending forward/reverse maps
- clear stale pending registrations on formula edit / overwrite / deletion paths
- rebuild waiting formulas when a matching name or source scalar is defined
- preserve scope behavior for sheet-scoped names

## Tests

Added/updated coverage for:
- unresolved formulas evaluating to `#NAME?`
- healing via workbook names
- healing via source scalars
- case-insensitive name healing
- sheet-scoped healing isolation
- stale pending cleanup on formula edit and overwrite with value
- incremental healing for mixed / multi-symbol formulas
- LET/LAMBDA expectations under the new store-then-evaluate semantics

## Validation

Passed locally:

```bash
cargo fmt --all
cargo test -p formualizer-eval --all-features
cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings
```
