### PR TITLE
fix(sheetport): preserve raw batch baseline restores

### DIFF
--- a/crates/formualizer-sheetport/src/batch.rs
+++ b/crates/formualizer-sheetport/src/batch.rs
@@ -76,7 +76,8 @@ impl<'a> BatchExecutor<'a> {
 
         for (idx, case) in cases.into_iter().enumerate() {
             let BatchInput { id, update } = case;
-            self.sheetport.write_inputs(self.baseline_update.clone())?;
+            self.sheetport
+                .write_inputs_raw(self.baseline_update.clone())?;
             if !update.is_empty() {
                 self.sheetport.write_inputs(update)?;
             }
@@ -94,7 +95,8 @@ impl<'a> BatchExecutor<'a> {
         }
 
         // Restore baseline after all scenarios.
-        self.sheetport.write_inputs(self.baseline_update.clone())?;
+        self.sheetport
+            .write_inputs_raw(self.baseline_update.clone())?;
 
         Ok(results)
     }

--- a/crates/formualizer-sheetport/src/runtime.rs
+++ b/crates/formualizer-sheetport/src/runtime.rs
@@ -133,6 +133,22 @@ impl<'a> SheetPort<'a> {
         Ok(InputSnapshot::new(map))
     }
 
+    fn read_inputs_raw(&mut self) -> Result<InputSnapshot, SheetPortError> {
+        let bindings: Vec<PortBinding> = self
+            .bindings
+            .bindings()
+            .iter()
+            .filter(|binding| binding.direction == Direction::In)
+            .cloned()
+            .collect();
+        let mut map = BTreeMap::new();
+        for binding in bindings.iter() {
+            let value = self.read_port_value_raw(binding)?;
+            map.insert(binding.id.clone(), value);
+        }
+        Ok(InputSnapshot::new(map))
+    }
+
     pub fn read_outputs(&mut self) -> Result<OutputSnapshot, SheetPortError> {
         let bindings: Vec<PortBinding> = self
             .bindings
@@ -150,6 +166,18 @@ impl<'a> SheetPort<'a> {
     }
 
     pub fn write_inputs(&mut self, update: InputUpdate) -> Result<(), SheetPortError> {
+        self.write_inputs_inner(update, true)
+    }
+
+    pub(crate) fn write_inputs_raw(&mut self, update: InputUpdate) -> Result<(), SheetPortError> {
+        self.write_inputs_inner(update, false)
+    }
+
+    fn write_inputs_inner(
+        &mut self,
+        update: InputUpdate,
+        validate: bool,
+    ) -> Result<(), SheetPortError> {
         let mut writes = Vec::new();
 
         for (port_id, value) in update.into_inner() {
@@ -166,17 +194,23 @@ impl<'a> SheetPort<'a> {
                     message: "cannot write to output port".to_string(),
                 });
             }
-            let scope = match &binding.kind {
-                BoundPort::Record(_) => ValidationScope::Partial,
-                _ => ValidationScope::Full,
-            };
-            if let Err(violations) = validate_port_value(binding, &value, scope) {
-                return Err(SheetPortError::ConstraintViolation { violations });
+            if validate {
+                let scope = match &binding.kind {
+                    BoundPort::Record(_) => ValidationScope::Partial,
+                    _ => ValidationScope::Full,
+                };
+                if let Err(violations) = validate_port_value(binding, &value, scope) {
+                    return Err(SheetPortError::ConstraintViolation { violations });
+                }
             }
             let binding_clone = binding.clone();
             self.write_port_value(&binding_clone, value, &mut writes)?;
         }
 
+        self.apply_writes(writes)
+    }
+
+    fn apply_writes(&mut self, writes: Vec<PreparedWrite>) -> Result<(), SheetPortError> {
         self.workbook
             .action("sheetport.write_inputs", move |action| {
                 for write in writes {
@@ -451,24 +485,28 @@ impl<'a> SheetPort<'a> {
         &'a mut self,
         options: BatchOptions<'a>,
     ) -> Result<BatchExecutor<'a>, SheetPortError> {
-        let baseline = self.read_inputs()?;
-        let baseline_update = baseline.to_update();
+        self.read_inputs()?;
+        let baseline_update = self.read_inputs_raw()?.to_update();
         let plan = self.workbook().engine().build_recalc_plan()?;
         Ok(BatchExecutor::new(self, baseline_update, options, plan))
     }
 
     fn read_port_value(&mut self, binding: &PortBinding) -> Result<PortValue, SheetPortError> {
-        let mut value = match &binding.kind {
-            BoundPort::Scalar(scalar) => self.read_scalar(binding, scalar),
-            BoundPort::Record(record) => self.read_record(binding, record),
-            BoundPort::Range(range) => self.read_range(binding, range),
-            BoundPort::Table(table) => self.read_table(binding, table),
-        }?;
+        let mut value = self.read_port_value_raw(binding)?;
         value = apply_defaults(binding, value);
         if let Err(violations) = validate_port_value(binding, &value, ValidationScope::Full) {
             return Err(SheetPortError::ConstraintViolation { violations });
         }
         Ok(value)
+    }
+
+    fn read_port_value_raw(&mut self, binding: &PortBinding) -> Result<PortValue, SheetPortError> {
+        match &binding.kind {
+            BoundPort::Scalar(scalar) => self.read_scalar(binding, scalar),
+            BoundPort::Record(record) => self.read_record(binding, record),
+            BoundPort::Range(range) => self.read_range(binding, range),
+            BoundPort::Table(table) => self.read_table(binding, table),
+        }
     }
 
     fn read_scalar(
@@ -796,7 +834,38 @@ impl<'a> SheetPort<'a> {
                         grid,
                     },
                     writes,
-                )
+                )?;
+
+                let existing_height = bounds.end_row - bounds.start_row + 1;
+                if height < existing_height {
+                    for row in (bounds.start_row + height)..=bounds.end_row {
+                        for &col in &bounds.columns {
+                            writes.push(PreparedWrite::new(
+                                bounds.sheet.clone(),
+                                row,
+                                col,
+                                LiteralValue::Empty,
+                            ));
+                        }
+                    }
+                }
+
+                match layout.terminate {
+                    sheetport_spec::LayoutTermination::FirstBlankRow
+                    | sheetport_spec::LayoutTermination::UntilMarker => {
+                        let blank_row = bounds.start_row + height;
+                        for &col in &bounds.columns {
+                            writes.push(PreparedWrite::new(
+                                bounds.sheet.clone(),
+                                blank_row,
+                                col,
+                                LiteralValue::Empty,
+                            ));
+                        }
+                    }
+                    sheetport_spec::LayoutTermination::SheetEnd => {}
+                }
+                Ok(())
             }
             crate::location::AreaLocation::Name(name) => {
                 let addr = self.named_range_address(&binding.id, name)?;

--- a/crates/formualizer-sheetport/tests/io.rs
+++ b/crates/formualizer-sheetport/tests/io.rs
@@ -146,6 +146,30 @@ ports:
       type: number
 "#;
 
+const LAYOUT_RANGE_MANIFEST: &str = r#"
+spec: fio
+spec_version: "0.3.0"
+manifest:
+  id: layout-range-test
+  name: Layout Range Test Manifest
+  workbook:
+    uri: memory://layout-range.xlsx
+    locale: en-US
+    date_system: 1900
+ports:
+  - id: matrix
+    dir: in
+    shape: range
+    location:
+      layout:
+        sheet: Sheet
+        header_row: 1
+        anchor_col: A
+        terminate: first_blank_row
+    schema:
+      cell_type: string
+"#;
+
 fn build_workbook() -> Result<Workbook, SheetPortError> {
     let mut wb = Workbook::new();
     wb.add_sheet("Inputs").map_err(SheetPortError::from)?;
@@ -238,6 +262,18 @@ fn build_rng_workbook() -> Result<Workbook, SheetPortError> {
     let mut wb = Workbook::new();
     wb.add_sheet("Random").map_err(SheetPortError::from)?;
     set_formula(&mut wb, "Random", 1, 1, "RAND()")?;
+    Ok(wb)
+}
+
+fn build_layout_range_workbook() -> Result<Workbook, SheetPortError> {
+    let mut wb = Workbook::new();
+    wb.add_sheet("Sheet").map_err(SheetPortError::from)?;
+    set_value(&mut wb, "Sheet", 1, 1, LiteralValue::Text("col_a".into()))?;
+    set_value(&mut wb, "Sheet", 1, 2, LiteralValue::Text("col_b".into()))?;
+    set_value(&mut wb, "Sheet", 2, 1, LiteralValue::Text("r1a".into()))?;
+    set_value(&mut wb, "Sheet", 2, 2, LiteralValue::Text("r1b".into()))?;
+    set_value(&mut wb, "Sheet", 3, 1, LiteralValue::Text("r2a".into()))?;
+    set_value(&mut wb, "Sheet", 3, 2, LiteralValue::Text("r2b".into()))?;
     Ok(wb)
 }
 
@@ -1114,6 +1150,125 @@ fn batch_executor_handles_empty_scenarios() -> Result<(), SheetPortError> {
     let mut sheetport = SheetPort::new(&mut workbook, manifest)?;
     let after = sheetport.read_inputs()?;
     assert_eq!(after, baseline);
+    Ok(())
+}
+
+#[test]
+fn batch_restore_does_not_materialize_defaults_into_workbook() -> Result<(), SheetPortError> {
+    let mut workbook = build_workbook()?;
+    set_value(&mut workbook, "Inputs", 2, 2, LiteralValue::Empty)?;
+
+    {
+        let manifest = parse_manifest();
+        let mut sheetport = SheetPort::new(&mut workbook, manifest)?;
+        let inputs = sheetport.read_inputs()?;
+        assert_scalar(
+            &inputs,
+            "warehouse_code",
+            |value| matches!(value, LiteralValue::Text(code) if code == "WH-900"),
+        );
+        run_empty_batch(&mut sheetport)?;
+    }
+
+    assert_eq!(
+        workbook
+            .get_value("Inputs", 2, 2)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Empty
+    );
+    Ok(())
+}
+
+#[test]
+fn layout_range_updates_clear_trailing_rows_when_shrinking() -> Result<(), SheetPortError> {
+    let mut workbook = build_layout_range_workbook()?;
+    let manifest: Manifest =
+        Manifest::from_yaml_str(LAYOUT_RANGE_MANIFEST).expect("manifest parses");
+    let mut sheetport = SheetPort::new(&mut workbook, manifest)?;
+
+    let mut expand = InputUpdate::new();
+    expand.insert(
+        "matrix",
+        PortValue::Range(vec![
+            vec![
+                LiteralValue::Text("col_a".into()),
+                LiteralValue::Text("col_b".into()),
+            ],
+            vec![
+                LiteralValue::Text("r1a".into()),
+                LiteralValue::Text("r1b".into()),
+            ],
+            vec![
+                LiteralValue::Text("r2a".into()),
+                LiteralValue::Text("r2b".into()),
+            ],
+            vec![
+                LiteralValue::Text("r3a".into()),
+                LiteralValue::Text("r3b".into()),
+            ],
+            vec![
+                LiteralValue::Text("r4a".into()),
+                LiteralValue::Text("r4b".into()),
+            ],
+        ]),
+    );
+    sheetport.write_inputs(expand)?;
+
+    let expanded = sheetport.read_inputs()?;
+    match expanded.get("matrix") {
+        Some(PortValue::Range(rows)) => assert_eq!(rows.len(), 5),
+        other => panic!("expected range after expand, got {other:?}"),
+    }
+
+    let mut shrink = InputUpdate::new();
+    shrink.insert(
+        "matrix",
+        PortValue::Range(vec![
+            vec![
+                LiteralValue::Text("col_a".into()),
+                LiteralValue::Text("col_b".into()),
+            ],
+            vec![
+                LiteralValue::Text("r1a".into()),
+                LiteralValue::Text("r1b".into()),
+            ],
+            vec![
+                LiteralValue::Text("r2a".into()),
+                LiteralValue::Text("r2b".into()),
+            ],
+        ]),
+    );
+    sheetport.write_inputs(shrink)?;
+
+    let after = sheetport.read_inputs()?;
+    match after.get("matrix") {
+        Some(PortValue::Range(rows)) => {
+            assert_eq!(rows.len(), 3);
+            assert_eq!(
+                rows[0],
+                vec![
+                    LiteralValue::Text("col_a".into()),
+                    LiteralValue::Text("col_b".into()),
+                ]
+            );
+        }
+        other => panic!("expected range after shrink, got {other:?}"),
+    }
+
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Sheet", 4, 1)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Empty
+    );
+    assert_eq!(
+        sheetport
+            .workbook()
+            .get_value("Sheet", 5, 1)
+            .unwrap_or(LiteralValue::Empty),
+        LiteralValue::Empty
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- capture batch baselines from raw workbook inputs so restore writes blanks back instead of materializing defaults
- route batch restore through the raw input writer to preserve original cell state
- clear trailing rows and the sentinel row when layout-backed range writes shrink
- add regressions for empty-batch default restore and shrinking layout-range tails

## Verification
- `cargo fmt --all`
- `cargo test -p formualizer-sheetport --test io --test runtime`
