### PR TITLE
fix(workbook): harden staged formula lifecycle

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1257,6 +1257,7 @@ where
         let name = self.graph.sheet_name(sheet_id).to_string();
         self.graph.remove_sheet(sheet_id)?;
         self.arrow_sheets.sheets.retain(|s| s.name.as_ref() != name);
+        self.staged_formulas.remove(&name);
         if self.row_visibility.remove(&sheet_id).is_some() {
             self.invalidate_row_visibility_mask_cache();
         }
@@ -1287,6 +1288,7 @@ where
         // Graph Update (Metadata + Rescue Logic)
         match self.graph.rename_sheet(sheet_id, new_name) {
             Ok(_) => {
+                self.rename_staged_formula_sheet(&old_name, new_name);
                 // Success! Invalidate cache for the moved sheet
                 let sheet_vertices: Vec<VertexId> =
                     self.graph.vertices_in_sheet(sheet_id).collect();
@@ -1786,6 +1788,7 @@ where
         let batch = undo.undo(&mut self.graph, log)?;
         for item in batch.iter().rev() {
             self.apply_inverse_row_visibility_event(&item.event);
+            self.apply_inverse_staged_formula_event(&item.event);
         }
         self.mirror_undo_batch_to_arrow(&batch);
         Ok(())
@@ -1799,6 +1802,7 @@ where
         let batch = undo.redo(&mut self.graph, log)?;
         for item in &batch {
             self.apply_forward_row_visibility_event(&item.event);
+            self.apply_forward_staged_formula_event(&item.event);
         }
         self.mirror_redo_batch_to_arrow(&batch);
         Ok(())
@@ -2026,18 +2030,78 @@ where
         &mut self.arrow_sheets
     }
 
+    pub fn staged_formula_state_snapshot(&self) -> Vec<(String, u32, u32, String)> {
+        let mut snapshot = Vec::new();
+        for (sheet, entries) in &self.staged_formulas {
+            for (row, col, text) in entries {
+                snapshot.push((sheet.clone(), *row, *col, text.clone()));
+            }
+        }
+        snapshot.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then(a.1.cmp(&b.1))
+                .then(a.2.cmp(&b.2))
+                .then(a.3.cmp(&b.3))
+        });
+        snapshot
+    }
+
+    pub fn restore_staged_formula_state(&mut self, snapshot: &[(String, u32, u32, String)]) {
+        self.staged_formulas.clear();
+        for (sheet, row, col, text) in snapshot {
+            self.stage_formula_text(sheet, *row, *col, text.clone());
+        }
+    }
+
     /// Stage a formula text instead of inserting into the graph (used when deferring is enabled).
     pub fn stage_formula_text(&mut self, sheet: &str, row: u32, col: u32, text: String) {
-        self.staged_formulas
-            .entry(sheet.to_string())
-            .or_default()
-            .push((row, col, text));
+        let entries = self.staged_formulas.entry(sheet.to_string()).or_default();
+        if let Some((_, _, existing)) = entries
+            .iter_mut()
+            .find(|(existing_row, existing_col, _)| *existing_row == row && *existing_col == col)
+        {
+            *existing = text;
+        } else {
+            entries.push((row, col, text));
+        }
+    }
+
+    pub fn clear_staged_formula_text(&mut self, sheet: &str, row: u32, col: u32) -> Option<String> {
+        let mut removed = None;
+        let mut remove_sheet = false;
+        if let Some(entries) = self.staged_formulas.get_mut(sheet) {
+            if let Some(idx) = entries.iter().position(|(existing_row, existing_col, _)| {
+                *existing_row == row && *existing_col == col
+            }) {
+                let (_, _, text) = entries.remove(idx);
+                removed = Some(text);
+            }
+            remove_sheet = entries.is_empty();
+        }
+        if remove_sheet {
+            self.staged_formulas.remove(sheet);
+        }
+        removed
+    }
+
+    pub fn clear_staged_formulas_for_sheet(&mut self, sheet: &str) {
+        self.staged_formulas.remove(sheet);
+    }
+
+    pub fn rename_staged_formula_sheet(&mut self, old: &str, new: &str) {
+        let Some(entries) = self.staged_formulas.remove(old) else {
+            return;
+        };
+        for (row, col, text) in entries {
+            self.stage_formula_text(new, row, col, text);
+        }
     }
 
     /// Get a staged formula text for a given cell if present (cloned).
     pub fn get_staged_formula_text(&self, sheet: &str, row: u32, col: u32) -> Option<String> {
         self.staged_formulas.get(sheet).and_then(|v| {
             v.iter()
+                .rev()
                 .find(|(r, c, _)| *r == row && *c == col)
                 .map(|(_, _, s)| s.clone())
         })
@@ -2407,6 +2471,18 @@ where
     fn apply_forward_row_visibility_events(&mut self, events: &[crate::engine::ChangeEvent]) {
         for event in events {
             self.apply_forward_row_visibility_event(event);
+        }
+    }
+
+    fn apply_inverse_staged_formula_event(&mut self, event: &crate::engine::ChangeEvent) {
+        if let crate::engine::ChangeEvent::StagedFormulaStateChanged { before, .. } = event {
+            self.restore_staged_formula_state(before);
+        }
+    }
+
+    fn apply_forward_staged_formula_event(&mut self, event: &crate::engine::ChangeEvent) {
+        if let crate::engine::ChangeEvent::StagedFormulaStateChanged { after, .. } = event {
+            self.restore_staged_formula_state(after);
         }
     }
 

--- a/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
@@ -145,6 +145,11 @@ pub enum ChangeEvent {
         anchor: VertexId,
         old: SpillSnapshot,
     },
+    /// Workbook-level staged formula snapshot used to keep deferred edits undoable.
+    StagedFormulaStateChanged {
+        before: Vec<(String, u32, u32, String)>,
+        after: Vec<(String, u32, u32, String)>,
+    },
 }
 
 /// Audit trail for tracking all changes to the dependency graph

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -528,6 +528,9 @@ impl<'g> VertexEditor<'g> {
                     )
                     .map_err(EditorError::Excel)?;
             }
