### PR TITLE
fix: unary minus binds tighter than exponent (Excel parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Formualizer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unary minus precedence to bind tighter than exponentiation, matching Excel semantics (`=-2^2` now evaluates to `4` instead of `-4`).
+
 ## [0.5.6] - 2026-04-14
 
 ### Fixed

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -2150,8 +2150,8 @@ impl Parser {
             let op_token = self.tokens[self.position].clone();
             self.position += 1;
 
-            // Prefix unary binds looser than exponent, so parse the RHS with
-            // min_precedence equal to unary's precedence.
+            // Prefix unary binds tighter than exponent (Excel semantics),
+            // so parse the RHS with min_precedence equal to unary's precedence.
             let (precedence, _) = op_token
                 .get_precedence()
                 .unwrap_or((0, Associativity::Right));
@@ -2511,8 +2511,8 @@ impl<'a> SpanParser<'a> {
         match op {
             ":" | " " | "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
-            "^" => Some((6, Associativity::Right)),
-            "u" => Some((5, Associativity::Right)),
+            "u" => Some((6, Associativity::Right)),
+            "^" => Some((5, Associativity::Right)),
             "*" | "/" => Some((4, Associativity::Left)),
             "+" | "-" => Some((3, Associativity::Left)),
             "&" => Some((2, Associativity::Left)),

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -23,7 +23,7 @@ enum Side {
 fn infix_info(op: &str) -> (u8, Associativity) {
     match op {
         ":" | " " | "," => (8, Associativity::Left),
-        "^" => (6, Associativity::Right),
+        "^" => (5, Associativity::Right),
         "*" | "/" => (4, Associativity::Left),
         "+" | "-" => (3, Associativity::Left),
         "&" => (2, Associativity::Left),
@@ -36,8 +36,7 @@ fn unary_precedence(op: &str) -> u8 {
     if op == "%" {
         7
     } else {
-        // Prefix unary.
-        5
+        6
     }
 }
 

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -33,11 +33,7 @@ fn infix_info(op: &str) -> (u8, Associativity) {
 }
 
 fn unary_precedence(op: &str) -> u8 {
-    if op == "%" {
-        7
-    } else {
-        6
-    }
+    if op == "%" { 7 } else { 6 }
 }
 
 fn node_precedence(ast: &ASTNode) -> u8 {

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -2055,21 +2055,21 @@ mod semantics_regressions {
     }
 
     #[test]
-    fn unary_minus_binds_less_tightly_than_exponent() {
+    fn unary_minus_binds_tighter_than_exponent() {
         let t = Tokenizer::new("=-2^2").unwrap();
         let mut p = Parser::new(t.items, false);
         let ast = p.parse().unwrap();
 
-        // Expected: -(2^2)
+        // Excel: =-2^2 means (-2)^2 = 4
         match ast.node_type {
-            ASTNodeType::UnaryOp { op, expr } => {
-                assert_eq!(op, "-");
-                match expr.node_type {
-                    ASTNodeType::BinaryOp { op: op2, .. } => assert_eq!(op2, "^"),
-                    other => panic!("expected exponent under unary, got {other:?}"),
+            ASTNodeType::BinaryOp { op, left, .. } => {
+                assert_eq!(op, "^");
+                match left.node_type {
+                    ASTNodeType::UnaryOp { op: op2, .. } => assert_eq!(op2, "-"),
+                    other => panic!("expected unary under exponent, got {other:?}"),
                 }
             }
-            other => panic!("expected UnaryOp, got {other:?}"),
+            other => panic!("expected BinaryOp, got {other:?}"),
         }
     }
 

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -248,8 +248,8 @@ impl Token {
         // Excel precedence (high to low, simplified):
         //   reference ops (:
         //   postfix %
+        //   prefix unary +/- (binds tighter than ^)
         //   exponent ^ (right-assoc)
-        //   prefix unary +/-(...) (binds looser than ^)
         //   */
         //   +-
         //   &
@@ -257,8 +257,8 @@ impl Token {
         match op {
             ":" | " " | "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
-            "^" => Some((6, Associativity::Right)),
-            "u" => Some((5, Associativity::Right)),
+            "u" => Some((6, Associativity::Right)),
+            "^" => Some((5, Associativity::Right)),
             "*" | "/" => Some((4, Associativity::Left)),
             "+" | "-" => Some((3, Associativity::Left)),
             "&" => Some((2, Associativity::Left)),

--- a/tests/formula_tests/math_basic.json
+++ b/tests/formula_tests/math_basic.json
@@ -34,7 +34,6 @@
       "result_type": "int",
       "description": "exponentiation"
     },
-
     {
       "formula": "=-5",
       "result": -5,
@@ -58,6 +57,12 @@
       "result": 7,
       "result_type": "int",
       "description": "operator precedence"
+    },
+    {
+      "formula": "=-2^2",
+      "result": 4,
+      "result_type": "int",
+      "description": "unary minus binds tighter than exponent (Excel semantics)"
     }
   ]
 }


### PR DESCRIPTION
## Problem
`=-2^2` evaluates to `-4` instead of `4`. The precedence table gives `^` higher precedence than unary minus, but Excel does the opposite.

Fixes #65

## Solution
Swap precedence values so unary prefix (6) binds tighter than `^` (5) across all three precedence tables (tokenizer, span parser, pretty printer).

## Changes
- Swap `^` (6→5) and unary prefix (5→6) in `tokenizer.rs`, `parser.rs`, and `pretty.rs`
- Fix existing test that asserted the wrong AST shape
- Add `=-2^2 = 4` eval test case to `math_basic.json`

## Test plan
- [x] `cargo test -p formualizer-parse` — 157 passed
- [x] `cargo clippy -p formualizer-parse` — clean
- [x] `cargo test -p formualizer-eval run_formula_test_suite` — 902 passed (2 pre-existing IMSIN/IMCOS fp failures)