### PR TITLE
fix(parse): prevent R1C1-shaped input from misclassifying as tables

### DIFF
--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -708,6 +708,16 @@ impl ReferenceType {
         // Table references live in the ref_part (e.g., "Table1[Column]").
         // Sheet names can contain '[' for external workbook refs (e.g., "[1]Sheet1!A1").
         if ref_part.contains('[') {
+            // Issue #76: R1C1-shaped operands like `R[1]C[2]`, `R1C[2]`, `RC[1]`
+            // contain `[` but are not table references. Without this gate they
+            // either misclassify as `Table { name: "R1C", specifier: Column("2") }`
+            // or get rejected by the structured-references trailing-garbage check.
+            // We don't add an R1C1 dialect; we just refuse to fabricate a table
+            // and fall back to the same `NamedRange` outcome that bracket-free
+            // R1C1 strings (e.g. `R1C1`, `RC`) already produce.
+            if Self::is_r1c1_shape(&ref_part) {
+                return Ok(ReferenceType::NamedRange(reference.to_string()));
+            }
             return Self::parse_table_reference(&ref_part);
         }
 
@@ -1029,6 +1039,82 @@ impl ReferenceType {
         }
 
         (None, reference.to_string())
+    }
+
+    /// Detect R1C1-shaped operands so they aren't routed through the table-
+    /// reference parser (issue #76).
+    ///
+    /// Matches `^R\d*(\[-?\d+\])?C\d*(\[-?\d+\])?$` and additionally requires
+    /// the operand to contain at least one digit or bracket so that bare `R`,
+    /// `C`, and `RC` (which already classify cleanly as `NamedRange` via the
+    /// non-bracket path) are not pulled in here. Plain A1 cells like `R1`,
+    /// `C5`, and `RC1` never reach this function because they don't contain
+    /// `[` and are handled by the cell-reference path.
+    fn is_r1c1_shape(s: &str) -> bool {
+        let bytes = s.as_bytes();
+        let len = bytes.len();
+        let mut i = 0usize;
+        let mut anchored = false;
+
+        if i >= len || bytes[i] != b'R' {
+            return false;
+        }
+        i += 1;
+
+        let row_digits_start = i;
+        while i < len && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i > row_digits_start {
+            anchored = true;
+        }
+
+        if i < len && bytes[i] == b'[' {
+            i += 1;
+            if i < len && bytes[i] == b'-' {
+                i += 1;
+            }
+            let n_start = i;
+            while i < len && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            if i == n_start || i >= len || bytes[i] != b']' {
+                return false;
+            }
+            i += 1;
+            anchored = true;
+        }
+
+        if i >= len || bytes[i] != b'C' {
+            return false;
+        }
+        i += 1;
+
+        let col_digits_start = i;
+        while i < len && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i > col_digits_start {
+            anchored = true;
+        }
+
+        if i < len && bytes[i] == b'[' {
+            i += 1;
+            if i < len && bytes[i] == b'-' {
+                i += 1;
+            }
+            let n_start = i;
+            while i < len && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            if i == n_start || i >= len || bytes[i] != b']' {
+                return false;
+            }
+            i += 1;
+            anchored = true;
+        }
+
+        i == len && anchored
     }
 
     /// Parse a table reference like "Table1[Column1]" or more complex ones

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -2495,3 +2495,181 @@ mod semantics_regressions {
         );
     }
 }