+            ChangeEvent::StagedFormulaStateChanged { .. } => {
+                // Workbook-level deferred state is replayed by Engine undo/redo wrappers.
+            }
             // Granular events for compound operations
             ChangeEvent::CompoundStart { .. } | ChangeEvent::CompoundEnd { .. } => {
                 // These are markers, no inverse needed

--- a/crates/formualizer-eval/src/engine/journal.rs
+++ b/crates/formualizer-eval/src/engine/journal.rs
@@ -289,7 +289,9 @@ fn apply_forward_change_event(
             let mut editor = VertexEditor::new(graph);
             let _ = editor.remove_edge(*from, *to);
         }
-        ChangeEvent::CompoundStart { .. } | ChangeEvent::CompoundEnd { .. } => {}
+        ChangeEvent::CompoundStart { .. }
+        | ChangeEvent::CompoundEnd { .. }
+        | ChangeEvent::StagedFormulaStateChanged { .. } => {}
     }
     Ok(())
 }

--- a/crates/formualizer-eval/src/engine/tests/changelog_replay.rs
+++ b/crates/formualizer-eval/src/engine/tests/changelog_replay.rs
@@ -166,8 +166,11 @@ fn replay_events(graph: &mut DependencyGraph, events: &[ChangeEvent]) {
                 graph.clear_spill_region(anchor);
             }
 
-            // Not currently emitted by public editor mutations.
-            ChangeEvent::EdgeAdded { .. } | ChangeEvent::EdgeRemoved { .. } => {}
+            // Replay intentionally ignores editor-side bookkeeping that does not directly
+            // mutate the graph snapshot under test.
+            ChangeEvent::EdgeAdded { .. }
+            | ChangeEvent::EdgeRemoved { .. }
+            | ChangeEvent::StagedFormulaStateChanged { .. } => {}
         }
     }
 }

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -862,6 +862,8 @@ pub struct Workbook {
     undo: formualizer_eval::engine::graph::editor::undo_engine::UndoEngine,
 }
 
