### PR TITLE
perf(eval): fix O(N²) bulk ingest via CoordBuildHasher

### DIFF
--- a/crates/formualizer-common/src/coord_hash.rs
+++ b/crates/formualizer-common/src/coord_hash.rs
@@ -1,0 +1,148 @@
+//! Dedicated hasher for keys built around [`crate::Coord`] /
+//! workbook cell addresses.
+//!
+//! Background
+//! ----------
+//!
+//! `Coord` packs a 20-bit row and 14-bit column (plus small flag bits) into a
+//! single `u64`, with bits `0..10` and bits `44..64` reserved/zero. On
+//! row-major workloads the dynamic range of the packed value is narrow and
+//! concentrated in the middle of the word.
+//!
+//! Combined with `FxHasher`'s weak avalanche (a single multiply), this causes
+//! severe clustering in `FxHashMap<CellRef, _>` and
+//! `FxHashMap<(SheetId, Coord), _>` keys: bulk-ingest phases that should be
+//! O(N) exhibit O(N^2) behavior. See
+//! `/tmp/issue-63-investigation/REPORT_PERF.md` for the full analysis and
+//! micro-benchmark.
+//!
+//! This module provides [`CoordBuildHasher`] and [`CoordHasher`]: a
+//! xor-rotate-multiply-fold finalizer that is strong enough to scatter the
+//! structured packed-int keys across the table while still costing only a
+//! handful of integer ops. It is *not* a general-purpose hasher — it is
+//! tailored for keys dominated by `u64`/`u32`/`u16` fields, which is exactly
+//! what the hot maps in the engine use.
+
+use core::hash::{BuildHasher, Hasher};
+
+/// Golden-ratio-derived odd multiplier (same class as the wyhash /
+/// rapidhash finalizer constants).
+const K: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// Zero-sized `BuildHasher` that constructs [`CoordHasher`] instances.
+///
+/// Intended for use with `std::collections::HashMap` /
+/// `std::collections::HashSet` on keys composed of `Coord`, `CellRef`,
+/// `SheetId`, or tuples thereof.
+#[derive(Default, Clone, Copy, Debug)]
+pub struct CoordBuildHasher;
+
+impl BuildHasher for CoordBuildHasher {
+    type Hasher = CoordHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> CoordHasher {
+        CoordHasher(0)
+    }
+}
+
+/// State for one hash computation. See module docs for the rationale.
+#[derive(Clone, Copy, Debug)]
+pub struct CoordHasher(u64);
+
+impl Hasher for CoordHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    /// Byte-wise fallback for keys that don't go through the typed
+    /// `write_uN` paths (e.g. `String` components of named-range keys).
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut state = self.0;
+        for &b in bytes {
+            state = (state ^ b as u64).wrapping_mul(K);
+        }
+        self.0 = state;
+    }
+
+    #[inline]
+    fn write_u64(&mut self, n: u64) {
+        // xor-rotate-multiply-fold avalanche.
+        let x = (self.0 ^ n).rotate_left(27).wrapping_mul(K);
+        self.0 = x ^ (x >> 32);
+    }
+
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.write_u64(n as u64);
+    }
+
+    #[inline]
+    fn write_u16(&mut self, n: u16) {
+        self.write_u64(n as u64);
+    }
+
+    #[inline]
+    fn write_u8(&mut self, n: u8) {
+        self.write_u64(n as u64);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, n: usize) {
+        self.write_u64(n as u64);
+    }
+
+    #[inline]
+    fn write_i64(&mut self, n: i64) {
+        self.write_u64(n as u64);
+    }
+
+    #[inline]
+    fn write_i32(&mut self, n: i32) {
+        self.write_u64(n as u64);
+    }
+}
+
+/// Convenience aliases mirroring the `FxHashMap` / `FxHashSet` shape used
+/// throughout the engine.
+pub type CoordHashMap<K, V> = std::collections::HashMap<K, V, CoordBuildHasher>;
+pub type CoordHashSet<K> = std::collections::HashSet<K, CoordBuildHasher>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Coord;
+    use std::collections::HashMap;
+
+    #[test]
+    fn basic_insert_lookup() {
+        let mut m: CoordHashMap<Coord, u32> = HashMap::default();
+        for r in 0..1000u32 {
+            m.insert(Coord::new(r, r % 64), r);
+        }
+        for r in 0..1000u32 {
+            assert_eq!(m.get(&Coord::new(r, r % 64)), Some(&r));
+        }
+        assert_eq!(m.len(), 1000);
+    }
+
+    #[test]
+    fn distinct_coords_produce_distinct_hashes() {
+        use core::hash::Hash;
+        fn h(c: Coord) -> u64 {
+            let mut hasher = CoordBuildHasher.build_hasher();
+            c.hash(&mut hasher);
+            hasher.finish()
+        }
+        // Adjacent row-major coords must not collide (this is exactly the
+        // degenerate pattern FxHasher stumbles on).
+        let a = h(Coord::new(0, 0));
+        let b = h(Coord::new(0, 1));
+        let c = h(Coord::new(1, 0));
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+}

