### PR TITLE
Preserve scoped defined names on workbook import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+dependencies = [
+ "debug_unsafe",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,17 +566,19 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.24.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3a315226fdc5b1c3e33521073e1712a05944bc0664d665ff1f6ff0396334da"
+checksum = "20ae05a4e39297eecf9a994210d27501318c37a9318201f8e11050add82bb6f0"
 dependencies = [
+ "atoi_simd",
  "byteorder",
  "codepage",
  "encoding_rs",
+ "fast-float2",
  "log",
- "quick-xml 0.31.0",
+ "quick-xml 0.39.2",
  "serde",
- "zip 0.6.6",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -1081,6 +1092,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1295,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1494,6 +1518,7 @@ dependencies = [
  "memmap2",
  "once_cell",
  "parking_lot",
+ "quick-xml 0.39.2",
  "reqwest",
  "rustc-hash 1.1.0",
  "serde",
@@ -3088,22 +3113,22 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "encoding_rs",
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -4124,6 +4149,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -5526,6 +5557,26 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/crates/formualizer-workbook/Cargo.toml
+++ b/crates/formualizer-workbook/Cargo.toml
@@ -24,12 +24,13 @@ chrono = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"], optional = true }
+quick-xml = { version = "0.39", features = ["encoding"], optional = true }
 
 [features]
 default = ["json", "csv"]
 json = ["dep:serde_json", "formualizer-common/serde"]
 csv = ["dep:csv"]
-calamine = ["dep:calamine", "dep:zip"]
+calamine = ["dep:calamine", "dep:zip", "dep:quick-xml"]
 umya = ["dep:umya-spreadsheet", "dep:zip"]
 mmap = ["dep:memmap2"]
 io_builtins = []
@@ -43,7 +44,7 @@ wasm_plugins = ["dep:wasmparser", "dep:serde_json", "formualizer-common/serde"]
 wasm_runtime_wasmtime = ["wasm_plugins", "dep:wasmtime"]
 
 [dependencies.calamine]
-version = "0.24"
+version = "0.34"
 optional = true
 
 [dependencies.memmap2]

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -6,7 +6,7 @@ use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
 
 use calamine::{Data, Range, Reader, Xlsx, open_workbook};
@@ -16,6 +16,9 @@ use formualizer_eval::engine::Engine as EvalEngine;
 use formualizer_eval::engine::ingest::EngineLoadStream;
 use formualizer_eval::traits::EvaluationContext;
 use formualizer_parse::parser::ReferenceType;
+use quick_xml::Reader as XmlReader;
+use quick_xml::events::{BytesRef, BytesStart, Event};
+use quick_xml::name::QName;
 use zip::ZipArchive;
 
 type FormulaBatch = (String, Vec<(u32, u32, formualizer_parse::ASTNode)>);
@@ -24,6 +27,7 @@ pub struct CalamineAdapter {
     workbook: RwLock<Xlsx<BufReader<File>>>,
     loaded_sheets: HashSet<String>,
     cached_names: Option<Vec<String>>,
+    defined_names: Vec<DefinedName>,
     external_link_targets: BTreeMap<u32, String>,
 }
 
@@ -81,7 +85,12 @@ impl CalamineAdapter {
         Some((sr, sc, er, ec))
     }
 
-    fn convert_defined_name(name: &str, raw_formula: &str) -> Option<DefinedName> {
+    fn convert_defined_name(
+        name: &str,
+        raw_formula: &str,
+        local_sheet_id: Option<usize>,
+        sheet_names: &[String],
+    ) -> Option<DefinedName> {
         let mut trimmed = raw_formula.trim();
         if let Some(rest) = trimmed.strip_prefix('=') {
             trimmed = rest.trim();
@@ -91,12 +100,19 @@ impl CalamineAdapter {
         }
 
         let reference = ReferenceType::from_string(trimmed).ok()?;
+        let scope_sheet = local_sheet_id.and_then(|idx| sheet_names.get(idx).cloned());
+        let scope = if scope_sheet.is_some() {
+            DefinedNameScope::Sheet
+        } else {
+            DefinedNameScope::Workbook
+        };
+        let base_sheet = scope_sheet.as_deref();
 
         let (sheet_name, start_row, start_col, end_row, end_col) = match reference {
             ReferenceType::Cell {
                 sheet, row, col, ..
             } => {
-                let sheet = sheet?;
+                let sheet = sheet.or_else(|| base_sheet.map(|s| s.to_string()))?;
                 (sheet, row, col, row, col)
             }
             ReferenceType::Range {
@@ -109,7 +125,7 @@ impl CalamineAdapter {
             } => {
                 let (sr, sc, er, ec) =
                     Self::normalize_open_ended_bounds(start_row, start_col, end_row, end_col)?;
-                let sheet = sheet?;
+                let sheet = sheet.or_else(|| base_sheet.map(|s| s.to_string()))?;
                 (sheet, sr, sc, er, ec)
             }
             _ => return None,
@@ -119,10 +135,163 @@ impl CalamineAdapter {
 
         Some(DefinedName {
             name: name.to_string(),
-            scope: DefinedNameScope::Workbook,
-            scope_sheet: None,
+            scope,
+            scope_sheet,
             definition: DefinedNameDefinition::Range { address },
         })
+    }
+
+    fn decode_attr<R: BufRead>(
+        reader: &XmlReader<R>,
+        start: &BytesStart<'_>,
+        key: &[u8],
+    ) -> Option<String> {
+        start
+            .attributes()
+            .filter_map(Result::ok)
+            .find(|attr| attr.key == QName(key))
+            .and_then(|attr| {
+                attr.decode_and_unescape_value(reader.decoder())
+                    .ok()
+                    .map(|v| v.into_owned())
+            })
+    }
+
+    fn append_xml_entity(
+        entity: &BytesRef<'_>,
+        buffer: &mut String,
+    ) -> Result<(), quick_xml::Error> {
+        let decoded = entity.decode()?;
+        match decoded.as_ref() {
+            "lt" => buffer.push('<'),
+            "gt" => buffer.push('>'),
+            "amp" => buffer.push('&'),
+            "apos" => buffer.push('\''),
+            "quot" => buffer.push('"'),
+            _ => {
+                if let Some(ch) = entity.resolve_char_ref()? {
+                    buffer.push(ch);
+                } else {
+                    return Err(quick_xml::Error::Escape(
+                        quick_xml::escape::EscapeError::UnrecognizedEntity(
+                            0..0,
+                            format!("&{decoded};"),
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn fallback_defined_names_from_workbook(
+        workbook: &Xlsx<BufReader<File>>,
+        sheet_names: &[String],
+    ) -> Vec<DefinedName> {
+        let mut out = Vec::new();
+        let mut seen: HashSet<(DefinedNameScope, Option<String>, String)> = HashSet::new();
+
+        for (name, formula) in workbook.defined_names() {
+            if let Some(converted) = Self::convert_defined_name(name, formula, None, sheet_names) {
+                let key = (
+                    converted.scope.clone(),
+                    converted.scope_sheet.clone(),
+                    converted.name.clone(),
+                );
+                if seen.insert(key) {
+                    out.push(converted);
+                }
+            }
+        }
+
+        out
+    }
+
+    fn scan_defined_names(path: &Path, sheet_names: &[String]) -> Vec<DefinedName> {
+        let file = match File::open(path) {
+            Ok(f) => f,
+            Err(_) => return Vec::new(),
+        };
+        let reader = BufReader::new(file);
+        let mut archive = match ZipArchive::new(reader) {
+            Ok(a) => a,
+            Err(_) => return Vec::new(),
+        };
+        let entry = match archive.by_name("xl/workbook.xml") {
+            Ok(e) => e,
+            Err(_) => return Vec::new(),
+        };
+
+        // Calamine's public defined_names() surface flattens OOXML defined names to
+        // (name, formula_text) and drops localSheetId. We recover only the scoped
+        // defined-name metadata we need here with a targeted streaming pass over
+        // workbook.xml, avoiding a full file String allocation or any sheet XML reparse.
+        let mut xml = XmlReader::from_reader(BufReader::new(entry));
+        xml.config_mut().trim_text(true);
+
+        let mut out = Vec::new();
+        let mut seen: HashSet<(DefinedNameScope, Option<String>, String)> = HashSet::new();
+        let mut buf = Vec::new();
+        let mut inner_buf = Vec::new();
+        let mut in_defined_names = false;
+
+        loop {
+            buf.clear();
+            match xml.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) if e.local_name().as_ref() == b"definedNames" => {
+                    in_defined_names = true;
+                }
+                Ok(Event::End(ref e)) if e.local_name().as_ref() == b"definedNames" => {
+                    break;
+                }
+                Ok(Event::Start(ref e))
+                    if in_defined_names && e.local_name().as_ref() == b"definedName" =>
+                {
+                    let name = Self::decode_attr(&xml, e, b"name");
+                    let local_sheet_id = Self::decode_attr(&xml, e, b"localSheetId")
+                        .and_then(|v| v.parse::<usize>().ok());
+                    let mut value = String::new();
+
+                    loop {
+                        inner_buf.clear();
+                        match xml.read_event_into(&mut inner_buf) {
+                            Ok(Event::Text(t)) => match t.xml10_content() {
+                                Ok(text) => value.push_str(&text),
+                                Err(_) => return Vec::new(),
+                            },
+                            Ok(Event::GeneralRef(entity)) => {
+                                if Self::append_xml_entity(&entity, &mut value).is_err() {
+                                    return Vec::new();
+                                }
+                            }
+                            Ok(Event::End(end)) if end.name() == e.name() => break,
+                            Ok(Event::Eof) => return Vec::new(),
+                            Err(_) => return Vec::new(),
+                            _ => {}
+                        }
+                    }
+
+                    if let Some(name) = name
+                        && let Some(converted) =
+                            Self::convert_defined_name(&name, &value, local_sheet_id, sheet_names)
+                    {
+                        let key = (
+                            converted.scope.clone(),
+                            converted.scope_sheet.clone(),
+                            converted.name.clone(),
+                        );
+                        if seen.insert(key) {
+                            out.push(converted);
+                        }
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(_) => return Vec::new(),
+                _ => {}
+            }
+        }
+
+        out
     }
 
     fn scan_external_link_targets(path: &Path) -> BTreeMap<u32, String> {
@@ -311,24 +480,7 @@ impl SpreadsheetReader for CalamineAdapter {
     }
 
     fn defined_names(&mut self) -> Result<Vec<DefinedName>, Self::Error> {
-        let wb = self.workbook.read();
-        let mut out: Vec<DefinedName> = Vec::new();
-        let mut seen: HashSet<(DefinedNameScope, Option<String>, String)> = HashSet::new();
-
-        for (name, formula) in wb.defined_names() {
-            if let Some(converted) = Self::convert_defined_name(name, formula) {
-                let key = (
-                    converted.scope.clone(),
-                    converted.scope_sheet.clone(),
-                    converted.name.clone(),
-                );
-                if seen.insert(key) {
-                    out.push(converted);
-                }
-            }
-        }
-
-        Ok(out)
+        Ok(self.defined_names.clone())
     }
 
     fn open_path<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error>
@@ -338,10 +490,22 @@ impl SpreadsheetReader for CalamineAdapter {
         let path = path.as_ref();
         let external_link_targets = Self::scan_external_link_targets(path);
         let workbook: Xlsx<BufReader<File>> = open_workbook(path)?;
+        let sheet_names = workbook.sheet_names().to_vec();
+        let defined_names = if workbook.defined_names().is_empty() {
+            Vec::new()
+        } else {
+            let parsed = Self::scan_defined_names(path, &sheet_names);
+            if parsed.is_empty() {
+                Self::fallback_defined_names_from_workbook(&workbook, &sheet_names)
+            } else {
+                parsed
+            }
+        };
         Ok(Self {
             workbook: RwLock::new(workbook),
             loaded_sheets: HashSet::new(),
-            cached_names: None,
+            cached_names: Some(sheet_names),
+            defined_names,
             external_link_targets,
         })
     }

--- a/crates/formualizer-workbook/tests/calamine/named_ranges.rs
+++ b/crates/formualizer-workbook/tests/calamine/named_ranges.rs
@@ -1,8 +1,67 @@
 use crate::common::build_workbook;
+use formualizer_common::error::ExcelErrorKind;
 use formualizer_eval::engine::ingest::EngineLoadStream;
 use formualizer_eval::engine::{Engine, EvalConfig};
 use formualizer_workbook::traits::{DefinedNameDefinition, DefinedNameScope};
 use formualizer_workbook::{CalamineAdapter, LiteralValue, SpreadsheetReader};
+
+fn assert_name_error(value: LiteralValue) {
+    match value {
+        LiteralValue::Error(err) => assert_eq!(err.kind, ExcelErrorKind::Name),
+        other => panic!("expected #NAME?, got {other:?}"),
+    }
+}
+
+#[test]
+fn calamine_defined_names_preserve_sheet_scope_and_base_sheet_resolution() {
+    let path = build_workbook(|book| {
+        let _ = book.new_sheet("Sheet2");
+
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(9.0);
+        sheet1
+            .add_defined_name("LocalOnly", "$A$1")
+            .expect("add local defined name without sheet prefix");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("local defined name");
+        local.set_local_sheet_id(0);
+
+        let sheet2 = book.get_sheet_by_name_mut("Sheet2").expect("Sheet2");
+        sheet2.get_cell_mut((1, 1)).set_value_number(42.0);
+        sheet2
+            .add_defined_name("GlobalOnly", "Sheet2!$A$1")
+            .expect("add workbook defined name");
+    });
+
+    let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    let names = backend.defined_names().unwrap();
+
+    let local = names
+        .iter()
+        .find(|dn| dn.name == "LocalOnly")
+        .expect("LocalOnly should be imported by calamine");
+    assert_eq!(local.scope, DefinedNameScope::Sheet);
+    assert_eq!(local.scope_sheet.as_deref(), Some("Sheet1"));
+    match &local.definition {
+        DefinedNameDefinition::Range { address } => {
+            assert_eq!(address.sheet, "Sheet1");
+            assert_eq!(address.start_row, 1);
+            assert_eq!(address.start_col, 1);
+            assert_eq!(address.end_row, 1);
+            assert_eq!(address.end_col, 1);
+        }
+        other => panic!("expected range definition, got {other:?}"),
+    }
+
+    let global = names
+        .iter()
+        .find(|dn| dn.name == "GlobalOnly")
+        .expect("GlobalOnly should be imported by calamine");
+    assert_eq!(global.scope, DefinedNameScope::Workbook);
+    assert!(global.scope_sheet.is_none());
+}
 
 #[test]
 fn calamine_defined_names_include_open_ended_workbook_range() {
@@ -58,4 +117,118 @@ fn calamine_stream_into_engine_evaluates_vlookup_named_range() {
         engine.get_cell_value("Sheet1", 1, 3).unwrap(),
         LiteralValue::Number(123.0)
     );
+}
+
+#[test]
+fn calamine_sheet_local_name_resolves_only_on_declaring_sheet() {
+    let path = build_workbook(|book| {
+        let _ = book.new_sheet("Sheet2");
+
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(7.0);
+        sheet1
+            .add_defined_name("LocalOnly", "Sheet1!$A$1")
+            .expect("add local defined name");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("local defined name");
+        local.set_local_sheet_id(0);
+        sheet1.get_cell_mut((2, 1)).set_formula("=LocalOnly*2");
+
+        let sheet2 = book.get_sheet_by_name_mut("Sheet2").expect("Sheet2");
+        sheet2.get_cell_mut((2, 1)).set_formula("=LocalOnly");
+    });
+
+    let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    let ctx = formualizer_eval::test_workbook::TestWorkbook::new();
+    let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
+    backend.stream_into_engine(&mut engine).unwrap();
+    engine.evaluate_all().unwrap();
+
+    let local_value = engine.get_cell_value("Sheet1", 1, 2).unwrap();
+    assert!(matches!(local_value, LiteralValue::Number(n) if (n - 14.0).abs() < 1e-9));
+
+    let other_sheet_value = engine.get_cell_value("Sheet2", 1, 2).unwrap();
+    assert_name_error(other_sheet_value);
+}
+
+#[test]
+fn calamine_sheet_local_name_shadows_workbook_name_only_on_declaring_sheet() {
+    let path = build_workbook(|book| {
+        let _ = book.new_sheet("Sheet2");
+
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(10.0);
+        sheet1
+            .add_defined_name("ScopedValue", "Sheet1!$A$1")
+            .expect("add local defined name");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("local defined name");
+        local.set_local_sheet_id(0);
+        sheet1.get_cell_mut((2, 1)).set_formula("=ScopedValue*2");
+
+        let sheet2 = book.get_sheet_by_name_mut("Sheet2").expect("Sheet2");
+        sheet2.get_cell_mut((1, 1)).set_value_number(100.0);
+        sheet2
+            .add_defined_name("ScopedValue", "Sheet2!$A$1")
+            .expect("add workbook defined name");
+        sheet2.get_cell_mut((2, 1)).set_formula("=ScopedValue*2");
+    });
+
+    let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    let ctx = formualizer_eval::test_workbook::TestWorkbook::new();
+    let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
+    backend.stream_into_engine(&mut engine).unwrap();
+    engine.evaluate_all().unwrap();
+
+    let local_value = engine.get_cell_value("Sheet1", 1, 2).unwrap();
+    assert!(matches!(local_value, LiteralValue::Number(n) if (n - 20.0).abs() < 1e-9));
+
+    let workbook_value = engine.get_cell_value("Sheet2", 1, 2).unwrap();
+    assert!(matches!(workbook_value, LiteralValue::Number(n) if (n - 200.0).abs() < 1e-9));
+}
+
+#[test]
+fn calamine_same_local_name_on_multiple_sheets_is_isolated() {
+    let path = build_workbook(|book| {
+        let _ = book.new_sheet("Data");
+
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(2.0);
+        sheet1
+            .add_defined_name("LocalDup", "Sheet1!$A$1")
+            .expect("add Sheet1 local name");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("Sheet1 local defined name");
+        local.set_local_sheet_id(0);
+        sheet1.get_cell_mut((2, 1)).set_formula("=LocalDup*3");
+
+        let data = book.get_sheet_by_name_mut("Data").expect("Data");
+        data.get_cell_mut((1, 1)).set_value_number(5.0);
+        data.add_defined_name("LocalDup", "Data!$A$1")
+            .expect("add Data local name");
+        let local = data
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("Data local defined name");
+        local.set_local_sheet_id(1);
+        data.get_cell_mut((2, 1)).set_formula("=LocalDup*3");
+    });
+
+    let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    let ctx = formualizer_eval::test_workbook::TestWorkbook::new();
+    let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
+    backend.stream_into_engine(&mut engine).unwrap();
+    engine.evaluate_all().unwrap();
+
+    let sheet1_value = engine.get_cell_value("Sheet1", 1, 2).unwrap();
+    assert!(matches!(sheet1_value, LiteralValue::Number(n) if (n - 6.0).abs() < 1e-9));
+
+    let data_value = engine.get_cell_value("Data", 1, 2).unwrap();
+    assert!(matches!(data_value, LiteralValue::Number(n) if (n - 15.0).abs() < 1e-9));
 }

--- a/crates/formualizer-workbook/tests/umya/named_ranges.rs
+++ b/crates/formualizer-workbook/tests/umya/named_ranges.rs
@@ -1,4 +1,4 @@
-use formualizer_common::LiteralValue;
+use formualizer_common::{LiteralValue, error::ExcelErrorKind};
 use formualizer_workbook::{
     CellData, LoadStrategy, SpreadsheetReader, SpreadsheetWriter, UmyaAdapter, Workbook,
     WorkbookConfig,
@@ -223,6 +223,13 @@ fn book_to_bytes(book: &umya_spreadsheet::Spreadsheet) -> Vec<u8> {
     buf
 }
 
+fn assert_name_error(value: LiteralValue) {
+    match value {
+        LiteralValue::Error(err) => assert_eq!(err.kind, ExcelErrorKind::Name),
+        other => panic!("expected #NAME?, got {other:?}"),
+    }
+}
+
 /// Workbook-scoped names must remain Workbook-scoped in `defined_names()` regardless of
 /// which worksheet object they were associated with when the file was built.
 /// Before the fix, names without a localSheetId that came through the sheet-level
@@ -346,6 +353,178 @@ fn workbook_scoped_name_resolves_cross_sheet() {
         LiteralValue::Int(i) => assert_eq!(i, 20, "VLOOKUP Beta should be 20"),
         other => panic!("expected number for VLOOKUP, got {other:?}"),
     }
+}
+
+#[test]
+fn umya_sheet_local_name_resolves_only_on_declaring_sheet() {
+    let mut book = umya_spreadsheet::new_file();
+    let _ = book.new_sheet("Sheet2");
+
+    {
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(7.0);
+        sheet1
+            .add_defined_name("LocalOnly", "Sheet1!$A$1")
+            .expect("add local name");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("local defined name");
+        local.set_local_sheet_id(0);
+        sheet1.get_cell_mut((2, 1)).set_formula("=LocalOnly*2");
+    }
+
+    {
+        let sheet2 = book.get_sheet_by_name_mut("Sheet2").expect("Sheet2");
+        sheet2.get_cell_mut((2, 1)).set_formula("=LocalOnly");
+    }
+
+    let backend = UmyaAdapter::open_bytes(book_to_bytes(&book)).expect("open bytes");
+    let mut workbook = Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .expect("load workbook");
+    workbook.evaluate_all().expect("evaluate workbook");
+
+    let local_value = workbook.get_value("Sheet1", 1, 2).expect("Sheet1 B1");
+    assert!(matches!(local_value, LiteralValue::Number(n) if (n - 14.0).abs() < 1e-9));
+
+    let other_sheet_value = workbook.get_value("Sheet2", 1, 2).expect("Sheet2 B1");
+    assert_name_error(other_sheet_value);
+}
+
+#[test]
+fn umya_sheet_local_name_shadows_workbook_name_only_on_declaring_sheet() {
+    let mut book = umya_spreadsheet::new_file();
+    let _ = book.new_sheet("Sheet2");
+
+    {
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(10.0);
+        sheet1
+            .add_defined_name("ScopedValue", "Sheet1!$A$1")
+            .expect("add local name");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("local defined name");
+        local.set_local_sheet_id(0);
+        sheet1.get_cell_mut((2, 1)).set_formula("=ScopedValue*2");
+    }
+
+    {
+        let sheet2 = book.get_sheet_by_name_mut("Sheet2").expect("Sheet2");
+        sheet2.get_cell_mut((1, 1)).set_value_number(100.0);
+        sheet2
+            .add_defined_name("ScopedValue", "Sheet2!$A$1")
+            .expect("add workbook name");
+        sheet2.get_cell_mut((2, 1)).set_formula("=ScopedValue*2");
+    }
+
+    let backend = UmyaAdapter::open_bytes(book_to_bytes(&book)).expect("open bytes");
+    let mut workbook = Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .expect("load workbook");
+    workbook.evaluate_all().expect("evaluate workbook");
+
+    let local_value = workbook.get_value("Sheet1", 1, 2).expect("Sheet1 B1");
+    assert!(matches!(local_value, LiteralValue::Number(n) if (n - 20.0).abs() < 1e-9));
+
+    let workbook_value = workbook.get_value("Sheet2", 1, 2).expect("Sheet2 B1");
+    assert!(matches!(workbook_value, LiteralValue::Number(n) if (n - 200.0).abs() < 1e-9));
+}
+
+#[test]
+fn umya_same_local_name_on_multiple_sheets_is_isolated() {
+    let mut book = umya_spreadsheet::new_file();
+    let _ = book.new_sheet("Data");
+
+    {
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(2.0);
+        sheet1
+            .add_defined_name("LocalDup", "Sheet1!$A$1")
+            .expect("add Sheet1 local name");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("Sheet1 local defined name");
+        local.set_local_sheet_id(0);
+        sheet1.get_cell_mut((2, 1)).set_formula("=LocalDup*3");
+    }
+
+    {
+        let data = book.get_sheet_by_name_mut("Data").expect("Data");
+        data.get_cell_mut((1, 1)).set_value_number(5.0);
+        data.add_defined_name("LocalDup", "Data!$A$1")
+            .expect("add Data local name");
+        let local = data
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("Data local defined name");
+        local.set_local_sheet_id(1);
+        data.get_cell_mut((2, 1)).set_formula("=LocalDup*3");
+    }
+
+    let backend = UmyaAdapter::open_bytes(book_to_bytes(&book)).expect("open bytes");
+    let mut workbook = Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .expect("load workbook");
+    workbook.evaluate_all().expect("evaluate workbook");
+
+    let sheet1_value = workbook.get_value("Sheet1", 1, 2).expect("Sheet1 B1");
+    assert!(matches!(sheet1_value, LiteralValue::Number(n) if (n - 6.0).abs() < 1e-9));
+
+    let data_value = workbook.get_value("Data", 1, 2).expect("Data B1");
+    assert!(matches!(data_value, LiteralValue::Number(n) if (n - 15.0).abs() < 1e-9));
+}
+
+#[test]
+fn umya_sheet_local_name_without_sheet_prefix_uses_declaring_sheet() {
+    let mut book = umya_spreadsheet::new_file();
+    let _ = book.new_sheet("Sheet2");
+
+    {
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(11.0);
+        sheet1
+            .add_defined_name("BareLocal", "$A$1")
+            .expect("add local name without sheet prefix");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("local defined name");
+        local.set_local_sheet_id(0);
+        sheet1.get_cell_mut((2, 1)).set_formula("=BareLocal*2");
+    }
+
+    {
+        let sheet2 = book.get_sheet_by_name_mut("Sheet2").expect("Sheet2");
+        sheet2.get_cell_mut((2, 1)).set_formula("=BareLocal");
+    }
+
+    let backend = UmyaAdapter::open_bytes(book_to_bytes(&book)).expect("open bytes");
+    let mut workbook = Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .expect("load workbook");
+    workbook.evaluate_all().expect("evaluate workbook");
+
+    let local_value = workbook.get_value("Sheet1", 1, 2).expect("Sheet1 B1");
+    assert!(matches!(local_value, LiteralValue::Number(n) if (n - 22.0).abs() < 1e-9));
+
+    let other_sheet_value = workbook.get_value("Sheet2", 1, 2).expect("Sheet2 B1");
+    assert_name_error(other_sheet_value);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Shore up workbook import coverage for defined-name scope and fix Calamine import handling for sheet-local names.

This adds end-to-end integration coverage for:
- workbook-global defined names
- sheet-local defined names
- local-vs-global shadowing
- same-name local definitions on multiple sheets
- local names whose formulas omit an explicit sheet prefix

## Bug fixed

Users were right: the Calamine import path was flattening sheet-local defined names into workbook scope.

That caused imported names with `localSheetId` to behave incorrectly across sheets, including:
- leaking a sheet-local name into other sheets
- failing local-over-global shadowing rules
- failing isolation for same-name local definitions on different sheets

## Implementation

- add targeted Umya integration tests for sheet-local/workbook-global name behavior
- add targeted Calamine integration tests for the same scope semantics
- upgrade `calamine` from `0.24` to `0.34`
- preserve scoped defined names in the Calamine adapter by doing a conditional streaming parse of `xl/workbook.xml`

The Calamine adapter only performs this extra metadata pass when `defined_names()` is non-empty, and it streams only the `definedName` metadata needed to recover `localSheetId` rather than loading the whole workbook XML into a large string.

An inline code comment explains why this exists: Calamine's public `defined_names()` surface still flattens names to `(name, formula_text)` and does not expose scope metadata.

## Validation

Passed locally:

```bash
cargo test -p formualizer-workbook --features umya,calamine
cargo clippy -p formualizer-workbook --features umya,calamine --all-targets -- -D warnings
```
