### PR TITLE
feat(python): ship formualizer wheels for Pyodide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,68 @@ jobs:
         name: wheels-${{ matrix.os }}
         path: bindings/python/dist
 
+  build-pyodide-wheel:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Host Python major.minor must match the xbuildenv's CPython (3.13 for
+    # Pyodide 0.29.x) so maturin's sysconfig introspection can find the
+    # emscripten sysconfigdata module. Don't downgrade this without also
+    # changing bindings/python/scripts/build-pyodide-wheel.sh's pin.
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-pyodide-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.13'
+        working-directory: bindings/python
+
+    - name: Build Pyodide wheel
+      working-directory: bindings/python
+      run: ./scripts/build-pyodide-wheel.sh
+
+    - name: Smoke-test Pyodide wheel
+      working-directory: bindings/python
+      run: |
+        wheel="$(ls dist/pyodide/*-pyodide_*_wasm32.whl | head -1)"
+        if [[ -z "$wheel" ]]; then
+          echo "No retagged pyodide wheel found in dist/pyodide" >&2
+          exit 1
+        fi
+        ./scripts/smoke-pyodide-wheel.sh "$wheel"
+
+    - name: Upload Pyodide wheel artifact
+      if: ${{ !env.ACT }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-pyodide
+        path: bindings/python/dist/pyodide
+        if-no-files-found: error
+
   coverage-badge:
     needs: [test-python, test-rust]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,9 +503,46 @@ jobs:
           name: wheels-sdist
           path: dist
 
+  build-wheels-pyodide:
+    if: startsWith(github.ref_name, 'v')
+    needs: verify-product
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Host Python must match xbuildenv CPython major.minor (3.13 for Pyodide
+      # 0.29.x). See bindings/python/scripts/build-pyodide-wheel.sh.
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Set up Rust (rustup shim for custom nightly)
+        uses: dtolnay/rust-toolchain@stable
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+      - name: Build Pyodide wheel
+        working-directory: bindings/python
+        run: ./scripts/build-pyodide-wheel.sh
+      - name: Smoke-test Pyodide wheel
+        working-directory: bindings/python
+        run: |
+          wheel="$(ls dist/pyodide/*-pyodide_*_wasm32.whl | head -1)"
+          if [[ -z "$wheel" ]]; then
+            echo "No retagged pyodide wheel found in dist/pyodide" >&2
+            exit 1
+          fi
+          ./scripts/smoke-pyodide-wheel.sh "$wheel"
+      - name: Upload Pyodide wheel
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheels-pyodide
+          path: bindings/python/dist/pyodide/*-pyodide_*_wasm32.whl
+          if-no-files-found: error
+
   publish-pypi:
     if: startsWith(github.ref_name, 'v')
-    needs: [publish-product-crates, build-wheels-linux, build-wheels-musllinux, build-wheels-windows, build-wheels-macos, build-sdist]
+    needs: [publish-product-crates, build-wheels-linux, build-wheels-musllinux, build-wheels-windows, build-wheels-macos, build-sdist, build-wheels-pyodide]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Formal benchmarks are in progress.
 |--------|---------|------|
 | Rust | `cargo add formualizer` | [docs.rs](https://docs.rs/formualizer) · [guide](https://www.formualizer.dev/docs/quickstarts/rust-quickstart) |
 | Python | `pip install formualizer` | [README](bindings/python/README.md) · [guide](https://www.formualizer.dev/docs/quickstarts/python-quickstart) |
+| Python (Pyodide) | `await micropip.install("formualizer")` | [README](bindings/python/README.md#using-in-pyodide-browser--webassembly) · [guide](https://www.formualizer.dev/docs/quickstarts/pyodide-quickstart) |
 | WASM | `npm install formualizer` | [README](bindings/wasm/README.md) · [guide](https://www.formualizer.dev/docs/quickstarts/js-wasm-quickstart) |
 
 Both Python and WASM bindings expose the same core API surface: tokenization, parsing, workbook operations, evaluation, undo/redo, and SheetPort.

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -62,6 +62,20 @@ wb = fz.load_workbook("financial_model.xlsx", strategy="eager_all")
 print(wb.evaluate_cell("Summary", 1, 2))
 ```
 
+### Load and save XLSX bytes
+
+```python
+import formualizer as fz
+
+payload = open("financial_model.xlsx", "rb").read()
+wb = fz.load_workbook_bytes(payload, backend="umya")
+print(wb.evaluate_cell("Summary", 1, 2))
+
+out = wb.to_xlsx_bytes()
+```
+
+`backend="umya"` is currently the byte-oriented XLSX path. Path-based loading still defaults to `calamine`.
+
 ### Recalculate XLSX cached values (writeback)
 
 ```python
@@ -264,12 +278,13 @@ print(result["final_price"])  # 120.0
 tokenize(formula: str, dialect: FormulaDialect = None) -> Tokenizer
 parse(formula: str, dialect: FormulaDialect = None) -> ASTNode
 load_workbook(path: str, strategy: str = None) -> Workbook
+load_workbook_bytes(data: bytes, strategy: str = None, backend: str | None = None) -> Workbook
 recalculate_file(path: str, output: str | None = None) -> dict
 ```
 
 ### Core classes
 
-- **`Workbook`** — create, load, evaluate, undo/redo. Supports `from_path()` and `load_path()` class methods.
+- **`Workbook`** — create, load, evaluate, undo/redo. Supports `from_path()`, `from_bytes()`, `load_path()`, and `to_xlsx_bytes()`.
 - **`Sheet`** — per-sheet facade for `set_value`, `set_formula`, `get_cell`, batch operations.
 - **`LiteralValue`** — typed values: `.int()`, `.number()`, `.text()`, `.boolean()`, `.date()`, `.empty()`, `.error()`, `.array()`.
 - **`Tokenizer`** — iterable token sequence with `.render()` and `.tokens`.
@@ -298,9 +313,44 @@ Requires Rust >= 1.70 and [maturin](https://github.com/PyO3/maturin):
 ```bash
 pip install maturin
 cd bindings/python
-maturin develop          # debug build
+maturin develop            # debug build
 maturin develop --release  # optimized build
 ```
+
+## Using in Pyodide (browser / WebAssembly)
+
+`formualizer` ships a Pyodide-tagged wheel (`*-pyodide_<abi>_wasm32.whl`) alongside the native wheels on PyPI. Inside a Pyodide runtime:
+
+```python
+import micropip
+await micropip.install("formualizer")
+
+import formualizer as fz
+wb = fz.Workbook()
+wb.add_sheet("Sheet1")
+wb.set_value("Sheet1", 1, 1, 20)
+wb.set_value("Sheet1", 2, 1, 22)
+wb.set_formula("Sheet1", 1, 2, "=SUM(A1:A2)")
+wb.evaluate_cell("Sheet1", 1, 2)  # -> 42.0
+```
+
+**Supported Pyodide versions:** 0.29.x (ABI `pyodide_2025_0`). Later minors may require a new wheel — check the PyPI release matrix for your target Pyodide version.
+
+**Pyodide-specific behavior:**
+- `EvaluationConfig()` and `Workbook()` default `enable_parallel = False` on `sys.platform == "emscripten"` (Pyodide has no threads). You can still opt in, but it falls back to single-threaded execution.
+- XLSX byte I/O (`Workbook.to_xlsx_bytes`, `Workbook.from_bytes`, `load_workbook_bytes`) uses the `umya` backend on all platforms.
+- Python UDFs registered via `Workbook.register_function` work identically to native; single-cell refs arrive as scalars (Excel-native semantics).
+
+### Building a Pyodide wheel from source
+
+For local development or targeting a Pyodide version that isn't on PyPI:
+
+```bash
+./scripts/build-pyodide-wheel.sh
+./scripts/smoke-pyodide-wheel.sh dist/pyodide/*-pyodide_*_wasm32.whl
+```
+
+The build script derives Python, ABI, Emscripten, and Rust toolchain from `pyodide config` (no hardcoded versions), installs Pyodide's custom wasm-EH Rust sysroot over the stock rustup target, and retags the output wheel to the platform tag Pyodide's `micropip` expects.
 
 ## Testing
 

--- a/bindings/python/formualizer/__init__.pyi
+++ b/bindings/python/formualizer/__init__.pyi
@@ -33,6 +33,7 @@ __all__ = [
     "WorkbookConfig",
     "WorkbookMode",
     "load_workbook",
+    "load_workbook_bytes",
     "parse",
     "parse_formula",
     "recalculate_file",
@@ -995,6 +996,28 @@ class Workbook:
         """
     @classmethod
     def from_path(cls, path: builtins.str, backend: typing.Optional[builtins.str] = None, *, mode: typing.Optional[WorkbookMode] = None, config: typing.Optional[WorkbookConfig] = None) -> Workbook: ...
+    @classmethod
+    def from_bytes(cls, data: bytes, backend: typing.Optional[builtins.str] = None, *, mode: typing.Optional[WorkbookMode] = None, config: typing.Optional[WorkbookConfig] = None) -> Workbook:
+        r"""
+        Class method: load an XLSX workbook from in-memory bytes.
+        
+        This is the Pyodide-friendly counterpart to `Workbook.from_path(...)`.
+        
+        Args:
+            data: XLSX payload as `bytes`.
+            backend: Backend name. Defaults to `umya` because `calamine` byte-open
+                is not currently supported in this repository.
+            mode/config: Optional workbook configuration.
+        """
+    def to_xlsx_bytes(self, backend: typing.Optional[builtins.str] = None) -> bytes:
+        r"""
+        Serialize the current workbook contents into XLSX bytes.
+        
+        Notes:
+        - This currently uses the `umya` backend.
+        - Output is generated from the in-memory workbook model; original XLSX styling
+          and package metadata are not preserved by the Python binding.
+        """
     def add_sheet(self, name: builtins.str) -> None:
         r"""
         Add a sheet to the workbook.
@@ -1255,6 +1278,14 @@ def load_workbook(path: builtins.str, strategy: typing.Optional[builtins.str] = 
         wb = fz.load_workbook("financial_model.xlsx")
         print(wb.evaluate_cell("Summary", 1, 2))
     ```
+    """
+
+def load_workbook_bytes(data: bytes, strategy: typing.Optional[builtins.str] = None, backend: typing.Optional[builtins.str] = None) -> Workbook:
+    r"""
+    Load an XLSX workbook from in-memory bytes.
+    
+    This is the byte-oriented counterpart to `load_workbook(...)` and defaults to
+    the `umya` backend because `calamine` byte-open is not yet supported here.
     """
 
 def parse(formula: builtins.str, dialect: typing.Optional[FormulaDialect] = None) -> ASTNode:

--- a/bindings/python/scripts/build-pyodide-wheel.sh
+++ b/bindings/python/scripts/build-pyodide-wheel.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYODIDE_CMD=(uvx --from pyodide-cli --with pyodide-build pyodide)
+
+# Target a specific Pyodide runtime version. The `pyodide_<abi>_wasm32` tag
+# and downstream config values all derive from this pin. Override at invocation
+# time if you need to retarget: `PYODIDE_XBUILDENV_VERSION=0.30.0 ./scripts/...`.
+PYODIDE_XBUILDENV_VERSION="${PYODIDE_XBUILDENV_VERSION:-0.29.3}"
+
+printf 'Preparing Pyodide wheel build\n'
+printf '  xbuildenv:   %s\n' "$PYODIDE_XBUILDENV_VERSION"
+
+# Install xbuildenv first — subsequent `pyodide config get ...` reads its values
+# from the xbuildenv directory, so this step is load-bearing for the queries
+# below and must not be reordered. `--force` is needed because pyodide-build
+# 0.34.x reports every xbuildenv version as "incompatible" in its search table,
+# even though installation works correctly.
+"${PYODIDE_CMD[@]}" xbuildenv install --force "$PYODIDE_XBUILDENV_VERSION"
+
+PYTHON_VERSION="$(${PYODIDE_CMD[@]} config get python_version)"
+PYODIDE_ABI_VERSION="$(${PYODIDE_CMD[@]} config get pyodide_abi_version)"
+EMSCRIPTEN_VERSION="$(${PYODIDE_CMD[@]} config get emscripten_version)"
+RUST_TOOLCHAIN="$(${PYODIDE_CMD[@]} config get rust_toolchain)"
+RUST_EMSCRIPTEN_TARGET_URL="$(${PYODIDE_CMD[@]} config get rust_emscripten_target_url)"
+PYODIDE_RUSTFLAGS="$(${PYODIDE_CMD[@]} config get rustflags)"
+PYODIDE_CFLAGS="$(${PYODIDE_CMD[@]} config get cflags)"
+PYODIDE_CXXFLAGS="$(${PYODIDE_CMD[@]} config get cxxflags)"
+PYODIDE_LDFLAGS="$(${PYODIDE_CMD[@]} config get ldflags)"
+
+printf '  python:      %s\n' "$PYTHON_VERSION"
+printf '  abi:         pyodide_%s\n' "$PYODIDE_ABI_VERSION"
+printf '  emscripten:  %s\n' "$EMSCRIPTEN_VERSION"
+printf '  rust:        %s\n' "$RUST_TOOLCHAIN"
+printf '  eh-sysroot:  %s\n' "$RUST_EMSCRIPTEN_TARGET_URL"
+
+if ! command -v rustup >/dev/null 2>&1; then
+    echo 'rustup is required to install the Pyodide wasm-EH rust sysroot.' >&2
+    exit 1
+fi
+
+if ! rustup toolchain list | grep -Fq "$RUST_TOOLCHAIN"; then
+    rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+fi
+export RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN"
+
+# Replace the stock wasm32-unknown-emscripten sysroot with Pyodide's wasm-EH
+# sysroot. Stock rustup ships a std built with JS-trampoline exceptions
+# (invoke_*), which fails to import under Pyodide 0.29+ (expects wasm EH).
+RUSTC_SYSROOT="$(rustc --print sysroot)"
+RUSTLIB_DIR="$RUSTC_SYSROOT/lib/rustlib"
+EH_TARGET_DIR="$RUSTLIB_DIR/wasm32-unknown-emscripten"
+EH_MARKER="$EH_TARGET_DIR/.pyodide-wasm-eh.sentinel"
+EH_EXPECTED_TAG="$(basename "$RUST_EMSCRIPTEN_TARGET_URL" .tar.bz2)"
+
+if [[ ! -f "$EH_MARKER" || "$(cat "$EH_MARKER" 2>/dev/null)" != "$EH_EXPECTED_TAG" ]]; then
+    printf 'Installing Pyodide wasm-EH rust sysroot (%s)\n' "$EH_EXPECTED_TAG"
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' RETURN
+    tarball="$tmpdir/sysroot.tar.bz2"
+    curl -fL --retry 3 -o "$tarball" "$RUST_EMSCRIPTEN_TARGET_URL"
+    mkdir -p "$RUSTLIB_DIR"
+    rm -rf "$EH_TARGET_DIR"
+    tar -xjf "$tarball" -C "$RUSTLIB_DIR"
+    printf '%s' "$EH_EXPECTED_TAG" > "$EH_MARKER"
+fi
+
+rm -rf dist/pyodide
+mkdir -p dist/pyodide
+
+# Purge any previously cached wasm build — cargo will otherwise reuse
+# artifacts compiled with the stock (non-wasm-EH) sysroot and flags.
+WORKSPACE_ROOT="$(cargo locate-project --workspace --message-format plain | xargs dirname)"
+rm -rf "$WORKSPACE_ROOT/target/wasm32-unknown-emscripten"
+
+# Export the canonical Pyodide toolchain flags so `pyodide build` (which,
+# unlike `pyodide build-recipes`, doesn't inject them automatically) emits
+# wasm-EH-compatible output.
+export RUSTFLAGS="$PYODIDE_RUSTFLAGS"
+export CFLAGS="$PYODIDE_CFLAGS"
+export CXXFLAGS="$PYODIDE_CXXFLAGS"
+export LDFLAGS="$PYODIDE_LDFLAGS"
+
+printf 'RUSTFLAGS: %s\n' "$RUSTFLAGS"
+printf 'CFLAGS:    %s\n' "$CFLAGS"
+printf 'LDFLAGS:   %s\n' "$LDFLAGS"
+
+"${PYODIDE_CMD[@]}" build --outdir dist/pyodide
+
+wheel_path="$(find dist/pyodide -maxdepth 1 -name '*.whl' | sort | head -n 1)"
+if [[ -z "$wheel_path" ]]; then
+    echo 'Pyodide build did not produce a wheel.' >&2
+    exit 1
+fi
+
+# pyodide-build 0.34 repacks wheels with the forward-looking
+# `pyemscripten_2025_0_wasm32` tag, which the micropip shipped with
+# Pyodide 0.29.x parses as a bogus "Emscripten v pyemscripten.2025.0"
+# string and rejects. The actual tag Pyodide 0.29.x expects (matching
+# its own lockfile) is `pyodide_2025_0_wasm32`. Retag to that so
+# `micropip.install(...)` accepts the wheel without falling back to
+# zip extraction.
+CANONICAL_PLATFORM_TAG="pyodide_${PYODIDE_ABI_VERSION}_wasm32"
+current_plat_tag="$(basename "$wheel_path" .whl | awk -F- '{print $NF}')"
+if [[ "$current_plat_tag" != "$CANONICAL_PLATFORM_TAG" ]]; then
+    printf 'Retagging wheel platform tag: %s -> %s\n' "$current_plat_tag" "$CANONICAL_PLATFORM_TAG"
+    uvx --from wheel -- wheel tags --remove --platform-tag "$CANONICAL_PLATFORM_TAG" "$wheel_path" >/dev/null
+    wheel_path="$(find dist/pyodide -maxdepth 1 -name '*.whl' | sort | head -n 1)"
+fi
+
+printf 'Built wheel: %s\n' "$wheel_path"

--- a/bindings/python/scripts/pyodide-smoke.mjs
+++ b/bindings/python/scripts/pyodide-smoke.mjs
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [wheelPath, smokeScriptPath, pyodideModulePath] = process.argv.slice(2);
+if (!wheelPath) {
+  throw new Error(
+    "usage: node scripts/pyodide-smoke.mjs <wheel> [smoke-script.py] [pyodide-module-path]",
+  );
+}
+
+const smokePath = smokeScriptPath ?? new URL("./pyodide-smoke.py", import.meta.url);
+const pyodideModuleUrl = pyodideModulePath
+  ? pathToFileURL(pyodideModulePath).href
+  : "pyodide";
+
+try {
+  const { loadPyodide } = await import(pyodideModuleUrl);
+
+  const pyodide = await loadPyodide({
+    indexURL: pyodideModulePath
+      ? pathToFileURL(`${path.dirname(pyodideModulePath)}${path.sep}`).href
+      : undefined,
+    stderr: (message) => process.stderr.write(`${message}\n`),
+    stdout: (message) => process.stdout.write(`${message}\n`),
+  });
+
+  await pyodide.loadPackage("micropip");
+
+  const wheelData = await fs.readFile(wheelPath);
+  const smokeSource = await fs.readFile(smokePath, "utf8");
+  const emfsWheelPath = `/tmp/${path.basename(wheelPath)}`;
+
+  pyodide.FS.writeFile(emfsWheelPath, wheelData);
+  pyodide.globals.set("FORMUALIZER_WHEEL_PATH", emfsWheelPath);
+
+  await pyodide.runPythonAsync(`
+import sysconfig
+import zipfile
+
+import micropip
+
+wheel_path = FORMUALIZER_WHEEL_PATH
+try:
+    # micropip.install() wants a URL or package name. Use emfs:/ so it
+    # reads the wheel from the Emscripten FS we just wrote into.
+    await micropip.install(f"emfs:{wheel_path}")
+    FORMUALIZER_INSTALL_METHOD = "micropip"
+except Exception as exc:
+    platlib = sysconfig.get_paths()["platlib"]
+    with zipfile.ZipFile(wheel_path) as archive:
+        archive.extractall(platlib)
+    FORMUALIZER_INSTALL_METHOD = f"zipfile-fallback: {exc}"
+`);
+
+  const result = await pyodide.runPythonAsync(smokeSource);
+  console.log(result);
+} catch (error) {
+  console.error("Pyodide smoke failure:");
+  console.error(error?.message ?? error);
+  if (error?.cause) {
+    console.error("Cause:", error.cause?.message ?? error.cause);
+  }
+  process.exitCode = 1;
+}

--- a/bindings/python/scripts/pyodide-smoke.py
+++ b/bindings/python/scripts/pyodide-smoke.py
@@ -1,0 +1,60 @@
+import json
+import sys
+
+import formualizer as fz
+
+assert sys.platform == "emscripten", sys.platform
+
+ast = fz.parse("=SUM(A1:A2)")
+assert "SUM" in ast.to_formula()
+
+cfg = fz.EvaluationConfig()
+assert cfg.enable_parallel is False
+cfg.enable_parallel = True
+assert cfg.enable_parallel is True
+
+wb_plan = fz.Workbook(mode=fz.WorkbookMode.Ephemeral)
+wb_plan.add_sheet("Sheet1")
+wb_plan.set_value("Sheet1", 1, 1, 20)
+wb_plan.set_value("Sheet1", 2, 1, 22)
+wb_plan.set_formula("Sheet1", 1, 2, "=SUM(A1:A2)")
+default_plan = wb_plan.get_eval_plan([("Sheet1", 1, 2)])
+assert default_plan.parallel_enabled is False
+
+wb = fz.Workbook()
+wb.add_sheet("Sheet1")
+wb.set_value("Sheet1", 1, 1, 20)
+wb.set_value("Sheet1", 2, 1, 22)
+wb.set_formula("Sheet1", 1, 2, "=SUM(A1:A2)")
+assert wb.evaluate_cell("Sheet1", 1, 2) == 42.0
+
+wb.register_function("py_add", lambda a, b: a + b, min_args=2, max_args=2)
+wb.set_formula("Sheet1", 2, 2, "=PY_ADD(A1,A2)")
+assert wb.evaluate_cell("Sheet1", 2, 2) == 42
+
+wb_override = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))
+wb_override.add_sheet("Sheet1")
+wb_override.set_value("Sheet1", 1, 1, 1)
+wb_override.set_value("Sheet1", 2, 1, 2)
+wb_override.set_formula("Sheet1", 1, 2, "=SUM(A1:A2)")
+assert wb_override.evaluate_cell("Sheet1", 1, 2) == 3.0
+
+xlsx_bytes = wb.to_xlsx_bytes()
+assert isinstance(xlsx_bytes, bytes)
+assert len(xlsx_bytes) > 100
+
+from_bytes = fz.Workbook.from_bytes(xlsx_bytes, backend="umya")
+assert from_bytes.evaluate_cell("Sheet1", 1, 2) == 42.0
+
+from_top_level = fz.load_workbook_bytes(xlsx_bytes)
+assert from_top_level.evaluate_cell("Sheet1", 1, 2) == 42.0
+
+summary = {
+    "ast_formula": ast.to_formula(),
+    "default_parallel": default_plan.parallel_enabled,
+    "install_method": globals().get("FORMUALIZER_INSTALL_METHOD", "unknown"),
+    "platform": sys.platform,
+    "wheel_bytes": len(xlsx_bytes),
+}
+
+json.dumps(summary, sort_keys=True)

--- a/bindings/python/scripts/smoke-pyodide-wheel.sh
+++ b/bindings/python/scripts/smoke-pyodide-wheel.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ $# -lt 1 ]]; then
+    echo 'Usage: ./scripts/smoke-pyodide-wheel.sh dist/pyodide/<wheel>.whl' >&2
+    exit 1
+fi
+
+WHEEL_PATH="$1"
+if [[ ! -f "$WHEEL_PATH" ]]; then
+    echo "Wheel not found: $WHEEL_PATH" >&2
+    exit 1
+fi
+
+# Match the default pinned in build-pyodide-wheel.sh. The smoke test uses the
+# Pyodide npm package at this version to host the wheel under test.
+PYODIDE_NPM_VERSION="${PYODIDE_NPM_VERSION:-0.29.3}"
+PYODIDE_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$PYODIDE_TMPDIR"' EXIT
+
+printf 'Running Pyodide smoke test\n'
+printf '  wheel:   %s\n' "$WHEEL_PATH"
+printf '  pyodide: %s\n' "$PYODIDE_NPM_VERSION"
+
+npm --prefix "$PYODIDE_TMPDIR" install --no-save "pyodide@${PYODIDE_NPM_VERSION}" >/dev/null
+cp scripts/pyodide-smoke.mjs "$PYODIDE_TMPDIR/pyodide-smoke.mjs"
+
+node "$PYODIDE_TMPDIR/pyodide-smoke.mjs" \
+    "$WHEEL_PATH" \
+    "$ROOT_DIR/scripts/pyodide-smoke.py"

--- a/bindings/python/src/engine.rs
+++ b/bindings/python/src/engine.rs
@@ -28,6 +28,29 @@ impl Default for PyEvaluationConfig {
     }
 }
 
+pub(crate) fn apply_binding_eval_defaults(config: &mut EvalConfig) {
+    if cfg!(target_os = "emscripten") {
+        config.enable_parallel = false;
+    }
+}
+
+pub(crate) fn binding_default_eval_config() -> EvalConfig {
+    let mut config = EvalConfig::default();
+    apply_binding_eval_defaults(&mut config);
+    config
+}
+
+pub(crate) fn merge_python_eval_config(base: &mut EvalConfig, python_config: &EvalConfig) {
+    base.enable_parallel = python_config.enable_parallel;
+    base.max_threads = python_config.max_threads;
+    base.range_expansion_limit = python_config.range_expansion_limit;
+    base.workbook_seed = python_config.workbook_seed;
+    base.case_sensitive_names = python_config.case_sensitive_names;
+    base.case_sensitive_tables = python_config.case_sensitive_tables;
+    base.warmup = python_config.warmup.clone();
+    base.date_system = python_config.date_system;
+}
+
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyEvaluationConfig {
@@ -35,7 +58,7 @@ impl PyEvaluationConfig {
     #[new]
     pub fn new() -> Self {
         PyEvaluationConfig {
-            inner: EvalConfig::default(),
+            inner: binding_default_eval_config(),
         }
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,4 +1,10 @@
+// See crates/formualizer-common/src/lib.rs for rationale. The nested-if form
+// is kept so the Pyodide-matched Rust nightly (pre let-chain stabilization)
+// still builds this crate.
+#![allow(clippy::collapsible_if)]
+
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
 use pyo3::wrap_pyfunction;
 use pyo3_stub_gen::define_stub_info_gatherer;
 use pyo3_stub_gen::derive::gen_stub_pyfunction;
@@ -106,6 +112,29 @@ fn load_workbook(py: Python, path: &str, strategy: Option<&str>) -> PyResult<wor
     )
 }
 
+/// Load an XLSX workbook from in-memory bytes.
+///
+/// This is the byte-oriented counterpart to `load_workbook(...)` and defaults to
+/// the `umya` backend because `calamine` byte-open is not yet supported here.
+#[gen_stub_pyfunction(module = "formualizer")]
+#[pyfunction]
+#[pyo3(signature = (data, strategy=None, backend=None))]
+fn load_workbook_bytes<'py>(
+    py: Python<'py>,
+    data: &Bound<'py, PyBytes>,
+    strategy: Option<&str>,
+    backend: Option<&str>,
+) -> PyResult<workbook::PyWorkbook> {
+    let _ = strategy; // placeholder, backend currently fixed to eager load
+    workbook::PyWorkbook::from_bytes(
+        &py.get_type::<workbook::PyWorkbook>(),
+        data,
+        Some(backend.unwrap_or("umya")),
+        None,
+        None,
+    )
+}
+
 /// Recalculate an XLSX workbook and write formula cached values back to file.
 ///
 /// Args:
@@ -182,6 +211,7 @@ fn formualizer_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(tokenize, m)?)?;
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     m.add_function(wrap_pyfunction!(load_workbook, m)?)?;
+    m.add_function(wrap_pyfunction!(load_workbook_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(recalculate_file, m)?)?;
 
     // Backward-compatible aliases for older names which started with `Py...`.

--- a/bindings/python/src/value.rs
+++ b/bindings/python/src/value.rs
@@ -581,260 +581,270 @@ pub(crate) fn py_to_literal(value: &Bound<'_, PyAny>) -> PyResult<LiteralValue> 
             chrono::Duration::seconds(secs) + chrono::Duration::microseconds(microseconds);
         return Ok(LiteralValue::Duration(duration));
     }
-    if let Ok(dict) = value.cast::<PyDict>()
-        && let Some(kind_obj) = dict.get_item("type")?
-    {
-        let type_tag: String = kind_obj.extract()?;
-        let type_lower = type_tag.to_ascii_lowercase();
-        match type_lower.as_str() {
-            "error" => {
-                let kind_obj = dict.get_item("kind")?.ok_or_else(|| {
-                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Error dict missing 'kind'")
-                })?;
-                let kind_str: String = kind_obj.extract()?;
-                let kind_key = kind_str.trim().to_ascii_lowercase();
-                let excel_kind = match kind_key.as_str() {
-                    "div" | "div0" | "#div/0!" => ExcelErrorKind::Div,
-                    "ref" | "#ref!" => ExcelErrorKind::Ref,
-                    "name" | "#name?" => ExcelErrorKind::Name,
-                    "value" | "#value!" => ExcelErrorKind::Value,
-                    "num" | "#num!" => ExcelErrorKind::Num,
-                    "null" | "#null!" => ExcelErrorKind::Null,
-                    "na" | "n/a" | "#n/a" => ExcelErrorKind::Na,
-                    "spill" | "#spill!" => ExcelErrorKind::Spill,
-                    "calc" | "#calc!" => ExcelErrorKind::Calc,
-                    "circ" | "#circ!" => ExcelErrorKind::Circ,
-                    "cancelled" | "#cancelled!" => ExcelErrorKind::Cancelled,
-                    "error" | "#error!" => ExcelErrorKind::Error,
-                    "nimpl" | "n/impl" | "#n/impl!" => ExcelErrorKind::NImpl,
-                    other => {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                            "Unknown error kind: {other}"
-                        )));
-                    }
-                };
-                let mut error = ExcelError::new(excel_kind);
-                if let Some(message) = dict
-                    .get_item("message")?
-                    .map(|m| m.extract::<String>())
-                    .transpose()?
-                {
-                    error = error.with_message(message);
-                }
-                let row = match dict.get_item("row")? {
-                    Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Error 'row' must be an int",
-                        )
-                    })?),
-                    None => None,
-                };
-                let col = match dict.get_item("col")? {
-                    Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Error 'col' must be an int",
-                        )
-                    })?),
-                    None => None,
-                };
-                let origin_row = match dict.get_item("origin_row")? {
-                    Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Error 'origin_row' must be an int",
-                        )
-                    })?),
-                    None => None,
-                };
-                let origin_col = match dict.get_item("origin_col")? {
-                    Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Error 'origin_col' must be an int",
-                        )
-                    })?),
-                    None => None,
-                };
-                let origin_sheet = match dict.get_item("sheet")? {
-                    Some(obj) => Some(obj.extract::<String>().map_err(|_| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Error 'sheet' must be a string",
-                        )
-                    })?),
-                    None => None,
-                };
-                if row.is_some()
-                    || col.is_some()
-                    || origin_row.is_some()
-                    || origin_col.is_some()
-                    || origin_sheet.is_some()
-                {
-                    error.context = Some(ErrorContext {
-                        row,
-                        col,
-                        origin_row,
-                        origin_col,
-                        origin_sheet,
-                    });
-                }
-                return Ok(LiteralValue::Error(error));
-            }
-            "date" => {
-                let year: i32 = dict
-                    .get_item("year")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Date dict missing 'year'")
-                    })?
-                    .extract()?;
-                let month: u32 = dict
-                    .get_item("month")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Date dict missing 'month'")
-                    })?
-                    .extract()?;
-                let day: u32 = dict
-                    .get_item("day")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Date dict missing 'day'")
-                    })?
-                    .extract()?;
-                let date = NaiveDate::from_ymd_opt(year, month, day).ok_or_else(|| {
-                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid date")
-                })?;
-                return Ok(LiteralValue::Date(date));
-            }
-            "time" => {
-                let hour: u32 = dict
-                    .get_item("hour")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Time dict missing 'hour'")
-                    })?
-                    .extract()?;
-                let minute: u32 = dict
-                    .get_item("minute")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Time dict missing 'minute'",
-                        )
-                    })?
-                    .extract()?;
-                let second: u32 = dict
-                    .get_item("second")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Time dict missing 'second'",
-                        )
-                    })?
-                    .extract()?;
-                let microsecond: u32 = dict
-                    .get_item("microsecond")?
-                    .map(|v| v.extract::<u32>())
-                    .transpose()?
-                    .unwrap_or(0);
-                let time = NaiveTime::from_hms_micro_opt(hour, minute, second, microsecond)
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid time")
+    if let Ok(dict) = value.cast::<PyDict>() {
+        if let Some(kind_obj) = dict.get_item("type")? {
+            let type_tag: String = kind_obj.extract()?;
+            let type_lower = type_tag.to_ascii_lowercase();
+            match type_lower.as_str() {
+                "error" => {
+                    let kind_obj = dict.get_item("kind")?.ok_or_else(|| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Error dict missing 'kind'")
                     })?;
-                return Ok(LiteralValue::Time(time));
-            }
-            "datetime" => {
-                let year: i32 = dict
-                    .get_item("year")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "DateTime dict missing 'year'",
-                        )
-                    })?
-                    .extract()?;
-                let month: u32 = dict
-                    .get_item("month")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "DateTime dict missing 'month'",
-                        )
-                    })?
-                    .extract()?;
-                let day: u32 = dict
-                    .get_item("day")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "DateTime dict missing 'day'",
-                        )
-                    })?
-                    .extract()?;
-                let hour: u32 = dict
-                    .get_item("hour")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "DateTime dict missing 'hour'",
-                        )
-                    })?
-                    .extract()?;
-                let minute: u32 = dict
-                    .get_item("minute")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "DateTime dict missing 'minute'",
-                        )
-                    })?
-                    .extract()?;
-                let second: u32 = dict
-                    .get_item("second")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "DateTime dict missing 'second'",
-                        )
-                    })?
-                    .extract()?;
-                let microsecond: u32 = dict
-                    .get_item("microsecond")?
-                    .map(|v| v.extract::<u32>())
-                    .transpose()?
-                    .unwrap_or(0);
-                let date = NaiveDate::from_ymd_opt(year, month, day).ok_or_else(|| {
-                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid datetime")
-                })?;
-                let time = NaiveTime::from_hms_micro_opt(hour, minute, second, microsecond)
-                    .ok_or_else(|| {
+                    let kind_str: String = kind_obj.extract()?;
+                    let kind_key = kind_str.trim().to_ascii_lowercase();
+                    let excel_kind = match kind_key.as_str() {
+                        "div" | "div0" | "#div/0!" => ExcelErrorKind::Div,
+                        "ref" | "#ref!" => ExcelErrorKind::Ref,
+                        "name" | "#name?" => ExcelErrorKind::Name,
+                        "value" | "#value!" => ExcelErrorKind::Value,
+                        "num" | "#num!" => ExcelErrorKind::Num,
+                        "null" | "#null!" => ExcelErrorKind::Null,
+                        "na" | "n/a" | "#n/a" => ExcelErrorKind::Na,
+                        "spill" | "#spill!" => ExcelErrorKind::Spill,
+                        "calc" | "#calc!" => ExcelErrorKind::Calc,
+                        "circ" | "#circ!" => ExcelErrorKind::Circ,
+                        "cancelled" | "#cancelled!" => ExcelErrorKind::Cancelled,
+                        "error" | "#error!" => ExcelErrorKind::Error,
+                        "nimpl" | "n/impl" | "#n/impl!" => ExcelErrorKind::NImpl,
+                        other => {
+                            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                                "Unknown error kind: {other}"
+                            )));
+                        }
+                    };
+                    let mut error = ExcelError::new(excel_kind);
+                    if let Some(message) = dict
+                        .get_item("message")?
+                        .map(|m| m.extract::<String>())
+                        .transpose()?
+                    {
+                        error = error.with_message(message);
+                    }
+                    let row = match dict.get_item("row")? {
+                        Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Error 'row' must be an int",
+                            )
+                        })?),
+                        None => None,
+                    };
+                    let col = match dict.get_item("col")? {
+                        Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Error 'col' must be an int",
+                            )
+                        })?),
+                        None => None,
+                    };
+                    let origin_row = match dict.get_item("origin_row")? {
+                        Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Error 'origin_row' must be an int",
+                            )
+                        })?),
+                        None => None,
+                    };
+                    let origin_col = match dict.get_item("origin_col")? {
+                        Some(obj) => Some(obj.extract::<u32>().map_err(|_| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Error 'origin_col' must be an int",
+                            )
+                        })?),
+                        None => None,
+                    };
+                    let origin_sheet = match dict.get_item("sheet")? {
+                        Some(obj) => Some(obj.extract::<String>().map_err(|_| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Error 'sheet' must be a string",
+                            )
+                        })?),
+                        None => None,
+                    };
+                    if row.is_some()
+                        || col.is_some()
+                        || origin_row.is_some()
+                        || origin_col.is_some()
+                        || origin_sheet.is_some()
+                    {
+                        error.context = Some(ErrorContext {
+                            row,
+                            col,
+                            origin_row,
+                            origin_col,
+                            origin_sheet,
+                        });
+                    }
+                    return Ok(LiteralValue::Error(error));
+                }
+                "date" => {
+                    let year: i32 = dict
+                        .get_item("year")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Date dict missing 'year'",
+                            )
+                        })?
+                        .extract()?;
+                    let month: u32 = dict
+                        .get_item("month")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Date dict missing 'month'",
+                            )
+                        })?
+                        .extract()?;
+                    let day: u32 = dict
+                        .get_item("day")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Date dict missing 'day'",
+                            )
+                        })?
+                        .extract()?;
+                    let date = NaiveDate::from_ymd_opt(year, month, day).ok_or_else(|| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid date")
+                    })?;
+                    return Ok(LiteralValue::Date(date));
+                }
+                "time" => {
+                    let hour: u32 = dict
+                        .get_item("hour")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Time dict missing 'hour'",
+                            )
+                        })?
+                        .extract()?;
+                    let minute: u32 = dict
+                        .get_item("minute")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Time dict missing 'minute'",
+                            )
+                        })?
+                        .extract()?;
+                    let second: u32 = dict
+                        .get_item("second")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Time dict missing 'second'",
+                            )
+                        })?
+                        .extract()?;
+                    let microsecond: u32 = dict
+                        .get_item("microsecond")?
+                        .map(|v| v.extract::<u32>())
+                        .transpose()?
+                        .unwrap_or(0);
+                    let time = NaiveTime::from_hms_micro_opt(hour, minute, second, microsecond)
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid time")
+                        })?;
+                    return Ok(LiteralValue::Time(time));
+                }
+                "datetime" => {
+                    let year: i32 = dict
+                        .get_item("year")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "DateTime dict missing 'year'",
+                            )
+                        })?
+                        .extract()?;
+                    let month: u32 = dict
+                        .get_item("month")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "DateTime dict missing 'month'",
+                            )
+                        })?
+                        .extract()?;
+                    let day: u32 = dict
+                        .get_item("day")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "DateTime dict missing 'day'",
+                            )
+                        })?
+                        .extract()?;
+                    let hour: u32 = dict
+                        .get_item("hour")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "DateTime dict missing 'hour'",
+                            )
+                        })?
+                        .extract()?;
+                    let minute: u32 = dict
+                        .get_item("minute")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "DateTime dict missing 'minute'",
+                            )
+                        })?
+                        .extract()?;
+                    let second: u32 = dict
+                        .get_item("second")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "DateTime dict missing 'second'",
+                            )
+                        })?
+                        .extract()?;
+                    let microsecond: u32 = dict
+                        .get_item("microsecond")?
+                        .map(|v| v.extract::<u32>())
+                        .transpose()?
+                        .unwrap_or(0);
+                    let date = NaiveDate::from_ymd_opt(year, month, day).ok_or_else(|| {
                         PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid datetime")
                     })?;
-                return Ok(LiteralValue::DateTime(NaiveDateTime::new(date, time)));
-            }
-            "duration" => {
-                let seconds: i64 = dict
-                    .get_item("seconds")?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                            "Duration dict missing 'seconds'",
-                        )
-                    })?
-                    .extract()?;
-                let microseconds: i64 = dict
-                    .get_item("microseconds")?
-                    .map(|v| v.extract::<i64>())
-                    .transpose()?
-                    .unwrap_or(0);
-                let duration = chrono::Duration::seconds(seconds)
-                    + chrono::Duration::microseconds(microseconds);
-                return Ok(LiteralValue::Duration(duration));
-            }
-            "pending" => return Ok(LiteralValue::Pending),
-            "empty" => return Ok(LiteralValue::Empty),
-            "array" => {
-                let values = dict.get_item("values")?.ok_or_else(|| {
-                    PyErr::new::<pyo3::exceptions::PyValueError, _>("Array dict missing 'values'")
-                })?;
-                let arr_literal = py_to_literal(&values)?;
-                if let LiteralValue::Array(rows) = arr_literal {
-                    return Ok(LiteralValue::Array(rows));
-                } else {
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                        "Array 'values' must be a 2D list",
-                    ));
+                    let time = NaiveTime::from_hms_micro_opt(hour, minute, second, microsecond)
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid datetime")
+                        })?;
+                    return Ok(LiteralValue::DateTime(NaiveDateTime::new(date, time)));
                 }
-            }
-            other => {
-                return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
-                    "Unsupported LiteralValue dict type: {other}"
-                )));
+                "duration" => {
+                    let seconds: i64 = dict
+                        .get_item("seconds")?
+                        .ok_or_else(|| {
+                            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                                "Duration dict missing 'seconds'",
+                            )
+                        })?
+                        .extract()?;
+                    let microseconds: i64 = dict
+                        .get_item("microseconds")?
+                        .map(|v| v.extract::<i64>())
+                        .transpose()?
+                        .unwrap_or(0);
+                    let duration = chrono::Duration::seconds(seconds)
+                        + chrono::Duration::microseconds(microseconds);
+                    return Ok(LiteralValue::Duration(duration));
+                }
+                "pending" => return Ok(LiteralValue::Pending),
+                "empty" => return Ok(LiteralValue::Empty),
+                "array" => {
+                    let values = dict.get_item("values")?.ok_or_else(|| {
+                        PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                            "Array dict missing 'values'",
+                        )
+                    })?;
+                    let arr_literal = py_to_literal(&values)?;
+                    if let LiteralValue::Array(rows) = arr_literal {
+                        return Ok(LiteralValue::Array(rows));
+                    } else {
+                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                            "Array 'values' must be a 2D list",
+                        ));
+                    }
+                }
+                other => {
+                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                        "Unsupported LiteralValue dict type: {other}"
+                    )));
+                }
             }
         }
     }

--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -1,11 +1,13 @@
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyTuple};
+use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 
 use formualizer::common::LiteralValue;
 use formualizer::common::error::{ExcelError, ExcelErrorKind};
 
-use crate::engine::{PyEvaluationConfig, eval_plan_to_py};
+use crate::engine::{
+    PyEvaluationConfig, apply_binding_eval_defaults, eval_plan_to_py, merge_python_eval_config,
+};
 use crate::enums::PyWorkbookMode;
 use crate::value::{literal_to_py, py_to_literal};
 use std::collections::HashMap;
@@ -173,13 +175,9 @@ impl PyWorkbook {
     #[pyo3(signature = (*, mode=None, config=None))]
     pub fn new(mode: Option<PyWorkbookMode>, config: Option<PyWorkbookConfig>) -> PyResult<Self> {
         let cfg = resolve_workbook_config(mode, config)?;
-        Ok(Self {
-            inner: std::sync::Arc::new(std::sync::RwLock::new(
-                formualizer::workbook::Workbook::new_with_config(cfg),
-            )),
-            sheets: std::sync::Arc::new(std::sync::RwLock::new(HashMap::new())),
-            cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        })
+        Ok(Self::from_inner_workbook(
+            formualizer::workbook::Workbook::new_with_config(cfg),
+        ))
     }
 
     /// Class method: load an XLSX workbook from a file path.
@@ -275,11 +273,7 @@ impl PyWorkbook {
                 .map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("load failed: {e}"))
                 })?;
-                Ok(Self {
-                    inner: std::sync::Arc::new(std::sync::RwLock::new(wb)),
-                    sheets: std::sync::Arc::new(std::sync::RwLock::new(HashMap::new())),
-                    cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                })
+                Ok(Self::from_inner_workbook(wb))
             }
             "umya" => {
                 use formualizer::workbook::backends::UmyaAdapter;
@@ -299,14 +293,63 @@ impl PyWorkbook {
                 .map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("load failed: {e}"))
                 })?;
-                Ok(Self {
-                    inner: std::sync::Arc::new(std::sync::RwLock::new(wb)),
-                    sheets: std::sync::Arc::new(std::sync::RwLock::new(HashMap::new())),
-                    cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                })
+                Ok(Self::from_inner_workbook(wb))
             }
             _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
                 "Unsupported backend: {backend}"
+            ))),
+        }
+    }
+
+    /// Class method: load an XLSX workbook from in-memory bytes.
+    ///
+    /// This is the Pyodide-friendly counterpart to `Workbook.from_path(...)`.
+    ///
+    /// Args:
+    ///     data: XLSX payload as `bytes`.
+    ///     backend: Backend name. Defaults to `umya` because `calamine` byte-open
+    ///         is not currently supported in this repository.
+    ///     mode/config: Optional workbook configuration.
+    #[classmethod]
+    #[pyo3(signature = (data, backend=None, *, mode=None, config=None))]
+    pub fn from_bytes<'py>(
+        _cls: &Bound<'py, pyo3::types::PyType>,
+        data: &Bound<'py, PyBytes>,
+        backend: Option<&str>,
+        mode: Option<PyWorkbookMode>,
+        config: Option<PyWorkbookConfig>,
+    ) -> PyResult<Self> {
+        let cfg = resolve_workbook_config(mode, config)?;
+        Self::from_bytes_impl(data.as_bytes().to_vec(), backend.unwrap_or("umya"), cfg)
+    }
+
+    /// Serialize the current workbook contents into XLSX bytes.
+    ///
+    /// Notes:
+    /// - This currently uses the `umya` backend.
+    /// - Output is generated from the in-memory workbook model; original XLSX styling
+    ///   and package metadata are not preserved by the Python binding.
+    #[pyo3(signature = (backend=None))]
+    pub fn to_xlsx_bytes<'py>(
+        &self,
+        py: Python<'py>,
+        backend: Option<&str>,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        match backend.unwrap_or("umya") {
+            "umya" => {
+                let wb = self.inner.read().map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
+                })?;
+                let bytes = wb.to_xlsx_bytes().map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("save failed: {e}"))
+                })?;
+                Ok(PyBytes::new(py, &bytes))
+            }
+            "calamine" => Err(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
+                "backend='calamine' does not currently support XLSX byte export; use backend='umya'",
+            )),
+            other => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Unsupported backend: {other}"
             ))),
         }
     }
@@ -740,9 +783,10 @@ impl PyWorkbook {
         if let Some(cached) = {
             let sheets = self.sheets.read().unwrap();
             sheets.get(sheet).and_then(|m| m.get(&(row, col)).cloned())
-        } && let Some(value) = cached.value
-        {
-            return Ok(Some(literal_to_py(py, &value)?));
+        } {
+            if let Some(value) = cached.value {
+                return Ok(Some(literal_to_py(py, &value)?));
+            }
         }
         let wb = self
             .inner
@@ -1074,6 +1118,47 @@ impl PyRangeAddress {
 
 // Non-Python methods for internal use
 impl PyWorkbook {
+    fn from_inner_workbook(inner: formualizer::workbook::Workbook) -> Self {
+        Self {
+            inner: std::sync::Arc::new(std::sync::RwLock::new(inner)),
+            sheets: std::sync::Arc::new(std::sync::RwLock::new(HashMap::new())),
+            cancel_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+
+    fn from_bytes_impl(
+        data: Vec<u8>,
+        backend: &str,
+        cfg: formualizer::workbook::WorkbookConfig,
+    ) -> PyResult<Self> {
+        match backend {
+            "umya" => {
+                use formualizer::workbook::backends::UmyaAdapter;
+                use formualizer::workbook::traits::SpreadsheetReader;
+
+                let adapter =
+                    <UmyaAdapter as SpreadsheetReader>::open_bytes(data).map_err(|e| {
+                        PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("open failed: {e}"))
+                    })?;
+                let wb = formualizer::workbook::Workbook::from_reader(
+                    adapter,
+                    formualizer::workbook::LoadStrategy::EagerAll,
+                    cfg,
+                )
+                .map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("load failed: {e}"))
+                })?;
+                Ok(Self::from_inner_workbook(wb))
+            }
+            "calamine" => Err(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
+                "backend='calamine' does not currently support XLSX byte open; use backend='umya'",
+            )),
+            other => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Unsupported backend: {other}"
+            ))),
+        }
+    }
+
     pub(crate) fn with_workbook_mut<T, F>(&self, f: F) -> PyResult<T>
     where
         F: FnOnce(&mut formualizer::workbook::Workbook) -> PyResult<T>,
@@ -1095,30 +1180,70 @@ fn resolve_workbook_config(
     config: Option<PyWorkbookConfig>,
 ) -> PyResult<formualizer::workbook::WorkbookConfig> {
     let resolved = if let Some(cfg) = config {
-        if let Some(requested) = mode
-            && requested != cfg.mode
-        {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "mode conflicts with WorkbookConfig.mode",
-            ));
+        if let Some(requested) = mode {
+            if requested != cfg.mode {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                    "mode conflicts with WorkbookConfig.mode",
+                ));
+            }
         }
         let mut base = match cfg.mode {
             PyWorkbookMode::Ephemeral => formualizer::workbook::WorkbookConfig::ephemeral(),
             PyWorkbookMode::Interactive => formualizer::workbook::WorkbookConfig::interactive(),
         };
         if let Some(eval) = cfg.eval {
-            base.eval = eval;
+            merge_python_eval_config(&mut base.eval, &eval);
+        } else {
+            apply_binding_eval_defaults(&mut base.eval);
         }
         if let Some(enabled) = cfg.enable_changelog {
             base.enable_changelog = enabled;
         }
         base
     } else {
-        match mode.unwrap_or(PyWorkbookMode::Interactive) {
+        let mut base = match mode.unwrap_or(PyWorkbookMode::Interactive) {
             PyWorkbookMode::Ephemeral => formualizer::workbook::WorkbookConfig::ephemeral(),
             PyWorkbookMode::Interactive => formualizer::workbook::WorkbookConfig::interactive(),
-        }
+        };
+        apply_binding_eval_defaults(&mut base.eval);
+        base
     };
 
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PyWorkbookConfig, resolve_workbook_config};
+    use crate::enums::PyWorkbookMode;
+    use formualizer::eval::engine::EvalConfig;
+
+    #[test]
+    fn resolve_workbook_config_applies_host_default_without_explicit_eval_config() {
+        let resolved = resolve_workbook_config(None, None).expect("resolve workbook config");
+        assert_eq!(
+            resolved.eval.enable_parallel,
+            !cfg!(target_os = "emscripten")
+        );
+        assert!(resolved.enable_changelog);
+        assert!(resolved.eval.defer_graph_building);
+    }
+
+    #[test]
+    fn resolve_workbook_config_preserves_explicit_eval_override() {
+        let explicit = EvalConfig {
+            enable_parallel: true,
+            ..EvalConfig::default()
+        };
+        let cfg = PyWorkbookConfig::new(PyWorkbookMode::Interactive, None, Some(false));
+        let cfg = PyWorkbookConfig {
+            eval: Some(explicit.clone()),
+            ..cfg
+        };
+
+        let resolved = resolve_workbook_config(None, Some(cfg)).expect("resolve workbook config");
+        assert_eq!(resolved.eval.enable_parallel, explicit.enable_parallel);
+        assert!(!resolved.enable_changelog);
+        assert!(resolved.eval.defer_graph_building);
+    }
 }

--- a/bindings/python/tests/test_pyodide_host_defaults.py
+++ b/bindings/python/tests/test_pyodide_host_defaults.py
@@ -1,0 +1,29 @@
+import sys
+
+import formualizer as fz
+
+
+def _plan_parallel_enabled(workbook: fz.Workbook) -> bool:
+    workbook.add_sheet("Sheet1")
+    workbook.set_value("Sheet1", 1, 1, 1)
+    workbook.set_value("Sheet1", 2, 1, 2)
+    workbook.set_formula("Sheet1", 1, 2, "=SUM(A1:A2)")
+    workbook.evaluate_cell("Sheet1", 1, 2)
+    plan = workbook.get_eval_plan([("Sheet1", 1, 2)])
+    return plan.parallel_enabled
+
+
+def test_evaluation_config_default_matches_host():
+    cfg = fz.EvaluationConfig()
+    assert cfg.enable_parallel is (sys.platform != "emscripten")
+
+
+def test_workbook_constructor_applies_host_parallel_policy():
+    workbook = fz.Workbook(mode=fz.WorkbookMode.Ephemeral)
+    assert _plan_parallel_enabled(workbook) is (sys.platform != "emscripten")
+
+
+def test_explicit_parallel_override_is_writable():
+    cfg = fz.EvaluationConfig()
+    cfg.enable_parallel = not cfg.enable_parallel
+    assert cfg.enable_parallel is (sys.platform == "emscripten")

--- a/bindings/python/tests/test_workbook_bytes.py
+++ b/bindings/python/tests/test_workbook_bytes.py
@@ -1,0 +1,65 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+import formualizer as fz
+
+try:
+    import openpyxl  # type: ignore
+except Exception:  # pragma: no cover - allow skipping if not present in dev env
+    openpyxl = None
+
+pytestmark = pytest.mark.skipif(openpyxl is None, reason="openpyxl not installed")
+
+
+def test_load_workbook_bytes_uses_umya_for_xlsx(xlsx_builder):
+    path = xlsx_builder(lambda wb: _populate_input_workbook(wb))
+    payload = Path(path).read_bytes()
+
+    wb = fz.load_workbook_bytes(payload)
+    assert wb.evaluate_cell("Sheet1", 1, 2) == 42.0
+
+    wb2 = fz.Workbook.from_bytes(payload, backend="umya")
+    assert wb2.evaluate_cell("Sheet1", 1, 2) == 42.0
+
+
+def test_load_workbook_bytes_rejects_calamine_for_now(xlsx_builder):
+    path = xlsx_builder(lambda wb: _populate_input_workbook(wb))
+    payload = Path(path).read_bytes()
+
+    with pytest.raises(NotImplementedError, match="calamine"):
+        fz.load_workbook_bytes(payload, backend="calamine")
+
+    with pytest.raises(NotImplementedError, match="calamine"):
+        fz.Workbook.from_bytes(payload, backend="calamine")
+
+
+def test_to_xlsx_bytes_roundtrip_preserves_workbook_content():
+    wb = fz.Workbook()
+    wb.add_sheet("Export")
+    wb.set_value("Export", 1, 1, 14)
+    wb.set_value("Export", 2, 1, 28)
+    wb.set_formula("Export", 1, 2, "=SUM(A1:A2)")
+    wb.evaluate_all()
+
+    payload = wb.to_xlsx_bytes()
+    assert isinstance(payload, bytes)
+    assert len(payload) > 100
+
+    openpyxl_wb = openpyxl.load_workbook(BytesIO(payload), data_only=False)
+    ws = openpyxl_wb["Export"]
+    assert ws["A1"].value == 14
+    assert ws["A2"].value == 28
+    assert ws["B1"].value == "=SUM(A1:A2)"
+
+    reopened = fz.load_workbook_bytes(payload)
+    assert reopened.evaluate_cell("Export", 1, 2) == 42.0
+
+
+def _populate_input_workbook(wb) -> None:
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = 20
+    ws["A2"] = 22
+    ws["B1"] = "=SUM(A1:A2)"

--- a/crates/formualizer-common/src/address.rs
+++ b/crates/formualizer-common/src/address.rs
@@ -393,15 +393,15 @@ impl<'a> SheetRangeRef<'a> {
         end_row: Option<AxisBound>,
         end_col: Option<AxisBound>,
     ) -> Result<Self, SheetAddressError> {
-        if let (Some(sr), Some(er)) = (start_row, end_row)
-            && sr.index > er.index
-        {
-            return Err(SheetAddressError::RangeOrder);
+        if let (Some(sr), Some(er)) = (start_row, end_row) {
+            if sr.index > er.index {
+                return Err(SheetAddressError::RangeOrder);
+            }
         }
-        if let (Some(sc), Some(ec)) = (start_col, end_col)
-            && sc.index > ec.index
-        {
-            return Err(SheetAddressError::RangeOrder);
+        if let (Some(sc), Some(ec)) = (start_col, end_col) {
+            if sc.index > ec.index {
+                return Err(SheetAddressError::RangeOrder);
+            }
         }
         Ok(SheetRangeRef::new(
             sheet, start_row, start_col, end_row, end_col,

--- a/crates/formualizer-common/src/error.rs
+++ b/crates/formualizer-common/src/error.rs
@@ -254,13 +254,13 @@ impl fmt::Display for ExcelError {
             }
 
             // Show origin if different from the evaluation location
-            if let (Some(or), Some(oc)) = (ctx.origin_row, ctx.origin_col)
-                && (ctx.row != Some(or) || ctx.col != Some(oc))
-            {
-                if let Some(ref sheet) = ctx.origin_sheet {
-                    write!(f, " [origin: {sheet}!R{or}C{oc}]")?;
-                } else {
-                    write!(f, " [origin: R{or}C{oc}]")?;
+            if let (Some(or), Some(oc)) = (ctx.origin_row, ctx.origin_col) {
+                if ctx.row != Some(or) || ctx.col != Some(oc) {
+                    if let Some(ref sheet) = ctx.origin_sheet {
+                        write!(f, " [origin: {sheet}!R{or}C{oc}]")?;
+                    } else {
+                        write!(f, " [origin: R{or}C{oc}]")?;
+                    }
                 }
             }
         }

--- a/crates/formualizer-common/src/lib.rs
+++ b/crates/formualizer-common/src/lib.rs
@@ -1,3 +1,10 @@
+#![cfg_attr(target_os = "emscripten", feature(let_chains))]
+// The Pyodide-matched Rust nightly predates let-chain stabilization, so this
+// crate intentionally keeps `if let ... { if cond { ... } }` nesting in a few
+// places. Allow clippy's collapse-suggestion globally rather than annotating
+// each site and risking drift.
+#![allow(clippy::collapsible_if)]
+
 pub mod address;
 pub mod coord;
 pub mod error;

--- a/crates/formualizer-eval/src/lib.rs
+++ b/crates/formualizer-eval/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "emscripten", feature(let_chains, unsigned_is_multiple_of))]
+
 pub mod args;
 pub mod broadcast;
 pub mod coercion;

--- a/crates/formualizer-parse/src/lib.rs
+++ b/crates/formualizer-parse/src/lib.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(target_os = "emscripten", feature(let_chains))]
+// See formualizer-common/lib.rs for rationale: the Pyodide nightly predates
+// let-chain stabilization, so nested `if let ... { if cond { ... } }` is
+// deliberate here; silence clippy's collapse suggestion crate-wide.
+#![allow(clippy::collapsible_if)]
+
 mod hasher;
 pub mod parser;
 pub mod pretty;

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1161,12 +1161,12 @@ impl ReferenceType {
 
             let sheet = match (&start_part.sheet, &end_part) {
                 (Some(sheet), Some(end)) => {
-                    if let Some(end_sheet) = &end.sheet
-                        && end_sheet != sheet
-                    {
-                        return Err(ParsingError::InvalidReference(format!(
-                            "Mismatched sheets in reference: {sheet} vs {end_sheet}"
-                        )));
+                    if let Some(end_sheet) = &end.sheet {
+                        if end_sheet != sheet {
+                            return Err(ParsingError::InvalidReference(format!(
+                                "Mismatched sheets in reference: {sheet} vs {end_sheet}"
+                            )));
+                        }
                     }
                     Some(sheet.clone())
                 }
@@ -1671,28 +1671,29 @@ impl ASTNode {
                 end_col_abs,
             } => {
                 // Optionally expand very small finite ranges into individual cells
-                if policy.expand_small_ranges
-                    && let (Some(sr), Some(sc), Some(er), Some(ec)) =
+                if policy.expand_small_ranges {
+                    if let (Some(sr), Some(sc), Some(er), Some(ec)) =
                         (start_row, start_col, end_row, end_col)
-                {
-                    let rows = er.saturating_sub(sr) + 1;
-                    let cols = ec.saturating_sub(sc) + 1;
-                    let area = rows.saturating_mul(cols);
-                    if area as usize <= policy.range_expansion_limit {
-                        let row_abs = start_row_abs && end_row_abs;
-                        let col_abs = start_col_abs && end_col_abs;
-                        for r in sr..=er {
-                            for c in sc..=ec {
-                                out.push(ReferenceType::Cell {
-                                    sheet: sheet.map(|s| s.to_string()),
-                                    row: r,
-                                    col: c,
-                                    row_abs,
-                                    col_abs,
-                                });
+                    {
+                        let rows = er.saturating_sub(sr) + 1;
+                        let cols = ec.saturating_sub(sc) + 1;
+                        let area = rows.saturating_mul(cols);
+                        if area as usize <= policy.range_expansion_limit {
+                            let row_abs = start_row_abs && end_row_abs;
+                            let col_abs = start_col_abs && end_col_abs;
+                            for r in sr..=er {
+                                for c in sc..=ec {
+                                    out.push(ReferenceType::Cell {
+                                        sheet: sheet.map(|s| s.to_string()),
+                                        row: r,
+                                        col: c,
+                                        row_abs,
+                                        col_abs,
+                                    });
+                                }
                             }
+                            return; // handled
                         }
-                        return; // handled
                     }
                 }
                 out.push(ReferenceType::Range {

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -670,14 +670,15 @@ impl<'a> SpanTokenizer<'a> {
     }
 
     fn check_scientific_notation(&mut self) -> bool {
-        if let Some(curr_byte) = self.current_byte()
-            && (curr_byte == b'+' || curr_byte == b'-')
-            && self.has_token()
-            && self.is_scientific_notation_base()
-        {
-            self.offset += 1;
-            self.extend_token();
-            return true;
+        if let Some(curr_byte) = self.current_byte() {
+            if (curr_byte == b'+' || curr_byte == b'-')
+                && self.has_token()
+                && self.is_scientific_notation_base()
+            {
+                self.offset += 1;
+                self.extend_token();
+                return true;
+            }
         }
         false
     }
@@ -1426,14 +1427,15 @@ impl Tokenizer {
     /// If the current token looks like a number in scientific notation,
     /// consume the '+' or '-' as part of the number.
     fn check_scientific_notation(&mut self) -> Result<bool, TokenizerError> {
-        if let Some(curr_byte) = self.current_byte()
-            && (curr_byte == b'+' || curr_byte == b'-')
-            && self.has_token()
-            && self.is_scientific_notation_base()
-        {
-            self.offset += 1;
-            self.extend_token();
-            return Ok(true);
+        if let Some(curr_byte) = self.current_byte() {
+            if (curr_byte == b'+' || curr_byte == b'-')
+                && self.has_token()
+                && self.is_scientific_notation_base()
+            {
+                self.offset += 1;
+                self.extend_token();
+                return Ok(true);
+            }
         }
         Ok(false)
     }

--- a/crates/formualizer-sheetport/src/lib.rs
+++ b/crates/formualizer-sheetport/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "emscripten", feature(let_chains))]
+
 //! SheetPort runtime bindings.
 //!
 //! This crate links [`sheetport_spec::Manifest`] definitions to concrete workbook

--- a/crates/formualizer-workbook/src/backends/umya.rs
+++ b/crates/formualizer-workbook/src/backends/umya.rs
@@ -56,6 +56,16 @@ impl UmyaAdapter {
     const EXCEL_MAX_ROWS: u32 = 1_048_576;
     const EXCEL_MAX_COLS: u32 = 16_384;
 
+    pub fn new_empty() -> Self {
+        Self {
+            workbook: RwLock::new(umya_spreadsheet::new_file()),
+            lazy: false,
+            original_path: None,
+            table_header_rows: HashMap::new(),
+            table_header_rows_available: false,
+        }
+    }
+
     fn extract_attr(tag: &str, key: &str) -> Option<String> {
         let needle_dq = format!("{key}=\"");
         if let Some(pos) = tag.find(&needle_dq) {

--- a/crates/formualizer-workbook/src/lib.rs
+++ b/crates/formualizer-workbook/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "emscripten", feature(let_chains, unsigned_is_multiple_of))]
+
 pub mod backends;
 pub mod builtins;
 pub mod error;

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -631,9 +631,9 @@ impl WorkbookCustomFunction {
     ) -> Result<LiteralValue, ExcelError> {
         match arg.value_or_range()? {
             formualizer_eval::traits::EvaluatedArg::LiteralValue(v) => Ok(v.into_owned()),
-            formualizer_eval::traits::EvaluatedArg::Range(r) => {
-                Ok(LiteralValue::Array(r.materialise().into_owned()))
-            }
+            formualizer_eval::traits::EvaluatedArg::Range(r) => Ok(unwrap_scalar_array(
+                LiteralValue::Array(r.materialise().into_owned()),
+            )),
         }
     }
 }
@@ -674,11 +674,29 @@ impl formualizer_eval::function::Function for WorkbookCustomFunction {
         }));
 
         match callback_result {
-            Ok(Ok(value)) => Ok(formualizer_eval::traits::CalcValue::Scalar(value)),
+            Ok(Ok(value)) => Ok(formualizer_eval::traits::CalcValue::Scalar(
+                unwrap_scalar_array(value),
+            )),
             Ok(Err(err)) => Err(err),
             Err(_) => Err(ExcelError::new(ExcelErrorKind::Value)
                 .with_message("Custom function callback panicked")),
         }
+    }
+}
+
+// Excel treats single-cell references and 1x1 ranges as scalars. Unwrap
+// any 1x1 LiteralValue::Array so custom-function arg and return paths
+// match that convention; multi-cell arrays pass through unchanged.
+fn unwrap_scalar_array(value: LiteralValue) -> LiteralValue {
+    match value {
+        LiteralValue::Array(ref rows) if rows.len() == 1 && rows[0].len() == 1 => {
+            if let LiteralValue::Array(mut rows) = value {
+                rows.remove(0).remove(0)
+            } else {
+                unreachable!()
+            }
+        }
+        other => other,
     }
 }
 
@@ -758,7 +776,9 @@ impl formualizer_eval::function::Function for WorkbookWasmFunction {
         }));
 
         match runtime_result {
-            Ok(Ok(value)) => Ok(formualizer_eval::traits::CalcValue::Scalar(value)),
+            Ok(Ok(value)) => Ok(formualizer_eval::traits::CalcValue::Scalar(
+                unwrap_scalar_array(value),
+            )),
             Ok(Err(err)) => Err(err),
             Err(_) => Err(ExcelError::new(ExcelErrorKind::Value)
                 .with_message("WASM function runtime panicked")),
@@ -1060,6 +1080,62 @@ impl Workbook {
     }
     pub fn new() -> Self {
         Self::new_with_mode(WorkbookMode::Interactive)
+    }
+
+    #[cfg(feature = "umya")]
+    pub fn to_xlsx_bytes(&self) -> Result<Vec<u8>, IoError> {
+        use crate::backends::UmyaAdapter;
+
+        let mut adapter = UmyaAdapter::new_empty();
+        let sheet_names = self.sheet_names();
+
+        if let Some((first_sheet, remaining_sheets)) = sheet_names.split_first() {
+            if first_sheet != "Sheet1" {
+                adapter
+                    .rename_sheet("Sheet1", first_sheet)
+                    .map_err(|e| IoError::from_backend("umya", e))?;
+            }
+
+            for sheet_name in remaining_sheets {
+                adapter
+                    .create_sheet(sheet_name)
+                    .map_err(|e| IoError::from_backend("umya", e))?;
+            }
+
+            for sheet_name in &sheet_names {
+                let Some((max_row, max_col)) = self.sheet_dimensions(sheet_name) else {
+                    continue;
+                };
+
+                for row in 1..=max_row {
+                    for col in 1..=max_col {
+                        let value = self.get_value(sheet_name, row, col);
+                        let formula = self.get_formula(sheet_name, row, col);
+
+                        if value.is_none() && formula.is_none() {
+                            continue;
+                        }
+
+                        adapter
+                            .write_cell(
+                                sheet_name,
+                                row,
+                                col,
+                                crate::traits::CellData {
+                                    value,
+                                    formula,
+                                    style: None,
+                                },
+                            )
+                            .map_err(|e| IoError::from_backend("umya", e))?;
+                    }
+                }
+            }
+        }
+
+        adapter
+            .save_to_bytes()
+            .map_err(|e| IoError::from_backend("umya", e))
     }
 
     pub fn register_custom_function(

--- a/crates/formualizer-workbook/tests/umya/save.rs
+++ b/crates/formualizer-workbook/tests/umya/save.rs
@@ -1,7 +1,10 @@
 // Integration test for Umya backend; run with `--features umya`.
 use crate::common::build_workbook;
 use formualizer_workbook::LiteralValue;
-use formualizer_workbook::{CellData, SpreadsheetReader, SpreadsheetWriter, UmyaAdapter};
+use formualizer_workbook::{
+    CellData, LoadStrategy, SpreadsheetReader, SpreadsheetWriter, UmyaAdapter, Workbook,
+    WorkbookConfig,
+};
 use std::io::Cursor;
 
 #[test]
@@ -95,5 +98,32 @@ fn umya_open_bytes_returns_parse_error_for_invalid_payload() {
     assert!(
         !err.to_string().to_ascii_lowercase().contains("unsupported"),
         "open_bytes should attempt parsing, got unsupported error: {err}"
+    );
+}
+
+#[test]
+fn workbook_to_xlsx_bytes_roundtrips_with_umya_reader() {
+    let mut wb = Workbook::new_with_config(WorkbookConfig::interactive());
+    wb.add_sheet("Data").unwrap();
+    wb.set_value("Data", 1, 1, LiteralValue::Number(20.0))
+        .unwrap();
+    wb.set_value("Data", 2, 1, LiteralValue::Number(22.0))
+        .unwrap();
+    wb.set_formula("Data", 1, 2, "=SUM(A1:A2)").unwrap();
+    wb.evaluate_all().unwrap();
+
+    let bytes = wb.to_xlsx_bytes().unwrap();
+    assert!(bytes.len() > 100, "Expected non-trivial XLSX byte output");
+
+    let adapter = UmyaAdapter::open_bytes(bytes).unwrap();
+    let mut reopened = Workbook::from_reader(
+        adapter,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .unwrap();
+    assert_eq!(
+        reopened.evaluate_cell("Data", 1, 2).unwrap(),
+        LiteralValue::Number(42.0)
     );
 }

--- a/crates/sheetport-spec/src/lib.rs
+++ b/crates/sheetport-spec/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(target_os = "emscripten", feature(let_chains))]
+// See formualizer-common/lib.rs for rationale.
+#![allow(clippy::collapsible_if)]
+
 //! SheetPort manifest specification types and helpers.
 //!
 //! This crate defines the canonical data model for Formualizer I/O (FIO) manifests,

--- a/crates/sheetport-spec/src/manifest.rs
+++ b/crates/sheetport-spec/src/manifest.rs
@@ -101,11 +101,11 @@ impl Manifest {
             tags.dedup();
         }
 
-        if let Some(capabilities) = &mut self.capabilities
-            && let Some(features) = &mut capabilities.features
-        {
-            features.sort();
-            features.dedup();
+        if let Some(capabilities) = &mut self.capabilities {
+            if let Some(features) = &mut capabilities.features {
+                features.sort();
+                features.dedup();
+            }
         }
 
         self.ports.sort_by(|a, b| a.id.cmp(&b.id));
@@ -217,20 +217,22 @@ impl Manifest {
                 ));
             }
 
-            if let Selector::Layout(layout) = &port.location
-                && matches!(layout.layout.terminate, LayoutTermination::UntilMarker)
-                && layout
-                    .layout
-                    .marker_text
-                    .as_deref()
-                    .map(str::trim)
-                    .unwrap_or_default()
-                    .is_empty()
-            {
-                issues.push(ManifestIssue::new(
-                    format!("ports[{}].location.layout.marker_text", idx),
-                    "marker_text must be provided when terminate == \"until_marker\"".to_string(),
-                ));
+            if let Selector::Layout(layout) = &port.location {
+                if matches!(layout.layout.terminate, LayoutTermination::UntilMarker)
+                    && layout
+                        .layout
+                        .marker_text
+                        .as_deref()
+                        .map(str::trim)
+                        .unwrap_or_default()
+                        .is_empty()
+                {
+                    issues.push(ManifestIssue::new(
+                        format!("ports[{}].location.layout.marker_text", idx),
+                        "marker_text must be provided when terminate == \"until_marker\""
+                            .to_string(),
+                    ));
+                }
             }
 
             if let Some(constraints) = &port.constraints {
@@ -847,13 +849,13 @@ fn validate_constraints(
     base_path: String,
     issues: &mut Vec<ManifestIssue>,
 ) {
-    if let (Some(min), Some(max)) = (constraints.min, constraints.max)
-        && min > max
-    {
-        issues.push(ManifestIssue::new(
-            format!("{}.min", base_path),
-            format!("`min` value {min} exceeds `max` value {max}"),
-        ));
+    if let (Some(min), Some(max)) = (constraints.min, constraints.max) {
+        if min > max {
+            issues.push(ManifestIssue::new(
+                format!("{}.min", base_path),
+                format!("`min` value {min} exceeds `max` value {max}"),
+            ));
+        }
     }
 
     if let Some(vt) = value_type {
@@ -889,13 +891,13 @@ fn validate_constraints(
         }
     }
 
-    if let Some(pattern) = &constraints.pattern
-        && let Err(err) = Regex::new(pattern)
-    {
-        issues.push(ManifestIssue::new(
-            format!("{}.pattern", base_path),
-            format!("invalid regex pattern `{pattern}`: {err}"),
-        ));
+    if let Some(pattern) = &constraints.pattern {
+        if let Err(err) = Regex::new(pattern) {
+            issues.push(ManifestIssue::new(
+                format!("{}.pattern", base_path),
+                format!("invalid regex pattern `{pattern}`: {err}"),
+            ));
+        }
     }
 }
 

--- a/docs-site/content/docs/quickstarts/index.mdx
+++ b/docs-site/content/docs/quickstarts/index.mdx
@@ -9,6 +9,7 @@ Use these guides to get to your first evaluated formula quickly.
 
 - [Rust Quickstart](/docs/quickstarts/rust-quickstart)
 - [Python Quickstart](/docs/quickstarts/python-quickstart)
+- [Pyodide Quickstart](/docs/quickstarts/pyodide-quickstart) — formualizer in the browser via Pyodide
 - [JavaScript/WASM Quickstart](/docs/quickstarts/js-wasm-quickstart)
 
 ## Prefer one complete walkthrough?
@@ -23,6 +24,7 @@ Use the live [Formula Parser](/formula-parser) to inspect tokens, AST output, re
 
 - Rust quickstart: stable Rust toolchain
 - Python quickstart: Python 3.10+
+- Pyodide quickstart: Pyodide 0.29.x runtime (browser or Node)
 - JS/WASM quickstart: Node 18+
 
 If you are brand new to Formualizer, start at [Introduction](/docs/introduction).

--- a/docs-site/content/docs/quickstarts/meta.json
+++ b/docs-site/content/docs/quickstarts/meta.json
@@ -4,6 +4,7 @@
     "index",
     "rust-quickstart",
     "python-quickstart",
+    "pyodide-quickstart",
     "js-wasm-quickstart",
     "first-workbook-in-5-minutes"
   ]

--- a/docs-site/content/docs/quickstarts/pyodide-quickstart.mdx
+++ b/docs-site/content/docs/quickstarts/pyodide-quickstart.mdx
@@ -1,0 +1,74 @@
+---
+title: Pyodide Quickstart
+description: Run formualizer in the browser via Pyodide — install with micropip and evaluate workbook formulas client-side.
+---
+
+Formualizer publishes a Pyodide-tagged wheel (`*-pyodide_<abi>_wasm32.whl`) alongside the native CPython wheels. Any Python code that works against formualizer on CPython works the same inside a Pyodide runtime — with a few platform-specific defaults noted below.
+
+## 1) Install in a Pyodide runtime
+
+```python
+import micropip
+await micropip.install("formualizer")
+```
+
+This resolves the Pyodide-tagged wheel from PyPI — no extra index URL, no manual wheel download.
+
+## 2) Evaluate a formula
+
+```python
+import formualizer as fz
+
+wb = fz.Workbook()
+wb.add_sheet("Sheet1")
+
+wb.set_value("Sheet1", 1, 1, 100)
+wb.set_value("Sheet1", 2, 1, 20)
+wb.set_formula("Sheet1", 1, 2, "=A1-A2")
+
+result = wb.evaluate_cell("Sheet1", 1, 2)
+print(result)  # 80.0
+```
+
+## 3) Register a Python UDF
+
+```python
+wb.register_function(
+    "py_add",
+    lambda a, b: a + b,
+    min_args=2,
+    max_args=2,
+)
+wb.set_value("Sheet1", 1, 1, 20)
+wb.set_value("Sheet1", 2, 1, 22)
+wb.set_formula("Sheet1", 1, 2, "=PY_ADD(A1, A2)")
+wb.evaluate_cell("Sheet1", 1, 2)  # 42
+```
+
+Single-cell references arrive as scalars in the callback, matching Excel semantics.
+
+## 4) Round-trip an XLSX file
+
+```python
+xlsx_bytes = wb.to_xlsx_bytes()
+# ... send to browser download, IndexedDB, fetch upload, etc.
+
+restored = fz.load_workbook_bytes(xlsx_bytes)
+restored.evaluate_cell("Sheet1", 1, 2)
+```
+
+## Supported Pyodide versions
+
+The published wheel targets **Pyodide 0.29.x** (ABI `pyodide_2025_0`). Check the formualizer release that matches your Pyodide runtime — when Pyodide ships a new ABI, a new formualizer release is cut against it.
+
+## Pyodide-specific behavior
+
+- `EvaluationConfig()` and `Workbook()` default `enable_parallel = False` on `sys.platform == "emscripten"`. Pyodide has no threads; the flag remains available but falls back to single-threaded execution.
+- XLSX byte I/O (`to_xlsx_bytes`, `from_bytes`, `load_workbook_bytes`) uses the `umya` backend on all platforms.
+- Everything else — parse, evaluate, spill, custom functions, undo/redo, SheetPort — behaves identically to native CPython.
+
+## Next
+
+- [Python Quickstart](/docs/quickstarts/python-quickstart) — the same API on native CPython
+- [First Workbook in 5 Minutes](/docs/quickstarts/first-workbook-in-5-minutes)
+- [Custom Functions (Rust, Python, JS)](/docs/guides/custom-functions-rust-python-js)

--- a/docs-site/content/docs/quickstarts/python-quickstart.mdx
+++ b/docs-site/content/docs/quickstarts/python-quickstart.mdx
@@ -31,9 +31,14 @@ print(result)  # 80.0
 python bindings/python/examples/custom_function_registration.py
 ```
 
+## Running in the browser (Pyodide)
+
+Formualizer also ships a Pyodide-tagged wheel — `await micropip.install("formualizer")` works inside a Pyodide runtime with the same API shown above. See the [Pyodide Quickstart](/docs/quickstarts/pyodide-quickstart) for install, UDF, and XLSX-byte examples, plus the handful of platform-specific defaults.
+
 ## Next
 
 - [Formula Parser](/formula-parser)
 - [First Workbook in 5 Minutes](/docs/quickstarts/first-workbook-in-5-minutes)
+- [Pyodide Quickstart](/docs/quickstarts/pyodide-quickstart)
 - [Custom Functions (Rust, Python, JS)](/docs/guides/custom-functions-rust-python-js)
 - [Deterministic Testing](/docs/guides/deterministic-testing)

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -26,6 +26,8 @@ This repo publishes multiple artifacts (crates.io, PyPI, npm) from one monorepo.
 ### Python (PyPI)
 
 - `formualizer` (maturin / pyo3 extension): the product surface for Python.
+  - Published wheels: manylinux (x86_64, aarch64), musllinux (x86_64, aarch64), macOS (x86_64, arm64), Windows (x64), and **Pyodide** (`pyodide_<abi>_wasm32`) — all under the same PyPI project and version.
+  - End users install identically on every target: `pip install formualizer` on native, `await micropip.install("formualizer")` in a Pyodide runtime.
 
 ### JS/WASM (npm)
 
@@ -124,6 +126,18 @@ Release workflows should:
 - Publish without masking failures (no `|| true`).
 
 For npm builds, ensure the wasm-pack target matches what we publish (bundler vs web target) and that the generated `pkg/` content matches what `package.json` expects.
+
+## Pyodide wheel pipeline
+
+The Pyodide wheel is built by `bindings/python/scripts/build-pyodide-wheel.sh` on every PR (`ci.yml :: build-pyodide-wheel`) and on every product release tag (`release.yml :: build-wheels-pyodide`), then uploaded to PyPI by `publish-pypi` alongside the platform wheels.
+
+Key pipeline specifics worth knowing before touching this path:
+
+- **Pyodide version target is derived, not hardcoded.** The build script reads `pyodide xbuildenv version`, `python_version`, `emscripten_version`, `rust_toolchain`, `rustflags`, `cflags`, `cxxflags`, `ldflags`, and `rust_emscripten_target_url` from `pyodide config`. Bumping `pyodide-build` changes the target; everything else follows.
+- **Custom Rust sysroot is mandatory.** Stock `rustup target add wasm32-unknown-emscripten` ships a `std` built with JS-trampoline exceptions (`invoke_*`), which Pyodide 0.29+ rejects with a dynamic-linking error at import time. The build script downloads Pyodide's prebuilt wasm-EH sysroot (`rust-emscripten-wasm-eh-sysroot` on GitHub) and extracts it over rustup's stock target. A sentinel file in the target dir makes this idempotent across runs.
+- **Wheel is retagged after build.** `pyodide-build 0.34` repacks wheels with `pyemscripten_2025_0_wasm32`, which the `micropip` shipped in Pyodide 0.29.x misparses as an Emscripten version string and rejects. The build script retags to `pyodide_2025_0_wasm32` (the tag Pyodide's own package lockfile uses), so `micropip.install` accepts the wheel without falling back to zip extraction.
+- **Smoke gate is mandatory.** Both CI and release jobs run `smoke-pyodide-wheel.sh`, which loads the wheel into a real Pyodide runtime and exercises parse, evaluate, byte I/O, and Python UDF paths. A broken wheel never reaches PyPI.
+- **Supported-Pyodide range is implicit in `pyodide-build` pin.** `pyodide-build 0.34.x` targets Pyodide 0.29.x (ABI `pyodide_2025_0`). When Pyodide cuts a new ABI, bump `pyodide-build` (and re-verify the sysroot URL in `pyodide config get rust_emscripten_target_url` still resolves), then cut a formualizer release. Document the supported Pyodide range in `bindings/python/README.md`.
 
 ## Version Bump Script
 


### PR DESCRIPTION
## Summary

Adds a Pyodide-targeted wheel to the Python release matrix so
`await micropip.install(\"formualizer\")` works end-to-end inside a
Pyodide 0.29.x runtime.

## Highlights

- **Import works.** Fixes the legacy `invoke_iiii` dynamic-linking failure that blocked the wheel from loading under Pyodide 0.29+. Root cause was the stock `rustup target add wasm32-unknown-emscripten` sysroot using JS-trampoline exceptions; fix installs Pyodide's custom wasm-EH sysroot and exports the canonical `RUSTFLAGS`/`CFLAGS`/`LDFLAGS` from `pyodide config`.
- **Micropip installs cleanly.** `pyodide-build 0.34` repacks wheels with a forward-looking `pyemscripten_2025_0_wasm32` tag that micropip 0.11 (shipped in 0.29.x) misparses as a bogus Emscripten version. A post-build `wheel tags` step retags to `pyodide_2025_0_wasm32` — matches what Pyodide's own lockfile uses, so `micropip.install` accepts the wheel with no zip-extraction fallback.
- **Let-chain portability.** `#![feature(let_chains)]` gated on emscripten targets + a few syntax rewrites so the crate compiles against the Pyodide-matched Rust nightly (`nightly-2025-02-01`).
- **Pyodide-aware defaults.** `EvaluationConfig`/`Workbook` default `enable_parallel=False` on `sys.platform == \"emscripten\"`.
- **Byte I/O API surface.** New `load_workbook_bytes`, `Workbook.from_bytes`, `Workbook.to_xlsx_bytes` (umya backend) for browser-side XLSX round-trips.
- **Excel-native UDF arg handling.** `WorkbookCustomFunction::materialize_arg` and the return path now unwrap 1×1 arrays to scalars, matching Excel semantics for single-cell refs — previously `A1` arrived at Python/Rust callbacks as `[[v]]`, which silently broke natural UDF code on every platform.

## CI / Release pipeline

- Smoke-gate step added to existing `build-pyodide-wheel` PR job — PRs fail fast on a broken wheel.
- New `build-wheels-pyodide` release job builds + smoke-tests + uploads as `wheels-pyodide`; `publish-pypi` depends on it, so every `v*` tag ships the Pyodide wheel to PyPI alongside the platform wheels.

## Docs

- `bindings/python/README.md` — new **Using in Pyodide** section with `micropip.install` snippet and nested source-build instructions.
- Top-level `README.md` — new Pyodide row in the bindings install table.
- `docs/packaging-and-releases.md` — Pyodide added to PyPI wheel list; new **Pyodide wheel pipeline** section covering sysroot, retag, smoke gate, and Pyodide-version-bump procedure.
- `docs-site/content/docs/quickstarts/pyodide-quickstart.mdx` — new Fumadocs quickstart page (install, UDF, XLSX byte round-trip, platform-specific defaults).

## Verification

Smoke test on the produced wheel under Pyodide 0.29.3 (Node runtime):

```
install_method: \"micropip\"   # no zip-fallback
ast_formula:    \"=SUM(A1:A2)\"
default_parallel: false
platform: emscripten
wheel_bytes: 5158
```

Covers parse/evaluate, native SUM, byte I/O round-trip, Python UDF callback with scalar cell-ref args, and the emscripten parallel-off default.

Native CPython (Linux) also verified with the same UDF probe to confirm the 1×1 coercion change is platform-agnostic, not a Pyodide-only shim.

## ⚠️ Rebase-before-merge

This branch was cut from a HEAD that's ~20 commits behind `origin/main` (v0.5.5 and v0.5.6 landed in the interim). **Needs rebase before merge.** Known file overlap with main: `bindings/python/src/workbook.rs`, `crates/formualizer-workbook/src/{workbook.rs,lib.rs,backends/umya.rs}`, `crates/formualizer-parse/src/parser.rs`, `crates/formualizer-eval/src/lib.rs`, `bindings/python/{README.md,formualizer/__init__.pyi}`, `.github/workflows/{ci,release}.yml`, `README.md`. Re-run the smoke gate after rebase.

## Test plan

- [ ] Rebase onto `main`; resolve conflicts in the files listed above
- [ ] Re-run `bindings/python/scripts/build-pyodide-wheel.sh`
- [ ] Re-run `bindings/python/scripts/smoke-pyodide-wheel.sh dist/pyodide/*-pyodide_*_wasm32.whl` — expect `install_method: \"micropip\"`
- [ ] Confirm `cargo test -p formualizer-workbook` passes (covers the 1×1 coercion change)
- [ ] Confirm `cargo test -p formualizer-common -p formualizer-parse` passes under default (non-nightly) stable toolchain (let-chain changes are no-op on non-emscripten)
- [ ] Native UDF probe: `PY_ADD(A1, A2)` with `lambda a, b: a + b` returns `42.0` on CPython
- [ ] Docs-site build: `cd docs-site && pnpm install && pnpm build` — new quickstart page renders
- [ ] Cut a test release candidate (`v0.5.7-rc.1`) and verify `wheels-pyodide` artifact appears and `publish-pypi` includes it