+
+#[cfg(test)]
+mod r1c1_disambiguation {
+    //! Regression tests for issue #76: R1C1-shaped operands must never be
+    //! misclassified as table references in the A1 (Excel) dialect.
+    //!
+    //! This issue does NOT add R1C1 dialect support. Acceptable outcomes for
+    //! R1C1-shaped input are: existing `NamedRange` behaviour, or a clean
+    //! `ParserError`. The forbidden outcome is `ReferenceType::Table(...)`.
+    use crate::parser::{ASTNode, ASTNodeType, Parser, ReferenceType, TableReference, parse};
+    use crate::tokenizer::Tokenizer;
+
+    fn parse_classic(formula: &str) -> ASTNode {
+        let tokenizer = Tokenizer::new(formula).expect("tokenize");
+        let mut parser = Parser::new(tokenizer.items, false);
+        parser.parse().expect("classic parse")
+    }
+
+    fn parse_span(formula: &str) -> ASTNode {
+        parse(formula).expect("span parse")
+    }
+
+    fn assert_not_table(formula: &str, ast: &ASTNode) {
+        if let ASTNodeType::Reference {
+            reference: ReferenceType::Table(TableReference { name, specifier }),
+            ..
+        } = &ast.node_type
+        {
+            panic!(
+                "R1C1-shaped input {formula:?} produced a Table reference: \
+                 name={name:?}, specifier={specifier:?}"
+            );
+        }
+    }
+
+    /// `=R[1]C[2]` must NOT classify as a Table. With the structured-references
+    /// strict trailing-garbage rejection in place, the table path errors out;
+    /// the R1C1 pre-check then reroutes it as a NamedRange.
+    #[test]
+    fn test_r1c1_bracketed_offsets_not_table() {
+        let ref_type = ReferenceType::from_string("R[1]C[2]");
+        if let Ok(ReferenceType::Table(t)) = ref_type {
+            panic!("expected non-Table outcome for R[1]C[2], got Table({t:?})")
+        }
+
+        let classic = parse_classic("=R[1]C[2]");
+        assert_not_table("=R[1]C[2]", &classic);
+        let spanned = parse_span("=R[1]C[2]");
+        assert_not_table("=R[1]C[2]", &spanned);
+    }
+
+    /// `=R1C1` must NOT classify as a Table. Existing behaviour is `NamedRange`.
+    #[test]
+    fn test_r1c1_absolute() {
+        let ref_type = ReferenceType::from_string("R1C1").expect("R1C1 should parse");
+        assert!(
+            !matches!(ref_type, ReferenceType::Table(_)),
+            "R1C1 must not be a Table reference, got {ref_type:?}"
+        );
+        assert_not_table("=R1C1", &parse_classic("=R1C1"));
+        assert_not_table("=R1C1", &parse_span("=R1C1"));
+    }
+
+    /// `=R1C[2]` must NOT classify as a Table. Pre-fix it produced
+    /// `Table { name: "R1C", specifier: Column("2") }`.
+    #[test]
+    fn test_r1c1_mixed() {
+        let ref_type = ReferenceType::from_string("R1C[2]");
+        if let Ok(ReferenceType::Table(t)) = ref_type {
+            panic!("expected non-Table for R1C[2], got {t:?}")
+        }
+        assert_not_table("=R1C[2]", &parse_classic("=R1C[2]"));
+        assert_not_table("=R1C[2]", &parse_span("=R1C[2]"));
+    }
+
+    /// `=R[-1]C` must NOT classify as a Table.
+    #[test]
+    fn test_r1c1_negative_offset() {
+        let ref_type = ReferenceType::from_string("R[-1]C");
+        if let Ok(ReferenceType::Table(t)) = ref_type {
+            panic!("expected non-Table for R[-1]C, got {t:?}")
+        }
+        assert_not_table("=R[-1]C", &parse_classic("=R[-1]C"));
+        assert_not_table("=R[-1]C", &parse_span("=R[-1]C"));
+    }
+
+    /// `=RC[1]` must NOT classify as a Table. Pre-fix it produced
+    /// `Table { name: "RC", specifier: Column("1") }`.
+    #[test]
+    fn test_r1c1_rc_with_bracket_only_col() {
+        let ref_type = ReferenceType::from_string("RC[1]");
+        if let Ok(ReferenceType::Table(t)) = ref_type {
+            panic!("expected non-Table for RC[1], got {t:?}")
+        }
+        assert_not_table("=RC[1]", &parse_classic("=RC[1]"));
+        assert_not_table("=RC[1]", &parse_span("=RC[1]"));
+    }
+
+    /// `=R5C[1]` must NOT classify as a Table.
+    #[test]
+    fn test_r1c1_row_digit_col_bracket() {
+        let ref_type = ReferenceType::from_string("R5C[1]");
+        if let Ok(ReferenceType::Table(t)) = ref_type {
+            panic!("expected non-Table for R5C[1], got {t:?}")
+        }
+        assert_not_table("=R5C[1]", &parse_classic("=R5C[1]"));
+        assert_not_table("=R5C[1]", &parse_span("=R5C[1]"));
+    }
+
+    /// `=R1` must remain a normal A1 cell reference (column R, row 1).
+    /// Critical: do not over-broaden the heuristic.
+    #[test]
+    fn test_a1_r1_still_cell() {
+        let r = ReferenceType::from_string("R1").expect("R1 should parse");
+        match r {
+            ReferenceType::Cell {
+                row, col, sheet, ..
+            } => {
+                assert_eq!(row, 1);
+                assert_eq!(col, 18); // 'R'
+                assert!(sheet.is_none());
+            }
+            other => panic!("=R1 must remain an A1 cell, got {other:?}"),
+        }
+    }
+
+    /// `=C5` must remain a normal A1 cell reference (column C, row 5).
+    #[test]
+    fn test_a1_c5_still_cell() {
+        let r = ReferenceType::from_string("C5").expect("C5 should parse");
+        assert!(
+            matches!(r, ReferenceType::Cell { row: 5, col: 3, .. }),
+            "=C5 must remain an A1 cell, got {r:?}"
+        );
+    }
+
+    /// Regression: real Table references must keep working.
+    #[test]
+    fn test_table_reference_unchanged() {
+        let r = ReferenceType::from_string("Table1[Col]").expect("Table1[Col] should parse");
+        match r {
+            ReferenceType::Table(t) => {
+                assert_eq!(t.name, "Table1");
+            }
+            other => panic!("expected Table reference, got {other:?}"),
+        }
+    }
+
+    /// Regression: external workbook refs are unaffected.
+    #[test]
+    fn test_external_workbook_ref_unchanged() {
+        let r = ReferenceType::from_string("[1]Sheet1!A1").expect("external ref should parse");
+        assert!(
+            matches!(r, ReferenceType::External(_)),
+            "=[1]Sheet1!A1 must remain External, got {r:?}"
+        );
+    }
+
+    /// Cross-parser differential: classic and span-based parsers must agree on
+    /// the high-level outcome (table vs not-table) for R1C1-shaped input.
+    #[test]
+    fn test_cross_parser_agreement_r1c1() {
+        for formula in [
+            "=R[1]C[2]",
+            "=R1C1",
+            "=RC",
+            "=R[-1]C",
+            "=R1C[2]",
+            "=RC[1]",
+            "=R5C[1]",
+        ] {
+            let classic = parse_classic(formula);
+            let spanned = parse_span(formula);
+            assert_not_table(formula, &classic);
+            assert_not_table(formula, &spanned);
+        }
+    }
+}


