### PR TITLE
fix(parser): accept lowercase TRUE/FALSE as boolean literals

### DIFF
--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -2244,7 +2244,7 @@ impl Parser {
                 ))
             }
             TokenSubType::Logical => {
-                let value = token.value.to_uppercase() == "TRUE";
+                let value = token.value.eq_ignore_ascii_case("TRUE");
                 Ok(ASTNode::new(
                     ASTNodeType::Literal(LiteralValue::Boolean(value)),
                     Some(token),
@@ -2749,7 +2749,7 @@ impl<'a> SpanParser<'a> {
                 ))
             }
             TokenSubType::Logical => {
-                let v = value.to_uppercase() == "TRUE";
+                let v = value.eq_ignore_ascii_case("TRUE");
                 Ok(ASTNode::new(
                     ASTNodeType::Literal(LiteralValue::Boolean(v)),
                     Some(token),

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -875,6 +875,96 @@ mod tests {
         } else {
             panic!("Expected Boolean literal");
         }
+
+        // Lowercase/mixed-case forms must also parse as boolean literals (Excel
+        // is case-insensitive for TRUE/FALSE).
+        for (formula, expected) in [
+            ("=true", true),
+            ("=false", false),
+            ("=True", true),
+            ("=TrUe", true),
+            ("=fAlSe", false),
+        ] {
+            let ast = parse_formula(formula).unwrap();
+            match ast.node_type {
+                ASTNodeType::Literal(LiteralValue::Boolean(v)) => {
+                    assert_eq!(v, expected, "classic parser: {formula}");
+                }
+                other => {
+                    panic!("classic parser: expected Boolean literal for {formula}, got {other:?}")
+                }
+            }
+
+            let ast = crate::parser::parse(formula).unwrap();
+            match ast.node_type {
+                ASTNodeType::Literal(LiteralValue::Boolean(v)) => {
+                    assert_eq!(v, expected, "span parser: {formula}");
+                }
+                other => {
+                    panic!("span parser: expected Boolean literal for {formula}, got {other:?}")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_lowercase_boolean_in_function_call() {
+        type ParseFn = fn(&str) -> Result<ASTNode, ParserError>;
+        let parsers: [ParseFn; 2] = [parse_formula, |s| crate::parser::parse(s)];
+        for parse in parsers {
+            let ast = parse("=IF(true,1,2)").unwrap();
+            let ASTNodeType::Function { name, args } = ast.node_type else {
+                panic!("expected Function node");
+            };
+            assert_eq!(name, "IF");
+            assert_eq!(args.len(), 3);
+            match &args[0].node_type {
+                ASTNodeType::Literal(LiteralValue::Boolean(true)) => {}
+                other => panic!("expected Boolean(true) as first arg, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_lowercase_boolean_in_binary_op() {
+        type ParseFn = fn(&str) -> Result<ASTNode, ParserError>;
+        let parsers: [ParseFn; 2] = [parse_formula, |s| crate::parser::parse(s)];
+        for parse in parsers {
+            let ast = parse("=a1+true").unwrap();
+            let ASTNodeType::BinaryOp { op, left, right } = ast.node_type else {
+                panic!("expected BinaryOp node");
+            };
+            assert_eq!(op, "+");
+            match &left.node_type {
+                ASTNodeType::Reference { .. } => {}
+                other => panic!("expected Reference on lhs, got {other:?}"),
+            }
+            match &right.node_type {
+                ASTNodeType::Literal(LiteralValue::Boolean(true)) => {}
+                other => panic!("expected Boolean(true) on rhs, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_named_ranges_containing_bool_substrings_are_not_booleans() {
+        type ParseFn = fn(&str) -> Result<ASTNode, ParserError>;
+        let parsers: [ParseFn; 2] = [parse_formula, |s| crate::parser::parse(s)];
+        for parse in parsers {
+            for name in ["TRUENAME", "trueish", "NOT_TRUE", "false_positive"] {
+                let formula = format!("={name}");
+                let ast = parse(&formula).unwrap();
+                match &ast.node_type {
+                    ASTNodeType::Reference {
+                        reference: ReferenceType::NamedRange(actual),
+                        ..
+                    } => {
+                        assert_eq!(actual, name, "formula {formula}");
+                    }
+                    other => panic!("expected NamedRange({name}), got {other:?}"),
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -1489,4 +1489,41 @@ mod tests {
         assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
         assert_eq!(tokenizer.items[0].value, "source!#ref!");
     }
+
+    #[test]
+    fn lowercase_true_is_logical_subtype() {
+        let tokenizer = Tokenizer::new("=true").expect("tokenize lowercase true");
+        assert_eq!(tokenizer.items.len(), 1);
+        assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
+        assert_eq!(tokenizer.items[0].subtype, TokenSubType::Logical);
+        assert_eq!(tokenizer.items[0].value, "true");
+
+        let stream = TokenStream::new("=true").expect("span tokenize lowercase true");
+        assert_eq!(stream.spans.len(), 1);
+        assert_eq!(stream.spans[0].token_type, TokenType::Operand);
+        assert_eq!(stream.spans[0].subtype, TokenSubType::Logical);
+    }
+
+    #[test]
+    fn mixed_case_false_is_logical_subtype() {
+        let tokenizer = Tokenizer::new("=fAlSe").expect("tokenize mixed-case false");
+        assert_eq!(tokenizer.items.len(), 1);
+        assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
+        assert_eq!(tokenizer.items[0].subtype, TokenSubType::Logical);
+        assert_eq!(tokenizer.items[0].value, "fAlSe");
+
+        let stream = TokenStream::new("=fAlSe").expect("span tokenize mixed-case false");
+        assert_eq!(stream.spans.len(), 1);
+        assert_eq!(stream.spans[0].token_type, TokenType::Operand);
+        assert_eq!(stream.spans[0].subtype, TokenSubType::Logical);
+    }
+
+    #[test]
+    fn truename_is_not_logical_subtype() {
+        let tokenizer = Tokenizer::new("=TRUENAME").expect("tokenize TRUENAME");
+        assert_eq!(tokenizer.items.len(), 1);
+        assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
+        assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
+        assert_eq!(tokenizer.items[0].value, "TRUENAME");
+    }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -273,7 +273,7 @@ impl Token {
             TokenSubType::Text
         } else if value.starts_with('#') {
             TokenSubType::Error
-        } else if value == "TRUE" || value == "FALSE" {
+        } else if value.eq_ignore_ascii_case("TRUE") || value.eq_ignore_ascii_case("FALSE") {
             TokenSubType::Logical
         } else if value.parse::<f64>().is_ok() {
             TokenSubType::Number
@@ -289,7 +289,7 @@ impl Token {
             TokenSubType::Text
         } else if value.starts_with('#') {
             TokenSubType::Error
-        } else if value == "TRUE" || value == "FALSE" {
+        } else if value.eq_ignore_ascii_case("TRUE") || value.eq_ignore_ascii_case("FALSE") {
             TokenSubType::Logical
         } else if value.parse::<f64>().is_ok() {
             TokenSubType::Number
@@ -305,7 +305,8 @@ impl Token {
             TokenSubType::Text
         } else if value_str.starts_with('#') {
             TokenSubType::Error
-        } else if value_str == "TRUE" || value_str == "FALSE" {
+        } else if value_str.eq_ignore_ascii_case("TRUE") || value_str.eq_ignore_ascii_case("FALSE")
+        {
             TokenSubType::Logical
         } else if value_str.parse::<f64>().is_ok() {
             TokenSubType::Number
@@ -586,7 +587,7 @@ fn operand_subtype(value_str: &str) -> TokenSubType {
         TokenSubType::Text
     } else if value_str.starts_with('#') {
         TokenSubType::Error
-    } else if value_str == "TRUE" || value_str == "FALSE" {
+    } else if value_str.eq_ignore_ascii_case("TRUE") || value_str.eq_ignore_ascii_case("FALSE") {
         TokenSubType::Logical
     } else if value_str.parse::<f64>().is_ok() {
         TokenSubType::Number


### PR DESCRIPTION
Closes #72

## Summary

Excel formula syntax is case-insensitive for the boolean literals `TRUE` and `FALSE`, but the parser only accepted the uppercase forms. `=true`, `=True`, `=TrUe`, etc. fell through to `TokenSubType::Range` and parsed as `NamedRange`, which then evaluated to `#NAME?`.

This change switches the four `=="TRUE"/"FALSE"` checks in `crates/formualizer-parse/src/tokenizer.rs` and the two `to_uppercase() == "TRUE"` checks in `crates/formualizer-parse/src/parser.rs` (classic + span paths) to `eq_ignore_ascii_case`, which is also zero-allocation. Named ranges that merely contain `TRUE`/`FALSE` as a substring (`TRUENAME`, `trueish`, `NOT_TRUE`, `false_positive`) are unaffected.

## Tests added / changed

`crates/formualizer-parse/src/tests/parser.rs`:
- `test_boolean_literals` extended to assert `true`, `false`, `True`, `TrUe`, `fAlSe` parse as `Literal(Boolean(..))` on **both** the classic token-based parser and the span-based `crate::parser::parse` path.
- New `test_lowercase_boolean_in_function_call` — `=IF(true,1,2)` first arg is `Literal(Boolean(true))` (both parsers).
- New `test_lowercase_boolean_in_binary_op` — `=a1+true` is `BinaryOp(+, Reference(A1), Literal(Boolean(true)))` (both parsers).
- New `test_named_ranges_containing_bool_substrings_are_not_booleans` — `TRUENAME`, `trueish`, `NOT_TRUE`, `false_positive` remain `NamedRange` (both parsers).

`crates/formualizer-parse/src/tests/tokenizer.rs`:
- New `lowercase_true_is_logical_subtype` — `=true` produces `TokenSubType::Logical` via both `Tokenizer` and `TokenStream` paths.
- New `mixed_case_false_is_logical_subtype` — `=fAlSe` likewise.
- New `truename_is_not_logical_subtype` — regression guard for `=TRUENAME`.

Pre-fix run confirmed the new lowercase/mixed-case assertions failed (NamedRange / Range), and the regression guards already passed.

## Validation

```
cargo fmt --all
cargo test -p formualizer-parse        # 163 + 3 + 0 passed
cargo clippy -p formualizer-parse --all-targets -- -D warnings   # clean
```