### PR TITLE
parse: support 3D sheet-range references (Sheet1:Sheet3!A1)

### DIFF
--- a/bindings/python/src/reference.rs
+++ b/bindings/python/src/reference.rs
@@ -368,6 +368,12 @@ pub fn reference_type_to_py(ref_type: &ReferenceType, _original: &str) -> Refere
         ReferenceType::NamedRange(name) => {
             ReferenceLike::NamedRange(NamedRangeRef::new(name.clone()))
         }
+        // 3D refs aren't yet exposed to Python; surface them as opaque
+        // unknown references so the binding stays exhaustive without
+        // crashing.
+        ReferenceType::Cell3D { .. } | ReferenceType::Range3D { .. } => {
+            ReferenceLike::Unknown(UnknownRef::new(format!("{ref_type}")))
+        }
     }
 }
 

--- a/bindings/wasm/src/ast.rs
+++ b/bindings/wasm/src/ast.rs
@@ -295,6 +295,9 @@ impl ASTNodeData {
             ReferenceType::External(_) => Err("external references are not supported".to_string()),
             ReferenceType::Table(_) => Err("table references are not supported".to_string()),
             ReferenceType::NamedRange(_) => Err("named ranges are not supported".to_string()),
+            ReferenceType::Cell3D { .. } | ReferenceType::Range3D { .. } => {
+                Err("3D references are not supported".to_string())
+            }
         }
     }
 }

--- a/crates/formualizer-eval/src/engine/arena/ast.rs
+++ b/crates/formualizer-eval/src/engine/arena/ast.rs
@@ -109,6 +109,28 @@ pub enum CompactRefType {
         name_id: StringId,
         specifier_id: Option<TableSpecId>,
     },
+    /// 3D cell reference (`Sheet1:Sheet3!A1`).
+    Cell3D {
+        sheet_first: StringId,
+        sheet_last: StringId,
+        row: u32,
+        col: u32,
+        row_abs: bool,
+        col_abs: bool,
+    },
+    /// 3D range reference (`Sheet1:Sheet3!A1:B2`).
+    Range3D {
+        sheet_first: StringId,
+        sheet_last: StringId,
+        start_row: u32,
+        start_col: u32,
+        end_row: u32,
+        end_col: u32,
+        start_row_abs: bool,
+        start_col_abs: bool,
+        end_row_abs: bool,
+        end_col_abs: bool,
+    },
 }
 
 /// Arena for storing AST nodes with deduplication

--- a/crates/formualizer-eval/src/engine/arena/data_store.rs
+++ b/crates/formualizer-eval/src/engine/arena/data_store.rs
@@ -471,6 +471,54 @@ impl DataStore {
                     specifier_id,
                 }
             }
+
+            ReferenceType::Cell3D {
+                sheet_first,
+                sheet_last,
+                row,
+                col,
+                row_abs,
+                col_abs,
+            } => {
+                let sheet_first = self.asts.strings_mut().intern(sheet_first);
+                let sheet_last = self.asts.strings_mut().intern(sheet_last);
+                CompactRefType::Cell3D {
+                    sheet_first,
+                    sheet_last,
+                    row: *row,
+                    col: *col,
+                    row_abs: *row_abs,
+                    col_abs: *col_abs,
+                }
+            }
+
+            ReferenceType::Range3D {
+                sheet_first,
+                sheet_last,
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                start_row_abs,
+                start_col_abs,
+                end_row_abs,
+                end_col_abs,
+            } => {
+                let sheet_first = self.asts.strings_mut().intern(sheet_first);
+                let sheet_last = self.asts.strings_mut().intern(sheet_last);
+                CompactRefType::Range3D {
+                    sheet_first,
+                    sheet_last,
+                    start_row: start_row.unwrap_or(0),
+                    start_col: start_col.unwrap_or(0),
+                    end_row: end_row.unwrap_or(u32::MAX),
+                    end_col: end_col.unwrap_or(u32::MAX),
+                    start_row_abs: *start_row_abs,
+                    start_col_abs: *start_col_abs,
+                    end_row_abs: *end_row_abs,
+                    end_col_abs: *end_col_abs,
+                }
+            }
         }
     }
 
@@ -667,6 +715,62 @@ impl DataStore {
                     .cloned();
                 ReferenceType::Table(TableReference { name, specifier })
             }
