### PR TITLE
fix(eval): restore open-ended range scheduling

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -2920,6 +2920,115 @@ where
         }
     }
 
+    fn formula_row_bounds_for_columns(
+        &self,
+        sheet: &str,
+        start_col: u32,
+        end_col: u32,
+    ) -> Option<(u32, u32)> {
+        let sheet_id = self.graph.sheet_id(sheet)?;
+        let sc0 = start_col.saturating_sub(1);
+        let ec0 = end_col.saturating_sub(1);
+        let mut min_r0: Option<u32> = None;
+        let mut max_r0: Option<u32> = None;
+
+        if let Some(index) = self.graph.sheet_index(sheet_id) {
+            for vid in index.vertices_in_col_range(sc0, ec0) {
+                if !matches!(
+                    self.graph.get_vertex_kind(vid),
+                    VertexKind::FormulaScalar | VertexKind::FormulaArray
+                ) {
+                    continue;
+                }
+                let row0 = self.graph.vertex_coord(vid).row();
+                min_r0 = Some(min_r0.map(|m| m.min(row0)).unwrap_or(row0));
+                max_r0 = Some(max_r0.map(|m| m.max(row0)).unwrap_or(row0));
+            }
+        } else {
+            for vid in self.graph.vertices_in_sheet(sheet_id) {
+                if !matches!(
+                    self.graph.get_vertex_kind(vid),
+                    VertexKind::FormulaScalar | VertexKind::FormulaArray
+                ) {
+                    continue;
+                }
+                let coord = self.graph.vertex_coord(vid);
+                let col0 = coord.col();
+                if col0 < sc0 || col0 > ec0 {
+                    continue;
+                }
+                let row0 = coord.row();
+                min_r0 = Some(min_r0.map(|m| m.min(row0)).unwrap_or(row0));
+                max_r0 = Some(max_r0.map(|m| m.max(row0)).unwrap_or(row0));
+            }
+        }
+
+        match (min_r0, max_r0) {
+            (Some(a0), Some(b0)) => Some((a0 + 1, b0 + 1)),
+            _ => None,
+        }
+    }
+
+    fn formula_col_bounds_for_rows(
+        &self,
+        sheet: &str,
+        start_row: u32,
+        end_row: u32,
+    ) -> Option<(u32, u32)> {
+        let sheet_id = self.graph.sheet_id(sheet)?;
+        let sr0 = start_row.saturating_sub(1);
+        let er0 = end_row.saturating_sub(1);
+        let mut min_c0: Option<u32> = None;
+        let mut max_c0: Option<u32> = None;
+
+        if let Some(index) = self.graph.sheet_index(sheet_id) {
+            for vid in index.vertices_in_row_range(sr0, er0) {
+                if !matches!(
+                    self.graph.get_vertex_kind(vid),
+                    VertexKind::FormulaScalar | VertexKind::FormulaArray
+                ) {
+                    continue;
+                }
+                let col0 = self.graph.vertex_coord(vid).col();
+                min_c0 = Some(min_c0.map(|m| m.min(col0)).unwrap_or(col0));
+                max_c0 = Some(max_c0.map(|m| m.max(col0)).unwrap_or(col0));
+            }
+        } else {
+            for vid in self.graph.vertices_in_sheet(sheet_id) {
+                if !matches!(
+                    self.graph.get_vertex_kind(vid),
+                    VertexKind::FormulaScalar | VertexKind::FormulaArray
+                ) {
+                    continue;
+                }
+                let coord = self.graph.vertex_coord(vid);
+                let row0 = coord.row();
+                if row0 < sr0 || row0 > er0 {
+                    continue;
+                }
+                let col0 = coord.col();
+                min_c0 = Some(min_c0.map(|m| m.min(col0)).unwrap_or(col0));
+                max_c0 = Some(max_c0.map(|m| m.max(col0)).unwrap_or(col0));
+            }
+        }
+
+        match (min_c0, max_c0) {
+            (Some(a0), Some(b0)) => Some((a0 + 1, b0 + 1)),
+            _ => None,
+        }
+    }
+
+    fn union_used_bounds(
+        first: Option<(u32, u32)>,
+        second: Option<(u32, u32)>,
+    ) -> Option<(u32, u32)> {
+        match (first, second) {
+            (Some((a0, b0)), Some((a1, b1))) => Some((a0.min(a1), b0.max(b1))),
+            (Some(bounds), None) | (None, Some(bounds)) => Some(bounds),
+            (None, None) => None,
+        }
+    }
+
     /// Mirror a single cell value into the Arrow overlay if enabled.
     /// Handles capacity growth, per-chunk overlay set, and heuristic compaction.
     fn mirror_value_to_overlay(&mut self, sheet: &str, row: u32, col: u32, value: &LiteralValue) {
@@ -6969,10 +7078,14 @@ where
         start_col: u32,
         end_col: u32,
     ) -> Option<(u32, u32)> {
-        // Prefer Arrow-backed used-region; fallback to graph if formulas intersect region
+        // Union Arrow-backed used-region with formula rows that have not been materialized yet.
         let sheet_id = self.graph.sheet_id(sheet)?;
-        let arrow_ok = self.sheet_store().sheet(sheet).is_some();
-        if arrow_ok && let Some(bounds) = self.arrow_used_row_bounds(sheet, start_col, end_col) {
+        let arrow_bounds = self
+            .sheet_store()
+            .sheet(sheet)
+            .and_then(|_| self.arrow_used_row_bounds(sheet, start_col, end_col));
+        let formula_bounds = self.formula_row_bounds_for_columns(sheet, start_col, end_col);
+        if let Some(bounds) = Self::union_used_bounds(arrow_bounds, formula_bounds) {
             return Some(bounds);
         }
         let sc0 = start_col.saturating_sub(1);
@@ -6983,10 +7096,14 @@ where
     }
 
     fn used_cols_for_rows(&self, sheet: &str, start_row: u32, end_row: u32) -> Option<(u32, u32)> {
-        // Prefer Arrow-backed used-region; fallback to graph if formulas intersect region
+        // Union Arrow-backed used-region with formula columns that have not been materialized yet.
         let sheet_id = self.graph.sheet_id(sheet)?;
-        let arrow_ok = self.sheet_store().sheet(sheet).is_some();
-        if arrow_ok && let Some(bounds) = self.arrow_used_col_bounds(sheet, start_row, end_row) {
+        let arrow_bounds = self
+            .sheet_store()
+            .sheet(sheet)
+            .and_then(|_| self.arrow_used_col_bounds(sheet, start_row, end_row));
+        let formula_bounds = self.formula_col_bounds_for_rows(sheet, start_row, end_row);
+        if let Some(bounds) = Self::union_used_bounds(arrow_bounds, formula_bounds) {
             return Some(bounds);
         }
         let sr0 = start_row.saturating_sub(1);

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1416,69 +1416,7 @@ impl DependencyGraph {
                 }
             }
 
-            // Check range dependencies
-            let view = self.store.view(vertex_id);
-            let row = view.row();
-            let col = view.col();
-            let dirty_sheet_id = view.sheet_id();
-
-            // New stripe-based dependents lookup
-            let mut potential_dependents = FxHashSet::default();
-
-            // 1. Column stripe lookup
-            let column_key = StripeKey {
-                sheet_id: dirty_sheet_id,
-                stripe_type: StripeType::Column,
-                index: col,
-            };
-            if let Some(dependents) = self.stripe_to_dependents.get(&column_key) {
-                potential_dependents.extend(dependents);
-            }
-
-            // 2. Row stripe lookup
-            let row_key = StripeKey {
-                sheet_id: dirty_sheet_id,
-                stripe_type: StripeType::Row,
-                index: row,
-            };
-            if let Some(dependents) = self.stripe_to_dependents.get(&row_key) {
-                potential_dependents.extend(dependents);
-            }
-
-            // 3. Block stripe lookup
-            if self.config.enable_block_stripes {
-                let block_key = StripeKey {
-                    sheet_id: dirty_sheet_id,
-                    stripe_type: StripeType::Block,
-                    index: block_index(row, col),
-                };
-                if let Some(dependents) = self.stripe_to_dependents.get(&block_key) {
-                    potential_dependents.extend(dependents);
-                }
-            }
-
-            // Precision check: ensure the dirtied cell is actually within the formula's range
-            for &dep_id in &potential_dependents {
-                if let Some(ranges) = self.formula_to_range_deps.get(&dep_id) {
-                    for range in ranges {
-                        let range_sheet_id = match range.sheet {
-                            SharedSheetLocator::Id(id) => id,
-                            _ => dirty_sheet_id,
-                        };
-                        if range_sheet_id != dirty_sheet_id {
-                            continue;
-                        }
-                        let sr0 = range.start_row.map(|b| b.index).unwrap_or(0);
-                        let er0 = range.end_row.map(|b| b.index).unwrap_or(u32::MAX);
-                        let sc0 = range.start_col.map(|b| b.index).unwrap_or(0);
-                        let ec0 = range.end_col.map(|b| b.index).unwrap_or(u32::MAX);
-                        if row >= sr0 && row <= er0 && col >= sc0 && col <= ec0 {
-                            to_visit.push(dep_id);
-                            break;
-                        }
-                    }
-                }
-            }
+            to_visit.extend(self.collect_range_dependents_for_vertex(vertex_id));
         }
 
         while let Some(id) = to_visit.pop() {
@@ -1497,6 +1435,7 @@ impl DependencyGraph {
                 let dependents = self.get_dependents(id);
                 to_visit.extend(dependents);
             }
+            to_visit.extend(self.collect_range_dependents_for_vertex(id));
         }
 
         // Add to dirty set
@@ -2376,10 +2315,30 @@ impl DependencyGraph {
             affected.insert(id);
             self.store.set_dirty(id, true);
             to_visit.extend(self.edges.in_edges(id));
+            to_visit.extend(self.collect_range_dependents_for_vertex(id));
         }
 
         self.dirty_vertices.extend(&affected);
         affected.into_iter().collect()
+    }
+
+    fn collect_range_dependents_for_vertex(&self, vertex_id: VertexId) -> Vec<VertexId> {
+        match self.store.kind(vertex_id) {
+            VertexKind::Cell
+            | VertexKind::Empty
+            | VertexKind::FormulaScalar
+            | VertexKind::FormulaArray => {
+                let view = self.store.view(vertex_id);
+                self.collect_range_dependents_for_rect(
+                    view.sheet_id(),
+                    view.row(),
+                    view.col(),
+                    view.row(),
+                    view.col(),
+                )
+            }
+            _ => Vec::new(),
+        }
     }
 
     fn collect_range_dependents_for_rect(

--- a/crates/formualizer-eval/src/engine/tests/indirect.rs
+++ b/crates/formualizer-eval/src/engine/tests/indirect.rs
@@ -141,6 +141,47 @@ fn indirect_retarget_parity_across_full_recalc_entrypoints() {
 }
 
 #[test]
+fn indirect_whole_column_schedules_far_formula_rows() {
+    let cfg = EvalConfig {
+        enable_parallel: false,
+        ..Default::default()
+    };
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(1.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 2, LiteralValue::Text("A:A".to_string()))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 5, LiteralValue::Number(2.0))
+        .unwrap();
+    // Create the dynamic reader before the far formula so stale ordering is exposed.
+    engine
+        .set_cell_formula("Sheet1", 1, 4, parse("=SUM(INDIRECT(B1))"))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 200, 1, parse("=E1"))
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 4),
+        Some(LiteralValue::Number(3.0))
+    );
+
+    engine
+        .set_cell_value("Sheet1", 1, 5, LiteralValue::Number(4.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 4),
+        Some(LiteralValue::Number(5.0))
+    );
+}
+
+#[test]
 fn indirect_supports_quoted_sheet_and_ranges() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
 

