### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,9 +545,52 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract release notes from CHANGELOG.md
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+
+          python - "${VERSION}" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          version = sys.argv[1]
+          changelog = Path("CHANGELOG.md")
+          if not changelog.exists():
+              raise SystemExit("CHANGELOG.md not found")
+
+          text = changelog.read_text(encoding="utf-8")
+          heading_re = re.compile(rf"^##\s+\[?{re.escape(version)}\]?(?:\s+-\s+.*)?$", re.MULTILINE)
+          match = heading_re.search(text)
+          if not match:
+              raise SystemExit(f"No CHANGELOG.md section found for version {version}")
+
+          lines = text[match.end():].splitlines()
+          body_lines: list[str] = []
+          for line in lines:
+              if re.match(r"^##\s+", line):
+                  break
+              if re.match(r"^\[[^\]]+\]:\s+", line):
+                  break
+              body_lines.append(line)
+
+          body = "\n".join(body_lines).strip()
+          if not body:
+              raise SystemExit(f"CHANGELOG.md section for version {version} is empty")
+
+          Path("release-notes.md").write_text(body + "\n", encoding="utf-8")
+          PY
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: release-notes.md
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to Formualizer will be documented in this file.
+
+## [Unreleased]
+
+## [0.5.0] - 2026-03-22
+
+### Added
+
+- Added pending symbolic formula healing so formulas referencing not-yet-defined names now evaluate as `#NAME?` and automatically heal when a matching workbook-scoped, sheet-scoped, or source-backed name is later created. (#33)
+- Added the `RRI` financial function for equivalent rate-of-return calculations. (#25)
+
+### Fixed
+
+- Improved `IRR` convergence by using a two-phase solver with a Brent-method fallback, reducing `#NUM!` failures on difficult cash-flow patterns. (#24)
+- Corrected `WEEKDAY`, `WEEKNUM`, and `DATEDIF("YD")` behavior by switching to serial-based date arithmetic that handles Excel's 1900 date-system quirks correctly. (#23)
+- Hardened function arity validation with `min_args` checks to prevent panics when functions are called with too few arguments. (#26)
+- Preserved workbook-global and sheet-local defined names across both Umya and Calamine import pathways, including correct local shadowing and same-name isolation across sheets. (#34)
+
+### Performance
+
+- Added recalculation plan reuse and static schedule caching for stable workbook topologies, improving repeat recalculation performance on unchanged dependency graphs. (#28)
+
+### Tooling and quality
+
+- Added a comparative benchmark harness with scenario plans, real-world anchors, and fairness-oriented reporting to improve performance validation and regression tracking. (#28)
+- Expanded JSON-driven conformance coverage across info, logical, lookup, text, and date function families. (#32)
+
+[Unreleased]: https://github.com/PSU3D0/formualizer/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/PSU3D0/formualizer/compare/v0.4.4...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "formualizer-common",
  "formualizer-eval",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-eval"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-macros"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "formualizer-common",
  "proc-macro2",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-python"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "formualizer",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-sheetport"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "formualizer-common",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-wasm"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "console_error_panic_hook",
  "formualizer",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-workbook"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ documentation = "https://docs.rs/formualizer"
 [workspace.dependencies]
 
 formualizer-common = { version = "1.1.1", path = "crates/formualizer-common" }
-formualizer-macros = { version = "0.4.3", path = "crates/formualizer-macros" }
+formualizer-macros = { version = "0.5.0", path = "crates/formualizer-macros" }
 formualizer-parse = { version = "1.1.1", path = "crates/formualizer-parse" }
-formualizer-eval = { version = "0.4.3", path = "crates/formualizer-eval" }
-formualizer-workbook = { version = "0.4.3", path = "crates/formualizer-workbook" }
+formualizer-eval = { version = "0.5.0", path = "crates/formualizer-eval" }
+formualizer-workbook = { version = "0.5.0", path = "crates/formualizer-workbook" }
 
 chrono = "0.4.41"
 serde = "1.0.228"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-python"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 homepage = "https://github.com/PSU3D0/formualizer"
 license = "MIT OR Apache-2.0"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "formualizer"
-version = "0.4.3"
+version = "0.5.0"
 description = "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks at native speed"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "formualizer"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-wasm"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 authors = ["Formualizer Contributors"]
 homepage = "https://github.com/PSU3D0/formualizer"

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formualizer",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks in the browser. 320+ functions, Arrow-powered.",
   "homepage": "https://github.com/psu3d0/formualizer",
   "type": "module",

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-eval"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 description = "High-performance Arrow-backed Excel formula engine with dependency graph and incremental recalculation"
 homepage.workspace = true

--- a/crates/formualizer-macros/Cargo.toml
+++ b/crates/formualizer-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-macros"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 description = "Proc macros for authoring Formualizer built-ins (caps, schemas, and validation)"
 homepage.workspace = true

--- a/crates/formualizer-sheetport/Cargo.toml
+++ b/crates/formualizer-sheetport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-sheetport"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 description = "SheetPort runtime: bind manifests to workbooks, validate IO, and run sessions deterministically"
 homepage.workspace = true
@@ -13,10 +13,10 @@ categories = ["data-structures"]
 
 [dependencies]
 sheetport-spec = { path = "../sheetport-spec", version = "0.3.0" }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.4.3", features = ["umya_integration"] }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.0", features = ["umya_integration"] }
 formualizer-common = { path = "../formualizer-common", version = "1.1.1" }
 formualizer-parse = { path = "../formualizer-parse", version = "1.1.1" }
-formualizer-eval = { path = "../formualizer-eval", version = "0.4.3" }
+formualizer-eval = { path = "../formualizer-eval", version = "0.5.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/formualizer-workbook/Cargo.toml
+++ b/crates/formualizer-workbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-workbook"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 description = "Ergonomic workbook API over the Formualizer engine (sheets, loaders, staging, undo/redo)"
 homepage.workspace = true

--- a/crates/formualizer/Cargo.toml
+++ b/crates/formualizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 description = "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks from Rust"
 homepage.workspace = true
@@ -27,7 +27,7 @@ tracing_chrome = ["tracing", "formualizer-eval/tracing_chrome"]
 [dependencies]
 formualizer-common = { path = "../formualizer-common", version = "1.1.1", optional = true }
 formualizer-parse = { path = "../formualizer-parse", version = "1.1.1", optional = true }
-formualizer-eval = { path = "../formualizer-eval", version = "0.4.3", optional = true }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.4.3", optional = true }
-formualizer-sheetport = { path = "../formualizer-sheetport", version = "0.4.3", optional = true }
+formualizer-eval = { path = "../formualizer-eval", version = "0.5.0", optional = true }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.0", optional = true }
+formualizer-sheetport = { path = "../formualizer-sheetport", version = "0.5.0", optional = true }
 sheetport-spec = { path = "../sheetport-spec", version = "0.3.0", optional = true }


### PR DESCRIPTION
## Summary

Prepare the product release track for `v0.5.0`.

This PR:
- bumps the product version surface to `0.5.0`
- adds a root `CHANGELOG.md` with reviewed `0.5.0` release notes
- updates the product GitHub release workflow to publish the matching changelog section as the release body

## Context

The actual last shipped product tag is `v0.4.4`, but the product manifests on `main` had drifted and still read `0.4.3`.

This PR normalizes the next release prep around the real release baseline while moving the product surface forward to `0.5.0`.

## Details

### Version bump
Applied with the repo script:

```bash
uv run scripts/bump-version.py --track product --version 0.5.0
```

Updated:
- product Rust crates
- Python binding manifests
- WASM binding manifests
- internal product crate dependency pins
- root workspace dependency references
- `Cargo.lock`

### Changelog
Added a new root `CHANGELOG.md` with:
- `Unreleased`
- `0.5.0` release notes drafted from the actual product baseline `v0.4.4..HEAD`

### Release workflow
Updated `.github/workflows/release.yml` so product-tagged GitHub Releases:
- check out the repo
- extract the matching version section from `CHANGELOG.md`
- use that reviewed text as the release body

This replaces the previous product-release behavior of relying only on autogenerated GitHub release notes.

## Validation

Passed locally:

```bash
uv run scripts/bump-version.py --track product --version 0.5.0
```

The bump script completed successfully and verified the workspace with `cargo check`.

Also sanity-checked locally:
- `CHANGELOG.md` section extraction for `0.5.0`
- product manifest versions now read `0.5.0`
