### PR TITLE
fix(parse): tighten scientific-notation tokenization

### DIFF
--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -2073,6 +2073,139 @@ mod semantics_regressions {
         }
     }
 
+    mod scientific_notation {
+        use crate::parser::{ASTNode, ASTNodeType, Parser, ParserError, ReferenceType, parse};
+        use crate::tokenizer::Tokenizer;
+        use formualizer_common::LiteralValue;
+
+        fn parse_formula(formula: &str) -> Result<ASTNode, ParserError> {
+            let tokenizer = Tokenizer::new(formula).map_err(|e| ParserError {
+                message: e.to_string(),
+                position: Some(e.pos),
+            })?;
+            let mut parser = Parser::new(tokenizer.items, false);
+            parser.parse()
+        }
+
+        fn assert_parsers_agree(formula: &str) {
+            let token_ast = parse_formula(formula);
+            let span_ast = parse(formula);
+            match (&token_ast, &span_ast) {
+                (Ok(a), Ok(b)) => assert_eq!(
+                    a.node_type, b.node_type,
+                    "token vs span parser disagree on {formula:?}"
+                ),
+                (Err(_), Err(_)) => {}
+                other => panic!("token vs span parser disagree on {formula:?}: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_sci_number_basic() {
+            let ast = parse_formula("=1.5E+3").unwrap();
+            match ast.node_type {
+                ASTNodeType::Literal(LiteralValue::Number(n)) => assert_eq!(n, 1500.0),
+                other => panic!("expected Literal Number, got {other:?}"),
+            }
+            assert_parsers_agree("=1.5E+3");
+        }
+
+        #[test]
+        fn test_sci_minus_cell_ref() {
+            // `=1E-A1` should parse as `1E - A1`, not as a single named range.
+            let ast = parse_formula("=1E-A1").unwrap();
+            match ast.node_type {
+                ASTNodeType::BinaryOp { op, left, right } => {
+                    assert_eq!(op, "-");
+                    match left.node_type {
+                        ASTNodeType::Reference { reference, .. } => match reference {
+                            ReferenceType::NamedRange(name) => assert_eq!(name, "1E"),
+                            other => panic!("expected NamedRange(\"1E\"), got {other:?}"),
+                        },
+                        other => panic!("expected reference on lhs, got {other:?}"),
+                    }
+                    match right.node_type {
+                        ASTNodeType::Reference { reference, .. } => {
+                            assert_eq!(reference, ReferenceType::cell(None, 1, 1))
+                        }
+                        other => panic!("expected A1 reference on rhs, got {other:?}"),
+                    }
+                }
+                other => panic!("expected BinaryOp, got {other:?}"),
+            }
+            assert_parsers_agree("=1E-A1");
+        }
+
+        #[test]
+        fn test_sci_plus_cell_ref() {
+            let ast = parse_formula("=1E+A1").unwrap();
+            match ast.node_type {
+                ASTNodeType::BinaryOp { op, left, right } => {
+                    assert_eq!(op, "+");
+                    match left.node_type {
+                        ASTNodeType::Reference { reference, .. } => match reference {
+                            ReferenceType::NamedRange(name) => assert_eq!(name, "1E"),
+                            other => panic!("expected NamedRange(\"1E\"), got {other:?}"),
+                        },
+                        other => panic!("expected reference on lhs, got {other:?}"),
+                    }
+                    match right.node_type {
+                        ASTNodeType::Reference { reference, .. } => {
+                            assert_eq!(reference, ReferenceType::cell(None, 1, 1))
+                        }
+                        other => panic!("expected A1 reference on rhs, got {other:?}"),
+                    }
+                }
+                other => panic!("expected BinaryOp, got {other:?}"),
+            }
+            assert_parsers_agree("=1E+A1");
+        }
+
+        #[test]
+        fn test_sci_dangling_lower_e_plus_errors() {
+            // `=1e+` no longer becomes a silent NamedRange. The `+` is left
+            // dangling, which the parser must reject.
+            assert!(parse_formula("=1e+").is_err());
+            assert!(parse("=1e+").is_err());
+        }
+
+        #[test]
+        fn test_sci_dangling_decimal_minus_errors() {
+            assert!(parse_formula("=1.5e-").is_err());
+            assert!(parse("=1.5e-").is_err());
+        }
+
+        #[test]
+        fn test_sci_dangling_upper_e_plus_errors() {
+            assert!(parse_formula("=1E+").is_err());
+            assert!(parse("=1E+").is_err());
+        }
+
+        #[test]
+        fn test_sci_existing_numeric_literals_still_parse() {
+            for (formula, expected) in [
+                ("=1.5e-3", 0.0015),
+                ("=5e10", 5e10),
+                ("=1e2", 100.0),
+                ("=1.", 1.0),
+                ("=.5", 0.5),
+            ] {
+                let ast = parse_formula(formula)
+                    .unwrap_or_else(|e| panic!("failed to parse {formula:?}: {}", e.message));
+                match ast.node_type {
+                    ASTNodeType::Literal(LiteralValue::Number(n)) => {
+                        assert!(
+                            (n - expected).abs() < 1e-9,
+                            "{formula} -> {n}, expected {expected}"
+                        );
+                    }
+                    other => panic!("expected Number for {formula}, got {other:?}"),
+                }
+                assert_parsers_agree(formula);
+            }
+        }
+    }
+
     #[test]
     fn quoted_sheet_name_allows_escaped_single_quote() {
         let r = ReferenceType::from_string("'Bob''s Sheet'!A1").unwrap();

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -1472,6 +1472,116 @@ mod tests {
         }
     }
 
+    mod scientific_notation {
+        use crate::tokenizer::{TokenSubType, TokenType, Tokenizer};
+
+        #[test]
+        fn test_sci_extends_for_digit() {
+            let formula = "=1e+2";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.items.len(), 1);
+            assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
+            assert_eq!(tokenizer.items[0].subtype, TokenSubType::Number);
+            assert_eq!(tokenizer.items[0].value, "1e+2");
+        }
+
+        #[test]
+        fn test_sci_does_not_extend_for_letter() {
+            // `=1E-A1` must not slurp `-A1` into the numeric token.
+            let formula = "=1E-A1";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.items.len(), 3);
+            assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
+            assert_eq!(tokenizer.items[0].value, "1E");
+            assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
+            assert_eq!(tokenizer.items[1].token_type, TokenType::OpInfix);
+            assert_eq!(tokenizer.items[1].value, "-");
+            assert_eq!(tokenizer.items[2].token_type, TokenType::Operand);
+            assert_eq!(tokenizer.items[2].value, "A1");
+            assert_eq!(tokenizer.items[2].subtype, TokenSubType::Range);
+        }
+
+        #[test]
+        fn test_sci_does_not_extend_for_eof() {
+            // `=1e+` must flush `1e` and emit a trailing operator instead of
+            // consuming the dangling `+` as part of the number.
+            let formula = "=1e+";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.items.len(), 2);
+            assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
+            assert_eq!(tokenizer.items[0].value, "1e");
+            assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
+            assert_eq!(tokenizer.items[1].value, "+");
+            // The trailing operator may classify as either prefix or infix;
+            // the important property is that the number did not absorb it.
+            assert!(matches!(
+                tokenizer.items[1].token_type,
+                TokenType::OpInfix | TokenType::OpPrefix
+            ));
+        }
+
+        #[test]
+        fn test_sci_dot_after_exponent_documented_shape() {
+            // `=1e+2.5` is ambiguous (#78). Today the tokenizer keeps it as a
+            // single (non-numeric) operand because `parse::<f64>` rejects a
+            // dot after the exponent. The important property is that the
+            // text is preserved verbatim, so this test just pins the
+            // current shape so a future intentional change is visible.
+            let formula = "=1e+2.5";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.render(), formula);
+            assert_eq!(tokenizer.items.len(), 1);
+            assert_eq!(tokenizer.items[0].value, "1e+2.5");
+        }
+
+        #[test]
+        fn test_sci_with_decimal_base() {
+            let formula = "=1.5e-3";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.items.len(), 1);
+            assert_eq!(tokenizer.items[0].value, "1.5e-3");
+            assert_eq!(tokenizer.items[0].subtype, TokenSubType::Number);
+        }
+
+        #[test]
+        fn test_sci_without_sign() {
+            let formula = "=5e10";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.items.len(), 1);
+            assert_eq!(tokenizer.items[0].value, "5e10");
+            assert_eq!(tokenizer.items[0].subtype, TokenSubType::Number);
+        }
+
+        #[test]
+        fn test_bare_1e() {
+            let formula = "=1e";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.items.len(), 1);
+            assert_eq!(tokenizer.items[0].value, "1e");
+            // `1e` is not a valid float, so it falls through to a range/named
+            // range subtype.
+            assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
+        }
+
+        #[test]
+        fn test_sci_chain_after_valid_number() {
+            // `=1.5E+3E+2` is documented as ambiguous in #78. Today the
+            // tokenizer accumulates `1.5E+3E` as a single operand (the
+            // trailing `E` disqualifies the scientific-notation base check
+            // when the next `+` is processed), then emits `+ 2` separately.
+            // Pin that shape; the formula must render back losslessly.
+            let formula = "=1.5E+3E+2";
+            let tokenizer = Tokenizer::new(formula).unwrap();
+            assert_eq!(tokenizer.render(), formula);
+            assert_eq!(tokenizer.items.len(), 3);
+            assert_eq!(tokenizer.items[0].value, "1.5E+3E");
+            assert_eq!(tokenizer.items[1].token_type, TokenType::OpInfix);
+            assert_eq!(tokenizer.items[1].value, "+");
+            assert_eq!(tokenizer.items[2].value, "2");
+            assert_eq!(tokenizer.items[2].subtype, TokenSubType::Number);
+        }
+    }
+
     #[test]
     fn test_error_literals_are_case_insensitive() {
         let tokenizer = Tokenizer::new("=#ref!").expect("tokenize lowercase ref error");

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -674,6 +674,11 @@ impl<'a> SpanTokenizer<'a> {
             if (curr_byte == b'+' || curr_byte == b'-')
                 && self.has_token()
                 && self.is_scientific_notation_base()
+                && self
+                    .formula
+                    .as_bytes()
+                    .get(self.offset + 1)
+                    .is_some_and(|b| b.is_ascii_digit())
             {
                 self.offset += 1;
                 self.extend_token();
@@ -1426,11 +1431,21 @@ impl Tokenizer {
 
     /// If the current token looks like a number in scientific notation,
     /// consume the '+' or '-' as part of the number.
+    ///
+    /// The `+`/`-` is only consumed when the next byte is an ASCII digit.
+    /// Without that one-byte lookahead, inputs like `=1e+` and `=1E-A1`
+    /// would be silently absorbed into a single (invalid) numeric token
+    /// and surface later as a `NamedRange`. See issue #78.
     fn check_scientific_notation(&mut self) -> Result<bool, TokenizerError> {
         if let Some(curr_byte) = self.current_byte() {
             if (curr_byte == b'+' || curr_byte == b'-')
                 && self.has_token()
                 && self.is_scientific_notation_base()
+                && self
+                    .formula
+                    .as_bytes()
+                    .get(self.offset + 1)
+                    .is_some_and(|b| b.is_ascii_digit())
             {
                 self.offset += 1;
                 self.extend_token();


### PR DESCRIPTION
Closes #78

## Summary

`Tokenizer::check_scientific_notation` (and its span-based mirror) used
to consume a `+` or `-` after a scientific-notation base (`1`, `1.5e`,
`1E`, ...) without checking what came next. That caused two visible
defects:

- `=1e+` was silently accumulated into a single operand `1e+`. Because
  `parse::<f64>` rejected it, it fell through to `NamedRange("1e+")`.
- `=1E-A1` was greedily extended into `1E-A1` and again surfaced as
  `NamedRange("1E-A1")` instead of an arithmetic expression.

The fix is the minimal lookahead from the issue: only consume the
`+`/`-` when the byte that follows is an ASCII digit. The same guard is
applied to the classic `Tokenizer` and the span-based `TokenStream` so
both parser paths agree.

After the fix:

- `=1e+` flushes `1e` (a `NamedRange`) and the trailing `+` is left
  dangling, which the parser rejects cleanly.
- `=1E-A1` parses as `BinaryOp(\"-\", NamedRange(\"1E\"), Reference(A1))`.
- All existing valid numeric literals (`=1.5E+3`, `=1.5e-3`, `=5e10`,
  `=1e2`, `=1.`, `=.5`) keep parsing as numbers.

## Tests

Added `mod scientific_notation` blocks in
`crates/formualizer-parse/src/tests/tokenizer.rs` and
`crates/formualizer-parse/src/tests/parser.rs`:

- Tokenizer (9 tests): `extends_for_digit`, `does_not_extend_for_letter`,
  `does_not_extend_for_eof`, `dot_after_exponent_documented_shape`,
  `with_decimal_base`, `without_sign`, `bare_1e`,
  `chain_after_valid_number`, plus the existing
  `test_scientific_notation` regression continues to pass.
- Parser (7 tests): `number_basic` (1.5E+3 \u2192 1500), `minus_cell_ref`
  and `plus_cell_ref` (asserting the `BinaryOp` shape and that the
  classic and span parsers agree), `dangling_lower_e_plus_errors`,
  `dangling_decimal_minus_errors`, `dangling_upper_e_plus_errors`, and
  `existing_numeric_literals_still_parse` (regression guard for the
  passing-must-stay-correct list).

The two ambiguous edge cases noted in the issue (`=1e+2.5` and
`=1.5E+3E+2`) are pinned with documented-shape tests rather than being
re-litigated; the issue brief explicitly lists them as ambiguous and out
of scope for a tighter rewrite.

The TDD pass against the new tests went 9 failing \u2192 0 failing once the
two-line lookahead was applied.

## Validation

- \`cargo fmt --all\`
- \`cargo test -p formualizer-parse scientific_notation\` \u2192 17 passed
- \`cargo test -p formualizer-parse\` \u2192 172 passed (lib) + 3 passed
  (\`tokenizer_best_effort_integration\`)
- \`cargo clippy -p formualizer-parse --all-targets -- -D warnings\` \u2192
  clean