--- a/crates/formualizer-eval/src/engine/tests/infinite_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/infinite_ranges.rs
@@ -73,6 +73,75 @@ fn infinite_column_sparse_sum_and_count_correct() {
 }
 
 #[test]
+fn whole_column_includes_far_formula_rows_when_arrow_has_earlier_values() {
+    let wb = TestWorkbook::new();
+    let cfg = EvalConfig {
+        enable_parallel: false,
+        ..Default::default()
+    };
+    let mut engine = Engine::new(wb, cfg);
+
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 2, LiteralValue::Int(2))
+        .unwrap();
+    // Create the whole-column consumer before the far formula so scheduling must rely on
+    // virtual dependencies instead of vertex-id luck.
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=SUM(A:A)").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 200, 1, parse("=B1").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3).unwrap(),
+        LiteralValue::Number(3.0)
+    );
+}
+
+#[test]
+fn whole_column_recalc_tracks_formula_cells_beyond_direct_dirty_propagation() {
+    let wb = TestWorkbook::new();
+    let cfg = EvalConfig {
+        enable_parallel: false,
+        ..Default::default()
+    };
+    let mut engine = Engine::new(wb, cfg);
+
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 2, LiteralValue::Int(2))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=SUM(A:A)").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 200, 1, parse("=B1").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3).unwrap(),
+        LiteralValue::Number(3.0)
+    );
+
+    engine
+        .set_cell_value("Sheet1", 1, 2, LiteralValue::Int(5))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3).unwrap(),
+        LiteralValue::Number(6.0)
+    );
+}
+
+#[test]
 fn infinite_row_sum_and_count_correct() {
     let wb = TestWorkbook::new();
     let mut engine = Engine::new(wb, range_limit_config(16));

--- a/crates/formualizer-eval/src/engine/virtual_deps.rs
+++ b/crates/formualizer-eval/src/engine/virtual_deps.rs
@@ -63,6 +63,75 @@ impl<'a, R: EvaluationContext> DynamicRefCollector<'a, R> {
             }
         }
     }
