### PR TITLE
feat(workbook): add cell_budget override for recalculate_file and Wor…

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -93,8 +93,13 @@ fn parse(formula: &str, dialect: Option<PyFormulaDialect>) -> PyResult<PyASTNode
 /// ```
 #[gen_stub_pyfunction(module = "formualizer")]
 #[pyfunction]
-#[pyo3(signature = (path, strategy=None))]
-fn load_workbook(py: Python, path: &str, strategy: Option<&str>) -> PyResult<workbook::PyWorkbook> {
+#[pyo3(signature = (path, strategy=None, *, config=None))]
+fn load_workbook(
+    py: Python,
+    path: &str,
+    strategy: Option<&str>,
+    config: Option<workbook::PyWorkbookConfig>,
+) -> PyResult<workbook::PyWorkbook> {
     // Backward-compat convenience
     let _ = strategy; // placeholder, backend currently fixed to calamine
     workbook::PyWorkbook::from_path(
@@ -102,7 +107,7 @@ fn load_workbook(py: Python, path: &str, strategy: Option<&str>) -> PyResult<wor
         path,
         Some("calamine"),
         None,
-        None,
+        config,
     )
 }
 
@@ -120,14 +125,26 @@ fn load_workbook(py: Python, path: &str, strategy: Option<&str>) -> PyResult<wor
 ///     `umya-spreadsheet` implementation.
 #[gen_stub_pyfunction(module = "formualizer")]
 #[pyfunction]
-#[pyo3(signature = (path, output=None))]
-fn recalculate_file(py: Python<'_>, path: &str, output: Option<&str>) -> PyResult<Py<PyAny>> {
+#[pyo3(signature = (path, output=None, *, cell_budget=None))]
+fn recalculate_file(
+    py: Python<'_>,
+    path: &str,
+    output: Option<&str>,
+    cell_budget: Option<u64>,
+) -> PyResult<Py<PyAny>> {
     let input = std::path::Path::new(path);
     let output_path = output.map(std::path::Path::new);
 
-    let summary = formualizer::workbook::recalculate_file(input, output_path).map_err(|e| {
-        PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("recalculate failed: {e}"))
-    })?;
+    let limits = cell_budget.map(|budget| {
+        let mut l = formualizer::eval::engine::WorkbookLoadLimits::default();
+        l.max_sheet_logical_cells = budget;
+        l
+    });
+
+    let summary = formualizer::workbook::recalculate_file_with_config(input, output_path, limits)
+        .map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("recalculate failed: {e}"))
+        })?;
 
     let out = pyo3::types::PyDict::new(py);
     out.set_item("status", summary.status.as_str())?;

