### PR TITLE
fix(bindings): harden workbook coordinate validation

### DIFF
--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -15,6 +15,15 @@ type SheetCache = HashMap<String, SheetCellMap>;
 
 type PyObject = pyo3::Py<pyo3::PyAny>;
 
+fn validate_cell_coords(row: u32, col: u32) -> PyResult<()> {
+    if row == 0 || col == 0 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "Row/col are 1-based",
+        ));
+    }
+    Ok(())
+}
+
 struct PyCustomFnHandler {
     callback: PyObject,
 }
@@ -523,6 +532,8 @@ impl PyWorkbook {
         col: u32,
         value: &Bound<'_, PyAny>,
     ) -> PyResult<()> {
+        validate_cell_coords(row, col)?;
+
         let literal = py_to_literal(value)?;
         let mut wb = self
             .inner
@@ -560,6 +571,8 @@ impl PyWorkbook {
     ///     print(wb.evaluate_cell("Sheet1", 3, 1))
     /// ```
     pub fn set_formula(&self, sheet: &str, row: u32, col: u32, formula: &str) -> PyResult<()> {
+        validate_cell_coords(row, col)?;
+
         let mut wb = self
             .inner
             .write()
@@ -606,6 +619,8 @@ impl PyWorkbook {
         row: u32,
         col: u32,
     ) -> PyResult<PyObject> {
+        validate_cell_coords(row, col)?;
+
         let mut wb = self
             .inner
             .write()
@@ -642,6 +657,7 @@ impl PyWorkbook {
             let sheet: String = tuple.get_item(0)?.extract()?;
             let row: u32 = tuple.get_item(1)?.extract()?;
             let col: u32 = tuple.get_item(2)?.extract()?;
+            validate_cell_coords(row, col)?;
             target_vec.push((sheet, row, col));
         }
 
@@ -681,11 +697,7 @@ impl PyWorkbook {
             let sheet: String = tuple.get_item(0)?.extract()?;
             let row: u32 = tuple.get_item(1)?.extract()?;
             let col: u32 = tuple.get_item(2)?.extract()?;
-            if row == 0 || col == 0 {
-                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "Row/col are 1-based",
-                ));
-            }
+            validate_cell_coords(row, col)?;
             target_vec.push((sheet, row, col));
         }
 
@@ -721,6 +733,8 @@ impl PyWorkbook {
         row: u32,
         col: u32,
     ) -> PyResult<Option<PyObject>> {
+        validate_cell_coords(row, col)?;
+
         if let Some(cached) = {
             let sheets = self.sheets.read().unwrap();
             sheets.get(sheet).and_then(|m| m.get(&(row, col)).cloned())
@@ -739,6 +753,8 @@ impl PyWorkbook {
     }
 
     pub fn get_formula(&self, sheet: &str, row: u32, col: u32) -> PyResult<Option<String>> {
+        validate_cell_coords(row, col)?;
+
         let wb = self
             .inner
             .read()
@@ -854,6 +870,8 @@ impl PyWorkbook {
         start_col: u32,
         data: &Bound<'_, pyo3::types::PyList>,
     ) -> PyResult<()> {
+        validate_cell_coords(start_row, start_col)?;
+
         let mut rows_vec: Vec<Vec<LiteralValue>> = Vec::with_capacity(data.len());
         for row in data.iter() {
             let list: &Bound<'_, pyo3::types::PyList> = row.cast()?;
@@ -902,6 +920,8 @@ impl PyWorkbook {
         start_col: u32,
         formulas: &Bound<'_, pyo3::types::PyList>,
     ) -> PyResult<()> {
+        validate_cell_coords(start_row, start_col)?;
+
         let mut rows_vec: Vec<Vec<String>> = Vec::with_capacity(formulas.len());
         for row in formulas.iter() {
             let list: &Bound<'_, pyo3::types::PyList> = row.cast()?;

--- a/bindings/python/tests/test_coordinate_validation.py
+++ b/bindings/python/tests/test_coordinate_validation.py
@@ -1,0 +1,32 @@
+import pytest
+
+import formualizer as fz
+
+
+def make_workbook() -> fz.Workbook:
+    wb = fz.Workbook(mode=fz.WorkbookMode.Ephemeral)
+    wb.add_sheet("Sheet1")
+    wb.set_value("Sheet1", 1, 1, 123)
+    wb.set_formula("Sheet1", 1, 2, "=A1")
+    return wb
+
+
+def test_workbook_cell_apis_reject_zero_based_coords():
+    wb = make_workbook()
+
+    with pytest.raises(ValueError, match="1-based"):
+        wb.set_value("Sheet1", 0, 1, 99)
+    with pytest.raises(ValueError, match="1-based"):
+        wb.set_formula("Sheet1", 1, 0, "=1")
+    with pytest.raises(ValueError, match="1-based"):
+        wb.evaluate_cell("Sheet1", 0, 1)
+    with pytest.raises(ValueError, match="1-based"):
+        wb.evaluate_cells([("Sheet1", 1, 0)])
+    with pytest.raises(ValueError, match="1-based"):
+        wb.get_value("Sheet1", 0, 1)
+    with pytest.raises(ValueError, match="1-based"):
+        wb.get_formula("Sheet1", 1, 0)
+    with pytest.raises(ValueError, match="1-based"):
+        wb.set_values_batch("Sheet1", 0, 1, [[1]])
+    with pytest.raises(ValueError, match="1-based"):
+        wb.set_formulas_batch("Sheet1", 1, 0, [["=1"]])

--- a/bindings/wasm/src/sheetport.rs
+++ b/bindings/wasm/src/sheetport.rs
@@ -172,11 +172,11 @@ fn snapshot_to_js(map: &BTreeMap<String, PortValue>) -> Result<JsValue, JsValue>
 
 fn port_value_to_js(value: &PortValue) -> Result<JsValue, JsValue> {
     Ok(match value {
-        PortValue::Scalar(literal) => literal_to_js(literal.clone()),
+        PortValue::Scalar(literal) => literal_to_js(literal),
         PortValue::Record(fields) => {
             let obj = js_sys::Object::new();
             for (field, literal) in fields {
-                set(&obj, field, literal_to_js(literal.clone()))?;
+                set(&obj, field, literal_to_js(literal))?;
             }
             obj.into()
         }
@@ -185,7 +185,7 @@ fn port_value_to_js(value: &PortValue) -> Result<JsValue, JsValue> {
             for row in rows {
                 let arr = js_sys::Array::new();
                 for cell in row {
-                    arr.push(&literal_to_js(cell.clone()));
+                    arr.push(&literal_to_js(cell));
                 }
                 outer.push(&arr);
             }
@@ -200,7 +200,7 @@ fn table_value_to_js(table: &TableValue) -> Result<JsValue, JsValue> {
     for row in &table.rows {
         let obj = js_sys::Object::new();
         for (column, literal) in &row.values {
-            set(&obj, column, literal_to_js(literal.clone()))?;
+            set(&obj, column, literal_to_js(literal))?;
         }
         outer.push(&obj);
     }

--- a/bindings/wasm/src/workbook.rs
+++ b/bindings/wasm/src/workbook.rs
@@ -68,7 +68,7 @@ impl formualizer::workbook::CustomFnHandler for JsCustomFnHandler {
     ) -> Result<formualizer::LiteralValue, ExcelError> {
         let js_args = js_sys::Array::new();
         for arg in args {
-            js_args.push(&literal_to_js(arg.clone()));
+            js_args.push(&literal_to_js(arg));
         }
 
         let value = JS_CALLBACK_REGISTRY
@@ -91,6 +91,30 @@ fn register_js_callback(callback: js_sys::Function) -> u64 {
 
 fn unregister_js_callback(callback_id: u64) {
     JS_CALLBACK_REGISTRY.with(|registry| registry.borrow_mut().remove(callback_id));
+}
+
+fn cell_coords_are_valid(row: u32, col: u32) -> bool {
+    row != 0 && col != 0
+}
+
+fn validate_cell_coords(row: u32, col: u32) -> Result<(), JsValue> {
+    if cell_coords_are_valid(row, col) {
+        Ok(())
+    } else {
+        Err(js_error(format!(
+            "row/col are 1-based (row={row}, col={col})"
+        )))
+    }
+}
+
+fn parse_target_coord(raw: Option<f64>, label: &str, index: u32) -> Result<u32, JsValue> {
+    let value = raw.ok_or_else(|| js_error(format!("invalid {label} at index {index}")))?;
+    if !value.is_finite() || value.fract() != 0.0 || value < 1.0 || value > u32::MAX as f64 {
+        return Err(js_error(format!(
+            "invalid {label} at index {index}: expected a 1-based integer coordinate"
+        )));
+    }
+    Ok(value as u32)
 }
 
 fn parse_custom_function_options(
@@ -228,13 +252,13 @@ pub(crate) fn js_to_literal(value: &JsValue) -> formualizer::LiteralValue {
     LiteralValue::Text(format!("{value:?}"))
 }
 
-pub(crate) fn literal_to_js(v: formualizer::LiteralValue) -> JsValue {
+pub(crate) fn literal_to_js(v: &formualizer::LiteralValue) -> JsValue {
     match v {
         formualizer::LiteralValue::Empty => JsValue::NULL,
-        formualizer::LiteralValue::Boolean(b) => JsValue::from_bool(b),
-        formualizer::LiteralValue::Int(i) => JsValue::from_f64(i as f64),
-        formualizer::LiteralValue::Number(n) => JsValue::from_f64(n),
-        formualizer::LiteralValue::Text(s) => JsValue::from_str(&s),
+        formualizer::LiteralValue::Boolean(b) => JsValue::from_bool(*b),
+        formualizer::LiteralValue::Int(i) => JsValue::from_f64(*i as f64),
+        formualizer::LiteralValue::Number(n) => JsValue::from_f64(*n),
+        formualizer::LiteralValue::Text(s) => JsValue::from_str(s),
         formualizer::LiteralValue::Date(d) => JsValue::from_str(&d.to_string()),
         formualizer::LiteralValue::DateTime(dt) => JsValue::from_str(&dt.to_string()),
         formualizer::LiteralValue::Time(t) => JsValue::from_str(&t.to_string()),
@@ -633,7 +657,7 @@ impl Workbook {
                 }
                 formualizer::eval::engine::named_range::NamedDefinition::Literal(value) => {
                     set(&obj, "kind", JsValue::from_str("literal"))?;
-                    set(&obj, "value", literal_to_js(value))?;
+                    set(&obj, "value", literal_to_js(&value))?;
                 }
                 formualizer::eval::engine::named_range::NamedDefinition::Formula { .. } => {
                     set(&obj, "kind", JsValue::from_str("formula"))?;
@@ -669,6 +693,8 @@ impl Workbook {
         col: u32,
         value: JsValue,
     ) -> Result<(), JsValue> {
+        validate_cell_coords(row, col)?;
+
         let lv = js_to_literal(&value);
         self.inner
             .write()
@@ -685,6 +711,8 @@ impl Workbook {
         col: u32,
         formula: String,
     ) -> Result<(), JsValue> {
+        validate_cell_coords(row, col)?;
+
         self.inner
             .write()
             .map_err(|_| js_error("failed to lock workbook for write"))?
@@ -694,6 +722,8 @@ impl Workbook {
 
     #[wasm_bindgen(js_name = "evaluateCell")]
     pub fn evaluate_cell(&self, sheet: String, row: u32, col: u32) -> Result<JsValue, JsValue> {
+        validate_cell_coords(row, col)?;
+
         let v = self
             .inner
             .write()
@@ -704,7 +734,7 @@ impl Workbook {
                     "evaluate_cell failed for {sheet}!R{row}C{col}: {e}"
                 ))
             })?;
-        Ok(literal_to_js(v))
+        Ok(literal_to_js(&v))
     }
 
     #[wasm_bindgen(js_name = "evaluateAll")]
@@ -723,7 +753,6 @@ impl Workbook {
     #[wasm_bindgen(js_name = "evaluateCells")]
     pub fn evaluate_cells(&self, targets: js_sys::Array) -> Result<js_sys::Array, JsValue> {
         let mut target_vec = Vec::with_capacity(targets.length() as usize);
-        let mut sheet_names = Vec::new(); // Keep strings alive
         for i in 0..targets.length() {
             let item = targets.get(i);
             let arr: js_sys::Array = item.into();
@@ -731,25 +760,16 @@ impl Workbook {
                 .get(0)
                 .as_string()
                 .ok_or_else(|| js_error(format!("invalid sheet name at index {i}")))?;
-            let _row = arr
-                .get(1)
-                .as_f64()
-                .ok_or_else(|| js_error(format!("invalid row at index {i}")))?
-                as u32;
-            let _col = arr
-                .get(2)
-                .as_f64()
-                .ok_or_else(|| js_error(format!("invalid col at index {i}")))?
-                as u32;
-            sheet_names.push(sheet);
+            let row = parse_target_coord(arr.get(1).as_f64(), "row", i)?;
+            let col = parse_target_coord(arr.get(2).as_f64(), "col", i)?;
+            validate_cell_coords(row, col)?;
+            target_vec.push((sheet, row, col));
         }
 
-        for (i, name) in sheet_names.iter().enumerate() {
-            let arr: js_sys::Array = targets.get(i as u32).into();
-            let row = arr.get(1).as_f64().unwrap() as u32;
-            let col = arr.get(2).as_f64().unwrap() as u32;
-            target_vec.push((name.as_str(), row, col));
-        }
+        let refs: Vec<(&str, u32, u32)> = target_vec
+            .iter()
+            .map(|(sheet, row, col)| (sheet.as_str(), *row, *col))
+            .collect();
 
         let mut wb = self
             .inner
@@ -759,12 +779,12 @@ impl Workbook {
             .store(false, std::sync::atomic::Ordering::SeqCst);
 
         let results = wb
-            .evaluate_cells_cancellable(&target_vec, self.cancel_flag.clone())
+            .evaluate_cells_cancellable(&refs, self.cancel_flag.clone())
             .map_err(|e| js_error(format!("evaluate_cells failed: {e}")))?;
 
         let out = js_sys::Array::new();
         for v in results {
-            out.push(&literal_to_js(v));
+            out.push(&literal_to_js(&v));
         }
         Ok(out)
     }
@@ -779,17 +799,9 @@ impl Workbook {
                 .get(0)
                 .as_string()
                 .ok_or_else(|| js_error(format!("invalid sheet name at index {i}")))?;
-            let row = arr
-                .get(1)
-                .as_f64()
-                .ok_or_else(|| js_error(format!("invalid row at index {i}")))?
-                as u32;
-            let col = arr
-                .get(2)
-                .as_f64()
-                .ok_or_else(|| js_error(format!("invalid col at index {i}")))?
-                as u32;
-            if row == 0 || col == 0 {
+            let row = parse_target_coord(arr.get(1).as_f64(), "row", i)?;
+            let col = parse_target_coord(arr.get(2).as_f64(), "col", i)?;
+            if !cell_coords_are_valid(row, col) {
                 return Err(js_error(format!(
                     "row/col are 1-based at index {i} (row={row}, col={col})"
                 )));
@@ -888,6 +900,8 @@ pub struct Sheet {
 impl Sheet {
     #[wasm_bindgen(js_name = "setValue")]
     pub fn set_value(&self, row: u32, col: u32, value: JsValue) -> Result<(), JsValue> {
+        validate_cell_coords(row, col)?;
+
         let lv = js_to_literal(&value);
         self.wb
             .write()
@@ -903,6 +917,8 @@ impl Sheet {
 
     #[wasm_bindgen(js_name = "setFormula")]
     pub fn set_formula(&self, row: u32, col: u32, formula: String) -> Result<(), JsValue> {
+        validate_cell_coords(row, col)?;
+
         self.wb
             .write()
             .map_err(|_| js_error("failed to lock workbook for write"))?
@@ -917,17 +933,22 @@ impl Sheet {
 
     #[wasm_bindgen(js_name = "getValue")]
     pub fn get_value(&self, row: u32, col: u32) -> Result<JsValue, JsValue> {
+        validate_cell_coords(row, col)?;
+
         let v = self
             .wb
             .read()
             .map_err(|_| js_error("failed to lock workbook for read"))?
             .get_value(&self.name, row, col)
             .unwrap_or(formualizer::LiteralValue::Empty);
-        Ok(literal_to_js(v))
+        Ok(literal_to_js(&v))
     }
 
     #[wasm_bindgen(js_name = "getFormula")]
     pub fn get_formula(&self, row: u32, col: u32) -> Option<String> {
+        if !cell_coords_are_valid(row, col) {
+            return None;
+        }
         self.wb.read().ok()?.get_formula(&self.name, row, col)
     }
 
@@ -938,6 +959,8 @@ impl Sheet {
         start_col: u32,
         data: js_sys::Array,
     ) -> Result<(), JsValue> {
+        validate_cell_coords(start_row, start_col)?;
+
         // data: Array<Array<any>>
         let mut rows: Vec<Vec<formualizer::LiteralValue>> =
             Vec::with_capacity(data.length() as usize);
@@ -974,6 +997,8 @@ impl Sheet {
         start_col: u32,
         data: js_sys::Array,
     ) -> Result<(), JsValue> {
+        validate_cell_coords(start_row, start_col)?;
+
         // data: Array<Array<string>>
         let mut rows: Vec<Vec<String>> = Vec::with_capacity(data.length() as usize);
         for r in 0..data.length() {
@@ -1005,6 +1030,8 @@ impl Sheet {
 
     #[wasm_bindgen(js_name = "evaluateCell")]
     pub fn evaluate_cell(&self, row: u32, col: u32) -> Result<JsValue, JsValue> {
+        validate_cell_coords(row, col)?;
+
         let v = self
             .wb
             .write()
@@ -1016,7 +1043,7 @@ impl Sheet {
                     sheet = self.name
                 ))
             })?;
-        Ok(literal_to_js(v))
+        Ok(literal_to_js(&v))
     }
 
     /// Read a rectangular range of values as a 2D array (no evaluation)
@@ -1041,7 +1068,7 @@ impl Sheet {
         for row in vals {
             let arr = js_sys::Array::new();
             for v in row {
-                arr.push(&literal_to_js(v));
+                arr.push(&literal_to_js(&v));
             }
             outer.push(&arr);
         }

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -244,6 +244,46 @@ fn test_error_handling() {
 }
 
 #[wasm_bindgen_test]
+fn test_workbook_rejects_zero_based_coords() {
+    let wb = Workbook::new();
+    wb.add_sheet("Sheet1".to_string()).unwrap();
+
+    let err = wb
+        .set_value("Sheet1".to_string(), 0, 1, JsValue::from_f64(1.0))
+        .unwrap_err();
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    assert!(error.message().as_string().unwrap().contains("1-based"));
+
+    let targets = js_sys::Array::new();
+    let target = js_sys::Array::new();
+    target.push(&JsValue::from_str("Sheet1"));
+    target.push(&JsValue::from_f64(0.0));
+    target.push(&JsValue::from_f64(1.0));
+    targets.push(&target);
+
+    let err = wb.evaluate_cells(targets).unwrap_err();
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    assert!(error.message().as_string().unwrap().contains("1-based"));
+}
+
+#[wasm_bindgen_test]
+fn test_sheet_rejects_zero_based_coords() {
+    let wb = Workbook::new();
+    wb.add_sheet("Sheet1".to_string()).unwrap();
+    let sheet = wb.sheet("Sheet1".to_string()).unwrap();
+
+    let err = sheet.set_formula(0, 1, "=1".to_string()).unwrap_err();
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    assert!(error.message().as_string().unwrap().contains("1-based"));
+
+    let err = sheet.get_value(1, 0).unwrap_err();
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    assert!(error.message().as_string().unwrap().contains("1-based"));
+
+    assert!(sheet.get_formula(0, 1).is_none());
+}
+
+#[wasm_bindgen_test]
 fn test_array_formula() {
     let formula = "={1,2;3,4}";
     let ast = parse(formula, None).unwrap();


### PR DESCRIPTION
## Summary
- reject zero-based workbook and sheet coordinates across Python and wasm bindings
- tighten wasm target parsing so JS callers must pass positive integer coordinates
- remove an avoidable wasm literal clone hop and add regression coverage for the binding boundary

## Verification
- `cargo test -p formualizer-python --no-run`
- `cargo test -p formualizer-wasm --target wasm32-unknown-unknown --no-run`
- `cd bindings/python && maturin develop --quiet && pytest tests/test_coordinate_validation.py -q`
- `wasm-pack test --node bindings/wasm`
