### PR TITLE
fix(workbook): guard sparse sheet ingest

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -33,6 +33,7 @@ pub struct Engine<R> {
     pub(crate) graph: DependencyGraph,
     resolver: R,
     pub config: EvalConfig,
+    workbook_load_limits: crate::engine::WorkbookLoadLimits,
     clock: Arc<dyn crate::timezone::ClockProvider>,
     thread_pool: Option<Arc<rayon::ThreadPool>>,
     pub recalc_epoch: u64,
@@ -889,6 +890,7 @@ where
             graph: DependencyGraph::new_with_config(config.clone()),
             resolver,
             config,
+            workbook_load_limits: crate::engine::WorkbookLoadLimits::default(),
             clock,
             thread_pool,
             recalc_epoch: 0,
@@ -948,6 +950,7 @@ where
             graph: DependencyGraph::new_with_config(config.clone()),
             resolver,
             config,
+            workbook_load_limits: crate::engine::WorkbookLoadLimits::default(),
             clock,
             thread_pool: Some(thread_pool),
             recalc_epoch: 0,
@@ -979,6 +982,14 @@ where
         let default_sheet = engine.graph.default_sheet_name().to_string();
         engine.ensure_arrow_sheet(&default_sheet);
         engine
+    }
+
+    pub fn workbook_load_limits(&self) -> &crate::engine::WorkbookLoadLimits {
+        &self.workbook_load_limits
+    }
+
+    pub fn set_workbook_load_limits(&mut self, limits: crate::engine::WorkbookLoadLimits) {
+        self.workbook_load_limits = limits;
     }
 
     fn clear_source_cache(&self) {

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -192,6 +192,33 @@ pub struct FormulaParseDiagnostic {
     pub policy: FormulaParsePolicy,
 }
 
+/// Workbook ingest limits applied by loader backends before they materialize large sheets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkbookLoadLimits {
+    /// Hard cap for declared/logical sheet rows.
+    pub max_sheet_rows: u32,
+    /// Hard cap for declared/logical sheet columns.
+    pub max_sheet_cols: u32,
+    /// Hard cap for the rectangular logical area a backend may materialize.
+    pub max_sheet_logical_cells: u64,
+    /// Sparse-sheet checks only trigger once a sheet reaches this many logical cells.
+    pub sparse_sheet_cell_threshold: u64,
+    /// Maximum allowed logical-to-populated-cell ratio once the sparse threshold is crossed.
+    pub max_sparse_cell_ratio: u64,
+}
+
+impl Default for WorkbookLoadLimits {
+    fn default() -> Self {
+        Self {
+            max_sheet_rows: 1_048_576,
+            max_sheet_cols: 16_384,
+            max_sheet_logical_cells: 8_000_000,
+            sparse_sheet_cell_threshold: 250_000,
+            max_sparse_cell_ratio: 1_024,
+        }
+    }
+}
+
 /// Configuration for the evaluation engine
 #[derive(Debug, Clone)]
 pub struct EvalConfig {

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -1,3 +1,4 @@
+use crate::load_limits::enforce_sheet_load_limits;
 use crate::traits::{
     AccessGranularity, BackendCaps, CellData, DefinedName, DefinedNameDefinition, DefinedNameScope,
     MergedRange, SheetData, SpreadsheetReader,
@@ -646,16 +647,37 @@ where
                 let r = wb.worksheet_range(n)?;
                 let f = wb.worksheet_formula(n).ok();
                 // Respect potential non-(1,1) starts in calamine ranges
-                let sr0 = r.start().unwrap_or_default().0; // 0-based
-                let sc0 = r.start().unwrap_or_default().1; // 0-based
-                // Total logical dimensions include top/left padding
-                dims = (r.height() as u32 + sr0, r.width() as u32 + sc0);
+                let value_sr0 = r.start().unwrap_or_default().0; // 0-based
+                let value_sc0 = r.start().unwrap_or_default().1; // 0-based
+                let mut max_rows = r.height() as u32 + value_sr0;
+                let mut max_cols = r.width() as u32 + value_sc0;
+                if let Some(frm_range) = f.as_ref() {
+                    let formula_sr0 = frm_range.start().unwrap_or_default().0;
+                    let formula_sc0 = frm_range.start().unwrap_or_default().1;
+                    max_rows = max_rows.max(frm_range.height() as u32 + formula_sr0);
+                    max_cols = max_cols.max(frm_range.width() as u32 + formula_sc0);
+                }
+                dims = (max_rows, max_cols);
                 range = r;
                 formulas_range = f;
             }
             if debug {
                 eprintln!("[fz][load]    dims={}x{}", dims.0, dims.1);
             }
+            let populated_cells = range.used_cells().count()
+                + formulas_range
+                    .as_ref()
+                    .map(|frm_range| frm_range.used_cells().count())
+                    .unwrap_or(0);
+            enforce_sheet_load_limits(
+                "calamine",
+                n,
+                dims.0,
+                dims.1,
+                populated_cells,
+                engine.workbook_load_limits(),
+            )
+            .map_err(|err| calamine::Error::Io(std::io::Error::other(err.to_string())))?;
             // Local Arrow ingest builder for this sheet
             // Compute absolute alignment from range start offsets.
             let sr0 = range.start().unwrap_or_default().0 as usize; // top padding (rows)

--- a/crates/formualizer-workbook/src/backends/json.rs
+++ b/crates/formualizer-workbook/src/backends/json.rs
@@ -1,4 +1,5 @@
 use crate::IoError;
+use crate::load_limits::enforce_sheet_load_limits;
 use crate::traits::{
     AccessGranularity, BackendCaps, CellData, MergedRange, NamedRange, SaveDestination, SheetData,
     SpreadsheetReader, SpreadsheetWriter, TableDefinition,
@@ -718,6 +719,14 @@ where
             });
             let rows = dims.0 as usize;
             let cols = dims.1 as usize;