--- a/crates/formualizer-common/src/coord_hash.rs
+++ b/crates/formualizer-common/src/coord_hash.rs
@@ -130,11 +130,8 @@ mod tests {
 
     #[test]
     fn distinct_coords_produce_distinct_hashes() {
-        use core::hash::Hash;
         fn h(c: Coord) -> u64 {
-            let mut hasher = CoordBuildHasher.build_hasher();
-            c.hash(&mut hasher);
-            hasher.finish()
+            CoordBuildHasher.hash_one(c)
         }
         // Adjacent row-major coords must not collide (this is exactly the
         // degenerate pattern FxHasher stumbles on).

--- a/crates/formualizer-common/src/lib.rs
+++ b/crates/formualizer-common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod address;
 pub mod coord;
+pub mod coord_hash;
 pub mod error;
 pub mod function;
 pub mod range;
@@ -7,6 +8,7 @@ pub mod value;
 
 pub use address::*;
 pub use coord::*;
+pub use coord_hash::*;
 pub use error::*;
 pub use function::*;
 pub use range::*;

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -100,3 +100,7 @@ js-runtime = ["dep:web-time", "dep:getrandom", "dep:getrandom02"]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
 tracing_chrome = ["tracing", "dep:tracing-chrome"]
 perf_instrumentation = []
+
+[[example]]
+name = "recalc_quadratic"
+path = "examples/recalc_quadratic.rs"

--- a/crates/formualizer-eval/examples/recalc_quadratic.rs
+++ b/crates/formualizer-eval/examples/recalc_quadratic.rs
@@ -108,11 +108,7 @@ fn main() {
 
         println!(
             "{:>8} {:>12.1} {:>14.1} {:>14.2} {:>14}",
-            k,
-            build_ms,
-            eval_ms,
-            us_per_formula,
-            res.computed_vertices,
+            k, build_ms, eval_ms, us_per_formula, res.computed_vertices,
         );
     }
 }

--- a/crates/formualizer-eval/examples/recalc_quadratic.rs
+++ b/crates/formualizer-eval/examples/recalc_quadratic.rs
@@ -1,0 +1,118 @@
+//! Pure-Rust harness reproducing the O(N^2) recalc scaling reported for
+//! `formualizer::workbook::recalculate_file` on row-local trivial formulas.
+//!
+//! Mimics the xlsx-fixture used by the original Python repro:
+//!   cols A..E hold integer values, col F = SUM(A_R:E_R),
+//!   col G = A_R*B_R+C_R-D_R.
+//!
+//! We skip xlsx I/O and drive the Engine directly via `begin_bulk_ingest_arrow()`
+//! (base values) and `begin_bulk_ingest()` (formulas). That isolates the eval
+//! hotspot from umya parse/write.
+//!
+//! Run with:
+//!   cargo run --release -p formualizer-eval --example recalc_quadratic -- 1000 2000 5000 10000 20000
+//!
+//! Optional env knobs:
+//!   FZ_EXPAND_RANGES=1    mirror the xlsx loader which sets range_expansion_limit=0
+//!                         (default in this harness — matches recalculate_file).
+//!   FZ_SKIP_RANGE_FORMULA=1  skip the SUM(A:E) formulas to test the hypothesis
+//!                         that the O(N^2) cost is dominated by the range formula.
+
+use std::time::Instant;
+
+use formualizer_common::LiteralValue;
+use formualizer_eval::engine::{Engine, EvalConfig, SheetIndexMode};
+use formualizer_eval::test_workbook::TestWorkbook;
+use formualizer_parse::parser::parse as parse_formula;
+
+fn build_engine(rows: u32, skip_range_formula: bool) -> Engine<TestWorkbook> {
+    let cfg = EvalConfig::default();
+    let mut engine: Engine<TestWorkbook> = Engine::new(TestWorkbook::default(), cfg);
+    engine.add_sheet("Data").unwrap();
+
+    // Match the xlsx loader path in `UmyaAdapter::stream_into_engine`.
+    engine.set_sheet_index_mode(SheetIndexMode::Lazy);
+    engine.config.range_expansion_limit = 0;
+
+    // 1) Bulk-ingest base values for columns A..E.
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet("Data", 7, 32 * 1024);
+        for r in 0..rows {
+            let base = r as f64;
+            let row_vals = [
+                LiteralValue::Number(base + 1.0),
+                LiteralValue::Number(base + 2.0),
+                LiteralValue::Number(base + 3.0),
+                LiteralValue::Number(base + 4.0),
+                LiteralValue::Number(base + 5.0),
+                LiteralValue::Empty,
+                LiteralValue::Empty,
+            ];
+            ab.append_row("Data", &row_vals).unwrap();
+        }
+        ab.finish().unwrap();
+    }
+
+    // 2) Stage formulas in row-major order.
+    let mut builder = engine.begin_bulk_ingest();
+    let sheet = builder.add_sheet("Data");
+    let mut batch = Vec::with_capacity(rows as usize * 2);
+    for r0 in 0..rows {
+        let r = r0 + 1;
+        if !skip_range_formula {
+            let sum_text = format!("=SUM(A{r}:E{r})");
+            batch.push((r, 6, parse_formula(&sum_text).unwrap()));
+        }
+        let arith_text = format!("=A{r}*B{r}+C{r}-D{r}");
+        batch.push((r, 7, parse_formula(&arith_text).unwrap()));
+    }
+    builder.add_formulas(sheet, batch);
+    builder.finish().unwrap();
+
+    engine
+}
+
+fn main() {
+    let ks: Vec<u32> = std::env::args()
+        .skip(1)
+        .map(|s| s.parse::<u32>().expect("row count arg"))
+        .collect();
+    let ks = if ks.is_empty() {
+        vec![1000, 2000, 5000, 10000, 20000]
+    } else {
+        ks
+    };
+
+    let skip_range = std::env::var("FZ_SKIP_RANGE_FORMULA").ok().as_deref() == Some("1");
+    if skip_range {
+        eprintln!(
+            "[harness] FZ_SKIP_RANGE_FORMULA=1 → skipping =SUM(A_R:E_R); only arithmetic formula kept"
+        );
+    }
+
+    println!(
+        "{:>8} {:>12} {:>14} {:>14} {:>14}",
+        "rows", "build_ms", "eval_ms", "us_per_formula", "formulas"
+    );
+    for &k in &ks {
+        let t_build = Instant::now();
+        let mut engine = build_engine(k, skip_range);
+        let build_ms = t_build.elapsed().as_secs_f64() * 1000.0;
+
+        let t_eval = Instant::now();
+        let (res, _delta) = engine.evaluate_all_with_delta().expect("evaluate_all");
+        let eval_ms = t_eval.elapsed().as_secs_f64() * 1000.0;
+        let n_formulas = res.computed_vertices.max(1) as f64;
+        let us_per_formula = (eval_ms * 1000.0) / n_formulas;
+
+        println!(
+            "{:>8} {:>12.1} {:>14.1} {:>14.2} {:>14}",
+            k,
+            build_ms,
+            eval_ms,
+            us_per_formula,
+            res.computed_vertices,
+        );
+    }
+}

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -15,7 +15,7 @@ use crate::reference::{CellRef, Coord, RangeRef};
 use crate::traits::FunctionProvider;
 use crate::traits::{EvaluationContext, Resolver};
 use chrono::Timelike;
