### PR TITLE
fix(parse): real recursive-descent parser for structured (table) references

### DIFF
--- a/crates/formualizer-parse/src/lib.rs
+++ b/crates/formualizer-parse/src/lib.rs
@@ -7,6 +7,7 @@
 mod hasher;
 pub mod parser;
 pub mod pretty;
+mod structured_ref;
 mod tests;
 pub mod tokenizer;
 pub mod types;

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1,3 +1,4 @@
+use crate::structured_ref;
 use crate::tokenizer::{Associativity, Token, TokenSubType, TokenType, Tokenizer, TokenizerError};
 use crate::types::{FormulaDialect, ParsingError};
 use crate::{ExcelError, LiteralValue};
@@ -274,9 +275,24 @@ impl Display for TableSpecifier {
             TableSpecifier::SpecialItem(item) => write!(f, "{item}"),
             TableSpecifier::Combination(specs) => {
                 // Emit nested bracketed parts so the surrounding Table formatter prints
-                // canonical structured refs like Table[[#Headers],[Column1]:[Column2]]
-                let parts: Vec<String> = specs.iter().map(|s| format!("[{s}]")).collect();
-                write!(f, "{}", parts.join(","))
+                // canonical structured refs like Table[[#Headers],[Column1]:[Column2]].
+                // ColumnRange children must split their bracket boundary across
+                // both endpoints (`[A]:[B]`) rather than wrapping the whole
+                // range in one bracket pair.
+                let mut first = true;
+                for spec in specs {
+                    if !first {
+                        write!(f, ",")?;
+                    }
+                    first = false;
+                    match spec.as_ref() {
+                        TableSpecifier::ColumnRange(start, end) => {
+                            write!(f, "[{start}]:[{end}]")?;
+                        }
+                        other => write!(f, "[{other}]")?,
+                    }
+                }
+                Ok(())
             }
         }
     }
@@ -1015,128 +1031,49 @@ impl ReferenceType {
         (None, reference.to_string())
     }
 