--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -104,22 +104,25 @@ pub struct PyWorkbookConfig {
     mode: PyWorkbookMode,
     eval: Option<formualizer::eval::engine::EvalConfig>,
     enable_changelog: Option<bool>,
+    cell_budget: Option<u64>,
 }
 
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyWorkbookConfig {
     #[new]
-    #[pyo3(signature = (*, mode = PyWorkbookMode::Interactive, eval_config = None, enable_changelog = None))]
+    #[pyo3(signature = (*, mode = PyWorkbookMode::Interactive, eval_config = None, enable_changelog = None, cell_budget = None))]
     pub fn new(
         mode: PyWorkbookMode,
         eval_config: Option<PyEvaluationConfig>,
         enable_changelog: Option<bool>,
+        cell_budget: Option<u64>,
     ) -> Self {
         Self {
             mode,
             eval: eval_config.map(|c| c.inner),
             enable_changelog,
+            cell_budget,
         }
     }
 
@@ -1109,6 +1112,11 @@ fn resolve_workbook_config(
         }
         if let Some(enabled) = cfg.enable_changelog {
             base.enable_changelog = enabled;
+        }
+        if let Some(budget) = cfg.cell_budget {
+            let mut limits = base.ingest_limits.clone();
+            limits.max_sheet_logical_cells = budget;
+            base = base.with_ingest_limits(limits);
         }
         base
     } else {

--- a/bindings/python/tests/test_cell_budget.py
+++ b/bindings/python/tests/test_cell_budget.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+
+import formualizer as fz
+
+try:
+    import openpyxl  # type: ignore
+except Exception:  # pragma: no cover
+    openpyxl = None
+
+pytestmark = pytest.mark.skipif(openpyxl is None, reason="openpyxl not installed")
+
+
+def _dense_xlsx(path: Path, rows: int, cols: int) -> None:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    for r in range(1, rows + 1):
+        for c in range(1, cols + 1):
+            ws.cell(row=r, column=c, value=1)
+    wb.save(path)
+
+
+def test_recalculate_file_cell_budget_rejects_over_budget(tmp_path: Path):
+    path = tmp_path / "dense.xlsx"
+    _dense_xlsx(path, rows=11, cols=10)
+
+    with pytest.raises(IOError) as excinfo:
+        fz.recalculate_file(str(path), cell_budget=50)
+    assert "logical-cell budget" in str(excinfo.value)
+
+
+def test_recalculate_file_cell_budget_generous_succeeds(tmp_path: Path):
+    in_path = tmp_path / "in.xlsx"
+    out_path = tmp_path / "out.xlsx"
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = 2
+    ws["A2"] = 3
+    ws["B1"] = "=A1+A2"
+    wb.save(in_path)
+
+    summary = fz.recalculate_file(
+        str(in_path), output=str(out_path), cell_budget=10_000_000
+    )
+    assert summary["status"] == "success"
+    assert summary["evaluated"] == 1
+
+
+def test_workbook_config_cell_budget_rejects_on_load(tmp_path: Path):
+    path = tmp_path / "dense.xlsx"
+    _dense_xlsx(path, rows=11, cols=10)
+
+    cfg = fz.WorkbookConfig(cell_budget=50)
+    with pytest.raises(Exception) as excinfo:
+        fz.load_workbook(str(path), config=cfg)
+    assert "logical-cell budget" in str(excinfo.value)
+
+
+def test_workbook_config_cell_budget_generous_loads(tmp_path: Path):
+    path = tmp_path / "small.xlsx"
+    _dense_xlsx(path, rows=3, cols=3)
+
+    cfg = fz.WorkbookConfig(cell_budget=10_000_000)
+    wb = fz.load_workbook(str(path), config=cfg)
+    assert wb is not None

--- a/crates/formualizer-workbook/src/lib.rs
+++ b/crates/formualizer-workbook/src/lib.rs
@@ -31,7 +31,8 @@ pub use error::{IoError, with_cell_context};
 #[cfg(feature = "umya")]
 pub use recalculate::{
     DEFAULT_ERROR_LOCATION_LIMIT, RecalculateErrorSummary, RecalculateSheetSummary,
-    RecalculateStatus, RecalculateSummary, recalculate_file, recalculate_file_with_limit,
+    RecalculateStatus, RecalculateSummary, recalculate_file, recalculate_file_with_config,
+    recalculate_file_with_limit,
 };
 pub use resolver::IoResolver;
 pub use session::{EditorSession, IoConfig};

--- a/crates/formualizer-workbook/src/recalculate.rs
+++ b/crates/formualizer-workbook/src/recalculate.rs
@@ -75,7 +75,17 @@ pub fn recalculate_file(
     input: &Path,
     output: Option<&Path>,
 ) -> Result<RecalculateSummary, IoError> {
-    recalculate_file_with_limit(input, output, DEFAULT_ERROR_LOCATION_LIMIT)
+    recalculate_file_with_config(input, output, None)
+}
+
+/// Like [`recalculate_file`] but accepts optional [`WorkbookLoadLimits`] to override the default
+/// cell budget.
+pub fn recalculate_file_with_config(
+    input: &Path,
+    output: Option<&Path>,
+    limits: Option<formualizer_eval::engine::WorkbookLoadLimits>,
+) -> Result<RecalculateSummary, IoError> {
+    recalculate_file_inner(input, output, DEFAULT_ERROR_LOCATION_LIMIT, limits)
 }
 
 pub fn recalculate_file_with_limit(
@@ -83,10 +93,22 @@ pub fn recalculate_file_with_limit(
     output: Option<&Path>,
     error_location_limit: usize,
 ) -> Result<RecalculateSummary, IoError> {
+    recalculate_file_inner(input, output, error_location_limit, None)
+}
+
+fn recalculate_file_inner(
+    input: &Path,
+    output: Option<&Path>,
+    error_location_limit: usize,
+    limits: Option<formualizer_eval::engine::WorkbookLoadLimits>,
+) -> Result<RecalculateSummary, IoError> {
     let mut adapter =
         UmyaAdapter::open_path(input).map_err(|e| IoError::from_backend("umya", e))?;
 
     let mut engine: Engine<WBResolver> = Engine::new(WBResolver::default(), EvalConfig::default());
+    if let Some(limits) = limits {
+        engine.set_workbook_load_limits(limits);
+    }
     adapter.stream_into_engine(&mut engine)?;
     let (_eval_result, delta) = engine.evaluate_all_with_delta().map_err(IoError::Engine)?;
 

--- a/crates/formualizer-workbook/tests/load_limits.rs
+++ b/crates/formualizer-workbook/tests/load_limits.rs
@@ -103,6 +103,64 @@ fn umya_loader_rejects_sparse_sheet_over_guardrail() {
     );
 }
 
+#[cfg(feature = "umya")]
+fn dense_xlsx_bytes(rows: u32, cols: u32) -> Vec<u8> {
+    let mut book = umya_spreadsheet::new_file();
+    let sheet = book
+        .get_sheet_by_name_mut("Sheet1")
+        .expect("default sheet exists");
+    for row in 1..=rows {
+        for col in 1..=cols {
+            sheet.get_cell_mut((col, row)).set_value_number(1.0);
+        }
+    }
+    let mut buf = Vec::new();
+    umya_spreadsheet::writer::xlsx::write_writer(&book, &mut buf).expect("write xlsx bytes");
+    buf
+}
+
+#[cfg(feature = "umya")]
+#[test]
+fn recalculate_file_with_config_rejects_over_budget() {
+    use std::io::Write;
+
+    let bytes = dense_xlsx_bytes(11, 10);
+    let mut tmp = tempfile::NamedTempFile::new().expect("create temp xlsx");
+    tmp.write_all(&bytes).expect("persist xlsx");
+
+    let mut limits = WorkbookLoadLimits::default();
+    limits.max_sheet_logical_cells = 50;
+
+    let err = match formualizer_workbook::recalculate_file_with_config(
+        tmp.path(),
+        None,
+        Some(limits),
+    ) {
+        Ok(_) => panic!("dense workbook should hit logical-cell budget"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("logical-cell budget"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[cfg(feature = "umya")]
+#[test]
+fn recalculate_file_with_config_none_matches_default() {
+    use std::io::Write;
+
+    let bytes = dense_xlsx_bytes(3, 3);
+    let mut tmp = tempfile::NamedTempFile::new().expect("create temp xlsx");
+    tmp.write_all(&bytes).expect("persist xlsx");
+
+    let summary =
+        formualizer_workbook::recalculate_file_with_config(tmp.path(), None, None)
+            .expect("default budget should succeed");
+    assert_eq!(summary.errors, 0);
+}
+
 #[cfg(all(feature = "calamine", feature = "umya"))]
 #[test]
 fn calamine_loader_rejects_sparse_sheet_over_guardrail() {


### PR DESCRIPTION
Adds an optional cell-budget knob to bypass/tighten the default max_sheet_logical_cells guard when loading workbooks. Surfaces four entry points (Rust fn, Python  recalculate_file kwarg, Python WorkbookConfig kwarg, and load_workbook(config=)).

```
  Python — recalculate_file:                                                                                                                                                 
  import formualizer as fz                     
  fz.recalculate_file("in.xlsx", "out.xlsx", cell_budget=10_000_000)                                                                                                         
                                                                         
  Python — WorkbookConfig + load_workbook:                                                                                                                                   
  cfg = fz.WorkbookConfig(cell_budget=10_000_000)                                                                                                                            
  wb = fz.load_workbook("big.xlsx", config=cfg)                                                                                                                              
                                                                                                                                                                             
  Rust:                                                                                                                                                                      
  let mut limits = WorkbookLoadLimits::default();
  limits.max_sheet_logical_cells = 10_000_000;                                                                                                                               
  recalculate_file_with_config(input, output, Some(limits))?;                                                                                                                
                                                             
  Omitting cell_budget preserves existing default behavior.  
  ```
  
  Verification                                                                                                                                                               
                                                                         
  cargo fmt --all                                                                                                                                                            
  cargo clippy --workspace --all-targets -- -D warnings                  
  cargo test -p formualizer-workbook --features umya --test load_limits   # 5/5 pass
  ./scripts/dev-test.sh   