### PR TITLE
fix(parser): preserve error kind for sheet-qualified error literals

### DIFF
--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -50,10 +50,167 @@ mod tests {
 
     #[test]
     fn parser_accepts_sheet_prefixed_lowercase_error_literal() {
+        // Sheet-qualified error literals collapse to the bare error literal,
+        // preserving the error kind (here `#ref!` -> ExcelError::Ref).
         let ast = parse_formula("=source!#ref!").expect("parse sheet-prefixed lowercase");
         match ast.node_type {
-            ASTNodeType::Reference { .. } => {}
-            other => panic!("expected reference node, got {other:?}"),
+            ASTNodeType::Literal(LiteralValue::Error(e)) => {
+                assert_eq!(e.kind, ExcelError::new_ref().kind);
+            }
+            other => panic!("expected error literal, got {other:?}"),
+        }
+    }
+
+    mod sheet_qualified_errors {
+        use super::parse_formula;
+        use crate::parser::{ASTNode, ASTNodeType, Parser};
+        use crate::tokenizer::Tokenizer;
+        use formualizer_common::{ExcelErrorKind, LiteralValue};
+
+        fn parse_span(formula: &str) -> Result<ASTNode, crate::parser::ParserError> {
+            crate::parser::parse(formula)
+        }
+
+        fn assert_error_kind(formula: &str, expected: ExcelErrorKind) {
+            for (label, ast) in [
+                ("classic", parse_formula(formula).expect("classic parse")),
+                ("span", parse_span(formula).expect("span parse")),
+            ] {
+                match ast.node_type {
+                    ASTNodeType::Literal(LiteralValue::Error(e)) => {
+                        assert_eq!(e.kind, expected, "{label} parser kind for {formula:?}");
+                    }
+                    other => panic!(
+                        "{label} parser: expected error literal for {formula:?}, got {other:?}"
+                    ),
+                }
+            }
+        }
+
+        #[test]
+        fn test_sheet_qualified_ref_error() {
+            assert_error_kind("=Sheet1!#REF!", ExcelErrorKind::Ref);
+        }
+
+        #[test]
+        fn test_quoted_sheet_qualified_ref_error() {
+            assert_error_kind("='My Sheet'!#REF!", ExcelErrorKind::Ref);
+        }
+
+        #[test]
+        fn test_sheet_qualified_div_error() {
+            assert_error_kind("=Sheet1!#DIV/0!", ExcelErrorKind::Div);
+        }
+
+        #[test]
+        fn test_sheet_qualified_value_error() {
+            assert_error_kind("=Sheet1!#VALUE!", ExcelErrorKind::Value);
+        }
+
+        #[test]
+        fn test_sheet_qualified_name_error() {
+            assert_error_kind("=Sheet1!#NAME?", ExcelErrorKind::Name);
+        }
+
+        #[test]
+        fn test_sheet_qualified_lowercase() {
+            assert_error_kind("=sheet1!#ref!", ExcelErrorKind::Ref);
+        }
+
+        #[test]
+        fn test_external_sheet_qualified_error() {
+            assert_error_kind("=[1]Sheet1!#REF!", ExcelErrorKind::Ref);
+        }
+
+        #[test]
+        fn negative_unknown_error_code_with_sheet_prefix() {
+            // Classic and span parsers must both reject unknown error codes.
+            assert!(
+                parse_formula("=Sheet1!#BOGUS!").is_err(),
+                "classic parser should reject unknown error code"
+            );
+            assert!(
+                parse_span("=Sheet1!#BOGUS!").is_err(),
+                "span parser should reject unknown error code"
+            );
+        }
+
+        #[test]
+        fn negative_empty_sheet_prefix() {
+            assert!(
+                parse_formula("=!#REF!").is_err(),
+                "classic parser should reject empty sheet prefix"
+            );
+            assert!(
+                parse_span("=!#REF!").is_err(),
+                "span parser should reject empty sheet prefix"
+            );
+        }
+
+        #[test]
+        fn negative_trailing_garbage_after_error() {
+            assert!(
+                parse_formula("=#REF!Sheet1").is_err(),
+                "classic parser should reject trailing garbage after error literal"
+            );
+            assert!(
+                parse_span("=#REF!Sheet1").is_err(),
+                "span parser should reject trailing garbage after error literal"
+            );
+        }
+
+        #[test]
+        fn regression_ordinary_sheet_reference_unchanged() {
+            // Plain sheet-qualified cell references must not be affected.
+            let ast = parse_formula("=Sheet1!A1").expect("classic parse");
+            match ast.node_type {
+                ASTNodeType::Reference { .. } => {}
+                other => panic!("expected reference node, got {other:?}"),
+            }
+            let ast = parse_span("=Sheet1!A1").expect("span parse");
+            match ast.node_type {
+                ASTNodeType::Reference { .. } => {}
+                other => panic!("expected reference node, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn regression_bare_error_literal_unchanged() {
+            assert_error_kind("=#REF!", ExcelErrorKind::Ref);
+            assert_error_kind("=#DIV/0!", ExcelErrorKind::Div);
+            assert_error_kind("=#VALUE!", ExcelErrorKind::Value);
+            assert_error_kind("=#N/A", ExcelErrorKind::Na);
+            assert_error_kind("=#ref!", ExcelErrorKind::Ref);
+        }
+
+        #[test]
+        fn cross_parser_differential() {
+            // The classic and span parsers must produce identical ASTs for
+            // sheet-qualified error literals across all supported forms.
+            for formula in [
+                "=#REF!",
+                "=Sheet1!#REF!",
+                "='My Sheet'!#REF!",
+                "=Sheet1!#DIV/0!",
+                "=[1]Sheet1!#REF!",
+                "=sheet1!#ref!",
+            ] {
+                let classic = {
+                    let tok = Tokenizer::new(formula).expect("tokenize");
+                    let mut parser = Parser::new(tok.items, false);
+                    parser.parse().expect("classic parse")
+                };
+                let span = parse_span(formula).expect("span parse");
+                let classic_kind = match &classic.node_type {
+                    ASTNodeType::Literal(LiteralValue::Error(e)) => e.kind,
+                    other => panic!("classic non-error for {formula:?}: {other:?}"),
+                };
+                let span_kind = match &span.node_type {
+                    ASTNodeType::Literal(LiteralValue::Error(e)) => e.kind,
+                    other => panic!("span non-error for {formula:?}: {other:?}"),
+                };
+                assert_eq!(classic_kind, span_kind, "kind mismatch for {formula:?}");
+            }
         }
     }
 

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -1483,10 +1483,12 @@ mod tests {
 
     #[test]
     fn test_sheet_prefixed_lowercase_error_literal_tokenizes() {
+        // Sheet-qualified error literals discard the sheet prefix at tokenize
+        // time and emit a single Error operand identical to the bare literal.
         let tokenizer = Tokenizer::new("=source!#ref!").expect("tokenize sheet-prefixed lowercase");
         assert_eq!(tokenizer.items.len(), 1);
         assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
-        assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
-        assert_eq!(tokenizer.items[0].value, "source!#ref!");
+        assert_eq!(tokenizer.items[0].subtype, TokenSubType::Error);
+        assert_eq!(tokenizer.items[0].value, "#ref!");
     }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -1006,19 +1006,35 @@ impl<'a> SpanTokenizer<'a> {
     }
 
     fn parse_error(&mut self) -> Result<(), SpanTokenizerError> {
-        if self.has_token()
+        // OOXML serializes broken sheet-qualified references as `Sheet1!#REF!`.
+        // When an accumulated token ends with `!`, treat the prefix as a sheet
+        // qualifier and discard it: the resulting AST is identical to the bare
+        // error literal `=#REF!`, preserving the error kind via the matched
+        // `ERROR_CODES` entry below.
+        let has_sheet_prefix = self.has_token()
             && self.token_end > 0
-            && self.formula.as_bytes()[self.token_end - 1] != b'!'
-        {
+            && self.formula.as_bytes()[self.token_end - 1] == b'!';
+        if has_sheet_prefix {
+            if self.token_end - self.token_start <= 1 {
+                return Err(SpanTokenizerError {
+                    kind: SpanTokenizerErrorKind::InvalidErrorLiteral,
+                    pos: self.offset,
+                    message: format!(
+                        "Empty sheet qualifier before error literal at position {}",
+                        self.offset
+                    ),
+                    span_start: Some(self.token_start),
+                    span_end: Some(self.offset),
+                });
+            }
+            // Discard the sheet prefix; the error kind is what matters.
+            self.start_token();
+        } else if self.has_token() {
             self.save_token();
             self.start_token();
         }
 
-        let error_start = if self.has_token() {
-            self.token_start
-        } else {
-            self.offset
-        };
+        let error_start = self.offset;
 
         for &err_code in ERROR_CODES {
             let err_bytes = err_code.as_bytes();
@@ -1578,20 +1594,31 @@ impl Tokenizer {
 
     /// Parse an error literal that starts with '#'.
     fn parse_error(&mut self) -> Result<(), TokenizerError> {
-        // Check if we have a partial token ending with '!'
-        if self.has_token()
+        // OOXML serializes broken sheet-qualified references as `Sheet1!#REF!`.
+        // When an accumulated token ends with `!`, treat the prefix as a sheet
+        // qualifier and discard it: the resulting AST is identical to the bare
+        // error literal `=#REF!`, preserving the error kind via `ERROR_CODES`.
+        let has_sheet_prefix = self.has_token()
             && self.token_end > 0
-            && self.formula.as_bytes()[self.token_end - 1] != b'!'
-        {
+            && self.formula.as_bytes()[self.token_end - 1] == b'!';
+        if has_sheet_prefix {
+            if self.token_end - self.token_start <= 1 {
+                return Err(TokenizerError {
+                    message: format!(
+                        "Empty sheet qualifier before error literal at position {}",
+                        self.offset
+                    ),
+                    pos: self.offset,
+                });
+            }
+            // Discard the sheet prefix; the error kind is what matters.
+            self.start_token();
+        } else if self.has_token() {
             self.save_token();
             self.start_token();
         }
 
-        let error_start = if self.has_token() {
-            self.token_start
-        } else {
-            self.offset
-        };
+        let error_start = self.offset;
 
         // Try to match error codes
         for &err_code in ERROR_CODES {


### PR DESCRIPTION
Closes #74

## Summary

OOXML serializes broken sheet-qualified references as `Sheet1!#REF!`,
`'My Sheet'!#REF!`, or `[1]Sheet1!#REF!`. Previously the two parser paths
disagreed and neither preserved the error kind:

- **Span parser** (`parse` / `SpanParser`): emitted a single Error operand
  whose value was `Sheet1!#REF!`; `ExcelError::from_error_string` returned
  a generic `Error` with message `Unknown error code: Sheet1!#REF!`, losing
  the `Ref` kind.
- **Classic parser** (`Parser::new` / `Parser::try_from(&str)`): degraded
  to `NamedRange("Sheet1!#REF!")` inside a `Reference` node (confirmed by
  the strengthened regression test below).

Both `parse_error` implementations in `crates/formualizer-parse/src/tokenizer.rs`
now detect a partial token ending in `!` as a sheet qualifier, validate
that it is non-empty, then discard it before matching against
`ERROR_CODES`. The emitted Error operand is byte-identical to the bare
literal (`#REF!`), so the AST is the same as `=#REF!` and preserves the
kind. Bare error literals (`=#REF!`, lowercase `=#ref!`, etc.) and ordinary
sheet references (`=Sheet1!A1`) are unaffected.

No changes were needed in `formualizer-common::ExcelError::from_error_string`
because the cleanup happens at the tokenizer layer.

## Tests added / changed

- `crates/formualizer-parse/src/tests/parser.rs`:
  - **Strengthened** the existing weak
    `parser_accepts_sheet_prefixed_lowercase_error_literal` test: it now
    asserts `Literal(Error(Ref))` instead of merely accepting any
    `Reference` shape (the previous form silently allowed the
    `NamedRange` degradation).
  - New `mod sheet_qualified_errors` covering both classic and span
    parsers via a shared `assert_error_kind` helper:
    - `test_sheet_qualified_ref_error` (`=Sheet1!#REF!`)
    - `test_quoted_sheet_qualified_ref_error` (`='My Sheet'!#REF!`)
    - `test_sheet_qualified_div_error` (`=Sheet1!#DIV/0!`)
    - `test_sheet_qualified_value_error` (`=Sheet1!#VALUE!`)
    - `test_sheet_qualified_name_error` (`=Sheet1!#NAME?`)
    - `test_sheet_qualified_lowercase` (`=sheet1!#ref!`)
    - `test_external_sheet_qualified_error` (`=[1]Sheet1!#REF!`)
    - `negative_unknown_error_code_with_sheet_prefix` (`=Sheet1!#BOGUS!`)
    - `negative_empty_sheet_prefix` (`=!#REF!`)
    - `negative_trailing_garbage_after_error` (`=#REF!Sheet1`)
    - `regression_ordinary_sheet_reference_unchanged` (`=Sheet1!A1`)
    - `regression_bare_error_literal_unchanged` (covers `#REF!`,
      `#DIV/0!`, `#VALUE!`, `#N/A`, lowercase `#ref!`)
    - `cross_parser_differential` ensures classic and span parsers emit
      identical error kinds for every supported form.
- `crates/formualizer-parse/src/tests/tokenizer.rs`:
  - Updated `test_sheet_prefixed_lowercase_error_literal_tokenizes` to
    reflect the new tokenizer contract (single Error operand with value
    `#ref!`, sheet prefix discarded).

## Validation

```
cargo fmt --all
cargo test -p formualizer-parse sheet_qualified_errors
cargo test -p formualizer-parse
cargo clippy -p formualizer-parse --all-targets -- -D warnings
```

All commands pass cleanly. Pre-fix run of the new tests reproduced the
issue: 9/13 of the new sheet-qualified tests failed (classic parser
producing `NamedRange("Sheet1!#REF!")`, span parser producing the
generic-`Error` literal), plus the strengthened
`parser_accepts_sheet_prefixed_lowercase_error_literal`. After the fix
all 173 unit + integration tests pass.