### PR TITLE
feat(parse): support LAMBDA immediate-invocation (IIFE)

### DIFF
--- a/bindings/python/src/ast.rs
+++ b/bindings/python/src/ast.rs
@@ -69,6 +69,12 @@ impl PyASTNode {
             ASTNodeType::Function { args, .. } => {
                 args.iter().map(|arg| PyASTNode::new(arg.clone())).collect()
             }
+            ASTNodeType::Call { callee, args } => {
+                let mut out = Vec::with_capacity(args.len() + 1);
+                out.push(PyASTNode::new((**callee).clone()));
+                out.extend(args.iter().map(|arg| PyASTNode::new(arg.clone())));
+                out
+            }
             ASTNodeType::Array(rows) => rows
                 .iter()
                 .flat_map(|row| row.iter())
@@ -97,6 +103,7 @@ impl PyASTNode {
             ASTNodeType::UnaryOp { .. } => "UnaryOp".to_string(),
             ASTNodeType::BinaryOp { .. } => "BinaryOp".to_string(),
             ASTNodeType::Function { .. } => "Function".to_string(),
+            ASTNodeType::Call { .. } => "Call".to_string(),
             ASTNodeType::Array(_) => "Array".to_string(),
         }
     }
@@ -200,6 +207,18 @@ impl PyASTNode {
                 }
                 result
             }
+            ASTNodeType::Call { callee, args } => {
+                let mut result = format!("{indent_str}Call");
+                result.push('\n');
+                result.push_str(&format!("{}callee:", "  ".repeat(indent + 1)));
+                result.push('\n');
+                result.push_str(&PyASTNode::new((**callee).clone()).format_node(indent + 2));
+                for arg in args {
+                    result.push('\n');
+                    result.push_str(&PyASTNode::new(arg.clone()).format_node(indent + 1));
+                }
+                result
+            }
             ASTNodeType::Array(rows) => {
                 let mut result = format!("{indent_str}Array");
                 for (row_idx, row) in rows.iter().enumerate() {
@@ -257,6 +276,12 @@ impl PyASTNode {
                     PyASTNode::new(arg.clone()).collect_refs_recursive(refs);
                 }
             }
+            ASTNodeType::Call { callee, args } => {
+                PyASTNode::new((**callee).clone()).collect_refs_recursive(refs);
+                for arg in args {
+                    PyASTNode::new(arg.clone()).collect_refs_recursive(refs);
+                }
+            }
             ASTNodeType::Array(rows) => {
                 for row in rows {
                     for cell in row {
@@ -294,6 +319,15 @@ impl PyASTNode {
             }
             ASTNodeType::Function { name, args } => {
                 dict.set_item("name", name).unwrap();
+                let py_args: Vec<PyObject> = args
+                    .iter()
+                    .map(|arg| PyASTNode::new(arg.clone()).to_dict(py))
+                    .collect();
+                dict.set_item("args", py_args).unwrap();
+            }
+            ASTNodeType::Call { callee, args } => {
+                dict.set_item("callee", PyASTNode::new((**callee).clone()).to_dict(py))
+                    .unwrap();
                 let py_args: Vec<PyObject> = args
                     .iter()
                     .map(|arg| PyASTNode::new(arg.clone()).to_dict(py))

--- a/bindings/wasm/src/ast.rs
+++ b/bindings/wasm/src/ast.rs
@@ -64,6 +64,12 @@ pub enum ASTNodeData {
         #[serde(flatten)]
         source: NodeSourceData,
     },
+    Call {
+        callee: Box<ASTNodeData>,
+        args: Vec<ASTNodeData>,
+        #[serde(flatten)]
+        source: NodeSourceData,
+    },
     Error {
         message: String,
         #[serde(flatten)]
@@ -238,6 +244,11 @@ impl ASTNodeData {
                     .collect(),
                 source,
             },
+            ASTNodeType::Call { callee, args } => ASTNodeData::Call {
+                callee: Box::new(Self::from_core(callee)),
+                args: args.iter().map(Self::from_core).collect(),
+                source,
+            },
         }
     }
 
@@ -336,6 +347,7 @@ impl ASTNode {
             ASTNodeData::BinaryOp { .. } => "binaryOp".to_string(),
             ASTNodeData::UnaryOp { .. } => "unaryOp".to_string(),
             ASTNodeData::Array { .. } => "array".to_string(),
+            ASTNodeData::Call { .. } => "call".to_string(),
             ASTNodeData::Error { .. } => "error".to_string(),
         }
     }

--- a/crates/formualizer-cffi/src/parse.rs
+++ b/crates/formualizer-cffi/src/parse.rs
@@ -61,6 +61,12 @@ pub enum CffiASTNode {
         #[serde(skip_serializing_if = "Option::is_none")]
         span: Option<[usize; 2]>,
     },
+    Call {
+        callee: Box<CffiASTNode>,
+        args: Vec<CffiASTNode>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        span: Option<[usize; 2]>,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -156,6 +162,14 @@ impl CffiASTNode {
                             .map(|a| Self::from_core(a, include_spans))
                             .collect()
                     })
+                    .collect(),
+                span,
+            },
+            ASTNodeType::Call { callee, args } => CffiASTNode::Call {
+                callee: Box::new(Self::from_core(callee, include_spans)),
+                args: args
+                    .iter()
+                    .map(|a| Self::from_core(a, include_spans))
                     .collect(),
                 span,
             },

--- a/crates/formualizer-eval/src/engine/arena/data_store.rs
+++ b/crates/formualizer-eval/src/engine/arena/data_store.rs
@@ -378,6 +378,20 @@ impl DataStore {
 
                 self.asts.insert_array(rows_count, cols_count, elements)
             }
+
+            // Postfix call (e.g. LAMBDA immediate-invocation). The arena does
+            // not yet have a dedicated node kind for this, and full evaluator
+            // semantics are out of scope for the parser-side change. Store an
+            // unsupported-formula error literal so that downstream evaluation
+            // surfaces a clear #N/A!-style error instead of silently producing
+            // a wrong result.
+            ASTNodeType::Call { .. } => {
+                let value_ref = self.store_value(LiteralValue::Error(
+                    ExcelError::new(ExcelErrorKind::NImpl)
+                        .with_message("Immediate-invocation calls are not yet supported"),
+                ));
+                self.asts.insert_literal(value_ref)
+            }
         }
     }
 

