### PR TITLE
feat(wasm): load xlsx bytes via calamine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "zip 0.6.6",
 ]
 
 [[package]]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -22,7 +22,7 @@ js-sys = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 console_error_panic_hook = { version = "0.1", optional = true }
-formualizer = { path = "../../crates/formualizer", default-features = false, features = ["wasm-js", "json"] }
+formualizer = { path = "../../crates/formualizer", default-features = false, features = ["wasm-js"] }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 
@@ -34,12 +34,14 @@ features = [
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [features]
-default = ["console_panic", "json"]
+default = ["console_panic", "json", "calamine"]
 console_panic = ["console_error_panic_hook"]
-# Expose a local `json` feature and forward it to the workbook dependency
+# Expose local feature toggles and forward them to the workbook dependency
 json = ["formualizer/json"]
+calamine = ["formualizer/calamine"]
 
 # JS runtime (web-time + JS-backed getrandom) is activated transitively via
 # formualizer/wasm-js → formualizer-eval/js-runtime. No explicit getrandom

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -169,6 +169,7 @@ parse(formula: string, dialect?: FormulaDialect): Promise<ASTNodeData>
 | `unregisterFunction(name)` | Remove a previously registered custom function |
 | `listFunctions()` | List registered custom function metadata |
 | `static fromJson(json)` | Load workbook from JSON string |
+| `static fromXlsxBytes(bytes)` | Load workbook from XLSX bytes via the Calamine read path |
 
 ### Sheet
 

--- a/bindings/wasm/src/index.ts
+++ b/bindings/wasm/src/index.ts
@@ -310,9 +310,12 @@ export interface WorkbookApi extends wasm.Workbook {
   listFunctions(): RegisteredFunctionInfo[];
 }
 
+export type XlsxBytesSource = Uint8Array | ArrayBufferLike;
+
 export type WorkbookConstructor = {
   new (): WorkbookApi;
   fromJson(json: string): WorkbookApi;
+  fromXlsxBytes(bytes: XlsxBytesSource): WorkbookApi;
   prototype: WorkbookApi;
 };
 
@@ -325,7 +328,21 @@ export type SheetPortSessionConstructor = {
   prototype: SheetPortSessionApi;
 };
 
-export const Workbook = wasm.Workbook as unknown as WorkbookConstructor;
+const rawWorkbookCtor = wasm.Workbook as unknown as {
+  new (): WorkbookApi;
+  fromJson(json: string): WorkbookApi;
+  fromXlsxBytes(bytes: Uint8Array): WorkbookApi;
+  prototype: WorkbookApi;
+};
+const rawWorkbookFromXlsxBytes = rawWorkbookCtor.fromXlsxBytes.bind(rawWorkbookCtor);
+
+export const Workbook = Object.assign(rawWorkbookCtor, {
+  fromXlsxBytes(bytes: XlsxBytesSource): WorkbookApi {
+    return rawWorkbookFromXlsxBytes(
+      bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes),
+    );
+  },
+}) as WorkbookConstructor;
 export const SheetPortSession = wasm.SheetPortSession as unknown as SheetPortSessionConstructor;
 
 // Re-export the initialization function as default

--- a/bindings/wasm/src/workbook.rs
+++ b/bindings/wasm/src/workbook.rs
@@ -446,6 +446,35 @@ impl Workbook {
         }
     }
 