-use formualizer_common::{col_letters_from_1based, parse_a1_1based};
+use formualizer_common::{CoordBuildHasher, col_letters_from_1based, parse_a1_1based};
 use formualizer_parse::parser::ReferenceType;
 use formualizer_parse::{ASTNode, ASTNodeType, ExcelError, ExcelErrorKind, LiteralValue};
 use rayon::ThreadPoolBuilder;
@@ -7790,7 +7790,8 @@ where
         if let Some(delta) = delta
             && delta.mode != DeltaMode::Off
         {
-            let target_set: FxHashSet<CellRef> = targets.iter().copied().collect();
+            let target_set: std::collections::HashSet<CellRef, CoordBuildHasher> =
+                targets.iter().copied().collect();
             let empty = LiteralValue::Empty;
 
             // Clears (prev - targets)
@@ -7868,7 +7869,8 @@ where
             && self.config.write_formula_overlay_enabled
         {
             if !prev_spill_cells.is_empty() {
-                let target_set: FxHashSet<CellRef> = targets.iter().copied().collect();
+                let target_set: std::collections::HashSet<CellRef, CoordBuildHasher> =
+                    targets.iter().copied().collect();
                 let empty = LiteralValue::Empty;
                 for cell in prev_spill_cells.iter() {
                     if !target_set.contains(cell) {

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -2,7 +2,7 @@ use crate::SheetId;
 use crate::engine::TombstoneRegistry;
 use crate::engine::named_range::{NameScope, NamedDefinition, NamedRange};
 use crate::engine::sheet_registry::SheetRegistry;
-use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue, PackedSheetCell};
+use formualizer_common::{CoordBuildHasher, ExcelError, ExcelErrorKind, LiteralValue, PackedSheetCell};
 use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -132,9 +132,12 @@ pub struct DependencyGraph {
     #[cfg(debug_assertions)]
     graph_value_read_attempts: AtomicU64,
 
-    // Address mappings using fast hashing
-    cell_to_vertex: FxHashMap<CellRef, VertexId>,
-    load_packed_to_vertex: FxHashMap<PackedSheetCell, VertexId>,
+    // Address mappings using a hasher tuned for packed Coord / PackedSheetCell
+    // keys. FxHasher's weak avalanche produces O(N^2) collision cascades on
+    // row-major bulk ingest; CoordBuildHasher keeps these strictly O(N).
+    cell_to_vertex: std::collections::HashMap<CellRef, VertexId, CoordBuildHasher>,
+    load_packed_to_vertex:
+        std::collections::HashMap<PackedSheetCell, VertexId, CoordBuildHasher>,
 
     // Scheduling state - using HashSet for O(1) operations
     dirty_vertices: FxHashSet<VertexId>,
@@ -226,9 +229,12 @@ pub struct DependencyGraph {
     // Dynamic topology orderer (Pearce–Kelly) maintained alongside edges when enabled
     pk_order: Option<DynamicTopo<VertexId>>,
 
-    // Spill registry: anchor -> cells, and reverse mapping for blockers
+    // Spill registry: anchor -> cells, and reverse mapping for blockers.
+    // `spill_cell_to_anchor` is keyed by `CellRef` and uses the tuned hasher
+    // for the same reason as `cell_to_vertex`.
     spill_anchor_to_cells: FxHashMap<VertexId, Vec<CellRef>>,
-    spill_cell_to_anchor: FxHashMap<CellRef, VertexId>,
+    spill_cell_to_anchor:
+        std::collections::HashMap<CellRef, VertexId, CoordBuildHasher>,
 
     // Hint: during initial bulk load, many cells are guaranteed new; allow skipping existence checks per-sheet
     first_load_assume_new: bool,
@@ -958,8 +964,8 @@ impl DependencyGraph {
             value_cache_enabled: false,
             #[cfg(debug_assertions)]
             graph_value_read_attempts: AtomicU64::new(0),
-            cell_to_vertex: FxHashMap::default(),
-            load_packed_to_vertex: FxHashMap::default(),
+            cell_to_vertex: std::collections::HashMap::with_hasher(CoordBuildHasher),
+            load_packed_to_vertex: std::collections::HashMap::with_hasher(CoordBuildHasher),
             dirty_vertices: FxHashSet::default(),
             volatile_vertices: FxHashSet::default(),
             ref_error_vertices: FxHashSet::default(),
@@ -989,7 +995,7 @@ impl DependencyGraph {
             config: config.clone(),
             pk_order: None,
             spill_anchor_to_cells: FxHashMap::default(),
-            spill_cell_to_anchor: FxHashMap::default(),
+            spill_cell_to_anchor: std::collections::HashMap::with_hasher(CoordBuildHasher),
             first_load_assume_new: false,
             ensure_touched_sheets: FxHashSet::default(),
             tombstone_registry: TombstoneRegistry::default(),
@@ -2440,8 +2446,6 @@ impl DependencyGraph {
         values: Vec<Vec<LiteralValue>>,
         fault_after_ops: Option<usize>,
     ) -> Result<(), ExcelError> {
-        use rustc_hash::FxHashSet;
-
         // Anchor cell coordinates (0-based) for special-casing writes.
         // We must never overwrite the anchor via set_cell_value(), because that would
         // strip the formula and break incremental recalculation.
@@ -2458,8 +2462,12 @@ impl DependencyGraph {
             .get(&anchor)
             .cloned()
             .unwrap_or_default();
-        let new_set: FxHashSet<CellRef> = target_cells.iter().copied().collect();
-        let prev_set: FxHashSet<CellRef> = prev_cells.iter().copied().collect();
+        // Use CoordBuildHasher on CellRef keys to avoid FxHasher clustering on
+        // packed Coord values.
+        let new_set: std::collections::HashSet<CellRef, CoordBuildHasher> =
+            target_cells.iter().copied().collect();
+        let prev_set: std::collections::HashSet<CellRef, CoordBuildHasher> =
+            prev_cells.iter().copied().collect();
 
         // Compose operation list: clears first (prev - new), then writes for new rectangle
         #[derive(Clone)]
@@ -2939,7 +2947,9 @@ impl DependencyGraph {
     }
 
     #[cfg(test)]
-    pub fn cell_to_vertex(&self) -> &FxHashMap<CellRef, VertexId> {
+    pub fn cell_to_vertex(
+        &self,
+    ) -> &std::collections::HashMap<CellRef, VertexId, CoordBuildHasher> {
         &self.cell_to_vertex
     }
 

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -2,7 +2,9 @@ use crate::SheetId;
 use crate::engine::TombstoneRegistry;
 use crate::engine::named_range::{NameScope, NamedDefinition, NamedRange};
 use crate::engine::sheet_registry::SheetRegistry;
-use formualizer_common::{CoordBuildHasher, ExcelError, ExcelErrorKind, LiteralValue, PackedSheetCell};
+use formualizer_common::{
+    CoordBuildHasher, ExcelError, ExcelErrorKind, LiteralValue, PackedSheetCell,
+};
 use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -136,8 +138,7 @@ pub struct DependencyGraph {
     // keys. FxHasher's weak avalanche produces O(N^2) collision cascades on
     // row-major bulk ingest; CoordBuildHasher keeps these strictly O(N).
     cell_to_vertex: std::collections::HashMap<CellRef, VertexId, CoordBuildHasher>,
-    load_packed_to_vertex:
-        std::collections::HashMap<PackedSheetCell, VertexId, CoordBuildHasher>,
+    load_packed_to_vertex: std::collections::HashMap<PackedSheetCell, VertexId, CoordBuildHasher>,
 
     // Scheduling state - using HashSet for O(1) operations
     dirty_vertices: FxHashSet<VertexId>,
@@ -233,8 +234,7 @@ pub struct DependencyGraph {
     // `spill_cell_to_anchor` is keyed by `CellRef` and uses the tuned hasher
     // for the same reason as `cell_to_vertex`.
     spill_anchor_to_cells: FxHashMap<VertexId, Vec<CellRef>>,
-    spill_cell_to_anchor:
-        std::collections::HashMap<CellRef, VertexId, CoordBuildHasher>,
+    spill_cell_to_anchor: std::collections::HashMap<CellRef, VertexId, CoordBuildHasher>,
 
     // Hint: during initial bulk load, many cells are guaranteed new; allow skipping existence checks per-sheet
     first_load_assume_new: bool,

--- a/crates/formualizer-eval/src/engine/plan.rs
+++ b/crates/formualizer-eval/src/engine/plan.rs
@@ -1,10 +1,11 @@
 use crate::SheetId;
 use crate::engine::sheet_registry::SheetRegistry;
 use formualizer_common::Coord as AbsCoord;
+use formualizer_common::CoordBuildHasher;
 use formualizer_common::ExcelError;
 use formualizer_common::PackedSheetCell;
 use formualizer_parse::parser::{CollectPolicy, ReferenceType};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 /// Compact range descriptor used during planning (engine-only)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -68,10 +69,17 @@ where
 {
     let mut plan = DependencyPlan::default();
 
-    // Global cell pool: packed absolute cell -> index
-    let mut cell_index: FxHashMap<PackedSheetCell, u32> = FxHashMap::default();
+    // Global cell pool: packed absolute cell -> index.
+    //
+    // Uses CoordBuildHasher because FxHasher's weak avalanche collides badly
+    // on structured packed keys (PackedSheetCell reserves bits 50..64 and has
+    // narrow dynamic range on row-major workloads), turning this O(N) loop
+    // into O(N^2). See formualizer_common::coord_hash.
+    let mut cell_index: HashMap<PackedSheetCell, u32, CoordBuildHasher> =
+        HashMap::with_hasher(CoordBuildHasher);
     // Unified vertex pool for loader-specialized ensure.
-    let mut vertex_pool_index: FxHashMap<PackedSheetCell, u32> = FxHashMap::default();
+    let mut vertex_pool_index: HashMap<PackedSheetCell, u32, CoordBuildHasher> =
+        HashMap::with_hasher(CoordBuildHasher);
 
     let mut ensure_vertex_pool_index =
         |plan: &mut DependencyPlan, key: (SheetId, AbsCoord)| -> u32 {


### PR DESCRIPTION
Follow-on to #66 (jemalloc allocator swap). Both came out of the #63 investigation.

## Root cause

`FxHasher`'s avalanche — a single wrapping multiply — collides heavily on packed integer keys whose entropy is concentrated in a narrow range of bits. Formualizer's hot `CellRef` / `PackedSheetCell` keys have exactly this shape:

- `Coord` packs row (20 bits) + col (14 bits) + flag bits into a `u64` with bits `0..10` and `44..64` reserved/zero.
- `PackedSheetCell` packs row (20 bits) + col (14 bits) + sheet (16 bits) into a `u64` with bits `50..64` zero.

On row-major bulk ingest, this turns `FxHashMap<CellRef, _>` and `FxHashMap<PackedSheetCell, _>` insertions into a linear-probe collision cascade, which makes the plan / ensure / edges phases of `begin_bulk_ingest` scale O(N²) in formula count.

An isolated hashmap micro-benchmark (no engine code) reproduces the same scaling with `FxHashMap` and eliminates it with `std::HashMap`'s `SipHash13` — confirming the problem is hash quality, not anything in the engine's data structures. See the investigation notes in `/tmp/issue-63-investigation/REPORT_PERF.md` for the full analysis.

## Fix

Introduces `formualizer_common::CoordBuildHasher` / `CoordHasher`: a dedicated `BuildHasher` using an xor-rotate-multiply-fold finalizer (golden-ratio-derived multiplier, same class as wyhash / rapidhash finalizers). Strong enough to scatter the structured packed-int keys while still costing only a handful of integer ops. Not a general-purpose hasher — tailored for keys dominated by `u64`/`u32`/`u16` fields, which is exactly what the hot engine maps use.

Applies it to the five `Coord`- / `PackedSheetCell`-keyed maps on the bulk-ingest hot path and the three ephemeral `HashSet<CellRef>` sites in the spill commit paths:

| Site | File |
|---|---|
| `plan::cell_index` | `crates/formualizer-eval/src/engine/plan.rs` |
| `plan::vertex_pool_index` | same |
| `DependencyGraph::cell_to_vertex` | `crates/formualizer-eval/src/engine/graph/mod.rs` |
| `DependencyGraph::load_packed_to_vertex` | same |
| `DependencyGraph::spill_cell_to_anchor` | same |
| `commit_spill_region_atomic_with_fault` new/prev sets | same |
| Spill delta / formula-overlay mirror `target_set` (×2) | `crates/formualizer-eval/src/engine/eval.rs` |

No API changes. No `Coord` / `PackedSheetCell` layout changes. All remaining `FxHashMap` / `FxHashSet` uses in the engine are keyed by `VertexId` / `SheetId` / `String` / dense tuples — none exhibit the packed-integer hash-quality issue and are left alone.

## Measurements

Pure-Rust bench harness `crates/formualizer-eval/examples/recalc_quadratic.rs` (included in this PR), release build. `K` rows × 2 row-local formulas per row (`=SUM(A_R:E_R)`, `=A_R*B_R+C_R-D_R`). `build_ms` is the bulk-ingest phase (plan + ensure + edges + finalize); `eval_ms` is `evaluate_all_with_delta`.

| rows | baseline main `build_ms` | with fix `build_ms` | build speedup | eval speedup |
|-----:|-------------------------:|--------------------:|--------------:|-------------:|
| 1000 | 13.1 | 13.1 | 1.00× | 0.93× |
| 2000 | 20.3 | 24.8 | 0.82× | 0.97× |
| 5000 | 70.6 | 71.3 | 0.99× | 1.03× |
| 10000 | 215.8 | 187.5 | 1.15× | 1.09× |
| 20000 | 774.5 | 447.4 | 1.73× | 1.52× |
| 50000 | 5838.7 | 1419.9 | **4.11×** | **2.90×** |

`t(20k) / t(5k)` `build_ms` ratio: **10.97× → 6.27×** (ideal O(N) is 4×).

Per-formula cost with the fix is stable at ~2.0–2.3 µs across the full K range. Without the fix it climbs from 1.85 µs at K=1000 to 6.61 µs at K=50000 — the signature of the hash-quality bug dominating bulk-ingest cost at scale.

Together with #66 (jemalloc), a 200k-row `recalculate_file` run on a 10 MB fixture goes from 395 s / 1.3 GB RSS to ~90 s / 1 GB RSS (4.4× faster), with no RSS staircase across repeated calls.

## What this does not fix

`t(20k)/t(5k) = 6.27×` under the fix is still above the 4× O(N) ideal. The residual super-linearity comes from allocator pressure, CSR adjacency construction, and an internal `seen: FxHashSet<(SheetId, AbsCoord)>` in `ingest_builder.rs` that wasn't in scope here. Out-of-scope for this PR; follow-up fodder.

Any `set_cell_value` / interactive-edit perf is unchanged — this only affects bulk ingest where the quadratic term manifested.

## Testing

- `cargo test -p formualizer-common` — 26 passed, includes two `coord_hash::tests` regressions.
- `cargo test -p formualizer-eval` — 1168 passed, 0 failed, 4 ignored.
- `cargo test -p formualizer-workbook` — all suites pass.
- `cargo check --release` — passes for all targets including `bindings/python` and `bindings/wasm`.

One pre-existing release-only failure on unmodified `origin/main` (`engine::arena::scalar::tests::test_scalar_arena_float_overflow` — a `#[should_panic]` test whose underlying `debug_assert!` is compiled out in release). Unrelated to this change.

## Behavioural safety

`Hash` is a behavioural trait — changing the hasher changes iteration order of affected maps. Audited the call sites: the only external consumer is a `#[cfg(test)]` accessor on `cell_to_vertex`. Internal iterations fully consume or do key-lookup; no assertion of specific order. All tests pass.

## Follow-up note

The `CoordHashMap<K, V>` / `CoordHashSet<K>` aliases in `coord_hash.rs` are unused at all call sites — each site spells out `std::collections::HashMap<_, _, CoordBuildHasher>` to match the surrounding style. If preferred, a mechanical pass to use the aliases is trivial — happy to do it in this PR or a separate cleanup.