--- a/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
@@ -405,6 +405,36 @@ impl DependencyGraph {
                     }
                 }
             }
+            ASTNodeType::Call { callee, args } => {
+                // Walk both the callee and the call arguments so any references
+                // they contain are tracked. Full evaluator semantics for
+                // immediate-invocation calls are not yet implemented, but
+                // dependency collection must still cover them.
+                self.extract_dependencies_recursive(
+                    callee,
+                    current_sheet_id,
+                    dependencies,
+                    range_dependencies,
+                    created_placeholders,
+                    named_dependencies,
+                    unresolved_names,
+                    local_scopes,
+                    unresolved_name_policy,
+                )?;
+                for arg in args {
+                    self.extract_dependencies_recursive(
+                        arg,
+                        current_sheet_id,
+                        dependencies,
+                        range_dependencies,
+                        created_placeholders,
+                        named_dependencies,
+                        unresolved_names,
+                        local_scopes,
+                        unresolved_name_policy,
+                    )?;
+                }
+            }
             ASTNodeType::Literal(_) => {}
         }
         Ok(())
@@ -458,6 +488,9 @@ impl DependencyGraph {
             ASTNodeType::Array(rows) => rows
                 .iter()
                 .any(|row| row.iter().any(|cell| self.is_ast_volatile(cell))),
+            ASTNodeType::Call { callee, args } => {
+                self.is_ast_volatile(callee) || args.iter().any(|a| self.is_ast_volatile(a))
+            }
             _ => false,
         }
     }
@@ -483,6 +516,9 @@ impl DependencyGraph {
             ASTNodeType::Array(rows) => rows
                 .iter()
                 .any(|row| row.iter().any(|cell| self.is_ast_dynamic(cell))),
+            ASTNodeType::Call { callee, args } => {
+                self.is_ast_dynamic(callee) || args.iter().any(|a| self.is_ast_dynamic(a))
+            }
             _ => false,
         }
     }

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1534,6 +1534,13 @@ impl DependencyGraph {
                 }
                 Ok(())
             }
+            ASTNodeType::Call { callee, args } => {
+                self.rewrite_structured_references_node(callee, cell)?;
+                for a in args.iter_mut() {
+                    self.rewrite_structured_references_node(a, cell)?;
+                }
+                Ok(())
+            }
             ASTNodeType::Array(rows) => {
                 for r in rows.iter_mut() {
                     for item in r.iter_mut() {

--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -187,6 +187,7 @@ impl<'a> Interpreter<'a> {
             ASTNodeType::Array(_)
             | ASTNodeType::UnaryOp { .. }
             | ASTNodeType::BinaryOp { .. }
+            | ASTNodeType::Call { .. }
             | ASTNodeType::Literal(_) => Err(ExcelError::new(ExcelErrorKind::Ref)
                 .with_message("Expression cannot be used as a reference")),
         }
@@ -641,6 +642,8 @@ impl<'a> Interpreter<'a> {
                 }
                 self.eval_function_to_calc(name, args)
             }
+            ASTNodeType::Call { .. } => Err(ExcelError::new(ExcelErrorKind::NImpl)
+                .with_message("Immediate-invocation calls are not yet supported")),
             ASTNodeType::Array(rows) => self.eval_array_literal_to_calc(rows),
         }
     }

