### PR TITLE
parse: recognize #SPILL! and #CALC! error literals

### DIFF
--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -899,6 +899,106 @@ mod tests {
             panic!("Expected a Function node");
         }
     }
+
+    mod modern_error_literals {
+        use super::*;
+        use formualizer_common::ExcelErrorKind;
+
+        fn expect_error_kind(ast: &ASTNode, expected: ExcelErrorKind) {
+            match &ast.node_type {
+                ASTNodeType::Literal(LiteralValue::Error(e)) => {
+                    assert_eq!(e.kind, expected);
+                }
+                other => panic!("expected error literal, got {other:?}"),
+            }
+        }
+
+        fn parse_both(formula: &str) -> ASTNode {
+            let token_ast =
+                parse_formula(formula).unwrap_or_else(|e| panic!("token parse {formula}: {e:?}"));
+            let span_ast = crate::parser::parse(formula)
+                .unwrap_or_else(|e| panic!("span parse {formula}: {e:?}"));
+            assert_eq!(
+                token_ast.node_type, span_ast.node_type,
+                "token and span parsers diverged for {formula}"
+            );
+            token_ast
+        }
+
+        #[test]
+        fn spill_literal_parses() {
+            let ast = parse_both("=#SPILL!");
+            expect_error_kind(&ast, ExcelErrorKind::Spill);
+        }
+
+        #[test]
+        fn spill_literal_lowercase_parses() {
+            let ast = parse_both("=#spill!");
+            expect_error_kind(&ast, ExcelErrorKind::Spill);
+        }
+
+        #[test]
+        fn calc_literal_parses() {
+            let ast = parse_both("=#CALC!");
+            expect_error_kind(&ast, ExcelErrorKind::Calc);
+        }
+
+        #[test]
+        fn calc_literal_lowercase_parses() {
+            let ast = parse_both("=#calc!");
+            expect_error_kind(&ast, ExcelErrorKind::Calc);
+        }
+
+        #[test]
+        fn spill_in_iferror_function_argument() {
+            let ast = parse_both("=IFERROR(A1, #SPILL!)");
+            match ast.node_type {
+                ASTNodeType::Function { name, args } => {
+                    assert_eq!(name, "IFERROR");
+                    assert_eq!(args.len(), 2);
+                    expect_error_kind(&args[1], ExcelErrorKind::Spill);
+                }
+                other => panic!("expected IFERROR call, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn calc_in_arithmetic_expression() {
+            // Nonsensical semantically, but must parse syntactically.
+            let ast = parse_both("=#CALC! + 1");
+            match ast.node_type {
+                ASTNodeType::BinaryOp { op, left, right } => {
+                    assert_eq!(op, "+");
+                    expect_error_kind(&left, ExcelErrorKind::Calc);
+                    match right.node_type {
+                        ASTNodeType::Literal(LiteralValue::Int(n)) => assert_eq!(n, 1),
+                        ASTNodeType::Literal(LiteralValue::Number(n)) => assert_eq!(n, 1.0),
+                        ref other => panic!("expected numeric 1, got {other:?}"),
+                    }
+                }
+                other => panic!("expected binary op, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn bogus_modern_error_is_rejected_by_parser() {
+            assert!(parse_formula("=#BOGUS!").is_err());
+            assert!(crate::parser::parse("=#BOGUS!").is_err());
+        }
+
+        #[test]
+        fn typo_spil_rejected_by_parser() {
+            assert!(parse_formula("=#SPIL!").is_err());
+            assert!(crate::parser::parse("=#SPIL!").is_err());
+        }
+
+        #[test]
+        fn spill_display_roundtrips_to_excel_literal() {
+            // Display of the kind matches the canonical Excel literal.
+            assert_eq!(format!("{}", ExcelErrorKind::Spill), "#SPILL!");
+            assert_eq!(format!("{}", ExcelErrorKind::Calc), "#CALC!");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -1489,4 +1489,60 @@ mod tests {
         assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
         assert_eq!(tokenizer.items[0].value, "source!#ref!");
     }
+
+    mod modern_error_literals {
+        use super::*;
+
+        fn assert_error_token(formula: &str, expected_value: &str) {
+            let tokenizer = Tokenizer::new(formula)
+                .unwrap_or_else(|e| panic!("failed to tokenize {formula}: {e}"));
+            assert_eq!(tokenizer.items.len(), 1, "formula {formula}");
+            assert_eq!(tokenizer.items[0].token_type, TokenType::Operand);
+            assert_eq!(tokenizer.items[0].subtype, TokenSubType::Error);
+            assert_eq!(tokenizer.items[0].value, expected_value);
+        }
+
+        #[test]
+        fn spill_uppercase() {
+            assert_error_token("=#SPILL!", "#SPILL!");
+        }
+
+        #[test]
+        fn spill_lowercase() {
+            assert_error_token("=#spill!", "#spill!");
+        }
+
+        #[test]
+        fn calc_uppercase() {
+            assert_error_token("=#CALC!", "#CALC!");
+        }
+
+        #[test]
+        fn calc_lowercase() {
+            assert_error_token("=#calc!", "#calc!");
+        }
+
+        #[test]
+        fn bogus_modern_error_is_rejected() {
+            assert!(Tokenizer::new("=#BOGUS!").is_err());
+        }
+
+        #[test]
+        fn typo_spil_is_rejected() {
+            assert!(Tokenizer::new("=#SPIL!").is_err());
+        }
+
+        #[test]
+        fn missing_bang_spill_is_rejected() {
+            // Without the trailing '!' this is not a complete error literal.
+            assert!(Tokenizer::new("=#SPILL").is_err());
+        }
+
+        #[test]
+        fn legacy_error_literals_still_tokenize() {
+            assert_error_token("=#REF!", "#REF!");
+            assert_error_token("=#DIV/0!", "#DIV/0!");
+            assert_error_token("=#N/A", "#N/A");
+        }
+    }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -27,15 +27,33 @@ fn is_token_ender(c: u8) -> bool {
     TOKEN_ENDERS_TABLE[c as usize]
 }
 
+// Recognised Excel error literals. The lookup matches an exact-length slice
+// using `eq_ignore_ascii_case`, so ordering only matters when one entry is a
+// prefix of another (none currently are). We keep entries grouped by era and
+// sorted longest-first defensively so future additions don't introduce
+// prefix-collision ambiguity.
+//
+// Modern (Excel 2018+) literals currently recognised here are limited to the
+// ones whose `ExcelErrorKind` already exists in `formualizer-common`:
+//   - `#SPILL!` (dynamic-array spill blocked)
+//   - `#CALC!`  (generic calc-engine error)
+// Other modern literals (`#FIELD!`, `#BLOCKED!`, `#CONNECT!`, `#UNKNOWN!`,
+// `#EXTERNAL!`, `#BUSY!`, `#PYTHON!`) are intentionally not recognised yet;
+// adding them requires a coordinated change in `ExcelErrorKind` and all
+// downstream exhaustive matches/bindings/serde/display.
+//
+// `#GETTING_DATA` is kept for OOXML/legacy compatibility.
 static ERROR_CODES: &[&str] = &[
-    "#NULL!",
+    "#GETTING_DATA",
     "#DIV/0!",
     "#VALUE!",
-    "#REF!",
+    "#SPILL!",
     "#NAME?",
+    "#NULL!",
+    "#CALC!",
     "#NUM!",
+    "#REF!",
     "#N/A",
-    "#GETTING_DATA",
 ];
 
 /// Represents operator associativity.


### PR DESCRIPTION
Closes #75

## Summary

Excel 2018+ introduced `#SPILL!` and Excel 2020+ introduced `#CALC!`. The token-based `Tokenizer` and the span-based parser previously raised `TokenizerError: Invalid error code at position 1` for both. This PR adds them to the recognised `ERROR_CODES` table so they tokenize as `Operand:Error` and parse to `Literal(Error(Spill | Calc))` using the `ExcelErrorKind::Spill` / `ExcelErrorKind::Calc` variants that already exist in `formualizer-common`.

Per the issue's refined two-slice scope, this PR implements **only the low-risk first slice**. The other modern error literals (`#FIELD!`, `#BLOCKED!`, `#CONNECT!`, `#UNKNOWN!`, `#EXTERNAL!`, `#BUSY!`, `#PYTHON!`) are intentionally deferred — those require coordinated growth of `ExcelErrorKind` plus downstream exhaustive-match / serde / binding / Display updates and should land as a separate coordinated change. A comment in `tokenizer.rs` documents this so future contributors don't add half a slice.

`#GETTING_DATA` is preserved for OOXML/legacy compatibility.

## Tests added

`crates/formualizer-parse/src/tests/tokenizer.rs` — new `mod modern_error_literals`:
- `spill_uppercase` / `spill_lowercase` — `=#SPILL!` and `=#spill!` tokenize to `Operand:Error`.
- `calc_uppercase` / `calc_lowercase` — same for `#CALC!`.
- `bogus_modern_error_is_rejected` — `=#BOGUS!` still errors.
- `typo_spil_is_rejected` — `=#SPIL!` still errors.
- `missing_bang_spill_is_rejected` — `=#SPILL` still errors.
- `legacy_error_literals_still_tokenize` — regression guard for `#REF!`, `#DIV/0!`, `#N/A`.

`crates/formualizer-parse/src/tests/parser.rs` — new `mod modern_error_literals`:
- `spill_literal_parses` / `spill_literal_lowercase_parses` — parse to `Literal(Error(Spill))`. Each test runs through both the token-based `Parser` and the span-based `parse(...)` and asserts the ASTs are identical (cross-parser differential).
- `calc_literal_parses` / `calc_literal_lowercase_parses` — same for `Calc`.
- `spill_in_iferror_function_argument` — `=IFERROR(A1, #SPILL!)` parses with `#SPILL!` as the second arg.
- `calc_in_arithmetic_expression` — `=#CALC! + 1` parses as a binary `+` with `Calc` on the left.
- `bogus_modern_error_is_rejected_by_parser` / `typo_spil_rejected_by_parser` — negative tests on both parser paths.
- `spill_display_roundtrips_to_excel_literal` — confirms `format!(\"{}\", ExcelErrorKind::Spill) == \"#SPILL!\"`.

Existing tests (including legacy error-literal coverage and the lowercase / sheet-prefixed tests) pass unchanged.

## Validation

```
cargo fmt --all
cargo test -p formualizer-parse modern_error_literals   # 17 passed
cargo test -p formualizer-parse                          # 174 passed in lib + integration tests green
cargo clippy -p formualizer-parse --all-targets -- -D warnings   # clean
```