-    /// Parse a table reference like "Table1[Column1]" or more complex ones like "Table1[[#All],[Column1]:[Column2]]".
+    /// Parse a table reference like "Table1[Column1]" or more complex ones
+    /// like "Table1[[#All],[Column1]:[Column2]]".
+    ///
+    /// The specifier syntax is parsed by a real recursive-descent parser
+    /// (`structured_ref::SpecifierParser`) following MS-XLSX §18.17.6.2.
     fn parse_table_reference(reference: &str) -> Result<Self, ParsingError> {
-        // Find the first '[' to separate table name from specifier
-        if let Some(bracket_pos) = reference.find('[') {
-            let table_name = reference[..bracket_pos].trim();
-            if table_name.is_empty() {
-                return Err(ParsingError::InvalidReference(reference.to_string()));
-            }
-
-            let specifier_str = &reference[bracket_pos..];
-            let specifier = Self::parse_table_specifier(specifier_str)?;
-
-            Ok(ReferenceType::Table(TableReference {
-                name: table_name.to_string(),
-                specifier,
-            }))
-        } else {
-            Err(ParsingError::InvalidReference(reference.to_string()))
-        }
-    }
-
-    fn parse_bracketed_structured_reference(reference: &str) -> Result<Self, ParsingError> {
-        debug_assert!(reference.starts_with('[') && reference.ends_with(']'));
-        let inner = reference[1..reference.len().saturating_sub(1)].trim();
-        if inner.is_empty() {
+        let bracket_pos = reference.find('[').ok_or_else(|| {
+            ParsingError::InvalidReference(format!("Missing '[' in table reference: {reference}"))
+        })?;
+        let table_name = reference[..bracket_pos].trim();
+        if table_name.is_empty() {
             return Err(ParsingError::InvalidReference(reference.to_string()));
         }
 
-        // This-row column selector: [@Column] or [@[Column Name]]
-        if let Some(rest) = inner.strip_prefix('@') {
-            let mut col = rest.trim();
-            if col.starts_with('[') && col.ends_with(']') && col.len() >= 2 {
-                col = col[1..col.len() - 1].trim();
-            }
-            if col.is_empty() {
-                return Err(ParsingError::InvalidReference(format!(
-                    "This-row structured reference missing column: {reference}"
-                )));
-            }
+        let specifier_str = &reference[bracket_pos..];
+        let specifier = structured_ref::parse_full_specifier(specifier_str)?;
 
-            let spec = TableSpecifier::Combination(vec![
-                Box::new(TableSpecifier::SpecialItem(SpecialItem::ThisRow)),
-                Box::new(TableSpecifier::Column(col.to_string())),
-            ]);
-            return Ok(ReferenceType::Table(TableReference {
-                name: String::new(),
-                specifier: Some(spec),
-            }));
-        }
-
-        // Table shorthand: [TableName] means data body.
         Ok(ReferenceType::Table(TableReference {
-            name: inner.to_string(),
-            specifier: Some(TableSpecifier::SpecialItem(SpecialItem::Data)),
+            name: table_name.to_string(),
+            specifier,
         }))
     }
 
-    /// Parse a table specifier like "[Column1]" or "[[#All],[Column1]:[Column2]]"
-    fn parse_table_specifier(specifier_str: &str) -> Result<Option<TableSpecifier>, ParsingError> {
-        if specifier_str.is_empty() || !specifier_str.starts_with('[') {
-            return Ok(None);
+    /// Handle the `[...]` shorthand that appears without a table name. The
+    /// resolver/evaluator binds the implicit table from cell context.
+    ///
+    /// `[TableName]` is the data-body shorthand and is materialised as
+    /// `Table { name = "TableName", specifier = #Data }`; everything else
+    /// produces an unnamed `Table` carrying the parsed specifier verbatim.
+    fn parse_bracketed_structured_reference(reference: &str) -> Result<Self, ParsingError> {
+        debug_assert!(reference.starts_with('[') && reference.ends_with(']'));
+        let specifier = structured_ref::parse_full_specifier(reference)?;
+
+        match specifier {
+            Some(TableSpecifier::Column(name)) => Ok(ReferenceType::Table(TableReference {
+                name,
+                specifier: Some(TableSpecifier::SpecialItem(SpecialItem::Data)),
+            })),
+            other => Ok(ReferenceType::Table(TableReference {
+                name: String::new(),
+                specifier: other,
+            })),
         }
-
-        // Find balanced closing bracket
-        let mut depth = 0;
-        let mut end_pos = 0;
-
-        for (i, c) in specifier_str.char_indices() {
-            if c == '[' {
-                depth += 1;
-            } else if c == ']' {
-                depth -= 1;
-                if depth == 0 {
-                    end_pos = i;
-                    break;
-                }
-            }
-        }
-
-        if depth != 0 || end_pos == 0 {
-            return Err(ParsingError::InvalidReference(format!(
-                "Unbalanced brackets in table specifier: {specifier_str}"
-            )));
-        }
-
-        // Extract content between outermost brackets
-        let content = &specifier_str[1..end_pos];
-
-        // Handle different types of specifiers
-        if content.is_empty() {
-            // Empty brackets means the whole table
-            return Ok(Some(TableSpecifier::All));
-        }
-
-        // Handle special items
-        if content.starts_with("#") {
-            return Self::parse_special_item(content);
-        }
-
-        // Handle column references
-        if !content.contains('[') && !content.contains('#') {
-            // Check for column range using iterator instead of split().collect()
-            if let Some(colon_pos) = content.find(':') {
-                let start = content[..colon_pos].trim();
-                let end = content[colon_pos + 1..].trim();
-                return Ok(Some(TableSpecifier::ColumnRange(
-                    start.to_string(),
-                    end.to_string(),
-                )));
-            } else {
-                // Single column
-                return Ok(Some(TableSpecifier::Column(content.trim().to_string())));
-            }
-        }
-
-        // Handle complex structured references with nested brackets
-        if content.contains('[') {
-            return Self::parse_complex_table_specifier(content);
-        }
-
-        // If we can't determine the type, just use the raw specifier
-        Ok(Some(TableSpecifier::Column(content.trim().to_string())))
     }
 
     fn parse_openformula_reference(reference: &str) -> Result<Self, ParsingError> {
@@ -1289,60 +1226,10 @@ impl ReferenceType {
         None
     }
 
-    /// Parse a special item specifier like "#Headers", "#Data", etc.
-    fn parse_special_item(content: &str) -> Result<Option<TableSpecifier>, ParsingError> {
-        match content {
-            "#All" => Ok(Some(TableSpecifier::SpecialItem(SpecialItem::All))),
-            "#Headers" => Ok(Some(TableSpecifier::SpecialItem(SpecialItem::Headers))),
-            "#Data" => Ok(Some(TableSpecifier::SpecialItem(SpecialItem::Data))),
-            "#Totals" => Ok(Some(TableSpecifier::SpecialItem(SpecialItem::Totals))),
-            "@" => Ok(Some(TableSpecifier::Row(TableRowSpecifier::Current))),
-            _ => Err(ParsingError::InvalidReference(format!(
-                "Unknown special item: {content}"
-            ))),
-        }
-    }
-
-    /// Parse complex table specifiers with nested brackets
-    fn parse_complex_table_specifier(
-        content: &str,
-    ) -> Result<Option<TableSpecifier>, ParsingError> {
-        // This is a more complex case like [[#Headers],[Column1]:[Column2]]
-        // For now, we'll just store the raw specifier and enhance this in the future
-
-        // Try to identify common patterns
-        if content.contains("[#Headers]")
-            || content.contains("[#All]")
-            || content.contains("[#Data]")
-            || content.contains("[#Totals]")
-            || content.contains("[@]")
-        {
-            // This is a combination of specifiers
-            // Parse them into a vector
-            let mut specifiers = Vec::new();
-
-            // Simple parsing - this would need enhancement for full support
-            if content.contains("[#Headers]") {
-                specifiers.push(Box::new(TableSpecifier::SpecialItem(SpecialItem::Headers)));
-            }
-            if content.contains("[#Data]") {
-                specifiers.push(Box::new(TableSpecifier::SpecialItem(SpecialItem::Data)));
-            }
-            if content.contains("[#Totals]") {
-                specifiers.push(Box::new(TableSpecifier::SpecialItem(SpecialItem::Totals)));
-            }
-            if content.contains("[#All]") {
-                specifiers.push(Box::new(TableSpecifier::SpecialItem(SpecialItem::All)));
-            }
-
-            if !specifiers.is_empty() {
-                return Ok(Some(TableSpecifier::Combination(specifiers)));
-            }
-        }
-
-        // Fallback to storing as a column specifier
-        Ok(Some(TableSpecifier::Column(content.trim().to_string())))
-    }
+    // The structured-reference grammar lives in the `structured_ref`
+    // submodule below; legacy `parse_special_item` /
+    // `parse_complex_table_specifier` helpers were removed when the real
+    // recursive-descent parser landed for issue #73.
 
     /// Get the Excel-style string representation of this reference
     pub fn to_excel_string(&self) -> String {

--- a/crates/formualizer-parse/src/structured_ref.rs
+++ b/crates/formualizer-parse/src/structured_ref.rs
@@ -1,0 +1,554 @@
+//! Recursive-descent parser for Excel structured (table) references.
+//!
+//! Implements the bracket-content grammar described in MS-XLSX
+//! \u00a718.17.6.2 and used throughout `Table[Column]` style references:
+//!
+//! ```text
+//! specifier       := "[" content "]"
+//! content         := "" | special | column | column_range | combination
+//! special         := "#All" | "#Headers" | "#Data" | "#Totals" | "#This Row" | "@"
+//! column          := "[" name "]"   ; outer bracket optional in simple form
+//! column_range    := column ":" column
+//! combination     := item ("," item)*
+//! item            := "[" special "]" | column | column_range
+//! ```
+//!
+//! Naming is case-insensitive for specials. Column names support an
+//! OOXML-style per-character escape `'X` that lets `[`, `]`, `'`, and `#`
+//! appear inside a column identifier.
+
+use crate::parser::{SpecialItem, TableSpecifier};
+use crate::types::ParsingError;
+
+/// Top-level entry point: parse a complete bracketed specifier and reject
+/// trailing garbage.
+pub(crate) fn parse_full_specifier(input: &str) -> Result<Option<TableSpecifier>, ParsingError> {
+    if input.is_empty() {
+        return Ok(None);
+    }
+    let mut p = SpecifierParser::new(input);
+    let spec = p.parse_specifier()?;
+    if p.pos != p.src.len() {
+        return Err(ParsingError::InvalidReference(format!(
+            "Trailing content after structured reference at offset {}: {:?}",
+            p.pos,
+            &p.src[p.pos..]
+        )));
+    }
+    Ok(Some(spec))
+}
+
+struct SpecifierParser<'a> {
+    src: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> SpecifierParser<'a> {
+    fn new(src: &'a str) -> Self {
+        Self {
+            src,
+            bytes: src.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn bump(&mut self, expected: u8) -> Result<(), ParsingError> {
+        match self.peek() {
+            Some(b) if b == expected => {
+                self.pos += 1;
+                Ok(())
+            }
+            Some(b) => Err(ParsingError::InvalidReference(format!(
+                "Expected {:?} at offset {}, found {:?}",
+                expected as char, self.pos, b as char
+            ))),
+            None => Err(ParsingError::InvalidReference(format!(
+                "Expected {:?} at offset {}, found end of input",
+                expected as char, self.pos
+            ))),
+        }
+    }
+
+    /// Parse the outermost `[ content ]` block.
+    fn parse_specifier(&mut self) -> Result<TableSpecifier, ParsingError> {
+        self.bump(b'[')?;
+        let inner_start = self.pos;
+        // Find the matching `]` that terminates this specifier (respecting
+        // nesting and `'`-escapes). The substring [inner_start..close) is
+        // the "content".
+        let close = self.find_matching_close(inner_start - 1)?;
+        let content = &self.src[inner_start..close];
+        // Advance past the closing bracket so callers see what comes next.
+        self.pos = close + 1;
+        parse_content(content)
+    }
+
+    /// Given the position of an opening `[`, return the byte index of the
+    /// matching `]`.
+    fn find_matching_close(&self, open_pos: usize) -> Result<usize, ParsingError> {
+        debug_assert_eq!(self.bytes[open_pos], b'[');
+        let mut depth: u32 = 1;
+        let mut i = open_pos + 1;
+        while i < self.bytes.len() {
+            match self.bytes[i] {
+                b'\'' => {
+                    // Per-character escape; skip the next byte unconditionally.
+                    if i + 1 < self.bytes.len() {
+                        i += 2;
+                        continue;
+                    } else {
+                        return Err(ParsingError::InvalidReference(
+                            "Trailing '\\'' inside structured reference".to_string(),
+                        ));
+                    }
+                }
+                b'[' => depth += 1,
+                b']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Ok(i);
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        Err(ParsingError::InvalidReference(format!(
+            "Unbalanced '[' at offset {open_pos} in structured reference"
+        )))
+    }
+}
+
+/// Parse the content between the outermost brackets of a specifier.
+fn parse_content(content: &str) -> Result<TableSpecifier, ParsingError> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        // `Table1[]` is canonically the whole table.
+        return Ok(TableSpecifier::All);
+    }
+
+    // Decide between three top-level shapes based on a structural scan that
+    // respects `'`-escapes and `[]` nesting:
+    //   * a single bracketed item or a comma-separated combination of items
+    //     (any `[` at depth 0)
+    //   * a column-range using bare names: `name : name`
+    //   * a special starting with `#` or `@`
+    //   * a single bare column name
+    // `@`-prefixed shorthands cannot be confused with combinations because
+    // the `@` always precedes either nothing (`@`) or a single column (a
+    // bracketed `[Col]` or bare `Col`). Handle this form first so the
+    // ordinary combination parser doesn't choke on the leading `@`.
+    if let Some(rest) = trimmed.strip_prefix('@') {
+        return parse_at_shorthand(rest.trim());
+    }
+
+    let scan = scan_top_level(trimmed)?;
+
+    if scan.has_top_level_bracket {
+        return parse_combination_or_item(trimmed);
+    }
+
+    if scan.has_top_level_comma {
+        return Err(ParsingError::InvalidReference(format!(
+            "Unexpected ',' in structured reference content: {trimmed:?}"
+        )));
+    }
+
+    if let Some(colon_idx) = scan.top_level_colon {
+        let start = trimmed[..colon_idx].trim();
+        let end = trimmed[colon_idx + 1..].trim();
+        return build_column_range(start, end);
+    }
+
+    if trimmed.starts_with('#') {
+        return parse_special_token(trimmed).map(TableSpecifier::SpecialItem);
+    }
+
+    Ok(TableSpecifier::Column(unescape_name(trimmed)))
+}
+
+struct TopLevelScan {
+    has_top_level_bracket: bool,
+    has_top_level_comma: bool,
+    top_level_colon: Option<usize>,
+}
+
+/// Walk `s` once, ignoring escaped bytes and bracket-enclosed regions, and
+/// report top-level structural punctuation.
+fn scan_top_level(s: &str) -> Result<TopLevelScan, ParsingError> {
+    let bytes = s.as_bytes();
+    let mut depth: u32 = 0;
+    let mut top_bracket = false;
+    let mut top_comma = false;
+    let mut top_colon: Option<usize> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' => {
+                if i + 1 < bytes.len() {
+                    i += 2;
+                    continue;
+                } else {
+                    return Err(ParsingError::InvalidReference(
+                        "Dangling '\\'' escape in structured reference".to_string(),
+                    ));
+                }
+            }
+            b'[' => {
+                if depth == 0 {
+                    top_bracket = true;
+                }
+                depth += 1;
+            }
+            b']' => {
+                if depth == 0 {
+                    return Err(ParsingError::InvalidReference(
+                        "Stray ']' in structured reference content".to_string(),
+                    ));
+                }
+                depth -= 1;
+            }
+            b',' if depth == 0 => top_comma = true,
+            b':' if depth == 0 && top_colon.is_none() => top_colon = Some(i),
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth != 0 {
+        return Err(ParsingError::InvalidReference(
+            "Unbalanced '[' in structured reference content".to_string(),
+        ));
+    }
+    Ok(TopLevelScan {
+        has_top_level_bracket: top_bracket,
+        has_top_level_comma: top_comma,
+        top_level_colon: top_colon,
+    })
+}
+
+/// Parse content that contains at least one bracketed segment: either a
+/// single bracketed item, a `[col]:[col]` range, or a combination.
+fn parse_combination_or_item(content: &str) -> Result<TableSpecifier, ParsingError> {
+    let mut items: Vec<TableSpecifier> = Vec::new();
+    let mut p = ItemParser::new(content);
+    p.skip_ws();
+    if p.eof() {
+        return Ok(TableSpecifier::All);
+    }
+    loop {
+        let item = p.parse_item()?;
+        items.push(item);
+        p.skip_ws();
+        if p.eof() {
+            break;
+        }
+        if p.peek() == Some(b',') {
+            p.advance(1);
+            p.skip_ws();
+            continue;
+        }
+        return Err(ParsingError::InvalidReference(format!(
+            "Expected ',' between structured-reference items at offset {} of {:?}",
+            p.pos, content
+        )));
+    }
+
+    if items.len() == 1 {
+        Ok(items.pop().unwrap())
+    } else {
+        Ok(TableSpecifier::Combination(
+            items.into_iter().map(Box::new).collect(),
+        ))
+    }
+}
+
+struct ItemParser<'a> {
+    src: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> ItemParser<'a> {
+    fn new(src: &'a str) -> Self {
+        Self {
+            src,
+            bytes: src.as_bytes(),
+            pos: 0,
+        }
+    }
+    fn eof(&self) -> bool {
+        self.pos >= self.bytes.len()
+    }
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+    fn advance(&mut self, n: usize) {
+        self.pos += n;
+    }
+    fn skip_ws(&mut self) {
+        while let Some(b) = self.peek() {
+            if b == b' ' || b == b'\t' || b == b'\n' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Parse a single item: a bracketed item (`[...]`), or - in a combination -
+    /// a bare column or column range. Bracketed items themselves may be
+    /// either a special, a column name, or part of a `[col]:[col]` range.
+    fn parse_item(&mut self) -> Result<TableSpecifier, ParsingError> {
+        self.skip_ws();
+        if self.peek() != Some(b'[') {
+            return Err(ParsingError::InvalidReference(format!(
+                "Expected '[' to start structured-reference item at offset {} of {:?}",
+                self.pos, self.src
+            )));
+        }
+        let first = self.parse_bracketed_token()?;
+        // Look-ahead for `:` (column range continuation).
+        let save = self.pos;
+        self.skip_ws();
+        if self.peek() == Some(b':') {
+            self.advance(1);
+            self.skip_ws();
+            if self.peek() != Some(b'[') {
+                return Err(ParsingError::InvalidReference(format!(
+                    "Expected '[' after ':' in column range at offset {} of {:?}",
+                    self.pos, self.src
+                )));
+            }
+            let second = self.parse_bracketed_token()?;
+            return build_column_range_from_tokens(first, second);
+        }
+        // No `:` follow-on; rewind whitespace skip.
+        self.pos = save;
+        bracketed_token_to_specifier(first)
+    }
+
+    fn parse_bracketed_token(&mut self) -> Result<BracketedToken, ParsingError> {
+        debug_assert_eq!(self.peek(), Some(b'['));
+        let open = self.pos;
+        self.pos += 1;
+        let inner_start = self.pos;
+        let mut depth: u32 = 1;
+        while !self.eof() {
+            match self.bytes[self.pos] {
+                b'\'' => {
+                    if self.pos + 1 < self.bytes.len() {
+                        self.pos += 2;
+                        continue;
+                    } else {
+                        return Err(ParsingError::InvalidReference(format!(
+                            "Trailing '\\'' inside item at offset {}",
+                            self.pos
+                        )));
+                    }
+                }
+                b'[' => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                b']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let inner = &self.src[inner_start..self.pos];
+                        self.pos += 1;
+                        return Ok(BracketedToken {
+                            inner: inner.to_string(),
+                        });
+                    }
+                    self.pos += 1;
+                }
+                _ => self.pos += 1,
+            }
+        }
+        Err(ParsingError::InvalidReference(format!(
+            "Unbalanced '[' starting at offset {open} in {:?}",
+            self.src
+        )))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BracketedToken {
+    inner: String,
+}
+
+fn bracketed_token_to_specifier(tok: BracketedToken) -> Result<TableSpecifier, ParsingError> {
+    let trimmed = tok.inner.trim();
+    if trimmed.is_empty() {
+        return Err(ParsingError::InvalidReference(
+            "Empty '[]' inside structured-reference combination".to_string(),
+        ));
+    }
+    if trimmed.starts_with('#') {
+        return parse_special_token(trimmed).map(TableSpecifier::SpecialItem);
+    }
+    if let Some(rest) = trimmed.strip_prefix('@') {
+        let rest = rest.trim();
+        if rest.is_empty() {
+            // Bare `[@]` inside a combination is the ThisRow special item; the
+            // combination form distinguishes itself from `Table1[@]` (which
+            // alone resolves to `Row(Current)`).
+            return Ok(TableSpecifier::SpecialItem(SpecialItem::ThisRow));
+        }
+        // `[@Column]` inside a combination/item still resolves to ThisRow + Column.
+        return parse_at_shorthand(rest);
+    }
+    Ok(TableSpecifier::Column(unescape_name(trimmed)))
+}
+
+fn build_column_range_from_tokens(
+    a: BracketedToken,
+    b: BracketedToken,
+) -> Result<TableSpecifier, ParsingError> {
+    let lhs = a.inner.trim();
+    let rhs = b.inner.trim();
+    if lhs.is_empty() || rhs.is_empty() {
+        return Err(ParsingError::InvalidReference(
+            "Empty column name in structured-reference range".to_string(),
+        ));
+    }
+    if lhs.starts_with('#') || lhs.starts_with('@') || rhs.starts_with('#') || rhs.starts_with('@')
+    {
+        return Err(ParsingError::InvalidReference(format!(
+            "Special items cannot appear in column range: [{lhs}]:[{rhs}]"
+        )));
+    }
+    Ok(TableSpecifier::ColumnRange(
+        unescape_name(lhs),
+        unescape_name(rhs),
+    ))
+}
+
+fn build_column_range(lhs: &str, rhs: &str) -> Result<TableSpecifier, ParsingError> {
+    if lhs.is_empty() || rhs.is_empty() {
+        return Err(ParsingError::InvalidReference(
+            "Empty column name in structured-reference range".to_string(),
+        ));
+    }
+    Ok(TableSpecifier::ColumnRange(
+        unescape_name(lhs),
+        unescape_name(rhs),
+    ))
+}
+
+/// Parse a `#`-prefixed special item, case-insensitively. Returns the bare
+/// `SpecialItem` enum (`@` is handled by the caller, not here).
+fn parse_special_token(token: &str) -> Result<SpecialItem, ParsingError> {
+    debug_assert!(token.starts_with('#'));
+    // Normalise internal whitespace runs to a single ASCII space so
+    // `#This  Row` and `#This\tRow` still match.
+    let normalized: String = token
+        .chars()
+        .map(|c| if c == '\t' { ' ' } else { c })
+        .collect();
+    let mut compact = String::with_capacity(normalized.len());
+    let mut prev_space = false;
+    for c in normalized.chars() {
+        if c == ' ' {
+            if !prev_space {
+                compact.push(' ');
+            }
+            prev_space = true;
+        } else {
+            compact.push(c);
+            prev_space = false;
+        }
+    }
+    match compact.to_ascii_lowercase().as_str() {
+        "#all" => Ok(SpecialItem::All),
+        "#headers" => Ok(SpecialItem::Headers),
+        "#data" => Ok(SpecialItem::Data),
+        "#totals" => Ok(SpecialItem::Totals),
+        "#this row" => Ok(SpecialItem::ThisRow),
+        _ => Err(ParsingError::InvalidReference(format!(
+            "Unknown special item: {token}"
+        ))),
+    }
+}
+
+/// Parse `@...` shorthand: `@`, `@Col`, `@[Col Name]` ...
+fn parse_at_shorthand(rest: &str) -> Result<TableSpecifier, ParsingError> {
+    if rest.is_empty() {
+        return Ok(TableSpecifier::Row(
+            crate::parser::TableRowSpecifier::Current,
+        ));
+    }
+    // Strip an optional surrounding `[ ... ]` to support `@[Col Name]`.
+    let trimmed = rest.trim();
+    let column = if let Some(stripped) = strip_outer_brackets(trimmed) {
+        stripped
+    } else {
+        trimmed.to_string()
+    };
+    if column.is_empty() {
+        return Err(ParsingError::InvalidReference(
+            "Empty column after '@' in structured reference".to_string(),
+        ));
+    }
+    Ok(TableSpecifier::Combination(vec![
+        Box::new(TableSpecifier::SpecialItem(SpecialItem::ThisRow)),
+        Box::new(TableSpecifier::Column(unescape_name(&column))),
+    ]))
+}
+
+fn strip_outer_brackets(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    if bytes.len() < 2 || bytes[0] != b'[' || bytes[bytes.len() - 1] != b']' {
+        return None;
+    }
+    // Validate balanced (with `'`-escape) and that the matching close is the
+    // final byte; if the first `[` matches an interior `]` then this isn't
+    // a single outer-bracketed token.
+    let mut depth: u32 = 1;
+    let mut i = 1;
+    while i < bytes.len() - 1 {
+        match bytes[i] {
+            b'\'' => {
+                i += 2;
+                continue;
+            }
+            b'[' => depth += 1,
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth != 1 {
+        return None;
+    }
+    Some(s[1..s.len() - 1].to_string())
+}
+
+/// Apply the OOXML `'X` per-character escape: a single apostrophe makes the
+/// next character literal. A trailing apostrophe is left as-is (the caller
+/// will already have caught structural truncation in earlier phases).
+fn unescape_name(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\'' {
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    // Trim outer ASCII whitespace; column names rarely have leading/trailing
+    // spaces and Excel itself strips them on round-trip.
+    out.trim().to_string()
+}

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -1607,36 +1607,36 @@ mod reference_tests {
 
     #[test]
     fn test_dual_bracket_structured_reference_parsing() {
+        use crate::parser::{SpecialItem, TableSpecifier};
         let formula = "=EffortDB[[#All],[NPI]:[JMG Group]]";
         let tokenizer = Tokenizer::new(formula).unwrap();
-        println!("tokenizer: {:?}", tokenizer.items);
         let mut parser = Parser::new(tokenizer.items, false);
         let ast = parser.parse().unwrap();
-        println!("ast: {ast:?}");
 
-        // When the formula is tokenized and parsed, the equals sign is removed,
-        // so we compare against the formula without the equals sign
-        if let ASTNodeType::Reference {
+        let ASTNodeType::Reference {
             original,
             reference,
         } = &ast.node_type
-        {
-            assert_eq!(original, &"EffortDB[[#All],[NPI]:[JMG Group]]".to_string());
-
-            // Check that reference is a Table type with the correct name
-            if let ReferenceType::Table(table_ref) = reference {
-                assert_eq!(table_ref.name, "EffortDB");
-
-                // Check that the specifier is correctly parsed
-                // (in this case, it should be a Column since we're not fully
-                // parsing the complex specifier yet)
-                assert!(table_ref.specifier.is_some());
-            } else {
-                panic!("Expected Table reference");
-            }
-        } else {
+        else {
             panic!("Expected Reference node");
-        }
+        };
+        assert_eq!(original, &"EffortDB[[#All],[NPI]:[JMG Group]]".to_string());
+
+        let ReferenceType::Table(table_ref) = reference else {
+            panic!("Expected Table reference");
+        };
+        assert_eq!(table_ref.name, "EffortDB");
+        let Some(TableSpecifier::Combination(parts)) = &table_ref.specifier else {
+            panic!("Expected Combination, got {:?}", table_ref.specifier);
+        };
+        let parts: Vec<TableSpecifier> = parts.iter().map(|p| (**p).clone()).collect();
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::All),
+                TableSpecifier::ColumnRange("NPI".to_string(), "JMG Group".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -1763,42 +1763,50 @@ mod reference_tests {
 
     #[test]
     fn test_table_item_with_column_reference() {
+        use crate::parser::SpecialItem;
         // Test a table reference with an item specifier and column
         let reference = "Table1[[#Data],[Column1]]";
         let ref_type = ReferenceType::from_string(reference).unwrap();
 
-        if let ReferenceType::Table(table_ref) = ref_type {
-            assert_eq!(table_ref.name, "Table1");
-
-            // Currently our implementation doesn't fully parse complex specifiers,
-            // but we should at least verify it's parsed as a table reference
-            assert!(table_ref.specifier.is_some());
-
-            // Note: In the future, we should enhance this to properly parse
-            // complex structured references and verify the exact specifier
-        } else {
+        let ReferenceType::Table(table_ref) = ref_type else {
             panic!("Expected Table reference");
-        }
+        };
+        assert_eq!(table_ref.name, "Table1");
+        let Some(TableSpecifier::Combination(parts)) = table_ref.specifier else {
+            panic!("Expected Combination specifier");
+        };
+        let parts: Vec<TableSpecifier> = parts.into_iter().map(|p| *p).collect();
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::Data),
+                TableSpecifier::Column("Column1".to_string()),
+            ]
+        );
     }
 
     #[test]
     fn test_table_this_row_with_column_reference() {
+        use crate::parser::SpecialItem;
         // Test a table reference with this row specifier and column
         let reference = "Table1[[@],[Column1]]";
         let ref_type = ReferenceType::from_string(reference).unwrap();
 
-        if let ReferenceType::Table(table_ref) = ref_type {
-            assert_eq!(table_ref.name, "Table1");
-
-            // Currently our implementation doesn't fully parse complex specifiers,
-            // but we should at least verify it's parsed as a table reference
-            assert!(table_ref.specifier.is_some());
-
-            // Note: In the future, we should enhance this to properly parse
-            // complex structured references and verify the exact specifier
-        } else {
+        let ReferenceType::Table(table_ref) = ref_type else {
             panic!("Expected Table reference");
-        }
+        };
+        assert_eq!(table_ref.name, "Table1");
+        let Some(TableSpecifier::Combination(parts)) = table_ref.specifier else {
+            panic!("Expected Combination specifier");
+        };
+        let parts: Vec<TableSpecifier> = parts.into_iter().map(|p| *p).collect();
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::ThisRow),
+                TableSpecifier::Column("Column1".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -1884,31 +1892,436 @@ mod reference_tests {
     }
 
     #[test]
-    fn structured_combination_dedupes_duplicate_specials() {
+    fn structured_combination_preserves_duplicate_specials_in_order() {
         use crate::parser::{ReferenceType, SpecialItem, TableReference, TableSpecifier};
-        // Input with duplicates of specials
+        // The OOXML grammar (`combination := item ("," item)*`) permits repeats.
+        // After the issue #73 rewrite, the parser preserves them in source order
+        // instead of silently de-duplicating.
         let s = "Table1[[#Data],[#Data],[#Totals],[#Totals]]";
         let r = ReferenceType::from_string(s).expect("parse ok");
-        // Our Display prints each special once when building Combination
-        // Note: order may follow detection order (#Data, then #Totals)
-        assert_eq!(r.to_string(), "Table1[[#Data],[#Totals]]");
-        if let ReferenceType::Table(TableReference {
+        assert_eq!(r.to_string(), s);
+        let ReferenceType::Table(TableReference {
             specifier: Some(TableSpecifier::Combination(parts)),
             ..
         }) = r
-        {
-            let has_data = parts
-                .iter()
-                .any(|p| matches!(**p, TableSpecifier::SpecialItem(SpecialItem::Data)));
-            let has_totals = parts
-                .iter()
-                .any(|p| matches!(**p, TableSpecifier::SpecialItem(SpecialItem::Totals)));
-            assert!(has_data && has_totals);
-            // Ensure duplicates were not kept
-            assert_eq!(parts.len(), 2);
-        } else {
+        else {
             panic!("expected table combination");
+        };
+        let parts: Vec<TableSpecifier> = parts.into_iter().map(|p| *p).collect();
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::Data),
+                TableSpecifier::SpecialItem(SpecialItem::Data),
+                TableSpecifier::SpecialItem(SpecialItem::Totals),
+                TableSpecifier::SpecialItem(SpecialItem::Totals),
+            ]
+        );
+    }
+}
+
+#[cfg(test)]
+mod structured_references {
+    //! Coverage for issue #73: real parser for structured (table) references.
+    //!
+    //! Each test runs across both the classic [`Parser`] and the span-based
+    //! [`crate::parse`] entrypoint to catch any divergence between paths.
+    use crate::parser::{
+        ASTNodeType, Parser, ReferenceType, SpecialItem, TableReference, TableRowSpecifier,
+        TableSpecifier,
+    };
+    use crate::tokenizer::Tokenizer;
+
+    fn parse_via_classic(formula: &str) -> Result<ReferenceType, String> {
+        let tokenizer = Tokenizer::new(formula).map_err(|e| e.to_string())?;
+        let mut parser = Parser::new(tokenizer.items, false);
+        let ast = parser.parse().map_err(|e| e.to_string())?;
+        match ast.node_type {
+            ASTNodeType::Reference { reference, .. } => Ok(reference),
+            other => Err(format!("expected reference node, got {other:?}")),
         }
+    }
+
+    fn parse_via_span(formula: &str) -> Result<ReferenceType, String> {
+        let ast = crate::parse(formula).map_err(|e| e.to_string())?;
+        match ast.node_type {
+            ASTNodeType::Reference { reference, .. } => Ok(reference),
+            other => Err(format!("expected reference node, got {other:?}")),
+        }
+    }
+
+    /// Parse via both paths and require they agree.
+    fn parse_both(formula: &str) -> Result<ReferenceType, String> {
+        let classic = parse_via_classic(formula)?;
+        let span = parse_via_span(formula)?;
+        assert_eq!(
+            classic, span,
+            "classic vs span parser disagree for {formula}"
+        );
+        Ok(classic)
+    }
+
+    fn expect_table(formula: &str) -> TableReference {
+        let r = parse_both(formula).expect("parse ok");
+        match r {
+            ReferenceType::Table(t) => t,
+            other => panic!("expected Table, got {other:?}"),
+        }
+    }
+
+    fn expect_parse_err(formula: &str) {
+        let classic = parse_via_classic(formula);
+        let span = parse_via_span(formula);
+        assert!(
+            classic.is_err(),
+            "classic parser unexpectedly accepted {formula}: {classic:?}"
+        );
+        assert!(
+            span.is_err(),
+            "span parser unexpectedly accepted {formula}: {span:?}"
+        );
+    }
+
+    fn expect_combination(spec: Option<TableSpecifier>) -> Vec<TableSpecifier> {
+        match spec {
+            Some(TableSpecifier::Combination(parts)) => parts.into_iter().map(|b| *b).collect(),
+            other => panic!("expected Combination, got {other:?}"),
+        }
+    }
+
+    // ----------- positive: simple regression -----------
+
+    #[test]
+    fn simple_column() {
+        let t = expect_table("=Table1[Column1]");
+        assert_eq!(t.name, "Table1");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::Column("Column1".to_string()))
+        );
+    }
+
+    #[test]
+    fn simple_column_range() {
+        let t = expect_table("=Table1[Column1:Column2]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::ColumnRange(
+                "Column1".to_string(),
+                "Column2".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn simple_specials() {
+        for (s, expected) in [
+            ("=Table1[#All]", SpecialItem::All),
+            ("=Table1[#Headers]", SpecialItem::Headers),
+            ("=Table1[#Data]", SpecialItem::Data),
+            ("=Table1[#Totals]", SpecialItem::Totals),
+        ] {
+            let t = expect_table(s);
+            assert_eq!(t.specifier, Some(TableSpecifier::SpecialItem(expected)));
+        }
+    }
+
+    #[test]
+    fn this_row_at_only() {
+        let t = expect_table("=Table1[@]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::Row(TableRowSpecifier::Current))
+        );
+    }
+
+    // ----------- positive: combinations preserving column parts -----------
+
+    #[test]
+    fn all_with_column_range_preserves_both_parts() {
+        let t = expect_table("=Table1[[#All],[A]:[B]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::All),
+                TableSpecifier::ColumnRange("A".to_string(), "B".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn headers_with_column() {
+        let t = expect_table("=Table1[[#Headers],[Column1]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::Headers),
+                TableSpecifier::Column("Column1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn data_with_column_range() {
+        let t = expect_table("=Table1[[#Data],[Column1]:[Column2]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::Data),
+                TableSpecifier::ColumnRange("Column1".to_string(), "Column2".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn totals_with_column() {
+        let t = expect_table("=Table1[[#Totals],[Column1]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::Totals),
+                TableSpecifier::Column("Column1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn effort_db_full_range_preserves_columns() {
+        let t = expect_table("=EffortDB[[#All],[NPI]:[JMG Group]]");
+        assert_eq!(t.name, "EffortDB");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::All),
+                TableSpecifier::ColumnRange("NPI".to_string(), "JMG Group".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn column_range_with_spaces_in_names() {
+        let t = expect_table("=Table1[[Col A]:[Col B]]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::ColumnRange(
+                "Col A".to_string(),
+                "Col B".to_string()
+            ))
+        );
+    }
+
+    // ----------- positive: this-row variants -----------
+
+    #[test]
+    fn this_row_with_column_combination() {
+        let t = expect_table("=Table1[[@],[Column1]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::ThisRow),
+                TableSpecifier::Column("Column1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn this_row_at_column_shorthand() {
+        let t = expect_table("=Table1[@Column1]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::ThisRow),
+                TableSpecifier::Column("Column1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn this_row_legacy_form() {
+        let t = expect_table("=Table1[[#This Row],[Col]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::ThisRow),
+                TableSpecifier::Column("Col".to_string()),
+            ]
+        );
+    }
+
+    // ----------- positive: case-insensitivity -----------
+
+    #[test]
+    fn specials_are_case_insensitive() {
+        let t = expect_table("=Table1[#headers]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::SpecialItem(SpecialItem::Headers))
+        );
+        let t = expect_table("=Table1[#ALL]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::SpecialItem(SpecialItem::All))
+        );
+        let t = expect_table("=Table1[[#this row],[col]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::ThisRow),
+                TableSpecifier::Column("col".to_string()),
+            ]
+        );
+    }
+
+    // ----------- positive: ' escape inside column names -----------
+    //
+    // OOXML / MS-XLSX uses a per-character escape: `'X` represents a literal
+    // `X` (where X is one of `[`, `]`, `'`). Excel itself serializes a
+    // column named `Col ]` as `[Col ']]` (single apostrophe before the
+    // escaped `]`). We follow that canonical encoding here.
+
+    #[test]
+    fn column_name_with_escaped_close_bracket() {
+        let t = expect_table("=Table1[Col ']]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::Column("Col ]".to_string()))
+        );
+    }
+
+    #[test]
+    fn column_name_with_escaped_open_bracket() {
+        let t = expect_table("=Table1[Col '[end]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::Column("Col [end".to_string()))
+        );
+    }
+
+    #[test]
+    fn column_name_with_escaped_apostrophe() {
+        // `''` -> literal `'`
+        let t = expect_table("=Table1[O''Brien]");
+        assert_eq!(
+            t.specifier,
+            Some(TableSpecifier::Column("O'Brien".to_string()))
+        );
+    }
+
+    #[test]
+    fn combination_with_escaped_close_bracket() {
+        let t = expect_table("=Table1[[#Headers],[Col ']]]");
+        let parts = expect_combination(t.specifier);
+        assert_eq!(
+            parts,
+            vec![
+                TableSpecifier::SpecialItem(SpecialItem::Headers),
+                TableSpecifier::Column("Col ]".to_string()),
+            ]
+        );
+    }
+
+    // ----------- positive: non-ASCII column names -----------
+
+    #[test]
+    fn unicode_column_names() {
+        for (formula, table, col) in [
+            ("=Sales[Акт]", "Sales", "Акт"),
+            ("=Café[Crème brûlée]", "Café", "Crème brûlée"),
+            ("=分析[数量]", "分析", "数量"),
+        ] {
+            let t = expect_table(formula);
+            assert_eq!(t.name, table);
+            assert_eq!(t.specifier, Some(TableSpecifier::Column(col.to_string())));
+        }
+    }
+
+    // ----------- positive: roundtrip via Display -----------
+
+    #[test]
+    fn display_roundtrips() {
+        for input in [
+            "Table1[Column1]",
+            "Table1[Column1:Column2]",
+            "Table1[#Headers]",
+            "Table1[#Data]",
+            "Table1[#Totals]",
+            "Table1[#All]",
+            "Table1[@]",
+            "Table1[[#All],[A]:[B]]",
+            "Table1[[#Headers],[Column1]]",
+            "Table1[[#Data],[Column1]:[Column2]]",
+            "Table1[[#Totals],[Column1]]",
+            "Table1[[@],[Column1]]",
+        ] {
+            let r = ReferenceType::from_string(input).expect("parse ok");
+            let printed = r.to_string();
+            let r2 = ReferenceType::from_string(&printed).expect("reparse ok");
+            assert_eq!(r, r2, "roundtrip changed AST for {input}: {printed}");
+        }
+    }
+
+    // ----------- positive: sheet-scoped -----------
+
+    #[test]
+    fn sheet_scoped_table_ref_still_drops_sheet() {
+        let r = ReferenceType::from_string("Sheet1!Table1[Column1]").unwrap();
+        assert_eq!(
+            r,
+            ReferenceType::Table(TableReference {
+                name: "Table1".to_string(),
+                specifier: Some(TableSpecifier::Column("Column1".to_string())),
+            })
+        );
+    }
+
+    // ----------- negative -----------
+
+    #[test]
+    fn rejects_trailing_garbage_after_column() {
+        expect_parse_err("=Table1[Col]junk");
+    }
+
+    #[test]
+    fn rejects_trailing_garbage_after_empty_specifier() {
+        // Tokenizer may already split; verify the full formula still errors.
+        let classic = parse_via_classic("=Table1[]abc");
+        let span = parse_via_span("=Table1[]abc");
+        assert!(classic.is_err(), "classic accepted: {classic:?}");
+        assert!(span.is_err(), "span accepted: {span:?}");
+    }
+
+    #[test]
+    fn rejects_unknown_special_item() {
+        expect_parse_err("=Table1[#unknown]");
+    }
+
+    #[test]
+    fn rejects_garbage_inside_combination() {
+        expect_parse_err("=Table1[[#Data],junk]");
+    }
+
+    #[test]
+    fn rejects_unterminated_bracket() {
+        // Tokenizer error.
+        assert!(Tokenizer::new("=Table1[Col").is_err());
+        assert!(crate::parse("=Table1[Col").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_escape() {
+        // [Col '] — the ' is supposed to escape the next char; here it escapes ']'
+        // which means the bracket never terminates.
+        assert!(Tokenizer::new("=Table1[[Col ']]").is_err());
+        assert!(crate::parse("=Table1[[Col ']]").is_err());
     }
 }
 

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -982,6 +982,20 @@ impl<'a> SpanTokenizer<'a> {
 
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
+                // OOXML structured-reference escape: a single apostrophe makes
+                // the next byte literal (used to embed `[`, `]`, `'`, or `#`
+                // inside a column name). Skip the following byte without
+                // updating nesting depth.
+                b'\'' => {
+                    if self.offset + 1 < self.formula.len() {
+                        self.offset += 2;
+                        continue;
+                    }
+                    // Trailing apostrophe inside brackets is malformed; fall
+                    // through so the loop ends with an UnmatchedBracket error.
+                    self.offset += 1;
+                    continue;
+                }
                 b'[' => open_count += 1,
                 b']' => {
                     open_count -= 1;
@@ -1556,6 +1570,18 @@ impl Tokenizer {
 
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
+                // OOXML structured-reference escape: a single apostrophe makes
+                // the next byte literal (used to embed `[`, `]`, `'`, or `#`
+                // inside a column name). Skip the following byte without
+                // updating nesting depth.
+                b'\'' => {
+                    if self.offset + 1 < self.formula.len() {
+                        self.offset += 2;
+                        continue;
+                    }
+                    self.offset += 1;
+                    continue;
+                }
                 b'[' => open_count += 1,
                 b']' => {
                     open_count -= 1;


### PR DESCRIPTION
Closes #73.

## Summary

Replaces the heuristic `parse_complex_table_specifier` with a real
recursive-descent parser for the `Table[...]` specifier grammar
(MS-XLSX §18.17.6.2):

```
specifier    := "[" content "]"
content      := "" | special | column | column_range | combination
special      := "#All" | "#Headers" | "#Data" | "#Totals" | "#This Row" | "@"
combination  := item ("," item)*
item         := "[" special "]" | column | column_range
```

This fixes the silent-data-loss bugs called out in the issue:

| Input                                      | Before                                  | After                                                     |
|--------------------------------------------|------------------------------------------|-----------------------------------------------------------|
| `Table1[[#All],[A]:[B]]`                   | `Combination([All])`                    | `Combination([All, ColumnRange("A","B")])`                |
| `Table1[[#Headers],[Column1]:[Column2]]`   | `Combination([Headers])`                | `Combination([Headers, ColumnRange("Column1","Column2")])` |
| `Table1[[#Data],[Column1]]`                | `Combination([Data])`                   | `Combination([Data, Column("Column1")])`                  |
| `Table1[[@],[Column1]]`                    | `Column("[@],[Column1]")`               | `Combination([ThisRow, Column("Column1")])`               |
| `Table1[[#This Row],[Col]]`                | unknown-special-item error               | `Combination([ThisRow, Column("Col")])`                   |
| `Table1[Col ']]`                           | tokenizer malformed                      | `Column("Col ]")`                                         |
| `Table1[#headers]`                         | `Unknown special item: #headers`        | `SpecialItem(Headers)`                                    |
| `Table1[Col]junk`                          | silently accepted                        | ParserError                                               |

## Changes

* **Tokenizer.** `parse_brackets` (classic and span) now respects the
  OOXML `'X` per-character escape, so `[`, `]`, `'`, and `#` can appear
  inside column names without breaking bracket matching.
* **Parser.** `parse_table_reference` and
  `parse_bracketed_structured_reference` now delegate to
  `structured_ref::parse_full_specifier`, a new module that implements
  the grammar above. The old `parse_complex_table_specifier` and
  `parse_special_item` helpers are gone.
  * Specials are matched case-insensitively, with whitespace normalised
    so `#This  Row` and `#this row` both resolve to `SpecialItem::ThisRow`.
  * `[@]` standalone still resolves to `TableRowSpecifier::Current` for
    backwards compatibility, but `[@]` inside a combination becomes
    `SpecialItem(ThisRow)` so it composes correctly with column items.
  * Trailing garbage after a balanced specifier is rejected.
* **Display.** `TableSpecifier::Combination` now emits `ColumnRange`
  children as `[A]:[B]` (instead of `[A:B]`), matching Excel’s
  canonical serialization and roundtripping cleanly through `from_string`.

## Tests added / strengthened

* New `tests::parser::structured_references` module (33 tests). Each
  positive test runs through both the classic `Parser` and the
  span-based `parse` and asserts they agree:
  * Simple regression: `[Column]`, `[Column1:Column2]`, all four
    `#`-specials, `[@]`.
  * Combinations: `[#All],[A]:[B]`, `[#Headers],[Column1]`,
    `[#Data],[Column1]:[Column2]`, `[#Totals],[Column1]`,
    `EffortDB[[#All],[NPI]:[JMG Group]]`, `[Col A]:[Col B]`.
  * This-row: `[[@],[Column1]]`, `[@Column1]`,
    `[[#This Row],[Column1]]`.
  * Case-insensitivity: `#headers`, `#ALL`, `[[#this row],[col]]`.
  * Escape handling: `Col ']`, `Col '[end`, `O''Brien`,
    `[#Headers],[Col ']]`.
  * Unicode column names (Cyrillic, Latin-1, CJK).
  * Display roundtrip across all positive forms.
  * Sheet-scoped refs still drop the sheet (existing behaviour).
  * Negative: `[Col]junk`, `[]abc`, `[#unknown]`, `[[#Data],junk]`,
    unterminated `[Col`, malformed escape `[[Col ']]`.
* `test_dual_bracket_structured_reference_parsing`,
  `test_table_item_with_column_reference`, and
  `test_table_this_row_with_column_reference` upgraded from
  `is_some()` to full AST equality.
* `structured_combination_dedupes_duplicate_specials` renamed to
  `..._preserves_duplicate_specials_in_order` — the OOXML grammar
  permits repeats and the new parser preserves them in source order
  instead of silently de-duplicating.

## Validation

* `cargo fmt --all`
* `cargo test -p formualizer-parse` — 187 passed, 0 failed
* `cargo test --workspace` — full suite green; the engine regression
  test `engine::tests::tables::structured_ref_this_row_column_rewrites_to_concrete_cell`
  exercises the new parser and continues to pass
* `cargo clippy --workspace --all-targets -- -D warnings` — clean