--- a/crates/formualizer-eval/src/planner.rs
+++ b/crates/formualizer-eval/src/planner.rs
@@ -248,6 +248,31 @@ impl<'a> Planner<'a> {
                     0,
                 )
             }
+            Call { callee, args } => {
+                let callee_annot = self.annotate(callee);
+                let child_annots: Vec<NodeAnnot> = args.iter().map(|a| self.annotate(a)).collect();
+                let children_cost: u64 = callee_annot.cost.est_nanos
+                    + child_annots.iter().map(|a| a.cost.est_nanos).sum::<u64>();
+                let cells: u64 = callee_annot.cost.cells
+                    + child_annots.iter().map(|a| a.cost.cells).sum::<u64>();
+                let has_range =
+                    callee_annot.hints.has_range || child_annots.iter().any(|a| a.hints.has_range);
+                let dims = callee_annot
+                    .hints
+                    .dims
+                    .or_else(|| child_annots.iter().find_map(|a| a.hints.dims));
+                let fanout = (args.len() + 1) as u16;
+                (
+                    NodeCost {
+                        est_nanos: 5_000 + children_cost,
+                        cells,
+                        fanout,
+                    },
+                    has_range,
+                    dims,
+                    fanout,
+                )
+            }
         };
 
         // Sibling repeat detection (simple count of identical fingerprints among children)
@@ -311,6 +336,16 @@ impl<'a> Planner<'a> {
             }
             ASTNodeType::Function { args, .. } => {
                 let mut v = Vec::with_capacity(args.len());
+                for a in args {
+                    let an = self.annotate(a);
+                    v.push(self.select(a, &an));
+                }
+                v
+            }
+            ASTNodeType::Call { callee, args } => {
+                let mut v = Vec::with_capacity(args.len() + 1);
+                let callee_annot = self.annotate(callee);
+                v.push(self.select(callee, &callee_annot));
                 for a in args {
                     let an = self.annotate(a);
                     v.push(self.select(a, &an));

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1450,6 +1450,12 @@ pub enum ASTNodeType {
         name: String,
         args: Vec<ASTNode>, // Most functions have <= 4 args
     },
+    /// Generic call where the callee is itself an expression that produces
+    /// a callable value (e.g. LAMBDA immediate-invocation `LAMBDA(x, x+1)(5)`).
+    Call {
+        callee: Box<ASTNode>,
+        args: Vec<ASTNode>,
+    },
     Array(Vec<Vec<ASTNode>>), // Most arrays are small
 }
 
@@ -1463,6 +1469,7 @@ impl Display for ASTNodeType {
                 write!(f, "BinaryOp({op}, {left}, {right})")
             }
             ASTNodeType::Function { name, args } => write!(f, "Function({name}, {args:?})"),
+            ASTNodeType::Call { callee, args } => write!(f, "Call({callee}, {args:?})"),
             ASTNodeType::Array(rows) => write!(f, "Array({rows:?})"),
         }
     }
@@ -1550,6 +1557,14 @@ impl ASTNode {
                     arg.hash_node(hasher);
                 }
             }
+            ASTNodeType::Call { callee, args } => {
+                hasher.write(&[7]); // Discriminant for Call
+                callee.hash_node(hasher);
+                hasher.write_usize(args.len());
+                for arg in args {
+                    arg.hash_node(hasher);
+                }
+            }
             ASTNodeType::Array(rows) => {
                 hasher.write(&[6]); // Discriminant for Array
                 hasher.write_usize(rows.len());
@@ -1593,6 +1608,12 @@ impl ASTNode {
                     arg.collect_dependencies(dependencies);
                 }
             }
