### PR TITLE
fix(sheetport): make input writes atomic

### DIFF
--- a/crates/formualizer-sheetport/src/runtime.rs
+++ b/crates/formualizer-sheetport/src/runtime.rs
@@ -25,6 +25,24 @@ struct GridWrite<'a> {
     grid: Vec<Vec<LiteralValue>>,
 }
 
+struct PreparedWrite {
+    sheet: String,
+    row: u32,
+    col: u32,
+    value: LiteralValue,
+}
+
+impl PreparedWrite {
+    fn new(sheet: String, row: u32, col: u32, value: LiteralValue) -> Self {
+        Self {
+            sheet,
+            row,
+            col,
+            value,
+        }
+    }
+}
+
 /// Runtime container that pairs a manifest with a concrete workbook.
 pub struct SheetPort<'a> {
     workbook: &'a mut Workbook,
@@ -132,6 +150,8 @@ impl<'a> SheetPort<'a> {
     }
 
     pub fn write_inputs(&mut self, update: InputUpdate) -> Result<(), SheetPortError> {
+        let mut writes = Vec::new();
+
         for (port_id, value) in update.into_inner() {
             let binding =
                 self.bindings
@@ -154,9 +174,17 @@ impl<'a> SheetPort<'a> {
                 return Err(SheetPortError::ConstraintViolation { violations });
             }
             let binding_clone = binding.clone();
-            self.write_port_value(&binding_clone, value)?;
+            self.write_port_value(&binding_clone, value, &mut writes)?;
         }
-        Ok(())
+
+        self.workbook
+            .action("sheetport.write_inputs", move |action| {
+                for write in writes {
+                    action.set_value(&write.sheet, write.row, write.col, write.value)?;
+                }
+                Ok(())
+            })
+            .map_err(SheetPortError::from)
     }
 
     pub fn evaluate_once(
@@ -609,19 +637,20 @@ impl<'a> SheetPort<'a> {
         &mut self,
         binding: &PortBinding,
         value: PortValue,
+        writes: &mut Vec<PreparedWrite>,
     ) -> Result<(), SheetPortError> {
         match (binding.kind.clone(), value) {
             (BoundPort::Scalar(scalar), PortValue::Scalar(val)) => {
-                self.write_scalar(binding, &scalar, val)
+                self.write_scalar(binding, &scalar, val, writes)
             }
             (BoundPort::Record(record), PortValue::Record(map)) => {
-                self.write_record(binding, &record, map)
+                self.write_record(binding, &record, map, writes)
             }
             (BoundPort::Range(range), PortValue::Range(grid)) => {
-                self.write_range(binding, &range, grid)
+                self.write_range(binding, &range, grid, writes)
             }
             (BoundPort::Table(table), PortValue::Table(rows)) => {
-                self.write_table(binding, &table, rows)
+                self.write_table(binding, &table, rows, writes)
             }
             (_, unexpected) => Err(SheetPortError::InvariantViolation {
                 port: binding.id.clone(),
@@ -638,12 +667,18 @@ impl<'a> SheetPort<'a> {
         binding: &PortBinding,
         scalar: &ScalarBinding,
         value: LiteralValue,
+        writes: &mut Vec<PreparedWrite>,
     ) -> Result<(), SheetPortError> {
         match &scalar.location {
-            crate::location::ScalarLocation::Cell(addr) => self
-                .workbook
-                .set_value(&addr.sheet, addr.start_row, addr.start_col, value)
-                .map_err(SheetPortError::from),
+            crate::location::ScalarLocation::Cell(addr) => {
+                writes.push(PreparedWrite::new(
+                    addr.sheet.clone(),
+                    addr.start_row,
+                    addr.start_col,
+                    value,
+                ));
+                Ok(())
+            }
             crate::location::ScalarLocation::Name(name) => {
                 let addr = self.named_range_address(&binding.id, name)?;
                 if addr.height() != 1 || addr.width() != 1 {
@@ -654,9 +689,13 @@ impl<'a> SheetPort<'a> {
                         ),
                     });
                 }
-                self.workbook
-                    .set_value(&addr.sheet, addr.start_row, addr.start_col, value)
-                    .map_err(SheetPortError::from)
+                writes.push(PreparedWrite::new(
+                    addr.sheet,
+                    addr.start_row,
+                    addr.start_col,
+                    value,
+                ));
+                Ok(())
             }
             _ => Err(SheetPortError::UnsupportedSelector {
                 port: binding.id.clone(),
@@ -670,6 +709,7 @@ impl<'a> SheetPort<'a> {
         binding: &PortBinding,
         record: &RecordBinding,
         update: BTreeMap<String, LiteralValue>,
+        writes: &mut Vec<PreparedWrite>,
     ) -> Result<(), SheetPortError> {
         for (field_name, value) in update {
             let field_binding = record.fields.get(&field_name).ok_or_else(|| {
@@ -680,9 +720,12 @@ impl<'a> SheetPort<'a> {
             })?;
             match &field_binding.location {
                 crate::location::FieldLocation::Cell(addr) => {
-                    self.workbook
-                        .set_value(&addr.sheet, addr.start_row, addr.start_col, value)
-                        .map_err(SheetPortError::from)?;
+                    writes.push(PreparedWrite::new(
+                        addr.sheet.clone(),
+                        addr.start_row,
+                        addr.start_col,
+                        value,
+                    ));
                 }
                 crate::location::FieldLocation::Name(name) => {
                     let addr = self.named_range_address(&binding.id, name)?;
@@ -694,9 +737,12 @@ impl<'a> SheetPort<'a> {
                             ),
                         });
                     }
-                    self.workbook
-                        .set_value(&addr.sheet, addr.start_row, addr.start_col, value)
-                        .map_err(SheetPortError::from)?;
+                    writes.push(PreparedWrite::new(
+                        addr.sheet,
+                        addr.start_row,
+                        addr.start_col,
+                        value,
+                    ));
                 }
                 _ => {
                     return Err(SheetPortError::UnsupportedSelector {
@@ -714,17 +760,21 @@ impl<'a> SheetPort<'a> {
         binding: &PortBinding,
         range: &RangeBinding,
         grid: Vec<Vec<LiteralValue>>,
+        writes: &mut Vec<PreparedWrite>,
     ) -> Result<(), SheetPortError> {
         match &range.location {
-            crate::location::AreaLocation::Range(addr) => self.write_grid(GridWrite {
-                port_id: binding.id.as_str(),
-                sheet: &addr.sheet,
-                start_row: addr.start_row,
-                start_col: addr.start_col,
-                height: addr.height(),
-                width: addr.width(),
-                grid,
-            }),
+            crate::location::AreaLocation::Range(addr) => self.write_grid(
+                GridWrite {
+                    port_id: binding.id.as_str(),
+                    sheet: &addr.sheet,
+                    start_row: addr.start_row,
+                    start_col: addr.start_col,
+                    height: addr.height(),
+                    width: addr.width(),
+                    grid,
+                },
+                writes,
+            ),
             crate::location::AreaLocation::Layout(layout) => {
                 let bounds = resolve_range_layout(&binding.id, self.workbook, layout)?;
                 let expected_width = bounds.columns.len() as u32;
@@ -735,15 +785,18 @@ impl<'a> SheetPort<'a> {
                     });
                 }
                 let height = grid.len() as u32;
-                self.write_grid(GridWrite {
-                    port_id: binding.id.as_str(),
-                    sheet: &bounds.sheet,
-                    start_row: bounds.start_row,
-                    start_col: bounds.start_col,
-                    height,
-                    width: expected_width,
-                    grid,
-                })
+                self.write_grid(
+                    GridWrite {
+                        port_id: binding.id.as_str(),
+                        sheet: &bounds.sheet,
+                        start_row: bounds.start_row,
+                        start_col: bounds.start_col,
+                        height,
+                        width: expected_width,
+                        grid,
+                    },
+                    writes,
+                )
             }
             crate::location::AreaLocation::Name(name) => {
                 let addr = self.named_range_address(&binding.id, name)?;
@@ -765,15 +818,18 @@ impl<'a> SheetPort<'a> {
                         ),
                     });
                 }
-                self.write_grid(GridWrite {
-                    port_id: binding.id.as_str(),
-                    sheet: &addr.sheet,
-                    start_row: addr.start_row,
-                    start_col: addr.start_col,
-                    height,
-                    width: expected_width,
-                    grid,
-                })
+                self.write_grid(
+                    GridWrite {
+                        port_id: binding.id.as_str(),
+                        sheet: &addr.sheet,
+                        start_row: addr.start_row,
+                        start_col: addr.start_col,
+                        height,
+                        width: expected_width,
+                        grid,
+                    },
+                    writes,
+                )
             }
             other => Err(SheetPortError::UnsupportedSelector {
                 port: binding.id.clone(),
@@ -782,7 +838,11 @@ impl<'a> SheetPort<'a> {
         }
     }
 
-    fn write_grid(&mut self, params: GridWrite<'_>) -> Result<(), SheetPortError> {
+    fn write_grid(
+        &mut self,
+        params: GridWrite<'_>,
+        writes: &mut Vec<PreparedWrite>,
+    ) -> Result<(), SheetPortError> {
         let GridWrite {
             port_id,
             sheet,
@@ -808,9 +868,12 @@ impl<'a> SheetPort<'a> {
             let row_idx = start_row + row_offset as u32;
             for (col_offset, value) in row.into_iter().enumerate() {
                 let col_idx = start_col + col_offset as u32;
-                self.workbook
-                    .set_value(sheet, row_idx, col_idx, value)
-                    .map_err(SheetPortError::from)?;
+                writes.push(PreparedWrite::new(
+                    sheet.to_string(),
+                    row_idx,
+                    col_idx,
+                    value,
+                ));
             }
         }
         Ok(())
@@ -834,6 +897,7 @@ impl<'a> SheetPort<'a> {
         binding: &PortBinding,
         table: &TableBinding,
         value: TableValue,
+        writes: &mut Vec<PreparedWrite>,
     ) -> Result<(), SheetPortError> {
         match &table.location {
             crate::location::TableLocation::Layout(layout) => {
@@ -853,7 +917,7 @@ impl<'a> SheetPort<'a> {
                 let rows = value.rows;
                 let new_row_count = rows.len() as u32;
 
-                for (row_offset, row) in rows.iter().enumerate() {
+                for (row_offset, row) in rows.into_iter().enumerate() {
                     let row_idx = bounds.data_start_row + row_offset as u32;
                     for (col_binding, &col_index) in
                         table.columns.iter().zip(bounds.column_indices.iter())
@@ -863,18 +927,24 @@ impl<'a> SheetPort<'a> {
                             .get(&col_binding.name)
                             .cloned()
                             .unwrap_or(LiteralValue::Empty);
-                        self.workbook
-                            .set_value(&bounds.sheet, row_idx, col_index, cell_value)
-                            .map_err(SheetPortError::from)?;
+                        writes.push(PreparedWrite::new(
+                            bounds.sheet.clone(),
+                            row_idx,
+                            col_index,
+                            cell_value,
+                        ));
                     }
                 }
 
                 if new_row_count < existing_row_count {
                     for row in (bounds.data_start_row + new_row_count)..=bounds.data_end_row {
                         for &col_index in &bounds.column_indices {
-                            self.workbook
-                                .set_value(&bounds.sheet, row, col_index, LiteralValue::Empty)
-                                .map_err(SheetPortError::from)?;
+                            writes.push(PreparedWrite::new(
+                                bounds.sheet.clone(),
+                                row,
+                                col_index,
+                                LiteralValue::Empty,
+                            ));
                         }
                     }
                 }
@@ -884,9 +954,12 @@ impl<'a> SheetPort<'a> {
                     | sheetport_spec::LayoutTermination::UntilMarker => {
                         let blank_row = bounds.data_start_row + new_row_count;
                         for &col_index in &bounds.column_indices {
-                            self.workbook
-                                .set_value(&bounds.sheet, blank_row, col_index, LiteralValue::Empty)
-                                .map_err(SheetPortError::from)?;
+                            writes.push(PreparedWrite::new(
+                                bounds.sheet.clone(),
+                                blank_row,
+                                col_index,
+                                LiteralValue::Empty,
+                            ));
                         }
                     }
                     sheetport_spec::LayoutTermination::SheetEnd => {}

--- a/crates/formualizer-sheetport/tests/io.rs
+++ b/crates/formualizer-sheetport/tests/io.rs
@@ -578,6 +578,130 @@ fn write_inputs_rejects_out_of_range_record_field() -> Result<(), SheetPortError
 }
 
 #[test]
+fn write_inputs_are_atomic_across_ports() -> Result<(), SheetPortError> {
+    let mut workbook = build_workbook()?;
+    let manifest = parse_manifest();
+    let mut sheetport = SheetPort::new(&mut workbook, manifest)?;
+
+    let mut planning_window = BTreeMap::new();
+    planning_window.insert("month".into(), LiteralValue::Number(11.0));
+
+    let mut update = InputUpdate::new();
+    update.insert("planning_window", PortValue::Record(planning_window));
+    update.insert(
+        "warehouse_code",
+        PortValue::Scalar(LiteralValue::Text("INVALID".into())),
+    );
+
+    let err = sheetport
+        .write_inputs(update)
+        .expect_err("expected later port validation failure");
+    let violations = expect_constraint(err);
+    assert!(violations.iter().any(|v| v.port == "warehouse_code"));
+
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Inputs", 1, 2)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Number(3.0)
+    );
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Inputs", 2, 2)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Text("WH-001".into())
+    );
+    Ok(())
+}
+
+#[test]
+fn write_inputs_are_atomic_within_range_ports() -> Result<(), SheetPortError> {
+    let manifest_yaml = r#"
+spec: fio
+spec_version: "0.3.0"
+manifest: { id: range-atomicity, name: Range Atomicity }
+ports:
+  - id: matrix
+    dir: in
+    shape: range
+    location:
+      a1: Sheet!A1:B2
+    schema:
+      cell_type: integer
+"#;
+    let manifest: Manifest = Manifest::from_yaml_str(manifest_yaml).expect("manifest parses");
+
+    let mut workbook = Workbook::new();
+    workbook.add_sheet("Sheet").map_err(SheetPortError::from)?;
+    workbook
+        .set_value("Sheet", 1, 1, LiteralValue::Number(1.0))
+        .map_err(SheetPortError::from)?;
+    workbook
+        .set_value("Sheet", 1, 2, LiteralValue::Number(2.0))
+        .map_err(SheetPortError::from)?;
+    workbook
+        .set_value("Sheet", 2, 1, LiteralValue::Number(3.0))
+        .map_err(SheetPortError::from)?;
+    workbook
+        .set_value("Sheet", 2, 2, LiteralValue::Number(4.0))
+        .map_err(SheetPortError::from)?;
+
+    let mut sheetport = SheetPort::new(&mut workbook, manifest)?;
+
+    let mut update = InputUpdate::new();
+    update.insert(
+        "matrix",
+        PortValue::Range(vec![
+            vec![LiteralValue::Number(10.0), LiteralValue::Number(20.0)],
+            vec![LiteralValue::Number(30.0)],
+        ]),
+    );
+
+    let err = sheetport
+        .write_inputs(update)
+        .expect_err("expected range row width mismatch");
+    match err {
+        SheetPortError::InvariantViolation { port, message } => {
+            assert_eq!(port, "matrix");
+            assert!(message.contains("range row width mismatch"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Sheet", 1, 1)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Number(1.0)
+    );
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Sheet", 1, 2)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Number(2.0)
+    );
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Sheet", 2, 1)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Number(3.0)
+    );
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Sheet", 2, 2)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Number(4.0)
+    );
+    Ok(())
+}
+
+#[test]
 fn read_inputs_reports_manifest_violation() -> Result<(), SheetPortError> {
     let mut workbook = build_workbook()?;
     let manifest = parse_manifest();


### PR DESCRIPTION
## Summary
- stage all resolved SheetPort cell updates before mutating the workbook
- apply staged writes inside `Workbook::action(...)` so mid-write failures roll back cleanly
- add regressions covering cross-port and range-write partial-update failures

## Reproduction
Before this fix:
- `write_inputs_are_atomic_across_ports` failed because one port was updated before a later validation error aborted the request
- `write_inputs_are_atomic_within_range_ports` failed because the first row of a malformed range write landed before a later width mismatch aborted the call

## Verification
- `cargo fmt --all`
- `cargo test -p formualizer-sheetport --test io --test runtime`