+
+    fn collect_formula_vertices_for_range(
+        &self,
+        sheet_name: &str,
+        start_row: Option<u32>,
+        start_col: Option<u32>,
+        end_row: Option<u32>,
+        end_col: Option<u32>,
+    ) {
+        let mut sr = start_row;
+        let mut sc = start_col;
+        let mut er = end_row;
+        let mut ec = end_col;
+
+        if sr.is_none() && er.is_none() {
+            let scv = sc.unwrap_or(1u32);
+            let ecv = ec.unwrap_or(scv);
+            sr = Some(1);
+            if let Some((_, max_r)) = self.engine.used_rows_for_columns(sheet_name, scv, ecv) {
+                er = Some(max_r);
+            } else if self.engine.sheet_bounds(sheet_name).is_some() {
+                er = Some(self.engine.config.max_open_ended_rows);
+            }
+        }
+        if sc.is_none() && ec.is_none() {
+            let srv = sr.unwrap_or(1u32);
+            let erv = er.unwrap_or(srv);
+            sc = Some(1);
+            if let Some((_, max_c)) = self.engine.used_cols_for_rows(sheet_name, srv, erv) {
+                ec = Some(max_c);
+            } else if self.engine.sheet_bounds(sheet_name).is_some() {
+                ec = Some(self.engine.config.max_open_ended_cols);
+            }
+        }
+        if sr.is_some() && er.is_none() {
+            let scv = sc.unwrap_or(1u32);
+            let ecv = ec.unwrap_or(scv);
+            if let Some((_, max_r)) = self.engine.used_rows_for_columns(sheet_name, scv, ecv) {
+                er = Some(max_r);
+            } else if self.engine.sheet_bounds(sheet_name).is_some() {
+                er = Some(self.engine.config.max_open_ended_rows);
+            }
+        }
+        if er.is_some() && sr.is_none() {
+            sr = Some(1);
+        }
+        if sc.is_some() && ec.is_none() {
+            let srv = sr.unwrap_or(1u32);
+            let erv = er.unwrap_or(srv);
+            if let Some((_, max_c)) = self.engine.used_cols_for_rows(sheet_name, srv, erv) {
+                ec = Some(max_c);
+            } else if self.engine.sheet_bounds(sheet_name).is_some() {
+                ec = Some(self.engine.config.max_open_ended_cols);
+            }
+        }
+        if ec.is_some() && sc.is_none() {
+            sc = Some(1);
+        }
+
+        let sr = sr.unwrap_or(1);
+        let sc = sc.unwrap_or(1);
+        let er = er.unwrap_or(sr.saturating_sub(1));
+        let ec = ec.unwrap_or(sc.saturating_sub(1));
+        if er < sr || ec < sc {
+            return;
+        }
+
+        self.collect_formula_vertices_in_rect(sheet_name, sr, sc, er, ec);
+    }
 }
 
 impl<'a, R: EvaluationContext> ReferenceResolver for DynamicRefCollector<'a, R> {
@@ -94,13 +163,7 @@ impl<'a, R: EvaluationContext> RangeResolver for DynamicRefCollector<'a, R> {
         ec: Option<u32>,
     ) -> Result<Box<dyn Range>, ExcelError> {
         let sheet_name = sheet.unwrap_or(self.current_sheet);
-        let srv = sr.unwrap_or(1u32);
-        let scv = sc.unwrap_or(1u32);
-        let erv = er.unwrap_or(srv);
-        let ecv = ec.unwrap_or(scv);
-
-        self.collect_formula_vertices_in_rect(sheet_name, srv, scv, erv, ecv);
-
+        self.collect_formula_vertices_for_range(sheet_name, sr, sc, er, ec);
         self.engine.resolve_range_reference(sheet, sr, sc, er, ec)
     }
 }