+            ASTNodeType::Call { callee, args } => {
+                callee.collect_dependencies(dependencies);
+                for arg in args {
+                    arg.collect_dependencies(dependencies);
+                }
+            }
             ASTNodeType::Array(rows) => {
                 for row in rows {
                     for item in row {
@@ -1629,6 +1650,12 @@ impl ASTNode {
                     for a in args.iter().rev() {
                         stack.push(a);
                     }
+                }
+                ASTNodeType::Call { callee, args } => {
+                    for a in args.iter().rev() {
+                        stack.push(a);
+                    }
+                    stack.push(callee);
                 }
                 ASTNodeType::Array(rows) => {
                     for r in rows.iter().rev() {
@@ -1760,6 +1787,12 @@ impl ASTNode {
                     arg.update_sheet_references(target_name, new_name);
                 }
             }
+            ASTNodeType::Call { callee, args } => {
+                callee.update_sheet_references(target_name, new_name);
+                for arg in args {
+                    arg.update_sheet_references(target_name, new_name);
+                }
+            }
             ASTNodeType::Array(rows) => {
                 for row in rows {
                     for cell in row {
@@ -1881,6 +1914,12 @@ impl<'a> Iterator for RefIter<'a> {
                         self.stack.push(a);
                     }
                 }
+                ASTNodeType::Call { callee, args } => {
+                    for a in args.iter().rev() {
+                        self.stack.push(a);
+                    }
+                    self.stack.push(callee);
+                }
                 ASTNodeType::Array(rows) => {
                     for r in rows.iter().rev() {
                         for item in r.iter().rev() {
@@ -1933,6 +1972,9 @@ pub struct Parser {
     /// Optional classifier to determine whether a function name is volatile.
     volatility_classifier: Option<VolatilityClassifierBox>,
     dialect: FormulaDialect,
+    /// When > 0, treat a top-level `OpInfix(",")` as a terminator (call-arg
+    /// separator) instead of the union/list operator. Used by `parse_call_arguments`.
+    in_call_args_depth: usize,
 }
 
 impl TryFrom<&str> for Parser {
@@ -1971,6 +2013,7 @@ impl Parser {
             position: 0,
             volatility_classifier: None,
             dialect,
+            in_call_args_depth: 0,
         }
     }
 
@@ -2083,6 +2126,26 @@ impl Parser {
                 break;
             }
 
+            // Postfix call: a `(` directly following a closed expression denotes
+            // immediate invocation of a callable result (e.g. LAMBDA IIFE).
+            if self.tokens[self.position].token_type == TokenType::Paren
+                && self.tokens[self.position].subtype == TokenSubType::Open
+            {
+                self.position += 1;
+                let args = self.parse_call_arguments()?;
+                let call_volatile =
+                    left.contains_volatile || args.iter().any(|a| a.contains_volatile);
+                left = ASTNode::new_with_volatile(
+                    ASTNodeType::Call {
+                        callee: Box::new(left),
+                        args,
+                    },
+                    None,
+                    call_volatile,
+                );
+                continue;
+            }
+
             // Postfix operators (e.g. percent).
             if self.tokens[self.position].token_type == TokenType::OpPostfix {
                 let (precedence, _) = self.tokens[self.position]
@@ -2108,6 +2171,12 @@ impl Parser {
 
             let token = &self.tokens[self.position];
             if token.token_type != TokenType::OpInfix {
+                break;
+            }
+
+            // Inside a postfix call's argument list, treat top-level `,` as
+            // an argument separator, not as the union operator.
+            if self.in_call_args_depth > 0 && token.value == "," {
                 break;
             }
 
@@ -2296,6 +2365,61 @@ impl Parser {
         ))
     }
 
+    /// Parse arguments for a postfix call (immediate invocation), where the
+    /// opening `(` is a `Paren:Open` and the matching `)` is a `Paren:Close`.
+    /// Caller has already consumed the opening paren.
+    ///
+    /// Inside this region the tokenizer emits a top-level `,` as `OpInfix`
+    /// (Excel's union operator). For call arguments we want it to behave as a
+    /// separator, so we bump `in_call_args_depth` while parsing each argument.
+    fn parse_call_arguments(&mut self) -> Result<Vec<ASTNode>, ParserError> {
+        let mut args: Vec<ASTNode> = Vec::new();
+
+        self.skip_whitespace();
+        // Empty argument list: `f()`
+        if self.position < self.tokens.len()
+            && self.tokens[self.position].token_type == TokenType::Paren
+            && self.tokens[self.position].subtype == TokenSubType::Close
+        {
+            self.position += 1;
+            return Ok(args);
+        }
+
+        self.in_call_args_depth += 1;
+        let result = (|| -> Result<Vec<ASTNode>, ParserError> {
+            args.push(self.parse_expression()?);
+            loop {
+                self.skip_whitespace();
+                if self.position >= self.tokens.len() {
+                    return Err(ParserError {
+                        message: "Unterminated call argument list".to_string(),
+                        position: Some(self.position),
+                    });
+                }
+                let token = &self.tokens[self.position];
+                let is_separator = (token.token_type == TokenType::Sep
+                    && token.subtype == TokenSubType::Arg)
+                    || (token.token_type == TokenType::OpInfix && token.value == ",");
+                if is_separator {
+                    self.position += 1;
+                    args.push(self.parse_expression()?);
+                } else if token.token_type == TokenType::Paren
+                    && token.subtype == TokenSubType::Close
+                {
+                    self.position += 1;
+                    return Ok(std::mem::take(&mut args));
+                } else {
+                    return Err(ParserError {
+                        message: format!("Expected ',' or ')' in call arguments, got {token:?}"),
+                        position: Some(self.position),
+                    });
+                }
+            }
+        })();
+        self.in_call_args_depth -= 1;
+        result
+    }
+
     /// Parse function arguments.
     fn parse_function_arguments(&mut self) -> Result<Vec<ASTNode>, ParserError> {
         let mut args = Vec::new();
@@ -2447,6 +2571,8 @@ struct SpanParser<'a> {
     position: usize,
     volatility_classifier: Option<VolatilityClassifierBox>,
     dialect: FormulaDialect,
+    /// See `Parser::in_call_args_depth`.
+    in_call_args_depth: usize,
 }
 
 impl<'a> SpanParser<'a> {
@@ -2461,6 +2587,7 @@ impl<'a> SpanParser<'a> {
             position: 0,
             volatility_classifier: None,
             dialect,
+            in_call_args_depth: 0,
         }
     }
 
@@ -2585,6 +2712,26 @@ impl<'a> SpanParser<'a> {
                 break;
             }
 
+            // Postfix call: a `(` directly following a closed expression denotes
+            // immediate invocation of a callable result (e.g. LAMBDA IIFE).
+            if self.tokens[self.position].token_type == TokenType::Paren
+                && self.tokens[self.position].subtype == TokenSubType::Open
+            {
+                self.position += 1;
+                let args = self.parse_call_arguments()?;
+                let call_volatile =
+                    left.contains_volatile || args.iter().any(|a| a.contains_volatile);
+                left = ASTNode::new_with_volatile(
+                    ASTNodeType::Call {
+                        callee: Box::new(left),
+                        args,
+                    },
+                    None,
+                    call_volatile,
+                );
+                continue;
+            }
+
             if self.tokens[self.position].token_type == TokenType::OpPostfix {
                 let (precedence, _) = self
                     .span_precedence(&self.tokens[self.position])
@@ -2610,6 +2757,12 @@ impl<'a> SpanParser<'a> {
 
             let token = &self.tokens[self.position];
             if token.token_type != TokenType::OpInfix {
+                break;
+            }
+
+            // Inside a postfix call's argument list, treat top-level `,` as
+            // an argument separator, not as the union operator.
+            if self.in_call_args_depth > 0 && self.span_value(token) == "," {
                 break;
             }
 
@@ -2810,6 +2963,57 @@ impl<'a> SpanParser<'a> {
             Some(func_token),
             this_is_volatile || args_volatile,
         ))
+    }
+
+    /// Parse arguments for a postfix call (immediate invocation), where the
+    /// opening `(` is a `Paren:Open` and the matching `)` is a `Paren:Close`.
+    /// Caller has already consumed the opening paren. See the classic parser
+    /// version for details on how top-level `,` is handled.
+    fn parse_call_arguments(&mut self) -> Result<Vec<ASTNode>, ParserError> {
+        let mut args: Vec<ASTNode> = Vec::new();
+
+        self.skip_whitespace();
+        if self.position < self.tokens.len()
+            && self.tokens[self.position].token_type == TokenType::Paren
+            && self.tokens[self.position].subtype == TokenSubType::Close
+        {
+            self.position += 1;
+            return Ok(args);
+        }
+
+        self.in_call_args_depth += 1;
+        let result = (|| -> Result<Vec<ASTNode>, ParserError> {
+            args.push(self.parse_expression()?);
+            loop {
+                self.skip_whitespace();
+                if self.position >= self.tokens.len() {
+                    return Err(ParserError {
+                        message: "Unterminated call argument list".to_string(),
+                        position: Some(self.position),
+                    });
+                }
+                let token = &self.tokens[self.position];
+                let is_separator = (token.token_type == TokenType::Sep
+                    && token.subtype == TokenSubType::Arg)
+                    || (token.token_type == TokenType::OpInfix && self.span_value(token) == ",");
+                if is_separator {
+                    self.position += 1;
+                    args.push(self.parse_expression()?);
+                } else if token.token_type == TokenType::Paren
+                    && token.subtype == TokenSubType::Close
+                {
+                    self.position += 1;
+                    return Ok(std::mem::take(&mut args));
+                } else {
+                    return Err(ParserError {
+                        message: format!("Expected ',' or ')' in call arguments, got {token:?}"),
+                        position: Some(self.position),
+                    });
+                }
+            }
+        })();
+        self.in_call_args_depth -= 1;
+        result
     }
 
     fn parse_function_arguments(&mut self) -> Result<Vec<ASTNode>, ParserError> {

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -166,6 +166,22 @@ fn pretty_print_node(ast: &ASTNode) -> String {
 
             format!("{}({})", name.to_uppercase(), args_str)
         }
+        ASTNodeType::Call { callee, args } => {
+            let callee_str = pretty_print_node(callee);
+            // Wrap the callee in parentheses if it isn't already a callable-looking
+            // primary (function call or another call expression). This keeps things
+            // like `(1 + 2)(3)` unambiguous when round-tripping unusual ASTs.
+            let callee_rendered = match &callee.node_type {
+                ASTNodeType::Function { .. } | ASTNodeType::Call { .. } => callee_str,
+                _ => format!("({callee_str})"),
+            };
+            let args_str = args
+                .iter()
+                .map(pretty_print_node)
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("{callee_rendered}({args_str})")
+        }
         ASTNodeType::Array(rows) => {
             let rows_str = rows
                 .iter()

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -2073,6 +2073,256 @@ mod semantics_regressions {
         }
     }
 
+    mod lambda_iife {
+        use crate::parser::parse as span_parse;
+        use crate::parser::{ASTNode, ASTNodeType, Parser};
+        use crate::pretty::canonical_formula;
+        use crate::tokenizer::Tokenizer;
+        use formualizer_common::LiteralValue;
+
+        fn parse_classic(formula: &str) -> ASTNode {
+            let tokenizer = Tokenizer::new(formula).expect("tokenize");
+            let mut parser = Parser::new(tokenizer.items, false);
+            parser.parse().expect("classic parser")
+        }
+
+        fn parse_both(formula: &str) -> ASTNode {
+            let classic = parse_classic(formula);
+            let span = span_parse(formula).expect("span parser");
+            assert_eq!(
+                classic.fingerprint(),
+                span.fingerprint(),
+                "classic vs span parser produced different ASTs for {formula:?}"
+            );
+            classic
+        }
+
+        #[test]
+        fn test_lambda_immediate_invocation_unary() {
+            let ast = parse_both("=LAMBDA(x,x+1)(5)");
+            let (callee, args) = match ast.node_type {
+                ASTNodeType::Call { callee, args } => (callee, args),
+                other => panic!("expected Call, got {other:?}"),
+            };
+            assert_eq!(args.len(), 1);
+            match &args[0].node_type {
+                ASTNodeType::Literal(LiteralValue::Number(n)) => assert_eq!(*n, 5.0),
+                other => panic!("expected literal 5, got {other:?}"),
+            }
+            match callee.node_type {
+                ASTNodeType::Function {
+                    name,
+                    args: fn_args,
+                } => {
+                    assert_eq!(name.to_uppercase(), "LAMBDA");
+                    assert_eq!(fn_args.len(), 2);
+                    // First arg is the parameter name 'x' (parsed as a NamedRange ref).
+                    match &fn_args[1].node_type {
+                        ASTNodeType::BinaryOp { op, .. } => assert_eq!(op, "+"),
+                        other => panic!("expected binary op body, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Function callee, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_lambda_immediate_invocation_binary() {
+            let ast = parse_both("=LAMBDA(a,b,a+b)(1,2)");
+            let (callee, args) = match ast.node_type {
+                ASTNodeType::Call { callee, args } => (callee, args),
+                other => panic!("expected Call, got {other:?}"),
+            };
+            assert_eq!(args.len(), 2);
+            match callee.node_type {
+                ASTNodeType::Function {
+                    name,
+                    args: fn_args,
+                } => {
+                    assert_eq!(name.to_uppercase(), "LAMBDA");
+                    assert_eq!(fn_args.len(), 3);
+                }
+                other => panic!("expected Function callee, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_parenthesized_lambda_invocation() {
+            let ast = parse_both("=(LAMBDA(x,x))(5)");
+            match ast.node_type {
+                ASTNodeType::Call { callee, args } => {
+                    assert_eq!(args.len(), 1);
+                    match callee.node_type {
+                        ASTNodeType::Function { name, .. } => {
+                            assert_eq!(name.to_uppercase(), "LAMBDA")
+                        }
+                        other => panic!("expected Function callee, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Call, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_double_call_via_grouping() {
+            // (f())() => Call(Function(f, []), [])
+            // Note: tokenizer sees `f(` as Func/Open, so the first call binds
+            // to Function. The trailing `()` is the postfix Call.
+            let ast = parse_both("=f()()");
+            match ast.node_type {
+                ASTNodeType::Call { callee, args } => {
+                    assert!(args.is_empty(), "outer call should have no args");
+                    match callee.node_type {
+                        ASTNodeType::Function {
+                            name,
+                            args: inner_args,
+                        } => {
+                            assert_eq!(name, "f");
+                            assert!(inner_args.is_empty());
+                        }
+                        other => panic!("expected Function f callee, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Call, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_double_postfix_call() {
+            // (LAMBDA(x,x))(5)(6) => two postfix Call nodes stacked.
+            let ast = parse_both("=(LAMBDA(x,x))(5)(6)");
+            match ast.node_type {
+                ASTNodeType::Call { callee, args } => {
+                    assert_eq!(args.len(), 1);
+                    match &args[0].node_type {
+                        ASTNodeType::Literal(LiteralValue::Number(n)) => assert_eq!(*n, 6.0),
+                        other => panic!("expected literal 6, got {other:?}"),
+                    }
+                    match callee.node_type {
+                        ASTNodeType::Call {
+                            callee: inner_callee,
+                            args: inner_args,
+                        } => {
+                            assert_eq!(inner_args.len(), 1);
+                            match inner_callee.node_type {
+                                ASTNodeType::Function { name, .. } => {
+                                    assert_eq!(name.to_uppercase(), "LAMBDA")
+                                }
+                                other => panic!("expected Function callee, got {other:?}"),
+                            }
+                        }
+                        other => panic!("expected nested Call, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Call, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_lambda_nested_in_let_uses_plain_function_call() {
+            // LET body's `f(3)` is a regular Function(f, [3]), not a Call node.
+            let ast = parse_both("=LET(f,LAMBDA(x,x*2),f(3))");
+            let args = match ast.node_type {
+                ASTNodeType::Function { name, args } => {
+                    assert_eq!(name.to_uppercase(), "LET");
+                    args
+                }
+                other => panic!("expected LET function, got {other:?}"),
+            };
+            assert_eq!(args.len(), 3);
+            match &args[2].node_type {
+                ASTNodeType::Function { name, args: inner } => {
+                    assert_eq!(name, "f");
+                    assert_eq!(inner.len(), 1);
+                }
+                other => panic!("expected Function f(3), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_call_on_number_literal() {
+            // Permissive parse: `(1+2)(3)` parses as Call(BinaryOp, [3]).
+            let ast = parse_both("=(1+2)(3)");
+            match ast.node_type {
+                ASTNodeType::Call { callee, args } => {
+                    assert_eq!(args.len(), 1);
+                    match callee.node_type {
+                        ASTNodeType::BinaryOp { op, .. } => assert_eq!(op, "+"),
+                        other => panic!("expected BinaryOp callee, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Call, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_call_on_grouped_reference() {
+            // `(A1)(3)` — parens force the LHS to be parsed as a primary, so the
+            // trailing `(3)` becomes a postfix Call. (`A1(3)` itself tokenizes
+            // as a function token `A1(` and so parses as Function("A1", [3]).)
+            let ast = parse_both("=(A1)(3)");
+            match ast.node_type {
+                ASTNodeType::Call { callee, args } => {
+                    assert_eq!(args.len(), 1);
+                    match callee.node_type {
+                        ASTNodeType::Reference { .. } => {}
+                        other => panic!("expected Reference callee, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Call, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_lambda_empty_body_call_parses() {
+            // `LAMBDA()(1)` parses; evaluator may complain. Parser should accept.
+            let ast = parse_both("=LAMBDA()(1)");
+            match ast.node_type {
+                ASTNodeType::Call { args, .. } => assert_eq!(args.len(), 1),
+                other => panic!("expected Call, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_bare_lambda_still_parses_as_function() {
+            let ast = parse_both("=LAMBDA(x, x+1)");
+            match ast.node_type {
+                ASTNodeType::Function { name, args } => {
+                    assert_eq!(name.to_uppercase(), "LAMBDA");
+                    assert_eq!(args.len(), 2);
+                }
+                other => panic!("expected Function, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_lambda_as_argument_unchanged() {
+            let ast = parse_both("=SUM(LAMBDA(x,x),1,2,3)");
+            match ast.node_type {
+                ASTNodeType::Function { name, args } => {
+                    assert_eq!(name.to_uppercase(), "SUM");
+                    assert_eq!(args.len(), 4);
+                    matches!(args[0].node_type, ASTNodeType::Function { .. });
+                }
+                other => panic!("expected Function, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_pretty_print_call_round_trips() {
+            let ast = parse_both("=LAMBDA(x,x+1)(5)");
+            let printed = canonical_formula(&ast);
+            // Pretty printer should keep the call shape.
+            assert!(
+                printed.contains("LAMBDA(") && printed.ends_with("(5)"),
+                "unexpected pretty output: {printed}"
+            );
+            // Re-parsing the pretty form yields an equivalent fingerprint.
+            let reparsed = span_parse(&printed).expect("reparse pretty output");
+            assert_eq!(reparsed.fingerprint(), ast.fingerprint());
+        }
+    }
+
     #[test]
     fn quoted_sheet_name_allows_escaped_single_quote() {
         let r = ReferenceType::from_string("'Bob''s Sheet'!A1").unwrap();


### PR DESCRIPTION
## Summary

Excel 365 supports LAMBDA immediate-invocation idioms such as
`=LAMBDA(x, x+1)(5)` and `=(LAMBDA(x,x))(5)`. Previously the parser
treated any `(` after a closed expression as the end of the
expression, surfacing as `Unexpected token` errors.

This PR introduces a new AST variant
`ASTNodeType::Call { callee: Box<ASTNode>, args: Vec<ASTNode> }`
and teaches both the classic token-based `Parser` and the span-based
`SpanParser` to recognize `Paren:Open` directly following a closed
expression as a postfix call operator.

Inside the postfix call's argument list a top-level `,` (which the
tokenizer emits as `OpInfix` rather than `Sep:Arg` because the
surrounding `(...)` is not a function call) is treated as an argument
separator instead of the union operator, matching the shape produced
for ordinary function calls. This is implemented via a small
`in_call_args_depth` counter on each parser.

## Cross-crate AST plumbing

`Call` is a new public AST variant, so the change is cross-crate.
Every downstream traversal/rewriter is updated to handle it:

- Parser: `Display`, `hash_node`, `collect_dependencies`,
  `visit_refs`, `RefIter`, `update_sheet_references`.
- Pretty printer: prints `callee(args)`, wrapping non-call/non-function
  callees in parentheses for unambiguous round-trip.
- Evaluator (`formualizer-eval`):
  - `Interpreter::evaluate_ast_as_reference` and `eval_with_plan`
    return an explicit `#N/IMPL!` error for `Call` (full semantics
    are out of scope).
  - Planner annotation/selection.
  - `formula_analysis` dependency walk, `is_ast_volatile`,
    `is_ast_dynamic`.
  - `rewrite_structured_references_node`.
  - Arena `data_store::convert_ast_node` materialises an unsupported
    error literal (a follow-up can add a dedicated arena variant if
    we choose to evaluate `Call`).
- Bindings: `bindings/python` (`PyASTNode` children, node_type,
  `format_node`, `collect_refs_recursive`, `to_dict`), `bindings/wasm`
  (`ASTNodeData::Call` + `getType`), `crates/formualizer-cffi`
  (`CffiASTNode::Call`).

## Tests added (`crates/formualizer-parse/src/tests/parser.rs::lambda_iife`)

All tests assert that the classic `Parser` and span-based `parse`
produce identical AST fingerprints.

- `test_lambda_immediate_invocation_unary` — `=LAMBDA(x,x+1)(5)`
- `test_lambda_immediate_invocation_binary` — `=LAMBDA(a,b,a+b)(1,2)`
- `test_parenthesized_lambda_invocation` — `=(LAMBDA(x,x))(5)`
- `test_double_call_via_grouping` — `=f()()` (Function then postfix Call)
- `test_double_postfix_call` — `=(LAMBDA(x,x))(5)(6)` (nested Call)
- `test_lambda_nested_in_let_uses_plain_function_call` —
  `=LET(f,LAMBDA(x,x*2),f(3))` keeps `f(3)` as a plain Function
- `test_call_on_number_literal` — `=(1+2)(3)` parses as
  `Call(BinaryOp(+,1,2), [3])`
- `test_call_on_grouped_reference` — `=(A1)(3)` parses as
  `Call(Reference(A1), [3])`. Note: bare `=A1(3)` tokenises `A1(`
  as a function token and so still parses as `Function("A1",[3])`;
  this is unchanged.
- `test_lambda_empty_body_call_parses` — `=LAMBDA()(1)` parses
  (evaluator may complain).
- `test_bare_lambda_still_parses_as_function` — regression guard.
- `test_lambda_as_argument_unchanged` — regression guard.
- `test_pretty_print_call_round_trips` — pretty-printer emits a
  shape that re-parses to a fingerprint-equivalent AST.

## Validation

```
cargo fmt --all
cargo build --workspace
cargo test -p formualizer-parse        # 169 tests pass (incl. 12 new)
cargo test --workspace                 # all suites pass
cargo clippy -p formualizer-parse --all-targets -- -D warnings
cargo clippy --workspace --all-targets -- -D warnings
```

Closes #68