### PR TITLE
fix: improve Unicode matching for structured refs and lookups

### DIFF
--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -84,7 +84,7 @@ pub struct ColumnChunk {
     lazy_null_booleans: OnceCell<Arc<BooleanArray>>,
     lazy_null_text: OnceCell<ArrayRef>,
     lazy_null_errors: OnceCell<Arc<UInt8Array>>,
-    // Cache: lowered text lane (ASCII lower), nulls preserved
+    // Cache: lowered text lane, nulls preserved
     lowered_text: OnceCell<ArrayRef>,
     // Phase C: per-chunk overlay (delta edits since last compaction)
     pub overlay: Overlay,
@@ -147,7 +147,7 @@ impl ColumnChunk {
             .clone()
     }
 
-    /// Lowercased text lane (ASCII lower), with nulls preserved. Cached per chunk.
+    /// Lowercased text lane, with nulls preserved. Cached per chunk.
     pub fn text_lower_or_null(&self) -> ArrayRef {
         if let Some(a) = self.lowered_text.get() {
             return a.clone();
@@ -160,7 +160,7 @@ impl ColumnChunk {
                 if sa.is_null(i) {
                     b.append_null();
                 } else {
-                    b.append_value(sa.value(i).to_ascii_lowercase());
+                    b.append_value(sa.value(i).to_lowercase());
                 }
             }
             let lowered = b.finish();

--- a/crates/formualizer-eval/src/builtins/database.rs
+++ b/crates/formualizer-eval/src/builtins/database.rs
@@ -52,10 +52,10 @@ fn resolve_field_index(
 ) -> Result<usize, ExcelError> {
     match field {
         LiteralValue::Text(name) => {
-            let name_lower = name.to_ascii_lowercase();
+            let name_lower = name.to_lowercase();
             for (i, h) in headers.iter().enumerate() {
                 if let LiteralValue::Text(hdr) = h
-                    && hdr.to_ascii_lowercase() == name_lower
+                    && hdr.to_lowercase() == name_lower
                 {
                     return Ok(i);
                 }
@@ -105,11 +105,11 @@ fn parse_criteria_range(
     for c in 0..crit_cols {
         let crit_header = criteria_view.get_cell(0, c);
         if let LiteralValue::Text(name) = &crit_header {
-            let name_lower = name.to_ascii_lowercase();
+            let name_lower = name.to_lowercase();
             let mut found = None;
             for (i, h) in db_headers.iter().enumerate() {
                 if let LiteralValue::Text(hdr) = h
-                    && hdr.to_ascii_lowercase() == name_lower
+                    && hdr.to_lowercase() == name_lower
                 {
                     found = Some(i);
                     break;
@@ -2511,6 +2511,38 @@ mod tests {
         ])
     }
 
+    fn make_unicode_database() -> LiteralValue {
+        LiteralValue::Array(vec![
+            vec![
+                LiteralValue::Text("Имя".into()),
+                LiteralValue::Text("Статус".into()),
+                LiteralValue::Text("Акт".into()),
+            ],
+            vec![
+                LiteralValue::Text("Анна".into()),
+                LiteralValue::Text("ГОТОВО".into()),
+                LiteralValue::Int(10),
+            ],
+            vec![
+                LiteralValue::Text("Борис".into()),
+                LiteralValue::Text("готово".into()),
+                LiteralValue::Int(20),
+            ],
+            vec![
+                LiteralValue::Text("Вера".into()),
+                LiteralValue::Text("Черновик".into()),
+                LiteralValue::Int(30),
+            ],
+        ])
+    }
+
+    fn make_unicode_criteria_ready() -> LiteralValue {
+        LiteralValue::Array(vec![
+            vec![LiteralValue::Text("статус".into())],
+            vec![LiteralValue::Text("готово".into())],
+        ])
+    }
+
     #[test]
     fn dsum_all_salaries() {
         let wb = TestWorkbook::new().with_function(Arc::new(DSumFn));
@@ -2663,5 +2695,26 @@ mod tests {
 
         // Sum of all salaries: 210000
         assert_eq!(result.into_literal(), LiteralValue::Number(210000.0));
+    }
+
+    #[test]
+    fn dsum_unicode_headers_are_case_insensitive() {
+        let wb = TestWorkbook::new().with_function(Arc::new(DSumFn));
+        let ctx = interp(&wb);
+
+        let db = lit(make_unicode_database());
+        let field = lit(LiteralValue::Text("акт".into()));
+        let criteria = lit(make_unicode_criteria_ready());
+
+        let args = vec![
+            crate::traits::ArgumentHandle::new(&db, &ctx),
+            crate::traits::ArgumentHandle::new(&field, &ctx),
+            crate::traits::ArgumentHandle::new(&criteria, &ctx),
+        ];
+
+        let f = ctx.context.get_function("", "DSUM").unwrap();
+        let result = f.dispatch(&args, &ctx.function_context(None)).unwrap();
+
+        assert_eq!(result.into_literal(), LiteralValue::Number(30.0));
     }
 }

--- a/crates/formualizer-eval/src/builtins/lookup/core.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/core.rs
@@ -1001,6 +1001,49 @@ mod tests {
     }
 
     #[test]
+    fn match_unicode_exact_and_wildcard_are_case_insensitive() {
+        let wb = TestWorkbook::new()
+            .with_function(Arc::new(MatchFn))
+            .with_cell_a1("Sheet1", "A1", LiteralValue::Text("ИВАН".into()))
+            .with_cell_a1("Sheet1", "A2", LiteralValue::Text("Петр".into()))
+            .with_cell_a1("Sheet1", "A3", LiteralValue::Text("Иванов".into()));
+        let ctx = wb.interpreter();
+        let range = ASTNode::new(
+            ASTNodeType::Reference {
+                original: "A1:A3".into(),
+                reference: ReferenceType::range(None, Some(1), Some(1), Some(3), Some(1)),
+            },
+            None,
+        );
+        let f = ctx.context.get_function("", "MATCH").unwrap();
+        let zero = lit(LiteralValue::Int(0));
+
+        let exact = lit(LiteralValue::Text("иван".into()));
+        let exact_args = vec![
+            ArgumentHandle::new(&exact, &ctx),
+            ArgumentHandle::new(&range, &ctx),
+            ArgumentHandle::new(&zero, &ctx),
+        ];
+        let exact_v = f
+            .dispatch(&exact_args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert_eq!(exact_v, LiteralValue::Int(1));
+
+        let pat = lit(LiteralValue::Text("ив?н*".into()));
+        let pat_args = vec![
+            ArgumentHandle::new(&pat, &ctx),
+            ArgumentHandle::new(&range, &ctx),
+            ArgumentHandle::new(&zero, &ctx),
+        ];
+        let pat_v = f
+            .dispatch(&pat_args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert_eq!(pat_v, LiteralValue::Int(1));
+    }
+
+    #[test]
     fn match_exact_and_approx() {
         let wb = TestWorkbook::new().with_function(Arc::new(MatchFn));
         let wb = wb

--- a/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
@@ -4,7 +4,7 @@
 //! - XLOOKUP supports: lookup_value, lookup_array, return_array, [if_not_found], [match_mode], [search_mode]
 //!   * match_mode: 0 exact (default), -1 exact-or-next-smaller, 1 exact-or-next-larger, 2 wildcard (basic * ?)
 //!   * search_mode: 1 forward (default), -1 reverse; (2 / -2 binary not yet implemented -> treated as 1 / -1)
-//!   * Wildcard mode (2) currently case-insensitive ASCII only; TODO: full Excel semantics, escape handling (~)
+//!   * Wildcard mode (2) is case-insensitive and supports Excel-style escapes (~).
 //! - FILTER supports: array, include, [if_empty]; Shapes must be broadcast-compatible by rows (include is 1-D).
 //!   * include may be vertical column vector OR same sized 2D; we reduce any non-zero truthy cell to include row.
 //!   * if_empty omitted -> #CALC! per Excel when no matches.
@@ -31,128 +31,7 @@ use std::collections::HashMap;
 /* ───────────────────────── helpers ───────────────────────── */
 
 pub fn super_wildcard_match(pattern: &str, text: &str) -> bool {
-    // public for shared lookup utils
-    // Excel-style wildcards with escape (~): * any seq, ? single char, ~ escapes next (*, ?, ~)
-    // Implement non-recursive DP for performance & to support escapes.
-    #[derive(Clone, Copy, Debug)]
-    enum Token<'a> {
-        AnySeq,
-        AnyChar,
-        Lit(&'a str),
-    }
-    let mut tokens: Vec<Token> = Vec::new();
-    let mut i = 0;
-    let bytes = pattern.as_bytes();
-    let mut lit_start = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'~' => {
-                // escape next if present
-                if i + 1 < bytes.len() {
-                    // flush pending literal
-                    if lit_start < i {
-                        tokens.push(Token::Lit(&pattern[lit_start..i]));
-                    }
-                    tokens.push(Token::Lit(&pattern[i + 1..i + 2]));
-                    i += 2;
-                    lit_start = i;
-                } else {
-                    // trailing ~ treated literal
-                    i += 1;
-                }
-            }
-            b'*' => {
-                if lit_start < i {
-                    tokens.push(Token::Lit(&pattern[lit_start..i]));
-                }
-                tokens.push(Token::AnySeq);
-                i += 1;
-                lit_start = i;
-            }
-            b'?' => {
-                if lit_start < i {
-                    tokens.push(Token::Lit(&pattern[lit_start..i]));
-                }
-                tokens.push(Token::AnyChar);
-                i += 1;
-                lit_start = i;
-            }
-            _ => i += 1,
-        }
-    }
-    if lit_start < bytes.len() {
-        tokens.push(Token::Lit(&pattern[lit_start..]));
-    }
-    // Simplify consecutive AnySeq
-    let mut compact: Vec<Token> = Vec::new();
-    for t in tokens {
-        match t {
-            Token::AnySeq => {
-                if !matches!(compact.last(), Some(Token::AnySeq)) {
-                    compact.push(t);
-                }
-            }
-            _ => compact.push(t),
-        }
-    }
-    // Backtracking matcher
-    fn match_tokens<'a>(tokens: &[Token<'a>], text: &str) -> bool {
-        fn eq_icase(a: &str, b: &str) -> bool {
-            a.eq_ignore_ascii_case(b)
-        }
-        // Convert Lit tokens into lowercase for quick compare
-        let mut ti = 0;
-        let tb = tokens;
-        // Use manual stack for backtracking when encountering AnySeq
-        let mut backtrack: Vec<(usize, usize)> = Vec::new(); // (token_index, text_index after consuming 1 more char by *)
-        let text_bytes = text.as_bytes();
-        let mut si = 0; // text index
-        loop {
-            if ti == tb.len() {
-                // tokens consumed
-                if si == text_bytes.len() {
-                    return true;
-                }
-                // Maybe backtrack
-            } else {
-                match tb[ti] {
-                    Token::AnySeq => {
-                        // try to match zero chars first
-                        ti += 1;
-                        backtrack.push((ti - 1, si + 1));
-                        continue;
-                    }
-                    Token::AnyChar => {
-                        if si < text_bytes.len() {
-                            ti += 1;
-                            si += 1;
-                            continue;
-                        }
-                    }
-                    Token::Lit(l) => {
-                        let l_len = l.len();
-                        if si + l_len <= text_bytes.len() && eq_icase(&text[si..si + l_len], l) {
-                            ti += 1;
-                            si += l_len;
-                            continue;
-                        }
-                    }
-                }
-            }
-            // failed match; attempt backtrack
-            if let Some((tok_star, new_si)) = backtrack.pop() {
-                if new_si <= text_bytes.len() {
-                    ti = tok_star + 1;
-                    si = new_si;
-                    continue;
-                } else {
-                    continue;
-                }
-            }
-            return false;
-        }
-    }
-    match_tokens(&compact, text)
+    super::lookup_utils::wildcard_pattern_match(pattern, text)
 }
 
 /* ───────────────────────── XLOOKUP() ───────────────────────── */
@@ -3748,6 +3627,51 @@ mod tests {
     }
 
     #[test]
+    fn xlookup_unicode_exact_and_wildcard_are_case_insensitive() {
+        let wb = TestWorkbook::new().with_function(Arc::new(XLookupFn));
+        let wb = wb
+            .with_cell_a1("Sheet1", "A1", LiteralValue::Text("ИВАН".into()))
+            .with_cell_a1("Sheet1", "A2", LiteralValue::Text("Петр".into()))
+            .with_cell_a1("Sheet1", "A3", LiteralValue::Text("Иванов".into()))
+            .with_cell_a1("Sheet1", "B1", LiteralValue::Int(100))
+            .with_cell_a1("Sheet1", "B2", LiteralValue::Int(200))
+            .with_cell_a1("Sheet1", "B3", LiteralValue::Int(300));
+        let ctx = wb.interpreter();
+        let lookup_range = range("A1:A3", 1, 1, 3, 1);
+        let return_range = range("B1:B3", 1, 2, 3, 2);
+        let f = ctx.context.get_function("", "XLOOKUP").unwrap();
+        let nf = lit(LiteralValue::Text("NF".into()));
+
+        let exact = lit(LiteralValue::Text("иван".into()));
+        let exact_args = vec![
+            ArgumentHandle::new(&exact, &ctx),
+            ArgumentHandle::new(&lookup_range, &ctx),
+            ArgumentHandle::new(&return_range, &ctx),
+            ArgumentHandle::new(&nf, &ctx),
+        ];
+        let exact_v = f
+            .dispatch(&exact_args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert_eq!(exact_v, LiteralValue::Number(100.0));
+
+        let wildcard = lit(LiteralValue::Text("ив?н*".into()));
+        let wildcard_mode = lit(LiteralValue::Int(2));
+        let wildcard_args = vec![
+            ArgumentHandle::new(&wildcard, &ctx),
+            ArgumentHandle::new(&lookup_range, &ctx),
+            ArgumentHandle::new(&return_range, &ctx),
+            ArgumentHandle::new(&nf, &ctx),
+            ArgumentHandle::new(&wildcard_mode, &ctx),
+        ];
+        let wildcard_v = f
+            .dispatch(&wildcard_args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert_eq!(wildcard_v, LiteralValue::Number(100.0));
+    }
+
+    #[test]
     fn xlookup_reverse_search_mode_picks_last() {
         let wb = TestWorkbook::new().with_function(Arc::new(XLookupFn));
         let wb = wb
@@ -4131,6 +4055,30 @@ mod tests {
             .unwrap()
             .into_literal();
         assert_eq!(v, LiteralValue::Int(2)); // "beta" matches "*eta"
+    }
+
+    #[test]
+    fn xmatch_unicode_wildcard_is_case_insensitive() {
+        let wb = TestWorkbook::new().with_function(Arc::new(XMatchFn));
+        let wb = wb
+            .with_cell_a1("Sheet1", "A1", LiteralValue::Text("ИВАН".into()))
+            .with_cell_a1("Sheet1", "A2", LiteralValue::Text("Петр".into()))
+            .with_cell_a1("Sheet1", "A3", LiteralValue::Text("Иванов".into()));
+        let ctx = wb.interpreter();
+        let lookup_range = range("A1:A3", 1, 1, 3, 1);
+        let f = ctx.context.get_function("", "XMATCH").unwrap();
+        let pattern = lit(LiteralValue::Text("ив?н*".into()));
+        let match_mode = lit(LiteralValue::Int(2));
+        let args = vec![
+            ArgumentHandle::new(&pattern, &ctx),
+            ArgumentHandle::new(&lookup_range, &ctx),
+            ArgumentHandle::new(&match_mode, &ctx),
+        ];
+        let v = f
+            .dispatch(&args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert_eq!(v, LiteralValue::Int(1));
     }
 
     #[test]

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -23,7 +23,7 @@ pub fn value_to_f64_lenient(v: &LiteralValue) -> Option<f64> {
 
 /// Case-insensitive text equality (no wildcards).
 pub fn text_equal_ci(a: &str, b: &str) -> bool {
-    a.eq_ignore_ascii_case(b)
+    a.to_lowercase() == b.to_lowercase()
 }
 
 /// Compare two values for ordering using lenient numeric coercion first, fallback to case-insensitive text.
@@ -37,8 +37,8 @@ pub fn cmp_for_lookup(a: &LiteralValue, b: &LiteralValue) -> Option<i32> {
     }
     match (a, b) {
         (LiteralValue::Text(x), LiteralValue::Text(y)) => {
-            let xl = x.to_ascii_lowercase();
-            let yl = y.to_ascii_lowercase();
+            let xl = x.to_lowercase();
+            let yl = y.to_lowercase();
             Some(match xl.cmp(&yl) {
                 std::cmp::Ordering::Less => -1,
                 std::cmp::Ordering::Equal => 0,
@@ -149,55 +149,50 @@ pub fn guard_sorted_ascending(values: &[LiteralValue]) -> Result<(), ExcelError>
 
 /// Excel-style wildcard pattern matcher with escape (~) supporting *, ? and literal escaping of ~ * ?
 pub fn wildcard_pattern_match(pattern: &str, text: &str) -> bool {
-    #[derive(Clone, Copy, Debug)]
-    enum Token<'a> {
+    wildcard_pattern_match_folded(&pattern.to_lowercase(), &text.to_lowercase())
+}
+
+fn wildcard_pattern_match_folded(pattern: &str, text: &str) -> bool {
+    #[derive(Clone, Debug)]
+    enum Token {
         AnySeq,
         AnyChar,
-        Lit(&'a str),
+        Lit(Vec<char>),
     }
+
     let mut tokens: Vec<Token> = Vec::new();
-    let bytes = pattern.as_bytes();
-    let mut i = 0;
-    let mut lit_start = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'~' => {
-                if i + 1 < bytes.len() {
-                    if lit_start < i {
-                        tokens.push(Token::Lit(&pattern[lit_start..i]));
-                    }
-                    tokens.push(Token::Lit(&pattern[i + 1..i + 2]));
-                    i += 2;
-                    lit_start = i;
+    let mut lit = String::new();
+    let mut chars = pattern.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '~' => {
+                if let Some(next) = chars.next() {
+                    lit.push(next);
                 } else {
-                    i += 1;
+                    lit.push('~');
                 }
             }
-            b'*' => {
-                if lit_start < i {
-                    tokens.push(Token::Lit(&pattern[lit_start..i]));
+            '*' => {
+                if !lit.is_empty() {
+                    tokens.push(Token::Lit(lit.chars().collect()));
+                    lit.clear();
                 }
                 tokens.push(Token::AnySeq);
-                i += 1;
-                lit_start = i;
             }
-            b'?' => {
-                if lit_start < i {
-                    tokens.push(Token::Lit(&pattern[lit_start..i]));
+            '?' => {
+                if !lit.is_empty() {
+                    tokens.push(Token::Lit(lit.chars().collect()));
+                    lit.clear();
                 }
                 tokens.push(Token::AnyChar);
-                i += 1;
-                lit_start = i;
             }
-            _ => {
-                i += 1;
-            }
+            _ => lit.push(ch),
         }
     }
-    if lit_start < bytes.len() {
-        tokens.push(Token::Lit(&pattern[lit_start..]));
+    if !lit.is_empty() {
+        tokens.push(Token::Lit(lit.chars().collect()));
     }
-    // collapse consecutive *
+
     let mut compact: Vec<Token> = Vec::new();
     for t in tokens {
         match t {
@@ -209,34 +204,33 @@ pub fn wildcard_pattern_match(pattern: &str, text: &str) -> bool {
             _ => compact.push(t),
         }
     }
-    fn match_tokens(tokens: &[Token], text: &str) -> bool {
+
+    fn match_tokens(tokens: &[Token], text: &[char]) -> bool {
         let mut ti = 0usize;
         let mut si = 0usize;
         let mut bt: Vec<(usize, usize)> = Vec::new();
-        let tb = tokens;
-        let b = text.as_bytes();
         loop {
-            if ti == tb.len() {
-                if si == b.len() {
+            if ti == tokens.len() {
+                if si == text.len() {
                     return true;
                 }
             } else {
-                match tb[ti] {
+                match &tokens[ti] {
                     Token::AnySeq => {
                         ti += 1;
                         bt.push((ti - 1, si + 1));
                         continue;
                     }
                     Token::AnyChar => {
-                        if si < b.len() {
+                        if si < text.len() {
                             ti += 1;
                             si += 1;
                             continue;
                         }
                     }
-                    Token::Lit(l) => {
-                        let ll = l.len();
-                        if si + ll <= b.len() && text[si..si + ll].eq_ignore_ascii_case(l) {
+                    Token::Lit(lit) => {
+                        let ll = lit.len();
+                        if si + ll <= text.len() && &text[si..si + ll] == lit.as_slice() {
                             ti += 1;
                             si += ll;
                             continue;
@@ -245,7 +239,7 @@ pub fn wildcard_pattern_match(pattern: &str, text: &str) -> bool {
                 }
             }
             if let Some((star_tok, new_si)) = bt.pop()
-                && new_si <= b.len()
+                && new_si <= text.len()
             {
                 ti = star_tok + 1;
                 si = new_si;
@@ -254,7 +248,9 @@ pub fn wildcard_pattern_match(pattern: &str, text: &str) -> bool {
             return false;
         }
     }
-    match_tokens(&compact, text)
+
+    let text_chars: Vec<char> = text.chars().collect();
+    match_tokens(&compact, &text_chars)
 }
 
 /// Find index of exact (or wildcard) match in values; returns first match (Excel semantics).
@@ -344,7 +340,7 @@ fn find_exact_text_in_view(
     wildcard: bool,
     vertical: bool,
 ) -> Result<Option<usize>, ExcelError> {
-    let s_low = s.to_ascii_lowercase();
+    let s_low = s.to_lowercase();
     let has_wildcard = wildcard && (s.contains('*') || s.contains('?') || s.contains('~'));
 
     if vertical {
@@ -359,10 +355,11 @@ fn find_exact_text_in_view(
                     if !arr.is_null(i) {
                         let val = arr.value(i);
                         if has_wildcard {
-                            if wildcard_pattern_match(&s_low, &val.to_ascii_lowercase()) {
+                            let val_low = val.to_lowercase();
+                            if wildcard_pattern_match_folded(&s_low, &val_low) {
                                 return Ok(Some(row_start + i));
                             }
-                        } else if val.eq_ignore_ascii_case(s) {
+                        } else if text_equal_ci(val, s) {
                             return Ok(Some(row_start + i));
                         }
                     }
@@ -380,10 +377,11 @@ fn find_exact_text_in_view(
                 if !arr.is_null(0) {
                     let val = arr.value(0);
                     if has_wildcard {
-                        if wildcard_pattern_match(&s_low, &val.to_ascii_lowercase()) {
+                        let val_low = val.to_lowercase();
+                        if wildcard_pattern_match_folded(&s_low, &val_low) {
                             return Ok(Some(c));
                         }
-                    } else if val.eq_ignore_ascii_case(s) {
+                    } else if text_equal_ci(val, s) {
                         return Ok(Some(c));
                     }
                 }

--- a/crates/formualizer-eval/src/builtins/utils.rs
+++ b/crates/formualizer-eval/src/builtins/utils.rs
@@ -325,7 +325,7 @@ fn values_equal_invariant(a: &LiteralValue, b: &LiteralValue) -> bool {
         (LiteralValue::Number(x), LiteralValue::Number(y)) => (x - y).abs() < 1e-12,
         (LiteralValue::Int(x), LiteralValue::Int(y)) => x == y,
         (LiteralValue::Boolean(x), LiteralValue::Boolean(y)) => x == y,
-        (LiteralValue::Text(x), LiteralValue::Text(y)) => x.eq_ignore_ascii_case(y),
+        (LiteralValue::Text(x), LiteralValue::Text(y)) => x.to_lowercase() == y.to_lowercase(),
         // Treat blank and empty text as equal (Excel semantics)
         (LiteralValue::Text(x), LiteralValue::Empty) if x.is_empty() => true,
         (LiteralValue::Empty, LiteralValue::Text(y)) if y.is_empty() => true,
@@ -362,7 +362,7 @@ fn text_like_match(pattern: &str, case_insensitive: bool, v: &LiteralValue) -> b
         _ => return false,
     };
     let (pat, text) = if case_insensitive {
-        (pattern.to_ascii_lowercase(), s.to_ascii_lowercase())
+        (pattern.to_lowercase(), s.to_lowercase())
     } else {
         (pattern.to_string(), s)
     };

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -735,17 +735,17 @@ fn compute_criteria_mask(
     // This avoids concatenating full-string columns just to compute a boolean mask.
     let (text_kind, text_pat, empty_special) = match pred {
         crate::args::CriteriaPredicate::Eq(formualizer_common::LiteralValue::Text(t)) => {
-            (0u8, t.to_ascii_lowercase(), t.is_empty())
+            (0u8, t.to_lowercase(), t.is_empty())
         }
         crate::args::CriteriaPredicate::Ne(formualizer_common::LiteralValue::Text(t)) => {
-            (1u8, t.to_ascii_lowercase(), false)
+            (1u8, t.to_lowercase(), false)
         }
         crate::args::CriteriaPredicate::TextLike {
             pattern,
             case_insensitive,
         } => {
             let p = if *case_insensitive {
-                pattern.to_ascii_lowercase()
+                pattern.to_lowercase()
             } else {
                 pattern.clone()
             };
@@ -1102,8 +1102,10 @@ where
                 let cols = table.columns();
                 let start = start.trim();
                 let end = end.trim();
-                let start_idx = cols.iter().position(|n| n.eq_ignore_ascii_case(start));
-                let end_idx = cols.iter().position(|n| n.eq_ignore_ascii_case(end));
+                let start_key = start.to_lowercase();
+                let end_key = end.to_lowercase();
+                let start_idx = cols.iter().position(|n| n.to_lowercase() == start_key);
+                let end_idx = cols.iter().position(|n| n.to_lowercase() == end_key);
                 if let (Some(mut si), Some(mut ei)) = (start_idx, end_idx) {
                     if si > ei {
                         std::mem::swap(&mut si, &mut ei);

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -2,8 +2,8 @@ use super::*;
 use formualizer_common::parse_a1_1based;
 
 #[inline]
-fn normalize_ascii_key(name: &str) -> String {
-    name.to_ascii_lowercase()
+fn normalize_name_key(name: &str) -> String {
+    name.to_lowercase()
 }
 
 /// Validate that a name conforms to Excel naming rules.
@@ -93,7 +93,7 @@ impl DependencyGraph {
         if self.config.case_sensitive_names {
             name.to_string()
         } else {
-            normalize_ascii_key(name)
+            normalize_name_key(name)
         }
     }
 

--- a/crates/formualizer-eval/src/engine/graph/sheets.rs
+++ b/crates/formualizer-eval/src/engine/graph/sheets.rs
@@ -160,7 +160,7 @@ impl DependencyGraph {
         for key in sheet_names_to_remove {
             if let Some(named_range) = self.sheet_named_ranges.remove(&key) {
                 if !self.config.case_sensitive_names {
-                    let normalized = key.1.to_ascii_lowercase();
+                    let normalized = key.1.to_lowercase();
                     self.sheet_named_ranges_lookup
                         .remove(&(sheet_id, normalized));
                 } else {

--- a/crates/formualizer-eval/src/engine/graph/tables.rs
+++ b/crates/formualizer-eval/src/engine/graph/tables.rs
@@ -5,8 +5,8 @@ use crate::reference::RangeRef;
 use formualizer_common::{ExcelError, ExcelErrorKind};
 
 #[inline]
-fn normalize_ascii_key(name: &str) -> String {
-    name.to_ascii_lowercase()
+fn normalize_table_key(name: &str) -> String {
+    name.to_lowercase()
 }
 
 /// Native workbook table (Excel ListObject) metadata.
@@ -26,9 +26,10 @@ impl TableEntry {
     }
 
     pub fn col_index(&self, header: &str) -> Option<usize> {
+        let header_key = header.to_lowercase();
         self.headers
             .iter()
-            .position(|h| h.eq_ignore_ascii_case(header))
+            .position(|h| h.to_lowercase() == header_key)
     }
 }
 
@@ -38,7 +39,7 @@ impl DependencyGraph {
         if self.config.case_sensitive_tables {
             name.to_string()
         } else {
-            normalize_ascii_key(name)
+            normalize_table_key(name)
         }
     }
 

--- a/crates/formualizer-eval/src/engine/range_view.rs
+++ b/crates/formualizer-eval/src/engine/range_view.rs
@@ -962,7 +962,7 @@ impl<'a> RangeView<'a> {
                             mb.append_value(true);
                             match ov {
                                 arrow_store::OverlayValue::Text(s) => {
-                                    sb.append_value(s.to_ascii_lowercase());
+                                    sb.append_value(s.to_lowercase());
                                 }
                                 arrow_store::OverlayValue::Empty => {
                                     sb.append_null();
@@ -1256,7 +1256,7 @@ impl<'a> RangeView<'a> {
                                     mb.append_value(true);
                                     match ov {
                                         arrow_store::OverlayValue::Text(s) => {
-                                            sb.append_value(s.to_ascii_lowercase());
+                                            sb.append_value(s.to_lowercase());
                                         }
                                         arrow_store::OverlayValue::Empty => {
                                             sb.append_null();
@@ -1536,7 +1536,7 @@ impl<'a> RangeView<'a> {
                                     mask_b.append_value(true);
                                     match ov {
                                         arrow_store::OverlayValue::Text(s) => {
-                                            sb.append_value(s.to_ascii_lowercase())
+                                            sb.append_value(s.to_lowercase())
                                         }
                                         arrow_store::OverlayValue::Number(n)
                                         | arrow_store::OverlayValue::DateTime(n)

--- a/crates/formualizer-eval/src/engine/tests/criteria_mask_text_chunked.rs
+++ b/crates/formualizer-eval/src/engine/tests/criteria_mask_text_chunked.rs
@@ -118,3 +118,59 @@ fn criteria_mask_text_matches_values_across_chunks() {
         "expected mixed segments"
     );
 }
+
+#[test]
+fn criteria_mask_text_casefolds_unicode_values_across_chunks() {
+    crate::engine::eval::criteria_mask_test_hooks::reset_text_segment_counters();
+
+    let mut cfg = arrow_eval_config();
+    cfg.enable_parallel = false;
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+
+    let chunk_rows = 4usize;
+    let values = [
+        "ИВАН",
+        "Мария",
+        "иван",
+        "Петр",
+        "Иван",
+        "Ольга",
+        "ивАн",
+        "Анна",
+    ];
+
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet("Sheet1", 1, chunk_rows);
+        for value in values {
+            ab.append_row("Sheet1", &[LiteralValue::Text(value.into())])
+                .unwrap();
+        }
+        ab.finish().unwrap();
+    }
+
+    let rng = ReferenceType::range(
+        Some("Sheet1".to_string()),
+        Some(1),
+        Some(1),
+        Some(values.len() as u32),
+        Some(1),
+    );
+    let view = engine.resolve_range_view(&rng, "Sheet1").unwrap();
+
+    let pred = crate::args::parse_criteria(&LiteralValue::Text("иван".into())).unwrap();
+    let mask = engine.build_criteria_mask(&view, 0, &pred).expect("mask");
+
+    assert_eq!(mask.len(), values.len());
+    assert_eq!(mask.null_count(), 0);
+
+    let expected = [true, false, true, false, true, false, true, false];
+    for (idx, want) in expected.into_iter().enumerate() {
+        assert!(mask.is_valid(idx));
+        assert_eq!(mask.value(idx), want, "row {idx}");
+    }
+
+    let (segments_total, _) =
+        crate::engine::eval::criteria_mask_test_hooks::text_segment_counters();
+    assert!(segments_total >= 2, "expected multiple chunks");
+}

--- a/crates/formualizer-eval/src/engine/tests/named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/named_ranges.rs
@@ -731,6 +731,32 @@ fn named_range_resolution_is_case_insensitive_by_default() {
 }
 
 #[test]
+fn named_range_resolution_is_unicode_case_insensitive_by_default() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+
+    let sheet_id = engine.sheet_id_mut("Sheet1");
+    let input_ref = CellRef::new(sheet_id, Coord::new(0, 0, true, true));
+    engine
+        .define_name(
+            "Ввод",
+            NamedDefinition::Cell(input_ref),
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    let ast = parse("=ввод*2").unwrap();
+    engine.set_cell_formula("Sheet1", 2, 1, ast).unwrap();
+    let v = engine
+        .evaluate_cell("Sheet1", 2, 1)
+        .unwrap()
+        .expect("computed value");
+    assert_eq!(v, LiteralValue::Number(20.0));
+}
+
+#[test]
 fn named_range_definition_rejects_case_insensitive_collisions() {
     let mut graph = DependencyGraph::new();
     graph
@@ -744,6 +770,28 @@ fn named_range_definition_rejects_case_insensitive_collisions() {
     let err = graph
         .define_name(
             "sales",
+            NamedDefinition::Literal(LiteralValue::Number(2.0)),
+            NameScope::Workbook,
+        )
+        .expect_err("expected collision error");
+
+    assert_eq!(err.kind, ExcelErrorKind::Name);
+}
+
+#[test]
+fn named_range_definition_rejects_unicode_case_insensitive_collisions() {
+    let mut graph = DependencyGraph::new();
+    graph
+        .define_name(
+            "Ввод",
+            NamedDefinition::Literal(LiteralValue::Number(1.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    let err = graph
+        .define_name(
+            "ввод",
             NamedDefinition::Literal(LiteralValue::Number(2.0)),
             NameScope::Workbook,
         )

--- a/crates/formualizer-eval/src/engine/tests/tables.rs
+++ b/crates/formualizer-eval/src/engine/tests/tables.rs
@@ -213,6 +213,43 @@ fn structured_ref_table_name_resolution_is_case_insensitive_by_default() {
 }
 
 #[test]
+fn structured_ref_unicode_table_and_column_resolution_is_case_insensitive_by_default() {
+    let ctx = crate::test_workbook::TestWorkbook::new();
+    let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
+
+    engine.add_sheet("Sheet1").unwrap();
+
+    engine
+        .set_cell_value("Sheet1", 2, 2, LiteralValue::Number(10.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 3, 2, LiteralValue::Number(20.0))
+        .unwrap();
+
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let start = CellRef::new(sheet_id, Coord::from_excel(1, 1, true, true));
+    let end = CellRef::new(sheet_id, Coord::from_excel(3, 2, true, true));
+    let range = RangeRef::new(start, end);
+    engine
+        .define_table(
+            "Продажи",
+            range,
+            true,
+            vec!["Регион".into(), "Сумма".into()],
+            false,
+        )
+        .unwrap();
+
+    let ast = formualizer_parse::parser::parse("=SUM(продажи[сумма])").unwrap();
+    engine.set_cell_formula("Sheet1", 1, 4, ast).unwrap();
+    let v = engine
+        .evaluate_cell("Sheet1", 1, 4)
+        .unwrap()
+        .expect("computed value");
+    assert_eq!(v, LiteralValue::Number(30.0));
+}
+
+#[test]
 fn table_definition_rejects_case_insensitive_collisions() {
     let ctx = crate::test_workbook::TestWorkbook::new();
     let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());

--- a/crates/formualizer-eval/src/test_workbook.rs
+++ b/crates/formualizer-eval/src/test_workbook.rs
@@ -109,10 +109,11 @@ impl TestWorkbook {
         impl Table for SimpleTable {
             fn get_cell(&self, row: usize, column: &str) -> Result<V, ExcelError> {
                 // row is 0-based within data body
+                let column_key = column.to_lowercase();
                 let col_idx = self
                     .headers
                     .iter()
-                    .position(|h| h.eq_ignore_ascii_case(column))
+                    .position(|h| h.to_lowercase() == column_key)
                     .ok_or_else(|| ExcelError::from(ExcelErrorKind::Ref))?;
                 self.data
                     .get(row)
@@ -121,10 +122,11 @@ impl TestWorkbook {
                     .ok_or_else(|| ExcelError::from(ExcelErrorKind::Ref))
             }
             fn get_column(&self, column: &str) -> Result<Box<dyn Range>, ExcelError> {
+                let column_key = column.to_lowercase();
                 let col_idx = self
                     .headers
                     .iter()
-                    .position(|h| h.eq_ignore_ascii_case(column))
+                    .position(|h| h.to_lowercase() == column_key)
                     .ok_or_else(|| ExcelError::from(ExcelErrorKind::Ref))?;
                 let mut col: Vec<Vec<V>> = Vec::with_capacity(self.data.len());
                 for r in &self.data {

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -1002,8 +1002,10 @@ pub trait Resolver: ReferenceResolver + RangeResolver + NamedRangeResolver + Tab
                     Some(TableSpecifier::ColumnRange(start, end)) => {
                         // Build a rectangular range from start..=end columns in table order
                         let cols = t.columns();
-                        let start_idx = cols.iter().position(|n| n.eq_ignore_ascii_case(start));
-                        let end_idx = cols.iter().position(|n| n.eq_ignore_ascii_case(end));
+                        let start_key = start.to_lowercase();
+                        let end_key = end.to_lowercase();
+                        let start_idx = cols.iter().position(|n| n.to_lowercase() == start_key);
+                        let end_idx = cols.iter().position(|n| n.to_lowercase() == end_key);
                         if let (Some(mut si), Some(mut ei)) = (start_idx, end_idx) {
                             if si > ei {
                                 std::mem::swap(&mut si, &mut ei);

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1082,7 +1082,7 @@ impl ReferenceType {
         let mut depth = 0;
         let mut end_pos = 0;
 
-        for (i, c) in specifier_str.chars().enumerate() {
+        for (i, c) in specifier_str.char_indices() {
             if c == '[' {
                 depth += 1;
             } else if c == ']' {

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -1664,6 +1664,30 @@ mod reference_tests {
     }
 
     #[test]
+    fn test_table_reference_with_non_ascii_column_names() {
+        for (reference, expected_table, expected_column) in [
+            ("Sales[Акт]", "Sales", "Акт"),
+            ("Café[Crème brûlée]", "Café", "Crème brûlée"),
+            ("分析[数量]", "分析", "数量"),
+        ] {
+            let ref_type = ReferenceType::from_string(reference).unwrap();
+
+            match ref_type {
+                ReferenceType::Table(table_ref) => {
+                    assert_eq!(table_ref.name, expected_table);
+                    match table_ref.specifier {
+                        Some(TableSpecifier::Column(column)) => {
+                            assert_eq!(column, expected_column)
+                        }
+                        other => panic!("Expected Column specifier, got {other:?}"),
+                    }
+                }
+                other => panic!("Expected Table reference, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn test_table_reference_with_column_range() {
         // Test a table reference with a column range
         let reference = "Table1[Column1:Column2]";

--- a/crates/formualizer-workbook/src/resolver.rs
+++ b/crates/formualizer-workbook/src/resolver.rs
@@ -160,12 +160,17 @@ impl<B: SpreadsheetReader> TableResolver for IoResolver<B> {
             .sheet_names()
             .map_err(|e| ExcelError::new(ExcelErrorKind::NImpl).with_message(e.to_string()))?;
 
+        let table_name_key = tref.name.to_lowercase();
         let mut found: Option<(String, crate::traits::TableDefinition)> = None;
         for s in sheets {
             let sd = guard
                 .read_sheet(&s)
                 .map_err(|e| ExcelError::new(ExcelErrorKind::NImpl).with_message(e.to_string()))?;
-            if let Some(td) = sd.tables.into_iter().find(|t| t.name == tref.name) {
+            if let Some(td) = sd
+                .tables
+                .into_iter()
+                .find(|t| t.name.to_lowercase() == table_name_key)
+            {
                 found = Some((s, td));
                 break;
             }
@@ -208,9 +213,10 @@ struct BackendTable {
 
 impl BackendTable {
     fn col_index(&self, header: &str) -> Option<usize> {
+        let header_key = header.to_lowercase();
         self.headers
             .iter()
-            .position(|h| h.eq_ignore_ascii_case(header))
+            .position(|h| h.to_lowercase() == header_key)
     }
 
     fn body_bounds(&self) -> (usize, usize) {

--- a/crates/formualizer-workbook/tests/umya/tables.rs
+++ b/crates/formualizer-workbook/tests/umya/tables.rs
@@ -100,6 +100,44 @@ fn umya_loads_native_table_metadata_and_eval_structured_ref() {
 }
 
 #[test]
+fn umya_evals_sumifs_with_unicode_structured_refs_and_casefolded_criteria() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+
+        // Table region A1:B5: headers + 4 data rows.
+        sh.get_cell_mut((1, 1)).set_value("Статус");
+        sh.get_cell_mut((2, 1)).set_value("Акт");
+        sh.get_cell_mut((1, 2)).set_value("ГОТОВО");
+        sh.get_cell_mut((2, 2)).set_value_number(10);
+        sh.get_cell_mut((1, 3)).set_value("готово");
+        sh.get_cell_mut((2, 3)).set_value_number(20);
+        sh.get_cell_mut((1, 4)).set_value("Черновик");
+        sh.get_cell_mut((2, 4)).set_value_number(30);
+        sh.get_cell_mut((1, 5)).set_value("Готово");
+        sh.get_cell_mut((2, 5)).set_value_number(40);
+
+        sh.get_cell_mut((4, 1))
+            .set_formula("SUMIFS(Продажи[акт],Продажи[статус],\"готово\")");
+
+        let mut table = umya_spreadsheet::structs::Table::new("Продажи", ("A1", "B5"));
+        table.add_column(umya_spreadsheet::structs::TableColumn::new("Статус"));
+        table.add_column(umya_spreadsheet::structs::TableColumn::new("Акт"));
+        sh.add_table(table);
+    });
+
+    let backend = UmyaAdapter::open_path(&path).expect("open workbook");
+    let mut wb = Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .expect("load into engine workbook");
+
+    let v = wb.evaluate_cell("Sheet1", 1, 4).unwrap();
+    assert_eq!(v, LiteralValue::Number(70.0));
+}
+
+#[test]
 fn umya_respects_header_row_count_from_table_xml_when_headerless() {
     let path = build_workbook(|book| {
         let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();


### PR DESCRIPTION
## Summary
- fix UTF-8-safe parsing for structured table specifiers
- make table, named-range, criteria, and database header matching Unicode case-insensitive
- make MATCH/XMATCH/XLOOKUP exact and wildcard text matching Unicode-aware and char-safe
- add parser, engine, Arrow-path, and workbook regressions for Unicode structured refs and lookups

## Testing
- cargo test -p formualizer-parse test_table_reference_with_non_ascii_column_names
- cargo test -p formualizer-eval tables
- cargo test -p formualizer-eval criteria_mask_text
- cargo test -p formualizer-eval named_range
- cargo test -p formualizer-eval dsum_
- cargo test -p formualizer-eval builtins::lookup::core::tests::match_
- cargo test -p formualizer-eval builtins::lookup::dynamic::tests::xlookup_
- cargo test -p formualizer-eval builtins::lookup::dynamic::tests::xmatch_
- cargo test -p formualizer-workbook --features umya tables::