+
+            CompactRefType::Cell3D {
+                sheet_first,
+                sheet_last,
+                row,
+                col,
+                row_abs,
+                col_abs,
+            } => ReferenceType::Cell3D {
+                sheet_first: self.asts.resolve_string(*sheet_first).to_string(),
+                sheet_last: self.asts.resolve_string(*sheet_last).to_string(),
+                row: *row,
+                col: *col,
+                row_abs: *row_abs,
+                col_abs: *col_abs,
+            },
+
+            CompactRefType::Range3D {
+                sheet_first,
+                sheet_last,
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                start_row_abs,
+                start_col_abs,
+                end_row_abs,
+                end_col_abs,
+            } => ReferenceType::Range3D {
+                sheet_first: self.asts.resolve_string(*sheet_first).to_string(),
+                sheet_last: self.asts.resolve_string(*sheet_last).to_string(),
+                start_row: if *start_row == 0 {
+                    None
+                } else {
+                    Some(*start_row)
+                },
+                start_col: if *start_col == 0 {
+                    None
+                } else {
+                    Some(*start_col)
+                },
+                end_row: if *end_row == u32::MAX {
+                    None
+                } else {
+                    Some(*end_row)
+                },
+                end_col: if *end_col == u32::MAX {
+                    None
+                } else {
+                    Some(*end_col)
+                },
+                start_row_abs: *start_row_abs,
+                start_col_abs: *start_col_abs,
+                end_row_abs: *end_row_abs,
+                end_col_abs: *end_col_abs,
+            },
         }
     }
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -7674,6 +7674,10 @@ where
                 let owned = boxed.materialise().into_owned();
                 Ok(RangeView::from_owned_rows(owned, self.config.date_system))
             }
+            ReferenceType::Cell3D { .. } | ReferenceType::Range3D { .. } => {
+                Err(ExcelError::new(ExcelErrorKind::NImpl)
+                    .with_message("3D references are not yet supported".to_string()))
+            }
         }
     }
 

--- a/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
@@ -252,6 +252,11 @@ impl DependencyGraph {
                             .with_message(format!("Undefined table: {}", tref.name)));
                     }
                 }
+                // 3D references parse correctly but aren't yet wired through
+                // the dependency graph; treat them as no-op dependencies for
+                // now so formulas containing them still load. Evaluation will
+                // surface #N/IMPL! via the Resolver path.
+                ReferenceType::Cell3D { .. } | ReferenceType::Range3D { .. } => {}
             },
             ASTNodeType::BinaryOp { left, right, .. } => {
                 self.extract_dependencies_recursive(

--- a/crates/formualizer-eval/src/engine/plan.rs
+++ b/crates/formualizer-eval/src/engine/plan.rs
@@ -197,6 +197,10 @@ where
                     flags |= F_HAS_TABLES;
                     per_tables.push(tref.name);
                 }
+                // 3D refs are parsed but not yet planned. They neither create
+                // dependencies nor participate in the cell/range plan; the
+                // evaluator will surface #N/IMPL! when one is encountered.
+                ReferenceType::Cell3D { .. } | ReferenceType::Range3D { .. } => {}
             }
         }
 

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -1125,6 +1125,10 @@ pub trait Resolver: ReferenceResolver + RangeResolver + NamedRangeResolver + Tab
                 let v = self.resolve_cell_reference(sheet.as_deref(), *row, *col)?;
                 Ok(Box::new(InMemoryRange::new(vec![vec![v]])))
             }
+            ReferenceType::Cell3D { .. } | ReferenceType::Range3D { .. } => {
+                Err(ExcelError::new(ExcelErrorKind::NImpl)
+                    .with_message("3D references are not yet supported".to_string()))
+            }
         }
     }
 }

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -256,6 +256,31 @@ pub enum ReferenceType {
         end_row_abs: bool,
         end_col_abs: bool,
     },
+    /// 3D cell reference (`Sheet1:Sheet3!A1`).
+    ///
+    /// Excel evaluates aggregating functions across each sheet between
+    /// `sheet_first` and `sheet_last` (inclusive) at the same cell address.
+    Cell3D {
+        sheet_first: String,
+        sheet_last: String,
+        row: u32,
+        col: u32,
+        row_abs: bool,
+        col_abs: bool,
+    },
+    /// 3D range reference (`Sheet1:Sheet3!A1:B2`).
+    Range3D {
+        sheet_first: String,
+        sheet_last: String,
+        start_row: Option<u32>,
+        start_col: Option<u32>,
+        end_row: Option<u32>,
+        end_col: Option<u32>,
+        start_row_abs: bool,
+        start_col_abs: bool,
+        end_row_abs: bool,
+        end_col_abs: bool,
+    },
     External(ExternalReference),
     Table(TableReference),
     NamedRange(String),
