### PR TITLE
fix(workbook): raise default load cell budget

### DIFF
--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -212,7 +212,7 @@ impl Default for WorkbookLoadLimits {
         Self {
             max_sheet_rows: 1_048_576,
             max_sheet_cols: 16_384,
-            max_sheet_logical_cells: 8_000_000,
+            max_sheet_logical_cells: 128_000_000,
             sparse_sheet_cell_threshold: 250_000,
             max_sparse_cell_ratio: 1_024,
         }


### PR DESCRIPTION
## Summary
- raise the default workbook logical-cell ingest budget from `8_000_000` to `128_000_000`
- keep the existing row, column, and sparse-sheet guardrails unchanged
- unblock large dense workbook loads while we investigate formula-heavy load hot paths separately

Refs #56.

## Verification
- `cargo fmt --all`
- `cargo test -p formualizer-workbook --features calamine,umya --test load_limits`