@@ -170,13 +233,9 @@ impl<'a, R: EvaluationContext> EvaluationContext for DynamicRefCollector<'a, R> 
                 ..
             } => {
                 let sheet_name = sheet.as_deref().unwrap_or(current_sheet);
-
-                let srv = start_row.unwrap_or(1u32);
-                let scv = start_col.unwrap_or(1u32);
-                let erv = end_row.unwrap_or(srv);
-                let ecv = end_col.unwrap_or(scv);
-
-                self.collect_formula_vertices_in_rect(sheet_name, srv, scv, erv, ecv);
+                self.collect_formula_vertices_for_range(
+                    sheet_name, *start_row, *start_col, *end_row, *end_col,
+                );
             }
             ReferenceType::NamedRange(name) => {
                 let sid = self.engine.sheet_id(current_sheet);


### PR DESCRIPTION
## Summary
- union Arrow used bounds with graph-visible formula cells for whole and open-ended range resolution
- re-enqueue compressed/open-ended range consumers correctly during dirty propagation and dynamic dependency collection
- add regressions covering far-formula whole-column reads and dynamic `INDIRECT` scheduling

## Verification
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml whole_column_includes_far_formula_rows_when_arrow_has_earlier_values -- --nocapture`
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml whole_column_recalc_tracks_formula_cells_beyond_direct_dirty_propagation -- --nocapture`
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml indirect_whole_column_schedules_far_formula_rows -- --nocapture`
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml infinite_ranges -- --nocapture`
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml indirect -- --nocapture`
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml compressed_range_scheduler -- --nocapture`
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml open_ended_bounds_caps -- --nocapture`
- `cargo test --manifest-path crates/formualizer-eval/Cargo.toml criteria_mask_oob_column -- --nocapture`