@@ -347,6 +372,17 @@ struct OpenFormulaRefPart {
 
 type AxisPartWithAbs = Option<(u32, bool)>;
 type RangePartWithAbs = (AxisPartWithAbs, AxisPartWithAbs);
+
+/// Result of extracting the sheet portion of a reference string.
+#[derive(Debug, Clone)]
+enum SheetSpec {
+    /// No sheet segment was present (e.g. plain `A1`).
+    None,
+    /// Standard single-sheet reference (`Sheet1!A1`, `'Sheet 1'!A1`).
+    Single(String),
+    /// Excel 3D sheet range (`Sheet1:Sheet3!A1`, `'Sheet 1':'Sheet 3'!A1`).
+    Range { first: String, last: String },
+}
 
 impl ReferenceType {
     /// Build a cell reference with relative anchors.
@@ -525,7 +561,17 @@ impl ReferenceType {
     }
 
     fn parse_excel_sheet_ref(reference: &str) -> Result<SheetRef<'static>, ParsingError> {
-        let (sheet, ref_part) = Self::extract_sheet_name(reference);
+        let (spec, ref_part) = Self::extract_sheet_spec(reference);
+        if matches!(spec, SheetSpec::Range { .. }) {
+            return Err(ParsingError::InvalidReference(
+                "3D references are not supported for SheetRef".to_string(),
+            ));
+        }
+        let sheet = match spec {
+            SheetSpec::None => None,
+            SheetSpec::Single(name) => Some(name),
+            SheetSpec::Range { .. } => unreachable!(),
+        };
 
         if ref_part.contains('[') {
             return Err(ParsingError::InvalidReference(
@@ -675,6 +721,72 @@ impl ReferenceType {
         Ok((None, Some((row1, row_abs))))
     }
 
+    fn parse_3d_reference(first: &str, last: &str, ref_part: &str) -> Result<Self, ParsingError> {
+        if first.is_empty() || last.is_empty() {
+            return Err(ParsingError::InvalidReference(format!(
+                "3D reference requires two sheet names: {first}:{last}!{ref_part}"
+            )));
+        }
+        if ref_part.is_empty() {
+            return Err(ParsingError::InvalidReference(format!(
+                "3D reference {first}:{last}! is missing a cell or range"
+            )));
+        }
+        // 3D refs cannot point at structured table tokens.
+        if ref_part.contains('[') {
+            return Err(ParsingError::InvalidReference(format!(
+                "3D reference {first}:{last}!{ref_part} cannot target a table"
+            )));
+        }
+
+        if ref_part.contains(':') {
+            let mut parts = ref_part.splitn(2, ':');
+            let start = parts.next().unwrap();
+            let end = parts.next().ok_or_else(|| {
+                ParsingError::InvalidReference(format!("Invalid range: {ref_part}"))
+            })?;
+            let (start_col, start_row) = Self::parse_range_part_with_abs(start)?;
+            let (end_col, end_row) = Self::parse_range_part_with_abs(end)?;
+
+            let split = |bound: Option<(u32, bool)>| match bound {
+                Some((index, abs)) => (Some(index), abs),
+                None => (None, false),
+            };
+            let (start_col, start_col_abs) = split(start_col);
+            let (start_row, start_row_abs) = split(start_row);
+            let (end_col, end_col_abs) = split(end_col);
+            let (end_row, end_row_abs) = split(end_row);
+
+            Ok(ReferenceType::Range3D {
+                sheet_first: first.to_string(),
+                sheet_last: last.to_string(),
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                start_row_abs,
+                start_col_abs,
+                end_row_abs,
+                end_col_abs,
+            })
+        } else {
+            let (col, row, col_abs, row_abs) =
+                Self::parse_cell_reference(ref_part).map_err(|_| {
+                    ParsingError::InvalidReference(format!(
+                        "Invalid 3D reference target: {ref_part}"
+                    ))
+                })?;
+            Ok(ReferenceType::Cell3D {
+                sheet_first: first.to_string(),
+                sheet_last: last.to_string(),
+                row,
+                col,
+                row_abs,
+                col_abs,
+            })
+        }
+    }
+
     fn parse_excel_reference(reference: &str) -> Result<Self, ParsingError> {
         // Excel structured reference shorthands that appear as a single bracketed token.
         //
@@ -686,8 +798,21 @@ impl ReferenceType {
             return Self::parse_bracketed_structured_reference(reference);
         }
 
-        // Extract sheet name if present
-        let (sheet, ref_part) = Self::extract_sheet_name(reference);
+        // Extract sheet specification (none / single / 3D range) if present.
+        let (sheet_spec, ref_part) = Self::extract_sheet_spec(reference);
+
+        // 3D references (`Sheet1:Sheet3!A1` / `Sheet1:Sheet3!A1:B2`) take a
+        // dedicated path because they cannot reuse the 2D Cell/Range carriers.
+        if let SheetSpec::Range { first, last, .. } = &sheet_spec {
+            return Self::parse_3d_reference(first, last, &ref_part);
+        }
+
+        let sheet = match sheet_spec {
+            SheetSpec::None => None,
+            SheetSpec::Single(name) => Some(name),
+            // Already handled above.
+            SheetSpec::Range { .. } => unreachable!(),
+        };
 
         // Table references live in the ref_part (e.g., "Table1[Column]").
         // Sheet names can contain '[' for external workbook refs (e.g., "[1]Sheet1!A1").
@@ -919,6 +1044,55 @@ impl Display for ReferenceType {
                         range_part
                     }
                 }
+                ReferenceType::Cell3D {
+                    sheet_first,
+                    sheet_last,
+                    row,
+                    col,
+                    row_abs,
+                    col_abs,
+                } => {
+                    let col_str = Self::format_col(*col, *col_abs);
+                    let row_str = Self::format_row(*row, *row_abs);
+                    let prefix = format_3d_sheet_prefix(sheet_first, sheet_last);
+                    format!("{prefix}!{col_str}{row_str}")
+                }
+                ReferenceType::Range3D {
+                    sheet_first,
+                    sheet_last,
+                    start_row,
+                    start_col,
+                    end_row,
+                    end_col,
+                    start_row_abs,
+                    start_col_abs,
+                    end_row_abs,
+                    end_col_abs,
+                } => {
+                    let start_ref = match (start_col, start_row) {
+                        (Some(col), Some(row)) => format!(
+                            "{}{}",
+                            Self::format_col(*col, *start_col_abs),
+                            Self::format_row(*row, *start_row_abs)
+                        ),
+                        (Some(col), None) => Self::format_col(*col, *start_col_abs),
+                        (None, Some(row)) => Self::format_row(*row, *start_row_abs),
+                        (None, None) => "".to_string(),
+                    };
+                    let end_ref = match (end_col, end_row) {
+                        (Some(col), Some(row)) => format!(
+                            "{}{}",
+                            Self::format_col(*col, *end_col_abs),
+                            Self::format_row(*row, *end_row_abs)
+                        ),
+                        (Some(col), None) => Self::format_col(*col, *end_col_abs),
+                        (None, Some(row)) => Self::format_row(*row, *end_row_abs),
+                        (None, None) => "".to_string(),
+                    };
+                    let range_part = format!("{start_ref}:{end_ref}");
+                    let prefix = format_3d_sheet_prefix(sheet_first, sheet_last);
+                    format!("{prefix}!{range_part}")
+                }
                 ReferenceType::External(ext) => ext.raw.clone(),
                 ReferenceType::Table(table_ref) => {
                     if let Some(specifier) = &table_ref.specifier {
@@ -946,6 +1120,21 @@ impl Display for ReferenceType {
     }
 }
 
+/// Render the `Sheet1:SheetN` portion of a 3D reference. Either side may
+/// require quoting independently; quoting one side does not force the other
+/// to be quoted, matching Excel's behaviour.
+fn format_3d_sheet_prefix(first: &str, last: &str) -> String {
+    let format_one = |name: &str| -> String {
+        if sheet_name_needs_quoting(name) {
+            let escaped = name.replace('\'', "''");
+            format!("'{escaped}'")
+        } else {
+            name.to_string()
+        }
+    };
+    format!("{}:{}", format_one(first), format_one(last))
+}
+
 impl TryFrom<&str> for ReferenceType {
     type Error = ParsingError;
 
@@ -968,51 +1157,130 @@ impl ReferenceType {
         format!("{self}")
     }
 
-    /// Extract a sheet name from a reference using byte operations.
-    fn extract_sheet_name(reference: &str) -> (Option<String>, String) {
+    /// Read one sheet-name segment starting at `start`. Returns the parsed
+    /// (unescaped) name, the byte offset directly after the closing quote
+    /// (when quoted) or the last alphanumeric byte (when bare), and a flag
+    /// indicating whether the segment was quoted.
+    fn read_sheet_segment(reference: &str, start: usize) -> Option<(String, usize, bool)> {
         let bytes = reference.as_bytes();
-        let mut i = 0;
+        if start >= bytes.len() {
+            return None;
+        }
 
-        // Handle quoted sheet names.
-        // Excel escapes a single quote inside a quoted sheet name by doubling it.
-        // Example: 'Bob''s Sheet'!A1
-        if i < bytes.len() && bytes[i] == b'\'' {
-            i += 1;
-            let start = i;
-
+        if bytes[start] == b'\'' {
+            // Quoted segment. Excel doubles a literal `'` inside the name.
+            let mut i = start + 1;
+            let body_start = i;
             while i < bytes.len() {
                 if bytes[i] == b'\'' {
-                    // Escaped quote inside sheet name: ''
                     if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
                         i += 2;
                         continue;
                     }
-
-                    // Closing quote followed by '!'
-                    if i + 1 < bytes.len() && bytes[i + 1] == b'!' {
-                        let raw = &reference[start..i];
-                        let sheet = raw.replace("''", "'");
-                        let ref_part = String::from(&reference[i + 2..]);
-                        return (Some(sheet), ref_part);
-                    }
+                    let raw = &reference[body_start..i];
+                    let name = raw.replace("''", "'");
+                    return Some((name, i + 1, true));
                 }
-
                 i += 1;
+            }
+            None
+        } else {
+            // Bare segment. Sheet names cannot contain ':', '!', '\'', or any
+            // ASCII-whitespace/operator characters in unquoted form.
+            let mut i = start;
+            while i < bytes.len() {
+                let b = bytes[i];
+                match b {
+                    b':' | b'!' | b'\'' | b' ' | b'\t' | b'\n' | b'\r' => break,
+                    _ => i += 1,
+                }
+            }
+            if i == start {
+                None
+            } else {
+                Some((reference[start..i].to_string(), i, false))
+            }
+        }
+    }
+
+    /// Extract sheet specification (none, single sheet, or 3D sheet range)
+    /// from a reference string.
+    fn extract_sheet_spec(reference: &str) -> (SheetSpec, String) {
+        let Some((first_name, after_first, first_quoted)) = Self::read_sheet_segment(reference, 0)
+        else {
+            // No sheet segment recognised – fall back to looking for a bare
+            // `!` separator (e.g. external book tokens such as `[1]Sheet!A1`).
+            return Self::extract_sheet_spec_fallback(reference);
+        };
+        let _ = first_quoted;
+
+        let bytes = reference.as_bytes();
+
+        // 3D form: Name1:Name2!...
+        if after_first < bytes.len() && bytes[after_first] == b':' {
+            let second_start = after_first + 1;
+            if let Some((second_name, after_second, _)) =
+                Self::read_sheet_segment(reference, second_start)
+                && after_second < bytes.len()
+                && bytes[after_second] == b'!'
+            {
+                let ref_part = reference[after_second + 1..].to_string();
+                return (
+                    SheetSpec::Range {
+                        first: first_name,
+                        last: second_name,
+                    },
+                    ref_part,
+                );
+            }
+
+            // The reference looks like the start of a 3D ref but the second
+            // segment is malformed (e.g. `Sheet1:!A1`). Surface the broken
+            // form as a 3D range with an empty `last` so the parser layer
+            // can report a precise error rather than silently treating it as
+            // a sheet name containing `:`.
+            if second_start < bytes.len() {
+                if let Some(bang) = reference[second_start..].find('!') {
+                    let ref_part = reference[second_start + bang + 1..].to_string();
+                    return (
+                        SheetSpec::Range {
+                            first: first_name,
+                            last: String::new(),
+                        },
+                        ref_part,
+                    );
+                }
             }
         }
 
-        // Handle unquoted sheet names
-        i = 0;
+        // Single-sheet form: Name!...
+        if after_first < bytes.len() && bytes[after_first] == b'!' {
+            let ref_part = reference[after_first + 1..].to_string();
+            return (SheetSpec::Single(first_name), ref_part);
+        }
+
+        // The leading segment did not terminate in `!`; treat the whole input
+        // as if no sheet were present and fall through to the legacy logic.
+        Self::extract_sheet_spec_fallback(reference)
+    }
+
+    fn extract_sheet_spec_fallback(reference: &str) -> (SheetSpec, String) {
+        let bytes = reference.as_bytes();
+        // Handle unquoted sheet names containing characters our segment
+        // reader rejects (such as bracketed external workbook tokens, e.g.
+        // `[1]Sheet1!A1`). The original implementation scanned for the first
+        // `!` after byte 0; preserve that behaviour for compatibility.
+        let mut i = 0;
         while i < bytes.len() {
             if bytes[i] == b'!' && i > 0 {
-                let sheet = String::from(&reference[0..i]);
-                let ref_part = String::from(&reference[i + 1..]);
-                return (Some(sheet), ref_part);
+                let sheet = reference[..i].to_string();
+                let ref_part = reference[i + 1..].to_string();
+                return (SheetSpec::Single(sheet), ref_part);
             }
             i += 1;
         }
 
-        (None, reference.to_string())
+        (SheetSpec::None, reference.to_string())
     }
 
     /// Parse a table reference like "Table1[Column1]" or more complex ones like "Table1[[#All],[Column1]:[Column2]]".
@@ -1415,6 +1683,7 @@ impl ReferenceType {
                     range_part
                 }
             }
+            ReferenceType::Cell3D { .. } | ReferenceType::Range3D { .. } => format!("{self}"),
             ReferenceType::External(ext) => ext.raw.clone(),
             ReferenceType::Table(table_ref) => {
                 if let Some(specifier) = &table_ref.specifier {
@@ -1708,6 +1977,44 @@ impl ASTNode {
                     end_col_abs,
                 });
             }
+            RefView::Cell3D {
+                sheet_first,
+                sheet_last,
+                row,
+                col,
+                row_abs,
+                col_abs,
+            } => out.push(ReferenceType::Cell3D {
+                sheet_first: sheet_first.to_string(),
+                sheet_last: sheet_last.to_string(),
+                row,
+                col,
+                row_abs,
+                col_abs,
+            }),
+            RefView::Range3D {
+                sheet_first,
+                sheet_last,
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                start_row_abs,
+                start_col_abs,
+                end_row_abs,
+                end_col_abs,
+            } => out.push(ReferenceType::Range3D {
+                sheet_first: sheet_first.to_string(),
+                sheet_last: sheet_last.to_string(),
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                start_row_abs,
+                start_col_abs,
+                end_row_abs,
+                end_col_abs,
+            }),
             RefView::External {
                 raw,
                 book,
@@ -1748,6 +2055,27 @@ impl ASTNode {
                     *sheet = Some(new_name.to_string());
                 }
             }
+            ASTNodeType::Reference {
+                reference:
+                    ReferenceType::Cell3D {
+                        sheet_first,
+                        sheet_last,
+                        ..
+                    }
+                    | ReferenceType::Range3D {
+                        sheet_first,
+                        sheet_last,
+                        ..
+                    },
+                ..
+            } => {
+                if target_name.is_none() || target_name == Some(sheet_first.as_str()) {
+                    *sheet_first = new_name.to_string();
+                }
+                if target_name.is_none() || target_name == Some(sheet_last.as_str()) {
+                    *sheet_last = new_name.to_string();
+                }
+            }
             ASTNodeType::UnaryOp { expr, .. } => {
                 expr.update_sheet_references(target_name, new_name);
             }
@@ -1784,6 +2112,28 @@ pub enum RefView<'a> {
     },
     Range {
         sheet: Option<&'a str>,
+        start_row: Option<u32>,
+        start_col: Option<u32>,
+        end_row: Option<u32>,
+        end_col: Option<u32>,
+        start_row_abs: bool,
+        start_col_abs: bool,
+        end_row_abs: bool,
+        end_col_abs: bool,
+    },
+    /// 3D cell view (`Sheet1:Sheet3!A1`).
+    Cell3D {
+        sheet_first: &'a str,
+        sheet_last: &'a str,
+        row: u32,
+        col: u32,
+        row_abs: bool,
+        col_abs: bool,
+    },
+    /// 3D range view (`Sheet1:Sheet3!A1:B2`).
+    Range3D {
+        sheet_first: &'a str,
+        sheet_last: &'a str,
         start_row: Option<u32>,
         start_col: Option<u32>,
         end_row: Option<u32>,
@@ -1836,6 +2186,44 @@ impl<'a> From<&'a ReferenceType> for RefView<'a> {
                 end_col_abs,
             } => RefView::Range {
                 sheet: sheet.as_deref(),
+                start_row: *start_row,
+                start_col: *start_col,
+                end_row: *end_row,
+                end_col: *end_col,
+                start_row_abs: *start_row_abs,
+                start_col_abs: *start_col_abs,
+                end_row_abs: *end_row_abs,
+                end_col_abs: *end_col_abs,
+            },
+            ReferenceType::Cell3D {
+                sheet_first,
+                sheet_last,
+                row,
+                col,
+                row_abs,
+                col_abs,
+            } => RefView::Cell3D {
+                sheet_first: sheet_first.as_str(),
+                sheet_last: sheet_last.as_str(),
+                row: *row,
+                col: *col,
+                row_abs: *row_abs,
+                col_abs: *col_abs,
+            },
+            ReferenceType::Range3D {
+                sheet_first,
+                sheet_last,
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                start_row_abs,
+                start_col_abs,
+                end_row_abs,
+                end_col_abs,
+            } => RefView::Range3D {
+                sheet_first: sheet_first.as_str(),
+                sheet_last: sheet_last.as_str(),
                 start_row: *start_row,
                 start_col: *start_col,
                 end_row: *end_row,

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -2081,4 +2081,201 @@ mod semantics_regressions {
             ReferenceType::cell(Some("Bob's Sheet".to_string()), 1, 1)
         );
     }
+
+    mod sheet_3d_references {
+        use crate::parser::{
+            ASTNode, ASTNodeType, Parser, ParserError, ReferenceType, parse as parse_span,
+        };
+        use crate::tokenizer::Tokenizer;
+
+        fn parse_classic(formula: &str) -> Result<ASTNode, ParserError> {
+            let tokenizer = Tokenizer::new(formula).map_err(|e| ParserError {
+                message: e.to_string(),
+                position: Some(e.pos),
+            })?;
+            let mut parser = Parser::new(tokenizer.items, false);
+            parser.parse()
+        }
+
+        fn parse_both(formula: &str) -> ASTNode {
+            let classic = parse_classic(formula).expect("classic parser");
+            let span = parse_span(formula).expect("span parser");
+            // Both paths should agree on the parsed reference shape.
+            assert_eq!(classic.node_type, span.node_type);
+            classic
+        }
+
+        fn extract_reference(ast: &ASTNode) -> &ReferenceType {
+            match &ast.node_type {
+                ASTNodeType::Reference { reference, .. } => reference,
+                other => panic!("expected reference, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn test_3d_cell_bare() {
+            let ast = parse_both("=Sheet1:Sheet3!A1");
+            assert_eq!(
+                extract_reference(&ast),
+                &ReferenceType::Cell3D {
+                    sheet_first: "Sheet1".to_string(),
+                    sheet_last: "Sheet3".to_string(),
+                    row: 1,
+                    col: 1,
+                    row_abs: false,
+                    col_abs: false,
+                }
+            );
+        }
+
+        #[test]
+        fn test_3d_cell_quoted() {
+            let ast = parse_both("='Sheet 1':'Sheet 3'!A1");
+            assert_eq!(
+                extract_reference(&ast),
+                &ReferenceType::Cell3D {
+                    sheet_first: "Sheet 1".to_string(),
+                    sheet_last: "Sheet 3".to_string(),
+                    row: 1,
+                    col: 1,
+                    row_abs: false,
+                    col_abs: false,
+                }
+            );
+        }
+
+        #[test]
+        fn test_3d_range() {
+            let ast = parse_both("=Sheet1:Sheet3!A1:B2");
+            assert_eq!(
+                extract_reference(&ast),
+                &ReferenceType::Range3D {
+                    sheet_first: "Sheet1".to_string(),
+                    sheet_last: "Sheet3".to_string(),
+                    start_row: Some(1),
+                    start_col: Some(1),
+                    end_row: Some(2),
+                    end_col: Some(2),
+                    start_row_abs: false,
+                    start_col_abs: false,
+                    end_row_abs: false,
+                    end_col_abs: false,
+                }
+            );
+        }
+
+        #[test]
+        fn test_3d_range_absolute() {
+            let ast = parse_both("=Sheet1:Sheet3!$A$1:$B$2");
+            assert_eq!(
+                extract_reference(&ast),
+                &ReferenceType::Range3D {
+                    sheet_first: "Sheet1".to_string(),
+                    sheet_last: "Sheet3".to_string(),
+                    start_row: Some(1),
+                    start_col: Some(1),
+                    end_row: Some(2),
+                    end_col: Some(2),
+                    start_row_abs: true,
+                    start_col_abs: true,
+                    end_row_abs: true,
+                    end_col_abs: true,
+                }
+            );
+        }
+
+        #[test]
+        fn test_3d_inside_sum() {
+            let ast = parse_both("=SUM(Sheet1:Sheet3!A1)");
+            let args = match &ast.node_type {
+                ASTNodeType::Function { name, args } => {
+                    assert_eq!(name, "SUM");
+                    args
+                }
+                other => panic!("expected function, got {other:?}"),
+            };
+            assert_eq!(args.len(), 1);
+            assert_eq!(
+                extract_reference(&args[0]),
+                &ReferenceType::Cell3D {
+                    sheet_first: "Sheet1".to_string(),
+                    sheet_last: "Sheet3".to_string(),
+                    row: 1,
+                    col: 1,
+                    row_abs: false,
+                    col_abs: false,
+                }
+            );
+        }
+
+        #[test]
+        fn test_3d_quoted_escape() {
+            let ast = parse_both("='Bob''s Sheet':'End Sheet'!A1");
+            assert_eq!(
+                extract_reference(&ast),
+                &ReferenceType::Cell3D {
+                    sheet_first: "Bob's Sheet".to_string(),
+                    sheet_last: "End Sheet".to_string(),
+                    row: 1,
+                    col: 1,
+                    row_abs: false,
+                    col_abs: false,
+                }
+            );
+        }
+
+        #[test]
+        fn test_sheet_named_with_embedded_colon() {
+            // Excel forbids ':' in sheet names, so a quoted sheet whose name
+            // contains ':' must still parse as a single-sheet reference.
+            let r = ReferenceType::from_string("'Weird:Name'!A1").unwrap();
+            assert_eq!(
+                r,
+                ReferenceType::Cell {
+                    sheet: Some("Weird:Name".to_string()),
+                    row: 1,
+                    col: 1,
+                    row_abs: false,
+                    col_abs: false,
+                }
+            );
+        }
+
+        #[test]
+        fn test_incomplete_3d_reference() {
+            // Sheet1: with empty second sheet name should be a parse error.
+            assert!(parse_classic("=Sheet1:!A1").is_err());
+            assert!(parse_span("=Sheet1:!A1").is_err());
+        }
+
+        #[test]
+        fn test_3d_without_cell_part() {
+            // Sheet range without any cell reference is invalid.
+            assert!(parse_classic("=Sheet1:Sheet3!").is_err());
+            assert!(parse_span("=Sheet1:Sheet3!").is_err());
+        }
+
+        #[test]
+        fn test_3d_display_roundtrip() {
+            let cases = [
+                "=Sheet1:Sheet3!A1",
+                "=Sheet1:Sheet3!A1:B2",
+                "=Sheet1:Sheet3!$A$1:$B$2",
+                "='Sheet 1':'Sheet 3'!A1",
+                "='Bob''s Sheet':'End Sheet'!A1",
+            ];
+            for input in cases {
+                let ast = parse_both(input);
+                let r = extract_reference(&ast);
+                let rendered = format!("={r}");
+                assert_eq!(rendered, input, "display roundtrip mismatch for {input}");
+                let reparsed_ast = parse_both(&rendered);
+                assert_eq!(
+                    extract_reference(&reparsed_ast),
+                    r,
+                    "reparse mismatch for {input}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Excel 3D references such as `Sheet1:Sheet3!A1` and `=SUM(Sheet1:Sheet3!A1:B2)` were being silently mis-parsed as ordinary cell/range references on a sheet literally named `Sheet1:Sheet3` (or `Sheet 1':'Sheet 3` for quoted forms). Downstream evaluators would then return `#REF!` or, worse, the wrong answer.

This PR adds correct parsing for 3D references, preserves them through Display, and keeps every downstream pattern-match exhaustive. Evaluator-level 3D aggregation is intentionally left as future work (the resolver returns `#N/IMPL!` for now, per the issue's acceptance criteria).

## Implementation

- **AST shape** — adopts the issue's recommended approach: new `ReferenceType::Cell3D` / `Range3D` variants carrying `sheet_first`, `sheet_last`, anchor flags, and (for `Range3D`) optional bounds. Existing 2D `Cell` / `Range` variants are unchanged so 2D consumers are unaffected.
- **Parser** — replaces `extract_sheet_name` with a 3D-aware `extract_sheet_spec` that distinguishes `None` / `Single` / `Range { first, last }` and preserves single-quote escaping (`''` → `'`) on both sides. Bare and quoted segment readers reject `:` / `!` inside unquoted names. Malformed 3D forms (`Sheet1:!A1`, `Sheet1:Sheet3!`) now produce a parser error instead of falling back to a bogus single-sheet ref. The `parse_excel_reference` path dispatches to a dedicated `parse_3d_reference` helper that produces `Cell3D` / `Range3D`.
- **Display / roundtrip** — `Display` and `to_excel_string` render `Sheet1:Sheet3!A1`, quoting each side independently with doubled-quote escaping when required.
- **Cross-cutting traversal updates** —
  - `RefView` gains `Cell3D` / `Range3D` borrowed views; `From<&ReferenceType>`, `collect_references`, and `update_sheet_references` handle them.
  - `formualizer-eval` arena (`CompactRefType`) gains matching `Cell3D` / `Range3D` variants with intern/round-trip support so AST deduplication keeps working.
  - `Resolver::resolve_range_like`, `engine::eval::resolve_range_view`, `engine::plan::collect_dependencies`, and `engine::graph::formula_analysis` all add explicit arms for the new variants. Resolver/eval surface `#N/IMPL!` for 3D until a follow-up implements aggregation; plan / formula-analysis treat them as no-op dependencies so loading workbooks containing 3D formulas does not break.
  - WASM and Python bindings keep their reference conversions exhaustive (`Err(\"3D references are not supported\")` and `ReferenceLike::Unknown` respectively).
- **`SheetRef` parsing** — `parse_excel_sheet_ref` now explicitly rejects 3D inputs with `InvalidReference` rather than producing a `SheetRef` carrying a sheet name with an embedded `:`.

## Tests

New `mod sheet_3d_references` in `crates/formualizer-parse/src/tests/parser.rs` (10 tests, each exercises both the classic `Parser` and span-based `parse` paths via a `parse_both` helper that asserts the two AST shapes agree):

- `test_3d_cell_bare` — `=Sheet1:Sheet3!A1` → `Cell3D`
- `test_3d_cell_quoted` — `='Sheet 1':'Sheet 3'!A1`
- `test_3d_range` — `=Sheet1:Sheet3!A1:B2` → `Range3D`
- `test_3d_range_absolute` — `=Sheet1:Sheet3!\$A\$1:\$B\$2` preserves anchors
- `test_3d_inside_sum` — `=SUM(Sheet1:Sheet3!A1)`
- `test_3d_quoted_escape` — `='Bob''s Sheet':'End Sheet'!A1`
- `test_sheet_named_with_embedded_colon` — `'Weird:Name'!A1` stays a single-sheet ref
- `test_incomplete_3d_reference` — `=Sheet1:!A1` → ParserError on both paths
- `test_3d_without_cell_part` — `=Sheet1:Sheet3!` → ParserError on both paths
- `test_3d_display_roundtrip` — bare, range, absolute, quoted, and escaped-quote forms parse → Display → reparse to the same AST

## Validation

```
cargo fmt --all
cargo test -p formualizer-parse sheet_3d_references   # 10/10 pass
cargo test -p formualizer-parse                       # 167 + 3 + 0 pass
cargo test --workspace --no-fail-fast                 # all suites green (no FAILED)
cargo clippy -p formualizer-parse --all-targets -- -D warnings
cargo clippy --workspace --all-targets -- -D warnings
```

## Follow-up

Evaluator support for aggregating across the 3D sheet range is intentionally out of scope per the issue and should be tracked as a follow-up against the eval crate.

Closes #70