### PR TITLE
fix(wasm): support deterministic SheetPort clock options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,7 @@ dependencies = [
 name = "formualizer-wasm"
 version = "0.5.5"
 dependencies = [
+ "chrono",
  "console_error_panic_hook",
  "formualizer",
  "js-sys",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -24,6 +24,7 @@ serde-wasm-bindgen = "0.6.5"
 console_error_panic_hook = { version = "0.1", optional = true }
 formualizer = { path = "../../crates/formualizer", default-features = false, features = ["wasm-js", "json"] }
 serde_json = { workspace = true }
+chrono = { workspace = true }
 
 [dependencies.web-sys]
 workspace = true

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -195,6 +195,12 @@ parse(formula: string, dialect?: FormulaDialect): Promise<ASTNodeData>
 | `writeInputs(updates)` | Write typed input values |
 | `evaluateOnce(options)` | Evaluate with deterministic options |
 
+`evaluateOnce(options)` accepts:
+- `freezeVolatile?: boolean`
+- `rngSeed?: number` - non-negative safe integer
+- `deterministicTimestampUtc?: Date | string` - fixed instant as a JS `Date` or RFC3339 timestamp
+- `deterministicTimezone?: "utc" | "local" | number` - timezone for `NOW()` / `TODAY()`; numeric offsets are seconds east of UTC and require `deterministicTimestampUtc`
+
 ### Reference
 
 | Method / Property | Description |

--- a/bindings/wasm/src/index.ts
+++ b/bindings/wasm/src/index.ts
@@ -291,6 +291,15 @@ export interface RegisteredFunctionInfo {
   allowOverrideBuiltin: boolean;
 }
 
+export type DeterministicTimezone = 'utc' | 'local' | number;
+
+export interface SheetPortEvaluateOptions {
+  freezeVolatile?: boolean;
+  rngSeed?: number;
+  deterministicTimestampUtc?: Date | string;
+  deterministicTimezone?: DeterministicTimezone;
+}
+
 export interface WorkbookApi extends wasm.Workbook {
   registerFunction(
     name: string,
@@ -307,8 +316,17 @@ export type WorkbookConstructor = {
   prototype: WorkbookApi;
 };
 
+export interface SheetPortSessionApi extends wasm.SheetPortSession {
+  evaluateOnce(options?: SheetPortEvaluateOptions): Record<string, unknown>;
+}
+
+export type SheetPortSessionConstructor = {
+  fromManifestYaml(yaml: string, workbook: WorkbookApi): SheetPortSessionApi;
+  prototype: SheetPortSessionApi;
+};
+
 export const Workbook = wasm.Workbook as unknown as WorkbookConstructor;
-export const SheetPortSession = wasm.SheetPortSession;
+export const SheetPortSession = wasm.SheetPortSession as unknown as SheetPortSessionConstructor;
 
 // Re-export the initialization function as default
 export default initializeWasm;

--- a/bindings/wasm/src/sheetport.rs
+++ b/bindings/wasm/src/sheetport.rs
@@ -1,5 +1,8 @@
 use crate::utils::{js_error, js_error_with_cause};
 use crate::workbook::{Workbook, js_to_literal, literal_to_js};
+use chrono::{DateTime, Utc};
+use formualizer::eval::engine::DeterministicMode;
+use formualizer::eval::timezone::TimeZoneSpec;
 use formualizer::sheetport_spec::{Direction, Manifest, ManifestIssue};
 use formualizer::{
     BoundPort, ConstraintViolation, EvalOptions, ManifestBindings, PortBinding, PortValue,
@@ -467,6 +470,8 @@ fn range_address_to_js(addr: &RangeAddress) -> JsValue {
 }
 
 fn parse_eval_options(options: JsValue) -> Result<EvalOptions, JsValue> {
+    const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
     let mut eval = EvalOptions::default();
     if options.is_null() || options.is_undefined() {
         return Ok(eval);
@@ -479,36 +484,122 @@ fn parse_eval_options(options: JsValue) -> Result<EvalOptions, JsValue> {
         eval.freeze_volatile = value;
     }
     if let Some(value) = get_optional_number(&obj, "rngSeed")? {
-        if value < 0.0 {
-            return Err(js_error("rngSeed must be non-negative"));
+        if !value.is_finite() || value < 0.0 || value.fract() != 0.0 || value > MAX_SAFE_INTEGER {
+            return Err(js_error("rngSeed must be a non-negative safe integer"));
         }
         eval.rng_seed = Some(value as u64);
     }
+
+    let deterministic_timestamp_utc = get_optional_value(&obj, "deterministicTimestampUtc")?;
+    let deterministic_timezone = get_optional_value(&obj, "deterministicTimezone")?;
+    if let Some(value) = deterministic_timestamp_utc {
+        let timestamp_utc = parse_timestamp_utc(&value)?;
+        let timezone = if let Some(value) = deterministic_timezone {
+            parse_timezone_spec(&value)?
+        } else {
+            TimeZoneSpec::Utc
+        };
+        eval.deterministic_mode = Some(DeterministicMode::Enabled {
+            timestamp_utc,
+            timezone,
+        });
+    } else if deterministic_timezone.is_some() {
+        return Err(js_error(
+            "deterministicTimezone requires deterministicTimestampUtc",
+        ));
+    }
+
     Ok(eval)
 }
 
-fn get_optional_bool(obj: &js_sys::Object, key: &str) -> Result<Option<bool>, JsValue> {
+fn get_optional_value(obj: &js_sys::Object, key: &str) -> Result<Option<JsValue>, JsValue> {
     let value = js_sys::Reflect::get(obj, &JsValue::from_str(key))
         .map_err(|err| js_error(format!("failed to read `{key}`: {err:?}")))?;
     if value.is_undefined() || value.is_null() {
         Ok(None)
     } else {
-        Ok(Some(value.as_bool().ok_or_else(|| {
-            js_error(format!("`{key}` must be a boolean"))
-        })?))
+        Ok(Some(value))
     }
 }
 
+fn get_optional_bool(obj: &js_sys::Object, key: &str) -> Result<Option<bool>, JsValue> {
+    let Some(value) = get_optional_value(obj, key)? else {
+        return Ok(None);
+    };
+    Ok(Some(value.as_bool().ok_or_else(|| {
+        js_error(format!("`{key}` must be a boolean"))
+    })?))
+}
+
 fn get_optional_number(obj: &js_sys::Object, key: &str) -> Result<Option<f64>, JsValue> {
-    let value = js_sys::Reflect::get(obj, &JsValue::from_str(key))
-        .map_err(|err| js_error(format!("failed to read `{key}`: {err:?}")))?;
-    if value.is_undefined() || value.is_null() {
-        Ok(None)
-    } else {
-        Ok(Some(value.as_f64().ok_or_else(|| {
-            js_error(format!("`{key}` must be a number"))
-        })?))
+    let Some(value) = get_optional_value(obj, key)? else {
+        return Ok(None);
+    };
+    Ok(Some(value.as_f64().ok_or_else(|| {
+        js_error(format!("`{key}` must be a number"))
+    })?))
+}
+
+fn parse_timestamp_utc(value: &JsValue) -> Result<DateTime<Utc>, JsValue> {
+    if let Ok(date) = value.clone().dyn_into::<js_sys::Date>() {
+        let millis = date.get_time();
+        if !millis.is_finite() {
+            return Err(js_error(
+                "`deterministicTimestampUtc` must be a valid Date or RFC3339 timestamp string",
+            ));
+        }
+        if millis.fract() != 0.0 || millis < i64::MIN as f64 || millis > i64::MAX as f64 {
+            return Err(js_error(
+                "`deterministicTimestampUtc` is outside the supported timestamp range",
+            ));
+        }
+        return DateTime::<Utc>::from_timestamp_millis(millis as i64).ok_or_else(|| {
+            js_error("`deterministicTimestampUtc` is outside the supported timestamp range")
+        });
     }
+
+    if let Some(text) = value.as_string() {
+        return DateTime::parse_from_rfc3339(&text)
+            .map(|timestamp| timestamp.with_timezone(&Utc))
+            .map_err(|err| {
+                js_error(format!(
+                    "`deterministicTimestampUtc` must be a valid RFC3339 timestamp: {err}"
+                ))
+            });
+    }
+
+    Err(js_error(
+        "`deterministicTimestampUtc` must be a Date or RFC3339 timestamp string",
+    ))
+}
+
+fn parse_timezone_spec(value: &JsValue) -> Result<TimeZoneSpec, JsValue> {
+    if let Some(text) = value.as_string() {
+        return match text.to_ascii_lowercase().as_str() {
+            "utc" => Ok(TimeZoneSpec::Utc),
+            "local" => Ok(TimeZoneSpec::Local),
+            _ => Err(js_error(
+                "`deterministicTimezone` must be 'utc', 'local', or an integer offset in seconds",
+            )),
+        };
+    }
+
+    if let Some(secs) = value.as_f64() {
+        if !secs.is_finite()
+            || secs.fract() != 0.0
+            || secs < i32::MIN as f64
+            || secs > i32::MAX as f64
+        {
+            return Err(js_error(
+                "`deterministicTimezone` must be 'utc', 'local', or an integer offset in seconds",
+            ));
+        }
+        return Ok(TimeZoneSpec::FixedOffsetSeconds(secs as i32));
+    }
+
+    Err(js_error(
+        "`deterministicTimezone` must be 'utc', 'local', or an integer offset in seconds",
+    ))
 }
 
 fn set(target: &js_sys::Object, key: impl AsRef<str>, value: JsValue) -> Result<(), JsValue> {

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -646,6 +646,33 @@ ports:
       type: number
 "#;
 
+const NOW_TODAY_MANIFEST: &str = r#"
+spec: fio
+spec_version: "0.3.0"
+manifest:
+  id: wasm-deterministic-sheetport-tests
+  name: WASM Deterministic SheetPort Tests
+  workbook:
+    uri: memory://wasm-deterministic-sheetport.xlsx
+    locale: en-US
+    date_system: 1900
+ports:
+  - id: now_value
+    dir: out
+    shape: scalar
+    location:
+      a1: Outputs!A1
+    schema:
+      type: number
+  - id: today_value
+    dir: out
+    shape: scalar
+    location:
+      a1: Outputs!A2
+    schema:
+      type: number
+"#;
+
 fn build_sheetport_workbook() -> Workbook {
     let wb = Workbook::new();
     wb.add_sheet("Inputs".to_string()).unwrap();
@@ -658,6 +685,16 @@ fn build_sheetport_workbook() -> Workbook {
     wb.set_value("Inputs".to_string(), 1, 3, JsValue::from_str("seed"))
         .unwrap();
     wb.set_value("Outputs".to_string(), 1, 1, JsValue::from_f64(42.0))
+        .unwrap();
+    wb
+}
+
+fn build_now_today_workbook() -> Workbook {
+    let wb = Workbook::new();
+    wb.add_sheet("Outputs".to_string()).unwrap();
+    wb.set_formula("Outputs".to_string(), 1, 1, "NOW()".to_string())
+        .unwrap();
+    wb.set_formula("Outputs".to_string(), 2, 1, "TODAY()".to_string())
         .unwrap();
     wb
 }
@@ -788,4 +825,151 @@ fn test_sheetport_session_constraint_error() {
         .dyn_into::<js_sys::Array>()
         .unwrap();
     assert!(violations.length() > 0);
+}
+
+#[wasm_bindgen_test]
+fn test_sheetport_session_supports_deterministic_timestamp_and_timezone() {
+    let wb = build_now_today_workbook();
+    let mut session =
+        SheetPortSession::from_manifest_yaml(NOW_TODAY_MANIFEST.to_string(), &wb).unwrap();
+
+    let first_options = Object::new();
+    set_prop(
+        &first_options,
+        "deterministicTimestampUtc",
+        js_sys::Date::new(&JsValue::from_str("2025-01-15T10:00:00Z")).into(),
+    );
+    set_prop(
+        &first_options,
+        "deterministicTimezone",
+        JsValue::from_str("utc"),
+    );
+    let first: Object = session
+        .evaluate_once(first_options.into())
+        .unwrap()
+        .dyn_into()
+        .unwrap();
+
+    let second_options = Object::new();
+    set_prop(
+        &second_options,
+        "deterministicTimestampUtc",
+        JsValue::from_str("2025-01-15T10:00:00Z"),
+    );
+    set_prop(
+        &second_options,
+        "deterministicTimezone",
+        JsValue::from_f64(0.0),
+    );
+    let second: Object = session
+        .evaluate_once(second_options.into())
+        .unwrap()
+        .dyn_into()
+        .unwrap();
+
+    assert_eq!(
+        js_get_f64(&first, "now_value"),
+        js_get_f64(&second, "now_value")
+    );
+    assert_eq!(
+        js_get_f64(&first, "today_value"),
+        js_get_f64(&second, "today_value")
+    );
+
+    let different_options = Object::new();
+    set_prop(
+        &different_options,
+        "deterministicTimestampUtc",
+        JsValue::from_str("2025-01-16T10:00:00Z"),
+    );
+    set_prop(
+        &different_options,
+        "deterministicTimezone",
+        JsValue::from_str("utc"),
+    );
+    let different: Object = session
+        .evaluate_once(different_options.into())
+        .unwrap()
+        .dyn_into()
+        .unwrap();
+
+    assert_ne!(
+        js_get_f64(&first, "now_value"),
+        js_get_f64(&different, "now_value")
+    );
+    assert_ne!(
+        js_get_f64(&first, "today_value"),
+        js_get_f64(&different, "today_value")
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_sheetport_session_rejects_timezone_without_timestamp() {
+    let wb = build_now_today_workbook();
+    let mut session =
+        SheetPortSession::from_manifest_yaml(NOW_TODAY_MANIFEST.to_string(), &wb).unwrap();
+
+    let options = Object::new();
+    set_prop(&options, "deterministicTimezone", JsValue::from_str("utc"));
+    let err = session.evaluate_once(options.into()).unwrap_err();
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    assert!(
+        error
+            .message()
+            .as_string()
+            .unwrap()
+            .contains("requires deterministicTimestampUtc")
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_sheetport_session_rejects_non_integer_rng_seed() {
+    let wb = build_sheetport_workbook();
+    let mut session =
+        SheetPortSession::from_manifest_yaml(SHEETPORT_MANIFEST.to_string(), &wb).unwrap();
+
+    let options = Object::new();
+    set_prop(&options, "rngSeed", JsValue::from_f64(1.5));
+    let err = session.evaluate_once(options.into()).unwrap_err();
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    assert!(
+        error
+            .message()
+            .as_string()
+            .unwrap()
+            .contains("non-negative safe integer")
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_sheetport_session_surfaces_local_timezone_determinism_error() {
+    let wb = build_now_today_workbook();
+    let mut session =
+        SheetPortSession::from_manifest_yaml(NOW_TODAY_MANIFEST.to_string(), &wb).unwrap();
+
+    let options = Object::new();
+    set_prop(
+        &options,
+        "deterministicTimestampUtc",
+        JsValue::from_str("2025-01-15T10:00:00Z"),
+    );
+    set_prop(
+        &options,
+        "deterministicTimezone",
+        JsValue::from_str("local"),
+    );
+    let err = session.evaluate_once(options.into()).unwrap_err();
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    let kind = js_sys::Reflect::get(error.as_ref(), &JsValue::from_str("kind"))
+        .unwrap()
+        .as_string()
+        .unwrap();
+    assert_eq!(kind, "Engine");
+    assert!(
+        error
+            .message()
+            .as_string()
+            .unwrap()
+            .contains("Deterministic mode forbids `Local` timezone")
+    );
 }


### PR DESCRIPTION
## What
- wire `deterministicTimestampUtc` / `deterministicTimezone` into the wasm SheetPort eval options
- reject timezone-only requests and lossy non-integer `rngSeed` values
- add wasm regression coverage and document/type the new options

## Testing
- cargo fmt --all
- cargo test -p formualizer-wasm --target wasm32-unknown-unknown --no-run
- wasm-pack test --node bindings/wasm
- wasm-pack build --target bundler --out-dir pkg && tsc -p tsconfig.json