### PR DESCRIPTION
Closes #76

## Problem

Operands like `R1C[2]`, `RC[1]`, `R5C[1]` contain `[` and were routed
through `parse_table_reference`, producing fake
`Table { name: \"R1C\", specifier: Column(\"2\") }` ASTs unrelated to
R1C1 semantics. Forms with bracketed row offsets (`R[1]C[2]`,
`R[-1]C`) hit the structured-references trailing-garbage check (#73)
and surfaced as parser errors, but only by accident.

This PR is **not** R1C1 dialect support. OOXML stores formulas in A1
only; we just refuse to fabricate a fake `Table` AST and route
R1C1-shaped operands to the same `NamedRange` outcome that bracket-
free `R1C1`/`RC` already produce.

## Fix

`parse_excel_reference` adds an `is_r1c1_shape` gate ahead of the
table path. The shape detector matches
`^R\\d*(\\[-?\\d+\\])?C\\d*(\\[-?\\d+\\])?\$` and additionally requires
at least one digit or bracket so that bare `R`, `C`, `RC` fall
through untouched. Plain A1 cells like `R1`, `C5`, `RC1` never reach
this path because they don't contain `[`.

Stacked on `parse/issue-73-structured-refs` (real recursive-descent
specifier parser); base is set accordingly.

## Tests

New `r1c1_disambiguation` module in `crates/formualizer-parse/src/tests/parser.rs`:

- `test_r1c1_bracketed_offsets_not_table` — `=R[1]C[2]` is not a Table
- `test_r1c1_absolute` — `=R1C1` stays NamedRange
- `test_r1c1_mixed` — `=R1C[2]` is not a Table (regression)
- `test_r1c1_negative_offset` — `=R[-1]C` is not a Table
- `test_r1c1_rc_with_bracket_only_col` — `=RC[1]` is not a Table (regression)
- `test_r1c1_row_digit_col_bracket` — `=R5C[1]` is not a Table (regression)
- `test_a1_r1_still_cell` — `=R1` remains an A1 Cell
- `test_a1_c5_still_cell` — `=C5` remains an A1 Cell
- `test_table_reference_unchanged` — `Table1[Col]` still Table
- `test_external_workbook_ref_unchanged` — `[1]Sheet1!A1` still External
- `test_cross_parser_agreement_r1c1` — both classic and span-based
  parsers agree (no Table) for the full R1C1-shape battery

## Validation

- \`cargo fmt --all\`
- \`cargo test -p formualizer-parse r1c1_disambiguation\` — 11/11 pass
- \`cargo test -p formualizer-parse\` — 195 lib + 3 integration pass
- \`cargo clippy -p formualizer-parse --all-targets -- -D warnings\` — clean