### PR TITLE
parse: implement '#' spill-range postfix operator (#71)

### DIFF
--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -2509,6 +2509,7 @@ impl<'a> SpanParser<'a> {
         };
 
         match op {
+            "#" => Some((9, Associativity::Left)),
             ":" | " " | "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
             "u" => Some((6, Associativity::Right)),

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -33,7 +33,11 @@ fn infix_info(op: &str) -> (u8, Associativity) {
 }
 
 fn unary_precedence(op: &str) -> u8 {
-    if op == "%" { 7 } else { 6 }
+    match op {
+        "#" => 9,
+        "%" => 7,
+        _ => 6,
+    }
 }
 
 fn node_precedence(ast: &ASTNode) -> u8 {
@@ -41,7 +45,7 @@ fn node_precedence(ast: &ASTNode) -> u8 {
         ASTNodeType::BinaryOp { op, .. } => infix_info(op).0,
         ASTNodeType::UnaryOp { op, .. } => unary_precedence(op),
         // Treat everything else as an atom.
-        _ => 9,
+        _ => 10,
     }
 }
 
@@ -96,7 +100,7 @@ fn child_needs_parens(
 
 fn unary_operand_needs_parens(unary_op: &str, operand: &ASTNode) -> bool {
     match unary_op {
-        "%" => matches!(operand.node_type, ASTNodeType::BinaryOp { .. }),
+        "%" | "#" => matches!(operand.node_type, ASTNodeType::BinaryOp { .. }),
         _ => {
             let operand_prec = node_precedence(operand);
             operand_prec < unary_precedence(unary_op)
@@ -139,8 +143,8 @@ fn pretty_print_node(ast: &ASTNode) -> String {
                 inner
             };
 
-            if op == "%" {
-                format!("{inner}%")
+            if op == "%" || op == "#" {
+                format!("{inner}{op}")
             } else {
                 format!("{op}{inner}")
             }

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -899,6 +899,214 @@ mod tests {
             panic!("Expected a Function node");
         }
     }
+
+    mod spill_operator {
+        use super::parse_formula;
+        use crate::parser::{ASTNodeType, ReferenceType};
+        use crate::pretty::pretty_parse_render;
+
+        fn assert_unary_ref(ast: crate::parser::ASTNode, op: &str, expected: ReferenceType) {
+            match ast.node_type {
+                ASTNodeType::UnaryOp { op: o, expr } => {
+                    assert_eq!(o, op);
+                    match expr.node_type {
+                        ASTNodeType::Reference { reference, .. } => {
+                            assert_eq!(reference, expected);
+                        }
+                        other => panic!("expected Reference under UnaryOp, got {other:?}"),
+                    }
+                }
+                other => panic!("expected UnaryOp({op}, ...), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_spill_basic() {
+            // Classic Parser path
+            let ast = parse_formula("=A1#").expect("parse =A1#");
+            assert_unary_ref(ast, "#", ReferenceType::cell(None, 1, 1));
+
+            // Span parse path
+            let ast = crate::parser::parse("=A1#").expect("span parse =A1#");
+            assert_unary_ref(ast, "#", ReferenceType::cell(None, 1, 1));
+        }
+
+        #[test]
+        fn test_spill_in_arithmetic() {
+            for ast in [
+                parse_formula("=B2#+1").expect("classic"),
+                crate::parser::parse("=B2#+1").expect("span"),
+            ] {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, "+");
+                        match left.node_type {
+                            ASTNodeType::UnaryOp { op: o, expr } => {
+                                assert_eq!(o, "#");
+                                assert!(matches!(expr.node_type, ASTNodeType::Reference { .. }));
+                            }
+                            other => panic!("expected UnaryOp on left, got {other:?}"),
+                        }
+                        match right.node_type {
+                            ASTNodeType::Literal(_) => {}
+                            other => panic!("expected literal on right, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected BinaryOp, got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn test_spill_in_function() {
+            for ast in [
+                parse_formula("=SUM(A1#)").expect("classic"),
+                crate::parser::parse("=SUM(A1#)").expect("span"),
+            ] {
+                match ast.node_type {
+                    ASTNodeType::Function { name, args } => {
+                        assert_eq!(name, "SUM");
+                        assert_eq!(args.len(), 1);
+                        match &args[0].node_type {
+                            ASTNodeType::UnaryOp { op, expr } => {
+                                assert_eq!(op, "#");
+                                assert!(matches!(expr.node_type, ASTNodeType::Reference { .. }));
+                            }
+                            other => panic!("expected UnaryOp arg, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected Function, got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn test_spill_with_implicit_intersection() {
+            // =@A1# → @ wraps the spill ref.
+            for ast in [
+                parse_formula("=@A1#").expect("classic"),
+                crate::parser::parse("=@A1#").expect("span"),
+            ] {
+                match ast.node_type {
+                    ASTNodeType::UnaryOp { op, expr } => {
+                        assert_eq!(op, "@");
+                        match expr.node_type {
+                            ASTNodeType::UnaryOp {
+                                op: inner_op,
+                                expr: inner,
+                            } => {
+                                assert_eq!(inner_op, "#");
+                                assert!(matches!(inner.node_type, ASTNodeType::Reference { .. }));
+                            }
+                            other => panic!("expected UnaryOp(#) under @, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected UnaryOp(@, ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn test_spill_sheet_qualified() {
+            for ast in [
+                parse_formula("=Sheet1!A1#").expect("classic"),
+                crate::parser::parse("=Sheet1!A1#").expect("span"),
+            ] {
+                assert_unary_ref(
+                    ast,
+                    "#",
+                    ReferenceType::cell(Some("Sheet1".to_string()), 1, 1),
+                );
+            }
+        }
+
+        #[test]
+        fn test_anchorarray_xlfn_still_function() {
+            // Legacy serialization should still be a function call.
+            for ast in [
+                parse_formula("=_xlfn.ANCHORARRAY(A1)").expect("classic"),
+                crate::parser::parse("=_xlfn.ANCHORARRAY(A1)").expect("span"),
+            ] {
+                match ast.node_type {
+                    ASTNodeType::Function { name, args } => {
+                        assert!(name.eq_ignore_ascii_case("_xlfn.ANCHORARRAY"));
+                        assert_eq!(args.len(), 1);
+                    }
+                    other => panic!("expected Function, got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn test_error_literal_still_parses() {
+            // Negative regression — error literals must remain literals.
+            let ast = parse_formula("=#REF!").expect("=#REF!");
+            assert!(matches!(ast.node_type, ASTNodeType::Literal(_)));
+            let ast = crate::parser::parse("=#REF!").expect("span =#REF!");
+            assert!(matches!(ast.node_type, ASTNodeType::Literal(_)));
+        }
+
+        #[test]
+        fn test_sheet_prefixed_error_literal_still_parses() {
+            // The key invariant for #71: `Sheet1!#REF!` must NOT be split
+            // into `Sheet1!` + spill `#`. The classic Parser path produces a
+            // Reference node (sheet-qualified error) and the span path
+            // produces a Literal(Error) — both pre-existing behaviors that we
+            // simply must not regress.
+            let classic = parse_formula("=Sheet1!#REF!").expect("classic");
+            assert!(matches!(
+                classic.node_type,
+                ASTNodeType::Reference { .. } | ASTNodeType::Literal(_)
+            ));
+            let span = crate::parser::parse("=Sheet1!#REF!").expect("span");
+            assert!(matches!(
+                span.node_type,
+                ASTNodeType::Reference { .. } | ASTNodeType::Literal(_)
+            ));
+        }
+
+        #[test]
+        fn test_double_spill_parses() {
+            // =A1## — accept and produce nested UnaryOp(#, UnaryOp(#, A1)).
+            for ast in [
+                parse_formula("=A1##").expect("classic"),
+                crate::parser::parse("=A1##").expect("span"),
+            ] {
+                match ast.node_type {
+                    ASTNodeType::UnaryOp { op, expr } => {
+                        assert_eq!(op, "#");
+                        match expr.node_type {
+                            ASTNodeType::UnaryOp { op: inner_op, .. } => {
+                                assert_eq!(inner_op, "#");
+                            }
+                            other => panic!("expected nested UnaryOp(#), got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected outer UnaryOp(#), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn test_bare_hash_is_error() {
+            assert!(parse_formula("=#").is_err());
+            assert!(crate::parser::parse("=#").is_err());
+        }
+
+        #[test]
+        fn test_spill_display_roundtrip() {
+            // parse → pretty → parse must yield the same AST shape.
+            let pretty = pretty_parse_render("=A1#").expect("pretty");
+            assert_eq!(pretty, "=A1#");
+            let again = pretty_parse_render(&pretty).expect("pretty round");
+            assert_eq!(pretty, again);
+
+            let pretty = pretty_parse_render("=SUM(B2#)+1").expect("pretty");
+            assert_eq!(pretty, "=SUM(B2#) + 1");
+            let again = pretty_parse_render(&pretty).expect("pretty round");
+            assert_eq!(pretty, again);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1126,7 +1334,7 @@ mod normalise_tests {
 mod reference_tests {
     use crate::parser::ReferenceType;
     use crate::parser::*;
-    use crate::tokenizer::Tokenizer;
+    use crate::tokenizer::{TokenType, Tokenizer};
 
     #[test]
     fn test_cell_reference_parsing() {
@@ -1826,17 +2034,18 @@ mod reference_tests {
 
     #[test]
     fn test_table_reference_with_spill() {
-        // Test a table reference with spill operator
-        // Currently our implementation doesn't support spill operators (#),
-        // which is why we're seeing an error. This test confirms the current behavior.
+        // Spill operator (#) postfix on a table reference (issue #71).
         let formula = "=Table1[#Data]#";
-        let tokenizer_result = Tokenizer::new(formula);
-
-        // Verify that the current implementation rejects the spill operator
-        assert!(tokenizer_result.is_err());
-
-        // Note: In the future, we should enhance parsing to support spill operators
-        // for dynamic array formulas and structured references
+        let tokenizer = Tokenizer::new(formula).expect("tokenize spill on table ref");
+        // Last non-whitespace token is the spill postfix `#`.
+        let last = tokenizer
+            .items
+            .iter()
+            .rev()
+            .find(|t| t.token_type != TokenType::Whitespace)
+            .expect("non-empty");
+        assert_eq!(last.token_type, TokenType::OpPostfix);
+        assert_eq!(last.value, "#");
     }
 
     #[test]

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -1489,4 +1489,170 @@ mod tests {
         assert_eq!(tokenizer.items[0].subtype, TokenSubType::Range);
         assert_eq!(tokenizer.items[0].value, "source!#ref!");
     }
+
+    mod spill_operator {
+        use crate::tokenizer::{TokenStream, TokenSubType, TokenType, Tokenizer};
+
+        fn classic_non_ws(formula: &str) -> Vec<(TokenType, TokenSubType, String)> {
+            let t = Tokenizer::new(formula).expect("tokenize");
+            t.items
+                .iter()
+                .filter(|tok| tok.token_type != TokenType::Whitespace)
+                .map(|tok| (tok.token_type, tok.subtype, tok.value.clone()))
+                .collect()
+        }
+
+        fn span_non_ws(formula: &str) -> Vec<(TokenType, TokenSubType, String)> {
+            let stream = TokenStream::new(formula).expect("span tokenize");
+            stream
+                .spans
+                .iter()
+                .filter(|span| span.token_type != TokenType::Whitespace)
+                .map(|span| {
+                    (
+                        span.token_type,
+                        span.subtype,
+                        formula[span.start..span.end].to_string(),
+                    )
+                })
+                .collect()
+        }
+
+        #[test]
+        fn spill_postfix_after_cell() {
+            let expected = vec![
+                (TokenType::Operand, TokenSubType::Range, "A1".to_string()),
+                (TokenType::OpPostfix, TokenSubType::None, "#".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=A1#"), expected);
+            assert_eq!(span_non_ws("=A1#"), expected);
+        }
+
+        #[test]
+        fn spill_postfix_then_operator() {
+            let expected = vec![
+                (TokenType::Operand, TokenSubType::Range, "A1".to_string()),
+                (TokenType::OpPostfix, TokenSubType::None, "#".to_string()),
+                (TokenType::OpInfix, TokenSubType::None, "+".to_string()),
+                (TokenType::Operand, TokenSubType::Number, "1".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=A1#+1"), expected);
+            assert_eq!(span_non_ws("=A1#+1"), expected);
+        }
+
+        #[test]
+        fn hash_at_start_still_error_literal() {
+            let expected = vec![(TokenType::Operand, TokenSubType::Error, "#REF!".to_string())];
+            assert_eq!(classic_non_ws("=#REF!"), expected);
+            assert_eq!(span_non_ws("=#REF!"), expected);
+        }
+
+        #[test]
+        fn hash_after_operator_is_error_literal() {
+            let classic = classic_non_ws("=1+#DIV/0!");
+            assert_eq!(classic.last().unwrap().0, TokenType::Operand);
+            assert_eq!(classic.last().unwrap().1, TokenSubType::Error);
+            assert_eq!(classic.last().unwrap().2, "#DIV/0!");
+            let span = span_non_ws("=1+#DIV/0!");
+            assert_eq!(span.last().unwrap().0, TokenType::Operand);
+            assert_eq!(span.last().unwrap().1, TokenSubType::Error);
+            assert_eq!(span.last().unwrap().2, "#DIV/0!");
+        }
+
+        #[test]
+        fn hash_after_sheet_qualified_cell() {
+            let expected = vec![
+                (
+                    TokenType::Operand,
+                    TokenSubType::Range,
+                    "Sheet1!A1".to_string(),
+                ),
+                (TokenType::OpPostfix, TokenSubType::None, "#".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=Sheet1!A1#"), expected);
+            assert_eq!(span_non_ws("=Sheet1!A1#"), expected);
+        }
+
+        #[test]
+        fn sheet_qualified_error_literal_unchanged() {
+            // The key invariant: `Sheet1!#REF!` must remain a single Operand
+            // token and NOT be split into `Sheet1!` + `#` postfix. The exact
+            // operand subtype for sheet-qualified error literals is a
+            // pre-existing path divergence (classic=Range, span=Error) and is
+            // out of scope for #71.
+            let classic = classic_non_ws("=Sheet1!#REF!");
+            assert_eq!(classic.len(), 1);
+            assert_eq!(classic[0].0, TokenType::Operand);
+            assert_eq!(classic[0].2, "Sheet1!#REF!");
+            assert_ne!(classic[0].1, TokenSubType::None);
+            let span = span_non_ws("=Sheet1!#REF!");
+            assert_eq!(span.len(), 1);
+            assert_eq!(span[0].0, TokenType::Operand);
+            assert_eq!(span[0].2, "Sheet1!#REF!");
+            assert_ne!(span[0].1, TokenSubType::None);
+        }
+
+        #[test]
+        fn spill_after_external_ref() {
+            let expected = vec![
+                (
+                    TokenType::Operand,
+                    TokenSubType::Range,
+                    "[1]Sheet1!A1".to_string(),
+                ),
+                (TokenType::OpPostfix, TokenSubType::None, "#".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=[1]Sheet1!A1#"), expected);
+            assert_eq!(span_non_ws("=[1]Sheet1!A1#"), expected);
+        }
+
+        #[test]
+        fn spill_after_paren_close() {
+            let expected = vec![
+                (TokenType::Paren, TokenSubType::Open, "(".to_string()),
+                (TokenType::Operand, TokenSubType::Range, "A1".to_string()),
+                (TokenType::Paren, TokenSubType::Close, ")".to_string()),
+                (TokenType::OpPostfix, TokenSubType::None, "#".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=(A1)#"), expected);
+            assert_eq!(span_non_ws("=(A1)#"), expected);
+        }
+
+        #[test]
+        fn double_spill_emits_two_postfix() {
+            let classic = classic_non_ws("=A1##");
+            assert_eq!(
+                classic
+                    .iter()
+                    .filter(|t| t.0 == TokenType::OpPostfix && t.2 == "#")
+                    .count(),
+                2
+            );
+            let span = span_non_ws("=A1##");
+            assert_eq!(
+                span.iter()
+                    .filter(|t| t.0 == TokenType::OpPostfix && t.2 == "#")
+                    .count(),
+                2
+            );
+        }
+
+        #[test]
+        fn spill_with_whitespace_between_two_refs() {
+            // Two spilled ranges separated by whitespace; tokenizer-only check (parser
+            // intersection handling is tracked separately).
+            let classic = classic_non_ws("=A1# B1#");
+            let posts: Vec<_> = classic
+                .iter()
+                .filter(|t| t.0 == TokenType::OpPostfix && t.2 == "#")
+                .collect();
+            assert_eq!(posts.len(), 2);
+            let span = span_non_ws("=A1# B1#");
+            let posts_span: Vec<_> = span
+                .iter()
+                .filter(|t| t.0 == TokenType::OpPostfix && t.2 == "#")
+                .collect();
+            assert_eq!(posts_span.len(), 2);
+        }
+    }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -255,6 +255,7 @@ impl Token {
         //   &
         //   comparisons
         match op {
+            "#" => Some((9, Associativity::Left)),
             ":" | " " | "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
             "u" => Some((6, Associativity::Right)),
@@ -756,7 +757,14 @@ impl<'a> SpanTokenizer<'a> {
             let parse_result = match curr_byte {
                 b'"' | b'\'' => self.parse_string(),
                 b'[' => self.parse_brackets(),
-                b'#' => self.parse_error(),
+                b'#' => {
+                    if self.should_emit_hash_postfix() {
+                        self.emit_hash_postfix();
+                        Ok(())
+                    } else {
+                        self.parse_error()
+                    }
+                }
                 b' ' | b'\n' => self.parse_whitespace(),
                 b'+' | b'-' | b'*' | b'/' | b'^' | b'&' | b'=' | b'>' | b'<' | b'%' | b'@' => {
                     self.parse_operator()
@@ -1092,6 +1100,49 @@ impl<'a> SpanTokenizer<'a> {
             .find(|t| t.token_type != TokenType::Whitespace)
     }
 
+    /// Decide whether a `#` at `self.offset` should be emitted as a spill
+    /// postfix operator (`OpPostfix`) instead of routed to the error-literal
+    /// parser. The rule mirrors the space-operator gating: `#` is postfix when
+    /// it follows a reference-producing token.
+    fn should_emit_hash_postfix(&self) -> bool {
+        if self.has_token() {
+            // An accumulated token whose last byte is `!` is a sheet/file
+            // qualifier (e.g. `Sheet1!`). Defer to `parse_error` so it can
+            // merge `Sheet1!` + `#REF!` into a single qualified-error operand.
+            if self.formula.as_bytes()[self.token_end - 1] == b'!' {
+                return false;
+            }
+            let value = &self.formula[self.token_start..self.token_end];
+            return operand_subtype(value) == TokenSubType::Range;
+        }
+        match self.prev_non_whitespace() {
+            Some(prev) => match prev.token_type {
+                TokenType::OpPostfix => true,
+                TokenType::Paren | TokenType::Func | TokenType::Array
+                    if prev.subtype == TokenSubType::Close =>
+                {
+                    true
+                }
+                TokenType::Operand if prev.subtype == TokenSubType::Range => true,
+                _ => false,
+            },
+            None => false,
+        }
+    }
+
+    fn emit_hash_postfix(&mut self) {
+        self.save_token();
+        self.start_token();
+        self.push_span(
+            TokenType::OpPostfix,
+            TokenSubType::None,
+            self.offset,
+            self.offset + 1,
+        );
+        self.offset += 1;
+        self.start_token();
+    }
+
     fn parse_operator(&mut self) -> Result<(), SpanTokenizerError> {
         self.save_token();
 
@@ -1388,7 +1439,13 @@ impl Tokenizer {
             match curr_byte {
                 b'"' | b'\'' => self.parse_string()?,
                 b'[' => self.parse_brackets()?,
-                b'#' => self.parse_error()?,
+                b'#' => {
+                    if self.should_emit_hash_postfix() {
+                        self.emit_hash_postfix();
+                    } else {
+                        self.parse_error()?
+                    }
+                }
                 b' ' | b'\n' => self.parse_whitespace()?,
                 // operator characters
                 b'+' | b'-' | b'*' | b'/' | b'^' | b'&' | b'=' | b'>' | b'<' | b'%' | b'@' => {
@@ -1574,6 +1631,57 @@ impl Tokenizer {
             message: "Encountered unmatched '['".to_string(),
             pos: self.offset,
         })
+    }
+
+    /// See `SpanTokenizer::should_emit_hash_postfix` for rationale.
+    fn should_emit_hash_postfix(&self) -> bool {
+        if self.has_token() {
+            if self.formula.as_bytes()[self.token_end - 1] == b'!' {
+                return false;
+            }
+            let value = &self.formula[self.token_start..self.token_end];
+            // Mirror `make_operand_from_slice` subtype detection: the
+            // accumulated token forms a Range operand iff it isn't a quoted
+            // string, error literal, boolean, or number.
+            let is_range = !value.starts_with('"')
+                && !value.starts_with('#')
+                && value != "TRUE"
+                && value != "FALSE"
+                && value.parse::<f64>().is_err();
+            return is_range;
+        }
+        let prev = self
+            .items
+            .iter()
+            .rev()
+            .find(|t| t.token_type != TokenType::Whitespace);
+        match prev {
+            Some(p) => match p.token_type {
+                TokenType::OpPostfix => true,
+                TokenType::Paren | TokenType::Func | TokenType::Array
+                    if p.subtype == TokenSubType::Close =>
+                {
+                    true
+                }
+                TokenType::Operand if p.subtype == TokenSubType::Range => true,
+                _ => false,
+            },
+            None => false,
+        }
+    }
+
+    fn emit_hash_postfix(&mut self) {
+        self.save_token();
+        self.start_token();
+        self.items.push(Token::from_slice(
+            &self.formula,
+            TokenType::OpPostfix,
+            TokenSubType::None,
+            self.offset,
+            self.offset + 1,
+        ));
+        self.offset += 1;
+        self.start_token();
     }
 
     /// Parse an error literal that starts with '#'.


### PR DESCRIPTION
Closes #71

## Summary

Implements the dynamic-array spill-range postfix operator `#` (e.g. `=A1#`, `=B2#+1`, `=SUM(A1#)`, `=Sheet1!A1#`, `=@A1#`).

`#` is now context-sensitive in both the classic and span tokenizers:
- When it follows a reference-producing token (`Operand:Range`, `)`, `]`, another `OpPostfix`, or an accumulated Range token), it is emitted as `TokenType::OpPostfix` with value `#`.
- Otherwise, it is routed to the existing `parse_error` path, preserving error literals (`#REF!`, `#DIV/0!`, `#VALUE!`, `#N/A`, `#NUM!`, `#NAME?`, `#NULL!`, `#GETTING_DATA`).
- An accumulated token whose last byte is `!` (sheet/file qualifier such as `Sheet1!`) defers to `parse_error` so `Sheet1!#REF!` still merges into a single qualified-error operand. This is the key invariant that protects sheet-qualified errors from being mis-tokenized as `Sheet1!` + spill `#`.

The Pratt loop already supported `OpPostfix`; `#` is added to both precedence tables (`Token::get_precedence` and `SpanParser::span_precedence`) at level **9**, so it binds tighter than `:` (level 8) and `%` (level 7) per the issue guidance. The pretty-printer renders `UnaryOp { op: "#", expr }` as `expr#` and round-trips parse → print → parse.

## Tests added

New `spill_operator` modules in both `tests/tokenizer.rs` and `tests/parser.rs`, exercising both the classic `Tokenizer`/`Parser` path and the `parse(...)`/`SpanParser` path:

Tokenizer:
- `spill_postfix_after_cell` — `=A1#` → `[Operand:Range(A1), OpPostfix(#)]`
- `spill_postfix_then_operator` — `=A1#+1`
- `hash_at_start_still_error_literal` — `=#REF!`
- `hash_after_operator_is_error_literal` — `=1+#DIV/0!`
- `hash_after_sheet_qualified_cell` — `=Sheet1!A1#`
- `sheet_qualified_error_literal_unchanged` — `=Sheet1!#REF!` remains a single Operand
- `spill_after_external_ref` — `=[1]Sheet1!A1#`
- `spill_after_paren_close` — `=(A1)#`
- `double_spill_emits_two_postfix` — `=A1##`
- `spill_with_whitespace_between_two_refs` — `=A1# B1#`

Parser:
- `test_spill_basic`, `test_spill_in_arithmetic`, `test_spill_in_function`
- `test_spill_with_implicit_intersection` — `=@A1#` → `UnaryOp(@, UnaryOp(#, Reference(A1)))`
- `test_spill_sheet_qualified` — `=Sheet1!A1#`
- `test_anchorarray_xlfn_still_function` — `=_xlfn.ANCHORARRAY(A1)` parses as a function call
- `test_error_literal_still_parses`, `test_sheet_prefixed_error_literal_still_parses`
- `test_double_spill_parses` — `=A1##` accepted (nested `UnaryOp(#)`)
- `test_bare_hash_is_error` — `=#` rejected
- `test_spill_display_roundtrip` — `=A1#` and `=SUM(B2#) + 1` round-trip

Updated pre-existing `reference_tests::test_table_reference_with_spill`, which previously asserted the tokenizer rejected `=Table1[#Data]#`; it now verifies the trailing `#` is emitted as `OpPostfix`.

Downstream evaluation of spill ranges is intentionally out of scope (per issue).

## Validation

```
cargo fmt --all
cargo test -p formualizer-parse spill_operator   # 21/21 ok
cargo test -p formualizer-parse                  # 178 + 3 + 0 ok
cargo clippy -p formualizer-parse --all-targets -- -D warnings  # clean
cargo build --workspace                          # ok
```