+    /// Construct from XLSX bytes via the Calamine reader path (feature: calamine)
+    #[wasm_bindgen(js_name = "fromXlsxBytes")]
+    pub fn from_xlsx_bytes(bytes: Vec<u8>) -> Result<Workbook, JsValue> {
+        #[cfg(feature = "calamine")]
+        {
+            use formualizer::workbook::backends::CalamineAdapter;
+            use formualizer::workbook::traits::SpreadsheetReader;
+            let adapter = <CalamineAdapter as SpreadsheetReader>::open_bytes(bytes)
+                .map_err(|e| js_error(format!("open failed: {e}")))?;
+            let cfg = formualizer::workbook::WorkbookConfig::interactive();
+            let wb = formualizer::workbook::Workbook::from_reader(
+                adapter,
+                formualizer::workbook::LoadStrategy::EagerAll,
+                cfg,
+            )
+            .map_err(|e| js_error(format!("load failed: {e}")))?;
+            Ok(Workbook {
+                inner: Arc::new(RwLock::new(wb)),
+                cancel_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                callback_ids: Arc::new(RwLock::new(BTreeMap::new())),
+            })
+        }
+        #[cfg(not(feature = "calamine"))]
+        {
+            let _ = bytes;
+            Err(js_error("calamine feature not enabled"))
+        }
+    }
+
     #[wasm_bindgen(js_name = "addSheet")]
     pub fn add_sheet(&self, name: String) -> Result<(), JsValue> {
         self.inner

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -4,8 +4,11 @@ use formualizer_wasm::{
     FormulaDialect, Parser, Reference, SheetPortSession, Tokenizer, Workbook, parse, tokenize,
 };
 use js_sys::{Function, Object, Reflect};
+use std::io::{Cursor, Write};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::*;
+use zip::write::FileOptions;
+use zip::{CompressionMethod, ZipWriter};
 
 fn js_get(obj: &js_sys::Object, key: &str) -> JsValue {
     js_sys::Reflect::get(obj, &JsValue::from_str(key)).unwrap()
@@ -25,6 +28,71 @@ fn js_get_bool(obj: &js_sys::Object, key: &str) -> bool {
 
 fn set_prop(obj: &Object, key: &str, value: JsValue) {
     Reflect::set(obj, &JsValue::from_str(key), &value).unwrap();
+}
+
+fn build_fixture_xlsx_bytes() -> Vec<u8> {
+    let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    for (path, contents) in [
+        (
+            "[Content_Types].xml",
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+"#,
+        ),
+        (
+            "_rels/.rels",
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+"#,
+        ),
+        (
+            "xl/workbook.xml",
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+"#,
+        ),
+        (
+            "xl/_rels/workbook.xml.rels",
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+"#,
+        ),
+        (
+            "xl/worksheets/sheet1.xml",
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="A1:C1"/>
+  <sheetData>
+    <row r="1">
+      <c r="A1"><v>1</v></c>
+      <c r="B1"><v>2</v></c>
+      <c r="C1"><f>A1+B1</f><v>3</v></c>
+    </row>
+  </sheetData>
+</worksheet>
+"#,
+        ),
+    ] {
+        zip.start_file(path, options).unwrap();
+        zip.write_all(contents.as_bytes()).unwrap();
+    }
+
+    zip.finish().unwrap().into_inner()
 }
 
 fn make_custom_fn_options(
@@ -372,6 +440,25 @@ fn test_workbook_sheet_eval() {
 
     let v2 = sheet.evaluate_cell(1, 2).unwrap();
     assert_eq!(v2.as_f64().unwrap(), 30.0);
+}
+
+#[wasm_bindgen_test]
+fn test_workbook_from_xlsx_bytes_evaluates_formula() {
+    let bytes = build_fixture_xlsx_bytes();
+    let wb = Workbook::from_xlsx_bytes(bytes).unwrap();
+
+    let sheet_names = wb.sheet_names();
+    assert_eq!(sheet_names.length(), 1);
+    assert_eq!(sheet_names.get(0).as_string().unwrap(), "Sheet1");
+
+    let value = wb.evaluate_cell("Sheet1".to_string(), 1, 3).unwrap();
+    assert_eq!(value.as_f64().unwrap(), 3.0);
+
+    let sheet = wb.sheet("Sheet1".to_string()).unwrap();
+    let formula = sheet
+        .get_formula(1, 3)
+        .expect("formula preserved from XLSX");
+    assert_eq!(formula.replace(' ', ""), "=A1+B1");
 }
 
 #[wasm_bindgen_test]

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -7,10 +7,10 @@ use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufRead, BufReader, Cursor, Read, Seek};
 use std::path::Path;
 
-use calamine::{Data, Range, Reader, Xlsx, open_workbook};
+use calamine::{Data, Range, Reader, Xlsx, open_workbook, open_workbook_from_rs};
 use formualizer_common::RangeAddress;
 use formualizer_eval::arrow_store::{CellIngest, IngestBuilder, map_error_code};
 use formualizer_eval::engine::Engine as EvalEngine;
@@ -24,8 +24,54 @@ use zip::ZipArchive;
 
 type FormulaBatch = (String, Vec<(u32, u32, formualizer_parse::ASTNode)>);
 
+enum CalamineWorkbook {
+    File(Xlsx<BufReader<File>>),
+    Bytes(Xlsx<Cursor<Vec<u8>>>),
+}
+
+impl CalamineWorkbook {
+    fn worksheet_range(&mut self, sheet: &str) -> Result<Range<Data>, calamine::Error> {
+        match self {
+            Self::File(workbook) => workbook.worksheet_range(sheet).map_err(Into::into),
+            Self::Bytes(workbook) => workbook.worksheet_range(sheet).map_err(Into::into),
+        }
+    }
+
+    fn worksheet_formula(&mut self, sheet: &str) -> Result<Range<String>, calamine::Error> {
+        match self {
+            Self::File(workbook) => workbook.worksheet_formula(sheet).map_err(Into::into),
+            Self::Bytes(workbook) => workbook.worksheet_formula(sheet).map_err(Into::into),
+        }
+    }
+}
+
+struct DebugTimer {
+    #[cfg(not(target_arch = "wasm32"))]
+    started: std::time::Instant,
+}
+
+impl DebugTimer {
+    fn start() -> Self {
+        Self {
+            #[cfg(not(target_arch = "wasm32"))]
+            started: std::time::Instant::now(),
+        }
+    }
+
+    fn elapsed_millis(&self) -> u128 {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.started.elapsed().as_millis()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            0
+        }
+    }
+}
+
 pub struct CalamineAdapter {
-    workbook: RwLock<Xlsx<BufReader<File>>>,
+    workbook: RwLock<CalamineWorkbook>,
     loaded_sheets: HashSet<String>,
     cached_names: Option<Vec<String>>,
     defined_names: Vec<DefinedName>,
@@ -185,10 +231,13 @@ impl CalamineAdapter {
         Ok(())
     }
 
-    fn fallback_defined_names_from_workbook(
-        workbook: &Xlsx<BufReader<File>>,
+    fn fallback_defined_names_from_workbook<R>(
+        workbook: &Xlsx<R>,
         sheet_names: &[String],
-    ) -> Vec<DefinedName> {
+    ) -> Vec<DefinedName>
+    where
+        R: Read + Seek,
+    {
         let mut out = Vec::new();
         let mut seen: HashSet<(DefinedNameScope, Option<String>, String)> = HashSet::new();
 
@@ -208,12 +257,10 @@ impl CalamineAdapter {
         out
     }
 
-    fn scan_defined_names(path: &Path, sheet_names: &[String]) -> Vec<DefinedName> {
-        let file = match File::open(path) {
-            Ok(f) => f,
-            Err(_) => return Vec::new(),
-        };
-        let reader = BufReader::new(file);
+    fn scan_defined_names_from_reader<R>(reader: R, sheet_names: &[String]) -> Vec<DefinedName>
+    where
+        R: Read + Seek,
+    {
         let mut archive = match ZipArchive::new(reader) {
             Ok(a) => a,
             Err(_) => return Vec::new(),
@@ -295,12 +342,10 @@ impl CalamineAdapter {
         out
     }
 
-    fn scan_external_link_targets(path: &Path) -> BTreeMap<u32, String> {
-        let file = match File::open(path) {
-            Ok(f) => f,
-            Err(_) => return BTreeMap::new(),
-        };
-        let reader = BufReader::new(file);
+    fn scan_external_link_targets_from_reader<R>(reader: R) -> BTreeMap<u32, String>
+    where
+        R: Read + Seek,
+    {
         let mut archive = match ZipArchive::new(reader) {
             Ok(a) => a,
             Err(_) => return BTreeMap::new(),
@@ -460,7 +505,7 @@ impl SpreadsheetReader for CalamineAdapter {
             lazy_loading: false,
             random_access: false,
             styles: false,
-            bytes_input: false,
+            bytes_input: true,
             // conservative defaults
             date_system_1904: false,
             merged_cells: false,
@@ -473,11 +518,7 @@ impl SpreadsheetReader for CalamineAdapter {
     }
 
     fn sheet_names(&self) -> Result<Vec<String>, Self::Error> {
-        if let Some(names) = &self.cached_names {
-            return Ok(names.clone());
-        }
-        let names = self.workbook.read().sheet_names().to_vec();
-        Ok(names)
+        Ok(self.cached_names.clone().unwrap_or_default())
     }
 
     fn defined_names(&mut self) -> Result<Vec<DefinedName>, Self::Error> {
@@ -489,13 +530,21 @@ impl SpreadsheetReader for CalamineAdapter {
         Self: Sized,
     {
         let path = path.as_ref();
-        let external_link_targets = Self::scan_external_link_targets(path);
+        let external_link_targets = match File::open(path) {
+            Ok(file) => Self::scan_external_link_targets_from_reader(BufReader::new(file)),
+            Err(_) => BTreeMap::new(),
+        };
         let workbook: Xlsx<BufReader<File>> = open_workbook(path)?;
         let sheet_names = workbook.sheet_names().to_vec();
         let defined_names = if workbook.defined_names().is_empty() {
             Vec::new()
         } else {
-            let parsed = Self::scan_defined_names(path, &sheet_names);
+            let parsed = match File::open(path) {
+                Ok(file) => {
+                    Self::scan_defined_names_from_reader(BufReader::new(file), &sheet_names)
+                }
+                Err(_) => Vec::new(),
+            };
             if parsed.is_empty() {
                 Self::fallback_defined_names_from_workbook(&workbook, &sheet_names)
             } else {
@@ -503,7 +552,7 @@ impl SpreadsheetReader for CalamineAdapter {
             }
         };
         Ok(Self {
-            workbook: RwLock::new(workbook),
+            workbook: RwLock::new(CalamineWorkbook::File(workbook)),
             loaded_sheets: HashSet::new(),
             cached_names: Some(sheet_names),
             defined_names,
@@ -511,25 +560,42 @@ impl SpreadsheetReader for CalamineAdapter {
         })
     }
 
-    fn open_reader(_reader: Box<dyn Read + Send + Sync>) -> Result<Self, Self::Error>
+    fn open_reader(mut reader: Box<dyn Read + Send + Sync>) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {
-        // calamine expects concrete Read + Seek; not easily supported via trait object
-        Err(calamine::Error::Io(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "open_reader not supported for CalamineAdapter",
-        )))
+        let mut data = Vec::new();
+        reader.read_to_end(&mut data).map_err(calamine::Error::Io)?;
+        Self::open_bytes(data)
     }
 
-    fn open_bytes(_data: Vec<u8>) -> Result<Self, Self::Error>
+    fn open_bytes(data: Vec<u8>) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {
-        Err(calamine::Error::Io(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "open_bytes not supported for CalamineAdapter",
-        )))
+        let external_link_targets =
+            Self::scan_external_link_targets_from_reader(Cursor::new(data.as_slice()));
+        let workbook: Xlsx<Cursor<Vec<u8>>> = open_workbook_from_rs(Cursor::new(data.clone()))?;
+        let sheet_names = workbook.sheet_names().to_vec();
+        let defined_names = if workbook.defined_names().is_empty() {
+            Vec::new()
+        } else {
+            let parsed =
+                Self::scan_defined_names_from_reader(Cursor::new(data.as_slice()), &sheet_names);
+            if parsed.is_empty() {
+                Self::fallback_defined_names_from_workbook(&workbook, &sheet_names)
+            } else {
+                parsed
+            }
+        };
+
+        Ok(Self {
+            workbook: RwLock::new(CalamineWorkbook::Bytes(workbook)),
+            loaded_sheets: HashSet::new(),
+            cached_names: Some(sheet_names),
+            defined_names,
+            external_link_targets,
+        })
     }
 
     fn read_range(
@@ -603,7 +669,7 @@ where
         let debug = std::env::var("FZ_DEBUG_LOAD")
             .ok()
             .is_some_and(|v| v != "0");
-        let t0 = std::time::Instant::now();
+        let t0 = DebugTimer::start();
         let names = self.sheet_names()?;
         if debug {
             eprintln!("[fz][load] calamine: {} sheets", names.len());
@@ -633,7 +699,7 @@ where
         // Default Arrow chunk rows
         let chunk_rows: usize = 32 * 1024;
         for n in &names {
-            let t_sheet = std::time::Instant::now();
+            let t_sheet = DebugTimer::start();
             if debug {
                 eprintln!("[fz][load] >> sheet '{n}'");
             }
@@ -816,7 +882,7 @@ where
             }
 
             // Values: iterate rows and append to Arrow builder with absolute row/col alignment
-            let tv0 = std::time::Instant::now();
+            let tv0 = DebugTimer::start();
             let mut row_count = 0usize;
             // Prepend top padding rows (absolute alignment)
             for _ in 0..sr0 {
@@ -861,12 +927,12 @@ where
                 eprintln!(
                     "[fz][load]    rows={} → arrow in {} ms",
                     row_count,
-                    tv0.elapsed().as_millis()
+                    tv0.elapsed_millis()
                 );
             }
 
             // Formulas: iterate formulas_range and either stage or parse with caching
-            let tf0 = std::time::Instant::now();
+            let tf0 = DebugTimer::start();
             let mut parsed_n = 0usize;
             if let Some(frm_range) = &formulas_range {
                 let start_row = frm_range.start().unwrap_or_default().0 as usize;
@@ -945,12 +1011,12 @@ where
                 eprintln!(
                     "[fz][load]    formulas={} in {} ms",
                     parsed_n,
-                    tf0.elapsed().as_millis()
+                    tf0.elapsed_millis()
                 );
                 eprintln!(
                     "[fz][load] << sheet '{}' staged in {} ms",
                     n,
-                    t_sheet.elapsed().as_millis()
+                    t_sheet.elapsed_millis()
                 );
             }
             // Mark as loaded for API parity
@@ -1061,23 +1127,23 @@ where
             }
         }
 
-        let tend0 = std::time::Instant::now();
+        let tend0 = DebugTimer::start();
         // Finish builder and finalize ingestion
-        let tcommit0 = std::time::Instant::now();
+        let tcommit0 = DebugTimer::start();
         // (graph ingest finished per-sheet above)
         // Finish Arrow ingest after formulas are staged (stores ArrowSheets into engine)
         // (Arrow sheets are installed per-sheet above)
         if debug {
             eprintln!(
                 "[fz][load] commit: builder finish in {} ms",
-                tcommit0.elapsed().as_millis()
+                tcommit0.elapsed_millis()
             );
             eprintln!(
                 "[fz][load] done: values={}, formulas={}, batch_close={} ms, total={} ms",
                 total_values,
                 total_formulas,
-                tend0.elapsed().as_millis(),
-                t0.elapsed().as_millis(),
+                tend0.elapsed_millis(),
+                t0.elapsed_millis(),
             );
         }
         // Build sheet indexes after load to accelerate used-region queries
@@ -1094,8 +1160,8 @@ where
                 "[fz][load] done: values={}, formulas={}, batch_close={} ms, total={} ms",
                 total_values,
                 total_formulas,
-                tend0.elapsed().as_millis(),
-                t0.elapsed().as_millis(),
+                tend0.elapsed_millis(),
+                t0.elapsed_millis(),
             );
         }
         Ok(())

--- a/crates/formualizer-workbook/tests/calamine/deltas.rs
+++ b/crates/formualizer-workbook/tests/calamine/deltas.rs
@@ -49,26 +49,51 @@ fn calamine_read_range_filters() {
     assert!(!subset.contains_key(&(1, 1)));
 }
 
-// 3. Unsupported constructors produce errors
+// 3. Byte-backed constructors load the same workbook content as the path flow
 #[test]
-fn calamine_open_bytes_unsupported() {
-    match CalamineAdapter::open_bytes(vec![]) {
-        Ok(_) => panic!("open_bytes unexpectedly succeeded"),
-        Err(err) => {
-            let msg = err.to_string();
-            assert!(msg.contains("open_bytes"));
-        }
-    }
+fn calamine_open_bytes_reads_workbook() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(4);
+        sh.get_cell_mut((2, 1)).set_value_number(5);
+        sh.get_cell_mut((3, 1)).set_formula("=A1+B1");
+    });
+    let bytes = std::fs::read(path).expect("read workbook bytes");
+
+    let mut backend = CalamineAdapter::open_bytes(bytes).expect("open workbook from bytes");
+    let ctx = formualizer_eval::test_workbook::TestWorkbook::new();
+    let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
+    backend.stream_into_engine(&mut engine).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(9.0))
+    );
 }
 
 #[test]
-fn calamine_open_reader_unsupported() {
+fn calamine_open_reader_reads_workbook() {
     use std::io::Cursor;
-    let reader: Box<dyn std::io::Read + Send + Sync> = Box::new(Cursor::new(vec![]));
-    match CalamineAdapter::open_reader(reader) {
-        Ok(_) => panic!("open_reader unexpectedly succeeded"),
-        Err(err) => assert!(err.to_string().contains("open_reader")),
-    }
+
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(7);
+        sh.get_cell_mut((2, 1)).set_formula("=A1*2");
+    });
+    let bytes = std::fs::read(path).expect("read workbook bytes");
+    let reader: Box<dyn std::io::Read + Send + Sync> = Box::new(Cursor::new(bytes));
+
+    let mut backend = CalamineAdapter::open_reader(reader).expect("open workbook from reader");
+    let ctx = formualizer_eval::test_workbook::TestWorkbook::new();
+    let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
+    backend.stream_into_engine(&mut engine).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(14.0))
+    );
 }
 
 // 4. Values-only fast path: ensure formulas_loaded == 0 and cells_loaded == N

--- a/crates/formualizer-workbook/tests/calamine/formulas.rs
+++ b/crates/formualizer-workbook/tests/calamine/formulas.rs
@@ -3,10 +3,41 @@ use crate::common::build_workbook;
 use formualizer_eval::engine::ingest::EngineLoadStream;
 use formualizer_eval::engine::{Engine, EvalConfig};
 use formualizer_workbook::{CalamineAdapter, LiteralValue, SpreadsheetReader};
-use std::fs::File;
 use std::io::{Cursor, Read, Write};
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+fn inject_external_link_rels(bytes: Vec<u8>, idx: u32, target: &str) -> Vec<u8> {
+    let reader = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(reader).unwrap();
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).unwrap();
+        let name = entry.name().to_string();
+        if entry.is_dir() {
+            let _ = writer.add_directory(name, options);
+            continue;
+        }
+
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).unwrap();
+        writer.start_file(name, options).unwrap();
+        writer.write_all(&data).unwrap();
+    }
+
+    let rels_name = format!("xl/externalLinks/_rels/externalLink{idx}.xml.rels");
+    let rels_xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">\n  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath\" Target=\"{target}\" TargetMode=\"External\"/>\n</Relationships>\n"
+    );
+    let _ = writer.add_directory("xl/externalLinks/_rels/".to_string(), options);
+    writer.start_file(rels_name, options).unwrap();
+    writer.write_all(rels_xml.as_bytes()).unwrap();
+
+    writer.finish().unwrap().into_inner()
+}
 
 #[test]
 fn calamine_extracts_formulas_and_normalizes_equals() {
@@ -50,57 +81,40 @@ fn calamine_error_cells_map() {
 
 #[test]
 fn calamine_loads_external_link_index_formulas() {
-    fn inject_external_link_rels(path: &std::path::Path, idx: u32, target: &str) {
-        let mut input = File::open(path).unwrap();
-        let mut bytes = Vec::new();
-        input.read_to_end(&mut bytes).unwrap();
-
-        let reader = Cursor::new(bytes);
-        let mut archive = ZipArchive::new(reader).unwrap();
-
-        let tmp_path = path.with_extension("patched.xlsx");
-        let out = File::create(&tmp_path).unwrap();
-        let mut writer = ZipWriter::new(out);
-
-        let options = FileOptions::default().compression_method(CompressionMethod::Deflated);
-
-        for i in 0..archive.len() {
-            let mut entry = archive.by_index(i).unwrap();
-            let name = entry.name().to_string();
-            if entry.is_dir() {
-                let _ = writer.add_directory(name, options);
-                continue;
-            }
-
-            let mut data = Vec::new();
-            entry.read_to_end(&mut data).unwrap();
-            writer.start_file(name, options).unwrap();
-            writer.write_all(&data).unwrap();
-        }
-
-        let rels_name = format!("xl/externalLinks/_rels/externalLink{idx}.xml.rels");
-        let rels_xml = format!(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">\n  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath\" Target=\"{target}\" TargetMode=\"External\"/>\n</Relationships>\n"
-        );
-        let _ = writer.add_directory("xl/externalLinks/_rels/".to_string(), options);
-        writer.start_file(rels_name, options).unwrap();
-        writer.write_all(rels_xml.as_bytes()).unwrap();
-
-        writer.finish().unwrap();
-
-        std::fs::remove_file(path).unwrap();
-        std::fs::rename(tmp_path, path).unwrap();
-    }
-
     let path = build_workbook(|book| {
         let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
         sh.get_cell_mut((1, 1))
             .set_formula("=SUM([33]Sheet1!$B:$B)");
     });
 
-    inject_external_link_rels(&path, 33, "file:///C:/tmp/external.xlsx");
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let bytes = inject_external_link_rels(bytes, 33, "file:///C:/tmp/external.xlsx");
+    std::fs::write(&path, bytes).expect("rewrite workbook with external link rels");
 
     let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    assert_eq!(
+        backend.external_link_target(33),
+        Some("file:///C:/tmp/external.xlsx")
+    );
+
+    let ctx = formualizer_eval::test_workbook::TestWorkbook::new();
+    let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
+    backend.stream_into_engine(&mut engine).unwrap();
+    engine.build_graph_all().unwrap();
+}
+
+#[test]
+fn calamine_loads_external_link_index_formulas_from_bytes() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1))
+            .set_formula("=SUM([33]Sheet1!$B:$B)");
+    });
+
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let bytes = inject_external_link_rels(bytes, 33, "file:///C:/tmp/external.xlsx");
+
+    let mut backend = CalamineAdapter::open_bytes(bytes).expect("open workbook from bytes");
     assert_eq!(
         backend.external_link_target(33),
         Some("file:///C:/tmp/external.xlsx")

--- a/crates/formualizer-workbook/tests/calamine/named_ranges.rs
+++ b/crates/formualizer-workbook/tests/calamine/named_ranges.rs
@@ -64,6 +64,48 @@ fn calamine_defined_names_preserve_sheet_scope_and_base_sheet_resolution() {
 }
 
 #[test]
+fn calamine_defined_names_from_bytes_preserve_sheet_scope_and_base_sheet_resolution() {
+    let path = build_workbook(|book| {
+        let _ = book.new_sheet("Sheet2");
+
+        let sheet1 = book.get_sheet_by_name_mut("Sheet1").expect("Sheet1");
+        sheet1.get_cell_mut((1, 1)).set_value_number(9.0);
+        sheet1
+            .add_defined_name("LocalOnly", "$A$1")
+            .expect("add local defined name without sheet prefix");
+        let local = sheet1
+            .get_defined_names_mut()
+            .last_mut()
+            .expect("local defined name");
+        local.set_local_sheet_id(0);
+
+        let sheet2 = book.get_sheet_by_name_mut("Sheet2").expect("Sheet2");
+        sheet2.get_cell_mut((1, 1)).set_value_number(42.0);
+        sheet2
+            .add_defined_name("GlobalOnly", "Sheet2!$A$1")
+            .expect("add workbook defined name");
+    });
+    let bytes = std::fs::read(path).expect("read workbook bytes");
+
+    let mut backend = CalamineAdapter::open_bytes(bytes).expect("open workbook from bytes");
+    let names = backend.defined_names().unwrap();
+
+    let local = names
+        .iter()
+        .find(|dn| dn.name == "LocalOnly")
+        .expect("LocalOnly should be imported by calamine");
+    assert_eq!(local.scope, DefinedNameScope::Sheet);
+    assert_eq!(local.scope_sheet.as_deref(), Some("Sheet1"));
+
+    let global = names
+        .iter()
+        .find(|dn| dn.name == "GlobalOnly")
+        .expect("GlobalOnly should be imported by calamine");
+    assert_eq!(global.scope, DefinedNameScope::Workbook);
+    assert!(global.scope_sheet.is_none());
+}
+
+#[test]
 fn calamine_defined_names_include_open_ended_workbook_range() {
     let path = build_workbook(|book| {
         let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();


### PR DESCRIPTION
## Summary
- add Calamine byte/reader-backed workbook opening so XLSX ingest no longer requires a filesystem path
- expose `Workbook.fromXlsxBytes(...)` in the WASM bindings and TypeScript wrapper
- add Rust and WASM regression coverage for byte-based Calamine XLSX loading, defined names, external-link metadata, and formula evaluation

## Verification
- `cargo test -p formualizer-workbook --test calamine --features calamine`
- `cargo clippy -p formualizer-workbook -p formualizer-wasm --all-targets --all-features -- -D warnings`
- `cd bindings/wasm && wasm-pack build --target bundler --out-dir pkg`
- `cd bindings/wasm && pnpm run build:ts`
- `cd bindings/wasm && wasm-pack test --node`

## Notes
- Reference Node/WASM measurement on a synthetic 2000-row XLSX fixture for the new Calamine path: ~39.3 ms min / ~54.5 ms avg across 5 runs.
- Direct Umya WASM byte-load comparison is not yet a clean reference point because the current Umya byte-open path still panics under `wasm32` due to `std::time::Instant::now()` instrumentation in the adapter.