+type StagedFormulaState = Vec<(String, u32, u32, String)>;
+
 trait WorkbookActionOps {
     fn set_value(
         &mut self,
@@ -1434,6 +1436,27 @@ impl Workbook {
     pub fn set_reason(&mut self, reason: Option<String>) {
         self.log.set_reason(reason);
     }
+
+    fn staged_formula_state_snapshot(&self) -> StagedFormulaState {
+        self.engine.staged_formula_state_snapshot()
+    }
+
+    fn record_staged_formula_state_change(&mut self, before: StagedFormulaState) {
+        if !self.enable_changelog {
+            return;
+        }
+        let after = self.staged_formula_state_snapshot();
+        if before == after {
+            return;
+        }
+        self.log.record(
+            formualizer_eval::engine::graph::editor::change_log::ChangeEvent::StagedFormulaStateChanged {
+                before,
+                after,
+            },
+        );
+    }
+
     pub fn begin_action(&mut self, description: impl Into<String>) {
         if self.enable_changelog {
             self.log.begin_compound(description.into());
@@ -1892,6 +1915,7 @@ impl Workbook {
         if let Some(id) = self.engine.sheet_id(name) {
             self.engine.remove_sheet(id)?;
         }
+        self.engine.clear_staged_formulas_for_sheet(name);
         // Remove from Arrow store as well
         self.engine
             .sheet_store_mut()
@@ -1903,6 +1927,7 @@ impl Workbook {
         if let Some(id) = self.engine.sheet_id(old) {
             self.engine.rename_sheet(id, new)?;
         }
+        self.engine.rename_staged_formula_sheet(old, new);
         if let Some(asheet) = self.engine.sheet_store_mut().sheet_mut(old) {
             asheet.name = std::sync::Arc::<str>::from(new);
         }
@@ -1918,6 +1943,9 @@ impl Workbook {
         value: LiteralValue,
     ) -> Result<(), IoError> {
         self.ensure_arrow_sheet_capacity(sheet, row as usize, col as usize);
+        let staged_before = self
+            .enable_changelog
+            .then(|| self.staged_formula_state_snapshot());
         if self.enable_changelog {
             // Use VertexEditor with logging for graph, then mirror overlay and mark edited
             let sheet_id = self
@@ -1944,12 +1972,18 @@ impl Workbook {
             self.log
                 .patch_last_cell_event_old_state(cell, old_value, old_formula);
             self.mirror_value_to_overlay(sheet, row, col, &value);
+            self.engine.clear_staged_formula_text(sheet, row, col);
+            if let Some(before) = staged_before {
+                self.record_staged_formula_state_change(before);
+            }
             self.engine.mark_data_edited();
             Ok(())
         } else {
             self.engine
                 .set_cell_value(sheet, row, col, value)
-                .map_err(IoError::Engine)
+                .map_err(IoError::Engine)?;
+            self.engine.clear_staged_formula_text(sheet, row, col);
+            Ok(())
         }
     }
 
@@ -1961,6 +1995,9 @@ impl Workbook {
         formula: &str,
     ) -> Result<(), IoError> {
         self.ensure_arrow_sheet_capacity(sheet, row as usize, col as usize);
+        let staged_before = self
+            .enable_changelog
+            .then(|| self.staged_formula_state_snapshot());
         if self.engine.config.defer_graph_building {
             if self.engine.get_cell(sheet, row, col).is_some() {
                 let with_eq = if formula.starts_with('=') {
@@ -1989,16 +2026,25 @@ impl Workbook {
 
                     self.log
                         .patch_last_cell_event_old_state(cell, old_value, old_formula);
+                    self.engine.clear_staged_formula_text(sheet, row, col);
+                    if let Some(before) = staged_before {
+                        self.record_staged_formula_state_change(before);
+                    }
                     self.engine.mark_data_edited();
                     Ok(())
                 } else {
                     self.engine
                         .set_cell_formula(sheet, row, col, ast)
-                        .map_err(IoError::Engine)
+                        .map_err(IoError::Engine)?;
+                    self.engine.clear_staged_formula_text(sheet, row, col);
+                    Ok(())
                 }
             } else {
                 self.engine
                     .stage_formula_text(sheet, row, col, formula.to_string());
+                if let Some(before) = staged_before {
+                    self.record_staged_formula_state_change(before);
+                }
                 Ok(())
             }
         } else {
@@ -2021,12 +2067,18 @@ impl Workbook {
                 self.engine.edit_with_logger(&mut self.log, |editor| {
                     editor.set_cell_formula(cell, ast);
                 });
+                self.engine.clear_staged_formula_text(sheet, row, col);
+                if let Some(before) = staged_before {
+                    self.record_staged_formula_state_change(before);
+                }
                 self.engine.mark_data_edited();
                 Ok(())
             } else {
                 self.engine
                     .set_cell_formula(sheet, row, col, ast)
-                    .map_err(IoError::Engine)
+                    .map_err(IoError::Engine)?;
+                self.engine.clear_staged_formula_text(sheet, row, col);
+                Ok(())
             }
         }
     }
@@ -2115,6 +2167,9 @@ impl Workbook {
         _start: (u32, u32),
         cells: BTreeMap<(u32, u32), crate::traits::CellData>,
     ) -> Result<(), IoError> {
+        let staged_before = self
+            .enable_changelog
+            .then(|| self.staged_formula_state_snapshot());
         if self.enable_changelog {
             let sheet_id = self
                 .engine
@@ -2188,8 +2243,19 @@ impl Workbook {
             for (r, c, v) in overlay_ops {
                 self.mirror_value_to_overlay(sheet, r, c, &v);
             }
+            for (r, c, d, _cell, _old_value, _old_formula) in &items {
+                if d.formula.is_none() && d.value.is_some() {
+                    self.engine.clear_staged_formula_text(sheet, *r, *c);
+                }
+                if d.formula.is_some() && !defer_graph_building {
+                    self.engine.clear_staged_formula_text(sheet, *r, *c);
+                }
+            }
             for (r, c, f) in staged_forms {
                 self.engine.stage_formula_text(sheet, r, c, f);
+            }
+            if let Some(before) = staged_before {
+                self.record_staged_formula_state_change(before);
             }
             self.engine.mark_data_edited();
             Ok(())
@@ -2214,7 +2280,10 @@ impl Workbook {
                         self.engine
                             .set_cell_formula(sheet, r, c, ast)
                             .map_err(IoError::Engine)?;
+                        self.engine.clear_staged_formula_text(sheet, r, c);
                     }
+                } else if d.value.is_some() {
+                    self.engine.clear_staged_formula_text(sheet, r, c);
                 }
             }
             Ok(())
@@ -2229,6 +2298,9 @@ impl Workbook {
         start_col: u32,
         rows: &[Vec<LiteralValue>],
     ) -> Result<(), IoError> {
+        let staged_before = self
+            .enable_changelog
+            .then(|| self.staged_formula_state_snapshot());
         if self.enable_changelog {
             let sheet_id = self
                 .engine
@@ -2275,6 +2347,10 @@ impl Workbook {
 
             for (r, c, v, _cell, _old_value, _old_formula) in items {
                 self.mirror_value_to_overlay(sheet, r, c, &v);
+                self.engine.clear_staged_formula_text(sheet, r, c);
+            }
+            if let Some(before) = staged_before {
+                self.record_staged_formula_state_change(before);
             }
             self.engine.mark_data_edited();
             Ok(())
@@ -2286,6 +2362,7 @@ impl Workbook {
                     self.engine
                         .set_cell_value(sheet, r, c, v.clone())
                         .map_err(IoError::Engine)?;
+                    self.engine.clear_staged_formula_text(sheet, r, c);
                 }
             }
             Ok(())
@@ -2308,6 +2385,9 @@ impl Workbook {
         let end_row = start_row.saturating_add((height - 1) as u32);
         let end_col = start_col.saturating_add((width - 1) as u32);
         self.ensure_arrow_sheet_capacity(sheet, end_row as usize, end_col as usize);
+        let staged_before = self
+            .enable_changelog
+            .then(|| self.staged_formula_state_snapshot());
 
         if self.engine.config.defer_graph_building {
             for (ri, rforms) in rows.iter().enumerate() {
@@ -2316,6 +2396,9 @@ impl Workbook {
                     let c = start_col + ci as u32;
                     self.engine.stage_formula_text(sheet, r, c, f.clone());
                 }
+            }
+            if let Some(before) = staged_before {
+                self.record_staged_formula_state_change(before);
             }
             Ok(())
         } else if self.enable_changelog {
@@ -2347,6 +2430,16 @@ impl Workbook {
                     Ok(())
                 })?;
 
+            for (ri, rforms) in rows.iter().enumerate() {
+                let r = start_row + ri as u32;
+                for (ci, _f) in rforms.iter().enumerate() {
+                    let c = start_col + ci as u32;
+                    self.engine.clear_staged_formula_text(sheet, r, c);
+                }
+            }
+            if let Some(before) = staged_before {
+                self.record_staged_formula_state_change(before);
+            }
             self.engine.mark_data_edited();
             Ok(())
         } else {
@@ -2364,6 +2457,7 @@ impl Workbook {
                     self.engine
                         .set_cell_formula(sheet, r, c, ast)
                         .map_err(IoError::Engine)?;
+                    self.engine.clear_staged_formula_text(sheet, r, c);
                 }
             }
             Ok(())

--- a/crates/formualizer-workbook/tests/workbook_engine.rs
+++ b/crates/formualizer-workbook/tests/workbook_engine.rs
@@ -469,3 +469,81 @@ fn workbook_action_is_atomic_on_error() {
     assert_eq!(wb.get_value("S", 1, 2), Some(LiteralValue::Number(2.0)));
     assert_emptyish(wb.get_value("S", 10, 1));
 }
+
+#[test]
+fn staged_formula_literal_overwrite_is_last_write_wins() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    wb.set_formula("S", 1, 1, "1+1").unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("1+1".to_string()));
+
+    wb.set_value("S", 1, 1, LiteralValue::Int(9)).unwrap();
+
+    assert_eq!(wb.get_formula("S", 1, 1), None);
+    assert_numeric_eq(wb.get_value("S", 1, 1), 9.0);
+    assert_numeric_eq(Some(wb.evaluate_cell("S", 1, 1).unwrap()), 9.0);
+}
+
+#[test]
+fn delete_sheet_drops_staged_formulas_before_rebuild() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+    wb.set_formula("S", 1, 1, "1+1").unwrap();
+
+    wb.delete_sheet("S").unwrap();
+    assert!(!wb.has_sheet("S"));
+
+    wb.evaluate_all().unwrap();
+
+    assert!(!wb.has_sheet("S"));
+    assert!(!wb.sheet_names().iter().any(|name| name == "S"));
+}
+
+#[test]
+fn rename_sheet_moves_staged_formulas_to_new_name() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("Old").unwrap();
+    wb.set_value("Old", 1, 1, LiteralValue::Int(5)).unwrap();
+    wb.set_formula("Old", 1, 2, "A1*2").unwrap();
+
+    wb.rename_sheet("Old", "New").unwrap();
+
+    assert!(!wb.has_sheet("Old"));
+    assert!(wb.has_sheet("New"));
+    assert_eq!(wb.get_formula("Old", 1, 2), None);
+    assert_eq!(wb.get_formula("New", 1, 2), Some("A1*2".to_string()));
+    assert_eq!(
+        wb.evaluate_cell("New", 1, 2).unwrap(),
+        LiteralValue::Number(10.0)
+    );
+}
+
+#[test]
+fn undo_restores_staged_formula_after_literal_overwrite() {
+    let mut wb = Workbook::new();
+    wb.set_changelog_enabled(true);
+    wb.add_sheet("S").unwrap();
+
+    wb.begin_action("stage formula");
+    wb.set_formula("S", 1, 1, "1+1").unwrap();
+    wb.end_action();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("1+1".to_string()));
+
+    wb.begin_action("overwrite staged formula");
+    wb.set_value("S", 1, 1, LiteralValue::Int(9)).unwrap();
+    wb.end_action();
+    assert_eq!(wb.get_formula("S", 1, 1), None);
+    assert_numeric_eq(wb.get_value("S", 1, 1), 9.0);
+
+    wb.undo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("1+1".to_string()));
+    assert_eq!(
+        wb.evaluate_cell("S", 1, 1).unwrap(),
+        LiteralValue::Number(2.0)
+    );
+
+    wb.redo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), None);
+    assert_numeric_eq(wb.get_value("S", 1, 1), 9.0);
+}


### PR DESCRIPTION
## Summary
- make staged formulas last-write-wins by replacing existing deferred entries per cell
- clear or move staged formulas on literal overwrite, sheet delete, and sheet rename
- snapshot staged formula state into the changelog so undo/redo restores deferred edits
- handle `StagedFormulaStateChanged` events in changelog replay tests so the full test suite stays exhaustive

## Verification
- `cargo fmt --all`
- `cargo test -p formualizer-eval changelog_replay`
- `cargo test -p formualizer-workbook --test workbook_engine`