+            enforce_sheet_load_limits(
+                "json",
+                name,
+                dims.0,
+                dims.1,
+                sheet.cells.len(),
+                engine.workbook_load_limits(),
+            )?;
 
             let mut aib = formualizer_eval::arrow_store::IngestBuilder::new(
                 name,

--- a/crates/formualizer-workbook/src/backends/umya.rs
+++ b/crates/formualizer-workbook/src/backends/umya.rs
@@ -1,3 +1,4 @@
+use crate::load_limits::enforce_sheet_load_limits;
 use crate::traits::{
     AccessGranularity, BackendCaps, CellData, NamedRange, NamedRangeScope, SheetData,
     SpreadsheetReader, SpreadsheetWriter,
@@ -1121,6 +1122,14 @@ where
             });
             let rows = dims.0 as usize;
             let cols = dims.1 as usize;
+            enforce_sheet_load_limits(
+                "umya",
+                n,
+                dims.0,
+                dims.1,
+                sheet_data.cells.len(),
+                engine.workbook_load_limits(),
+            )?;
 
             let mut aib = IngestBuilder::new(n, cols, chunk_rows, engine.config.date_system);
             for r in 1..=rows {

--- a/crates/formualizer-workbook/src/error.rs
+++ b/crates/formualizer-workbook/src/error.rs
@@ -35,6 +35,13 @@ pub enum IoError {
         message: String,
     },
 
+    #[error("Workbook load budget exceeded in {backend} for sheet {sheet}: {message}")]
+    LoadBudgetExceeded {
+        backend: String,
+        sheet: String,
+        message: String,
+    },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
@@ -52,6 +59,14 @@ impl IoError {
         IoError::Backend {
             backend: backend.to_string(),
             message: err.to_string(),
+        }
+    }
+
+    pub fn load_budget_exceeded(backend: &str, sheet: &str, message: String) -> Self {
+        IoError::LoadBudgetExceeded {
+            backend: backend.to_string(),
+            sheet: sheet.to_string(),
+            message,
         }
     }
 }

--- a/crates/formualizer-workbook/src/lib.rs
+++ b/crates/formualizer-workbook/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod backends;
 pub mod builtins;
 pub mod error;
+pub(crate) mod load_limits;
 #[cfg(feature = "umya")]
 pub mod recalculate;
 pub mod resolver;
@@ -42,6 +43,7 @@ pub use transaction::{WriteOp, WriteTransaction};
 
 // Re-export for convenience
 pub use formualizer_common::{LiteralValue, RangeAddress};
