### PR TITLE
fix(python): ship wheel with jemalloc global allocator (closes #63)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ dependencies = [
  "pyo3",
  "pyo3-stub-gen",
  "serde_json",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -3940,6 +3941,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -15,13 +15,20 @@ name = "formualizer_py"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+# Default to jemalloc on platforms that support it; the cfg-gate in
+# src/lib.rs ensures we silently fall back to the system allocator on
+# MSVC / wasm32 even when this feature is enabled.
+default = ["allocator-jemalloc"]
 # Enable engine/IO tracing spans from the Python wheel/venv build.
 # Usage:
 #  - maturin develop --release --features tracing
 #  - maturin develop --release --features tracing,tracing_chrome
 tracing = ["formualizer/tracing"]
 tracing_chrome = ["tracing", "formualizer/tracing_chrome"]
+# Swap the wheel's global allocator to jemalloc. This dramatically reduces
+# cross-call RSS retention on glibc by avoiding the per-thread-arena
+# fragmentation caused by per-call rayon worker pools (see issue #63).
+allocator-jemalloc = ["dep:tikv-jemallocator"]
 
 [dependencies]
 pyo3 = { workspace = true, features = ["chrono", "abi3-py310"] }
@@ -29,3 +36,16 @@ formualizer = { path = "../../crates/formualizer", default-features = false, fea
 chrono = { workspace = true }
 serde_json = { workspace = true }
 pyo3-stub-gen = "0.18.0"
+
+# Optional jemalloc global allocator (see `allocator-jemalloc` feature).
+# The crate itself builds unconditionally on any platform, but we only
+# install it as `#[global_allocator]` where it is supported (not MSVC, not
+# wasm32); on other platforms the feature is a no-op and the system
+# allocator is used.
+[target.'cfg(not(any(target_env = "msvc", target_arch = "wasm32")))'.dependencies]
+# `disable_initial_exec_tls` is required because the wheel is a cdylib that
+# Python loads via dlopen() after program startup. Without it, jemalloc
+# requests initial-exec TLS which is only reserved for binaries/libraries
+# present at exec time and the import fails with "cannot allocate memory in
+# static TLS block" on glibc.
+tikv-jemallocator = { version = "0.6", optional = true, features = ["disable_initial_exec_tls"] }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3,6 +3,24 @@ use pyo3::wrap_pyfunction;
 use pyo3_stub_gen::define_stub_info_gatherer;
 use pyo3_stub_gen::derive::gen_stub_pyfunction;
 
+// Swap the wheel's global allocator to jemalloc to avoid glibc per-thread
+// arena fragmentation that causes the cross-call RSS staircase observed in
+// issue #63. This only affects allocations inside this cdylib; CPython and
+// other extension modules continue to use their own allocators.
+//
+// The cfg-gate mirrors `tikv-jemallocator`'s supported platforms:
+//   * not target_env = "msvc"  (Windows MSVC is incompatible)
+//   * not target_arch = "wasm32" (jemalloc cannot build for wasm)
+// On unsupported platforms the feature is a no-op and the system allocator
+// is used.
+#[cfg(all(
+    feature = "allocator-jemalloc",
+    not(target_env = "msvc"),
+    not(target_arch = "wasm32")
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod ast;
 mod engine;
 mod enums;


### PR DESCRIPTION
Fixes #63.

## Root cause

The reported `recalculate_file` cross-call RSS staircase is **not** a leak in formualizer's Rust code. It is glibc `ptmalloc` per-thread-arena fragmentation, amplified by the fact that every `recalculate_file` call constructs a fresh `rayon::ThreadPool` inside `Engine::new` (`crates/formualizer-eval/src/engine/eval.rs:871`). glibc assigns each worker thread its own arena and does not fully unmap those arenas when the thread exits; subsequent calls create fresh workers that cannot fully reuse the prior arenas. `malloc_trim(0)` only meaningfully affects the main arena, so the working set accumulates across calls.

Independent confirmations (see investigation notes):

- `MALLOC_ARENA_MAX=1` + `malloc_trim(0)` → RSS flat at ~13 MB across 25 iterations
- `EvalConfig { enable_parallel: false, .. }` → RSS flat at ~20 MB across 8 iterations
- Switching `#[global_allocator]` to jemalloc → plateau at ~220 MB, no monotonic growth
- `/proc/self/task` stable at 2 after each call → rayon workers do exit cleanly; the problem is what glibc *retains* from their arenas

## Fix

Install `tikv-jemallocator` as the `#[global_allocator]` for the Python wheel (the `formualizer-python` cdylib) only. No changes to the Rust crates. Users consuming formualizer as a Rust crate pick their own allocator.

## Cfg gates

- `cfg(not(any(target_env = "msvc", target_arch = "wasm32")))` at the Cargo target level — jemalloc doesn't support MSVC or wasm32, so the dep isn't pulled in on those platforms.
- Same cfg on the `#[global_allocator]` declaration. Unsupported platforms silently fall back to the system allocator.
- `tikv-jemallocator` is pulled in with `features = ["disable_initial_exec_tls"]`. This is **required** for Python wheel use: CPython `dlopen()`s the cdylib after program start, and jemalloc's default initial-exec TLS cannot be satisfied by the dynamic linker at that point. Without this feature, `import formualizer` panics at load time. Cost is a slightly slower TLS access inside jemalloc (generic-dynamic model), which is irrelevant compared to formula evaluation.

## Feature flag

New `allocator-jemalloc` cargo feature, on by default. Opt-out for users who need the system allocator (e.g., LD_PRELOAD heap profilers):

```
maturin develop --no-default-features
pip install formualizer --config-settings build-args="--no-default-features"
```

## Measurements (50k-row fixture × 6 iters, gc.collect each)

**Before** (system allocator, `--no-default-features`):
```
baseline RSS: 20 MB
after call #1:    413 MB  (+393)
after call #2:    419 MB  (+6)
after call #3:    413 MB  (-6)
after call #4:    424 MB  (+11)
after call #5:    434 MB  (+10)
after call #6:    444 MB  (+10)
```
Classic staircase; matches the issue reporter's observation exactly in shape.

**After** (jemalloc, default):
```
baseline RSS: 20 MB
after call #1:    267 MB  (+247)
after call #2:    205 MB  (-63)
after call #3:    213 MB  (+8)
after call #4:    252 MB  (+39)
after call #5:    253 MB  (+1)
after call #6:    233 MB  (-20)
```

12-iter confirmation: RSS oscillates in a ~170–270 MB band, no monotonic trend, final iter (215 MB) below first iter (267 MB). Cross-call growth is eliminated. First-call peak is also lower (~150 MB), likely because jemalloc's per-workload working set is tighter than glibc's.

## What this does NOT do

- Absolute RSS footprint on a single call is unchanged — jemalloc doesn't reduce the actual working set, only eliminates cross-call fragmentation. Users who need lower absolute RSS need the separate perf/architecture work tracked elsewhere.
- The issue reporter's 200k-row case has additional cost from an unrelated O(N²) ingest perf bug that will be addressed in a follow-up PR; that fix is independent of this one.

## Testing

- `cargo check --release` (jemalloc enabled) — passes
- `cargo check --release --no-default-features` (system allocator) — passes
- `pytest bindings/python/tests/` — 35/35 passing with jemalloc
- `pytest` with `--no-default-features` rebuild — 35/35 passing with system allocator

## CI note

jemalloc pulls in `tikv-jemalloc-sys`, which builds jemalloc from bundled C sources (~10–30s cold build, requires a C toolchain). Linux x86_64 CI already has this. macOS / aarch64 supported by `tikv-jemallocator 0.6`; verified `cargo check` resolves cleanly. Windows MSVC and wasm32 fall back to system allocator via cfg gates.