+pub use formualizer_eval::engine::WorkbookLoadLimits;
 pub use workbook::{
     CustomFnHandler, CustomFnInfo, CustomFnOptions, WASM_ABI_VERSION_V1, WASM_CODEC_VERSION_V1,
     WASM_MANIFEST_SCHEMA_V1, WASM_MANIFEST_SECTION_V1, WasmFunctionSpec, WasmManifestFunction,

--- a/crates/formualizer-workbook/src/lib.rs
+++ b/crates/formualizer-workbook/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod backends;
 pub mod builtins;
 pub mod error;
+#[cfg(any(feature = "calamine", feature = "json", feature = "umya"))]
 pub(crate) mod load_limits;
 #[cfg(feature = "umya")]
 pub mod recalculate;

--- a/crates/formualizer-workbook/src/load_limits.rs
+++ b/crates/formualizer-workbook/src/load_limits.rs
@@ -1,0 +1,66 @@
+use crate::IoError;
+use formualizer_eval::engine::WorkbookLoadLimits;
+
+pub(crate) fn enforce_sheet_load_limits(
+    backend: &str,
+    sheet: &str,
+    rows: u32,
+    cols: u32,
+    populated_cells: usize,
+    limits: &WorkbookLoadLimits,
+) -> Result<(), IoError> {
+    if rows == 0 || cols == 0 {
+        return Ok(());
+    }
+
+    if rows > limits.max_sheet_rows {
+        return Err(IoError::load_budget_exceeded(
+            backend,
+            sheet,
+            format!(
+                "sheet has {rows} rows, which exceeds the configured row budget of {}",
+                limits.max_sheet_rows
+            ),
+        ));
+    }
+
+    if cols > limits.max_sheet_cols {
+        return Err(IoError::load_budget_exceeded(
+            backend,
+            sheet,
+            format!(
+                "sheet has {cols} columns, which exceeds the configured column budget of {}",
+                limits.max_sheet_cols
+            ),
+        ));
+    }
+
+    let logical_cells = u64::from(rows) * u64::from(cols);
+    if logical_cells > limits.max_sheet_logical_cells {
+        return Err(IoError::load_budget_exceeded(
+            backend,
+            sheet,
+            format!(
+                "sheet logical rectangle {rows}x{cols} ({logical_cells} cells) exceeds the configured logical-cell budget of {}",
+                limits.max_sheet_logical_cells
+            ),
+        ));
+    }
+
+    if logical_cells >= limits.sparse_sheet_cell_threshold {
+        let populated = populated_cells.max(1) as u64;
+        let sparse_limit = populated.saturating_mul(limits.max_sparse_cell_ratio);
+        if logical_cells > sparse_limit {
+            return Err(IoError::load_budget_exceeded(
+                backend,
+                sheet,
+                format!(
+                    "sheet logical rectangle {rows}x{cols} ({logical_cells} cells, {populated_cells} populated cells) exceeds the sparse-sheet guardrail ratio {} once the sheet exceeds {} logical cells",
+                    limits.max_sparse_cell_ratio, limits.sparse_sheet_cell_threshold
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -976,6 +976,7 @@ pub enum WorkbookMode {
 pub struct WorkbookConfig {
     pub eval: formualizer_eval::engine::EvalConfig,
     pub enable_changelog: bool,
+    pub ingest_limits: formualizer_eval::engine::WorkbookLoadLimits,
 }
 
 impl WorkbookConfig {
@@ -983,6 +984,7 @@ impl WorkbookConfig {
         Self {
             eval: formualizer_eval::engine::EvalConfig::default(),
             enable_changelog: false,
+            ingest_limits: formualizer_eval::engine::WorkbookLoadLimits::default(),
         }
     }
 
@@ -995,7 +997,16 @@ impl WorkbookConfig {
         Self {
             eval,
             enable_changelog: true,
+            ingest_limits: formualizer_eval::engine::WorkbookLoadLimits::default(),
         }
+    }
+
+    pub fn with_ingest_limits(
+        mut self,
+        ingest_limits: formualizer_eval::engine::WorkbookLoadLimits,
+    ) -> Self {
+        self.ingest_limits = ingest_limits;
+        self
     }
 }
 
@@ -1011,9 +1022,11 @@ impl Workbook {
         config.eval.delta_overlay_enabled = true;
         config.eval.write_formula_overlay_enabled = true;
 
+        let ingest_limits = config.ingest_limits.clone();
         let custom_functions = Arc::new(RwLock::new(BTreeMap::new()));
         let resolver = WBResolver::new(custom_functions.clone());
-        let engine = formualizer_eval::engine::Engine::new(resolver, config.eval);
+        let mut engine = formualizer_eval::engine::Engine::new(resolver, config.eval);
+        engine.set_workbook_load_limits(ingest_limits);
 
         let mut log = formualizer_eval::engine::ChangeLog::new();
         log.set_enabled(config.enable_changelog);

--- a/crates/formualizer-workbook/tests/load_limits.rs
+++ b/crates/formualizer-workbook/tests/load_limits.rs
@@ -1,0 +1,127 @@
+use formualizer_workbook::{
+    CellData, LoadStrategy, SpreadsheetReader, SpreadsheetWriter, Workbook, WorkbookConfig,
+    WorkbookLoadLimits,
+};
+
+#[cfg(feature = "json")]
+use formualizer_workbook::JsonAdapter;
+#[cfg(feature = "umya")]
+use formualizer_workbook::UmyaAdapter;
+
+#[cfg(all(feature = "calamine", feature = "umya"))]
+use formualizer_workbook::CalamineAdapter;
+
+#[cfg(feature = "umya")]
+fn sparse_xlsx_bytes() -> Vec<u8> {
+    let mut book = umya_spreadsheet::new_file();
+    let sheet = book
+        .get_sheet_by_name_mut("Sheet1")
+        .expect("default sheet exists");
+    sheet.get_cell_mut((1, 1_000)).set_value_number(1.0);
+
+    let mut buf = Vec::new();
+    umya_spreadsheet::writer::xlsx::write_writer(&book, &mut buf).expect("write xlsx bytes");
+    buf
+}
+
+fn sparse_limits() -> WorkbookLoadLimits {
+    WorkbookLoadLimits {
+        max_sheet_rows: 10_000,
+        max_sheet_cols: 100,
+        max_sheet_logical_cells: u64::MAX,
+        sparse_sheet_cell_threshold: 100,
+        max_sparse_cell_ratio: 10,
+    }
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn json_loader_rejects_dense_sheet_over_logical_budget() {
+    let mut adapter = JsonAdapter::new();
+    for row in 1..=11 {
+        for col in 1..=10 {
+            adapter
+                .write_cell("S", row, col, CellData::from_value(1.0))
+                .expect("write dense cell");
+        }
+    }
+
+    let mut cfg = WorkbookConfig::ephemeral();
+    cfg.ingest_limits = WorkbookLoadLimits {
+        max_sheet_rows: 10_000,
+        max_sheet_cols: 10_000,
+        max_sheet_logical_cells: 100,
+        sparse_sheet_cell_threshold: u64::MAX,
+        max_sparse_cell_ratio: u64::MAX,
+    };
+
+    let err = match Workbook::from_reader(adapter, LoadStrategy::EagerAll, cfg) {
+        Ok(_) => panic!("dense sheet should hit logical budget"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("logical-cell budget"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn json_loader_rejects_sparse_sheet_over_guardrail() {
+    let mut adapter = JsonAdapter::new();
+    adapter
+        .write_cell("S", 1_000, 1, CellData::from_value(1.0))
+        .expect("write sparse cell");
+
+    let cfg = WorkbookConfig::ephemeral().with_ingest_limits(sparse_limits());
+    let err = match Workbook::from_reader(adapter, LoadStrategy::EagerAll, cfg) {
+        Ok(_) => panic!("sparse sheet should hit guardrail"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sparse-sheet guardrail"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[cfg(feature = "umya")]
+#[test]
+fn umya_loader_rejects_sparse_sheet_over_guardrail() {
+    let adapter = UmyaAdapter::open_bytes(sparse_xlsx_bytes()).expect("open sparse xlsx bytes");
+    let cfg = WorkbookConfig::ephemeral().with_ingest_limits(sparse_limits());
+
+    let err = match Workbook::from_reader(adapter, LoadStrategy::EagerAll, cfg) {
+        Ok(_) => panic!("sparse xlsx should hit guardrail"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sparse-sheet guardrail"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[cfg(all(feature = "calamine", feature = "umya"))]
+#[test]
+fn calamine_loader_rejects_sparse_sheet_over_guardrail() {
+    use std::io::Write;
+
+    let bytes = sparse_xlsx_bytes();
+    let mut tmp = tempfile::NamedTempFile::new().expect("create temp xlsx");
+    tmp.write_all(&bytes).expect("persist xlsx");
+
+    let adapter = CalamineAdapter::open_path(tmp.path()).expect("open sparse xlsx path");
+    let cfg = WorkbookConfig::ephemeral().with_ingest_limits(sparse_limits());
+
+    let err = match Workbook::from_reader(adapter, LoadStrategy::EagerAll, cfg) {
+        Ok(_) => panic!("sparse xlsx should hit guardrail"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sparse-sheet guardrail"),
+        "unexpected error: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- add configurable workbook ingest limits for logical sheet size and sparse-sheet ratios
- enforce the shared limits in the JSON, Umya, and Calamine loaders before they materialize oversized sheets
- gate the helper module by backend features so wasm facade builds stay warning-free
- add regression coverage for dense logical-budget failures and sparse-sheet guardrails across the affected backends

## Verification
- `cargo test --manifest-path crates/formualizer-workbook/Cargo.toml --features calamine,umya --test load_limits -- --nocapture`
- `cargo check -p formualizer --no-default-features --features portable-wasm --target wasm32-unknown-unknown`
- `cargo check -p formualizer --no-default-features --features wasm-js --target wasm32-unknown-unknown`
