### PR TITLE
feat(parser): implement reference operators

### DIFF
--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -2509,8 +2509,10 @@ impl<'a> SpanParser<'a> {
         };
 
         match op {
-            "#" => Some((9, Associativity::Left)),
-            ":" | " " | "," => Some((8, Associativity::Left)),
+            "#" => Some((11, Associativity::Left)),
+            ":" => Some((10, Associativity::Left)),
+            " " => Some((9, Associativity::Left)),
+            "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
             "u" => Some((6, Associativity::Right)),
             "^" => Some((5, Associativity::Right)),

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -22,7 +22,9 @@ enum Side {
 
 fn infix_info(op: &str) -> (u8, Associativity) {
     match op {
-        ":" | " " | "," => (8, Associativity::Left),
+        ":" => (10, Associativity::Left),
+        " " => (9, Associativity::Left),
+        "," => (8, Associativity::Left),
         "^" => (5, Associativity::Right),
         "*" | "/" => (4, Associativity::Left),
         "+" | "-" => (3, Associativity::Left),
@@ -34,7 +36,7 @@ fn infix_info(op: &str) -> (u8, Associativity) {
 
 fn unary_precedence(op: &str) -> u8 {
     match op {
-        "#" => 9,
+        "#" => 11,
         "%" => 7,
         _ => 6,
     }
@@ -154,11 +156,13 @@ fn pretty_print_node(ast: &ASTNode) -> String {
             let left_s = pretty_child(left, op, prec, assoc, Side::Left);
             let right_s = pretty_child(right, op, prec, assoc, Side::Right);
 
-            // Special handling for range operator ':'
-            if op == ":" {
-                format!("{left_s}:{right_s}")
-            } else {
-                format!("{left_s} {op} {right_s}")
+            match op.as_str() {
+                // Reference range operator prints tight; intersection is a
+                // single space rather than the generic three-space infix form.
+                ":" => format!("{left_s}:{right_s}"),
+                " " => format!("{left_s} {right_s}"),
+                "," => format!("{left_s}, {right_s}"),
+                _ => format!("{left_s} {op} {right_s}"),
             }
         }
         ASTNodeType::Function { name, args } => {

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -1107,6 +1107,284 @@ mod tests {
             assert_eq!(pretty, again);
         }
     }
+
+    mod reference_operators {
+        use super::parse_formula;
+        use crate::parser::{ASTNode, ASTNodeType, ReferenceType};
+        use crate::pretty::pretty_parse_render;
+
+        fn parse_both(formula: &str) -> [ASTNode; 2] {
+            let classic = parse_formula(formula)
+                .unwrap_or_else(|e| panic!("classic parser failed for {formula:?}: {e:?}"));
+            let span = crate::parser::parse(formula)
+                .unwrap_or_else(|e| panic!("span parser failed for {formula:?}: {e:?}"));
+            [classic, span]
+        }
+
+        fn assert_both_err(formula: &str) {
+            assert!(
+                parse_formula(formula).is_err(),
+                "classic parser unexpectedly accepted {formula:?}"
+            );
+            assert!(
+                crate::parser::parse(formula).is_err(),
+                "span parser unexpectedly accepted {formula:?}"
+            );
+        }
+
+        fn assert_range_ref(node: &ASTNode, expected_str: &str) {
+            match &node.node_type {
+                ASTNodeType::Reference {
+                    reference,
+                    original,
+                } => {
+                    assert!(
+                        matches!(reference, ReferenceType::Range { .. }),
+                        "expected Range ref for {expected_str:?}, got {reference:?}"
+                    );
+                    assert_eq!(original, expected_str);
+                }
+                other => panic!("expected Reference({expected_str:?}), got {other:?}"),
+            }
+        }
+
+        fn assert_cell_ref(node: &ASTNode, expected_str: &str) {
+            match &node.node_type {
+                ASTNodeType::Reference {
+                    reference,
+                    original,
+                } => {
+                    assert!(
+                        matches!(reference, ReferenceType::Cell { .. }),
+                        "expected Cell ref for {expected_str:?}, got {reference:?}"
+                    );
+                    assert_eq!(original, expected_str);
+                }
+                other => panic!("expected Reference({expected_str:?}), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn space_intersection_basic() {
+            for ast in parse_both("=A1:A3 B1:B3") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, " ");
+                        assert_range_ref(&left, "A1:A3");
+                        assert_range_ref(&right, "B1:B3");
+                    }
+                    other => panic!("expected BinaryOp(\" \", ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn space_intersection_inside_function() {
+            for ast in parse_both("=SUM(A1:A3 A2:C2)") {
+                match ast.node_type {
+                    ASTNodeType::Function { name, args } => {
+                        assert_eq!(name, "SUM");
+                        assert_eq!(args.len(), 1);
+                        match &args[0].node_type {
+                            ASTNodeType::BinaryOp { op, left, right } => {
+                                assert_eq!(op, " ");
+                                assert_range_ref(left, "A1:A3");
+                                assert_range_ref(right, "A2:C2");
+                            }
+                            other => panic!("expected BinaryOp arg, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected Function, got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn colon_composed_with_function() {
+            for ast in parse_both("=OFFSET(A1,1,1):B10") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, ":");
+                        match &left.node_type {
+                            ASTNodeType::Function { name, .. } => {
+                                assert_eq!(name, "OFFSET");
+                            }
+                            other => panic!("expected OFFSET function on left, got {other:?}"),
+                        }
+                        assert_cell_ref(&right, "B10");
+                    }
+                    other => panic!("expected BinaryOp(:, ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn colon_composed_with_index() {
+            for ast in parse_both("=INDEX(A:A,1):B10") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, ":");
+                        match &left.node_type {
+                            ASTNodeType::Function { name, .. } => {
+                                assert_eq!(name, "INDEX");
+                            }
+                            other => panic!("expected INDEX function on left, got {other:?}"),
+                        }
+                        assert_cell_ref(&right, "B10");
+                    }
+                    other => panic!("expected BinaryOp(:, ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn colon_composed_with_paren() {
+            for ast in parse_both("=(A1:A3):A5") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, ":");
+                        assert_range_ref(&left, "A1:A3");
+                        assert_cell_ref(&right, "A5");
+                    }
+                    other => panic!("expected BinaryOp(:, ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn cross_sheet_range() {
+            // 'Sheet1'!A1:'Sheet2'!B1 must compose as BinaryOp(:, A1, B1) with
+            // distinct sheets on each side.
+            for ast in parse_both("='Sheet1'!A1:'Sheet2'!B1") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, ":");
+                        match &left.node_type {
+                            ASTNodeType::Reference { reference, .. } => match reference {
+                                ReferenceType::Cell { sheet, .. } => {
+                                    assert_eq!(sheet.as_deref(), Some("Sheet1"));
+                                }
+                                other => panic!("expected Sheet1 cell, got {other:?}"),
+                            },
+                            other => panic!("expected Reference on left, got {other:?}"),
+                        }
+                        match &right.node_type {
+                            ASTNodeType::Reference { reference, .. } => match reference {
+                                ReferenceType::Cell { sheet, .. } => {
+                                    assert_eq!(sheet.as_deref(), Some("Sheet2"));
+                                }
+                                other => panic!("expected Sheet2 cell, got {other:?}"),
+                            },
+                            other => panic!("expected Reference on right, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected BinaryOp(:, ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn chained_colon() {
+            // =A1:A3:A5 — the first simple range remains on the fast path, then
+            // the second colon is parsed as a composed reference operator.
+            for ast in parse_both("=A1:A3:A5") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, ":");
+                        assert_range_ref(&left, "A1:A3");
+                        assert_cell_ref(&right, "A5");
+                    }
+                    other => panic!("expected BinaryOp(:, ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn intersection_precedence_below_colon() {
+            // =A1:B2 C1:D2 → BinaryOp(" ", Range(A1:B2), Range(C1:D2)).
+            // Both sides must be ranges (the simple-range fast path is preserved).
+            for ast in parse_both("=A1:B2 C1:D2") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right } => {
+                        assert_eq!(op, " ");
+                        assert_range_ref(&left, "A1:B2");
+                        assert_range_ref(&right, "C1:D2");
+                    }
+                    other => panic!("expected BinaryOp(\" \", ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn implicit_intersection_binds_tighter_than_colon() {
+            // =(@A1):A3 must produce BinaryOp(:, UnaryOp(@, A1), A3) — i.e. '@'
+            // attaches to A1 first because it is a prefix unary. The parentheses
+            // force a composed colon instead of the simple-range fast path.
+            for ast in parse_both("=(@A1):A3") {
+                match ast.node_type {
+                    ASTNodeType::BinaryOp { op, left, right: _ } => {
+                        assert_eq!(op, ":");
+                        match &left.node_type {
+                            ASTNodeType::UnaryOp { op, .. } => assert_eq!(op, "@"),
+                            other => panic!("expected UnaryOp(@, ...) on left, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected BinaryOp(:, ...), got {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn trailing_space_after_ref_is_not_intersection() {
+            // =A1 — trailing whitespace must not turn A1 into a binary op.
+            for ast in parse_both("=A1 ") {
+                assert!(matches!(ast.node_type, ASTNodeType::Reference { .. }));
+            }
+        }
+
+        #[test]
+        fn colon_with_no_rhs_is_error() {
+            assert_both_err("=A1: ");
+            assert_both_err("=A1:");
+        }
+
+        #[test]
+        fn leading_colon_is_error() {
+            assert_both_err("= :A1");
+        }
+
+        #[test]
+        fn space_between_function_name_and_paren_is_error() {
+            assert_both_err("=SUM A1");
+        }
+
+        #[test]
+        fn simple_range_remains_single_operand() {
+            // Regression guard: =A1:B2 still tokenizes as one Operand:Range.
+            use crate::tokenizer::{TokenStream, TokenType, Tokenizer};
+            let classic = Tokenizer::new("=A1:B2").unwrap();
+            assert_eq!(classic.items.len(), 1);
+            assert_eq!(classic.items[0].token_type, TokenType::Operand);
+            assert_eq!(classic.items[0].value, "A1:B2");
+            let span = TokenStream::new("=A1:B2").unwrap();
+            assert_eq!(span.spans.len(), 1);
+            assert_eq!(span.spans[0].token_type, TokenType::Operand);
+        }
+
+        #[test]
+        fn pretty_print_intersection_and_colon() {
+            // Intersection space prints with single-space gap; colon prints tight.
+            let pretty = pretty_parse_render("=A1:A3 B1:B3").unwrap();
+            assert_eq!(pretty, "=A1:A3 B1:B3");
+            let again = pretty_parse_render(&pretty).unwrap();
+            assert_eq!(pretty, again);
+
+            let pretty = pretty_parse_render("=OFFSET(A1,1,1):B10").unwrap();
+            assert_eq!(pretty, "=OFFSET(A1, 1, 1):B10");
+            let again = pretty_parse_render(&pretty).unwrap();
+            assert_eq!(pretty, again);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -1655,4 +1655,176 @@ mod tests {
             assert_eq!(posts_span.len(), 2);
         }
     }
+
+    mod reference_operators {
+        use crate::tokenizer::{TokenStream, TokenSubType, TokenType, Tokenizer};
+
+        fn classic_non_ws(formula: &str) -> Vec<(TokenType, TokenSubType, String)> {
+            let t = Tokenizer::new(formula).expect("tokenize");
+            t.items
+                .iter()
+                .filter(|tok| tok.token_type != TokenType::Whitespace)
+                .map(|tok| (tok.token_type, tok.subtype, tok.value.clone()))
+                .collect()
+        }
+
+        fn classic_all(formula: &str) -> Vec<(TokenType, TokenSubType, String)> {
+            let t = Tokenizer::new(formula).expect("tokenize");
+            t.items
+                .iter()
+                .map(|tok| (tok.token_type, tok.subtype, tok.value.clone()))
+                .collect()
+        }
+
+        fn span_non_ws(formula: &str) -> Vec<(TokenType, TokenSubType, String)> {
+            let stream = TokenStream::new(formula).expect("span tokenize");
+            stream
+                .spans
+                .iter()
+                .filter(|span| span.token_type != TokenType::Whitespace)
+                .map(|span| {
+                    (
+                        span.token_type,
+                        span.subtype,
+                        formula[span.start..span.end].to_string(),
+                    )
+                })
+                .collect()
+        }
+
+        fn span_all(formula: &str) -> Vec<(TokenType, TokenSubType, String)> {
+            let stream = TokenStream::new(formula).expect("span tokenize");
+            stream
+                .spans
+                .iter()
+                .map(|span| {
+                    (
+                        span.token_type,
+                        span.subtype,
+                        formula[span.start..span.end].to_string(),
+                    )
+                })
+                .collect()
+        }
+
+        #[test]
+        fn space_between_ranges_is_intersection_op() {
+            // =A1:A3 B1:B3 → Range, OpInfix(" "), Range
+            let expected = vec![
+                (TokenType::Operand, TokenSubType::Range, "A1:A3".to_string()),
+                (TokenType::OpInfix, TokenSubType::None, " ".to_string()),
+                (TokenType::Operand, TokenSubType::Range, "B1:B3".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=A1:A3 B1:B3"), expected);
+            assert_eq!(span_non_ws("=A1:A3 B1:B3"), expected);
+        }
+
+        #[test]
+        fn space_not_between_refs_is_whitespace() {
+            // = 1 + 2 → all whitespace stays Whitespace.
+            let classic = classic_all("= 1 + 2 ");
+            // After leading '=' there is a leading Whitespace before 1.
+            assert_eq!(classic[0].0, TokenType::Whitespace);
+            // No OpInfix " " anywhere.
+            assert!(
+                classic
+                    .iter()
+                    .all(|t| !(t.0 == TokenType::OpInfix && t.2 == " ")),
+                "unexpected space-intersection in {classic:?}"
+            );
+            let span = span_all("= 1 + 2 ");
+            assert!(
+                span.iter()
+                    .all(|t| !(t.0 == TokenType::OpInfix && t.2 == " ")),
+                "unexpected space-intersection in {span:?}"
+            );
+        }
+
+        #[test]
+        fn colon_after_close_paren_is_op() {
+            // =SUM(A1):B2 → Func, Range(A1), FuncClose, OpInfix(:), Range(B2)
+            let expected = vec![
+                (TokenType::Func, TokenSubType::Open, "SUM(".to_string()),
+                (TokenType::Operand, TokenSubType::Range, "A1".to_string()),
+                (TokenType::Func, TokenSubType::Close, ")".to_string()),
+                (TokenType::OpInfix, TokenSubType::None, ":".to_string()),
+                (TokenType::Operand, TokenSubType::Range, "B2".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=SUM(A1):B2"), expected);
+            assert_eq!(span_non_ws("=SUM(A1):B2"), expected);
+        }
+
+        #[test]
+        fn colon_inside_simple_range_is_not_op() {
+            // =A1:B2 still tokenizes as a single Operand:Range.
+            let expected = vec![(TokenType::Operand, TokenSubType::Range, "A1:B2".to_string())];
+            assert_eq!(classic_non_ws("=A1:B2"), expected);
+            assert_eq!(span_non_ws("=A1:B2"), expected);
+        }
+
+        #[test]
+        fn nested_space_and_colon() {
+            // =(A1:A3) (B1:B3)
+            let expected = vec![
+                (TokenType::Paren, TokenSubType::Open, "(".to_string()),
+                (TokenType::Operand, TokenSubType::Range, "A1:A3".to_string()),
+                (TokenType::Paren, TokenSubType::Close, ")".to_string()),
+                (TokenType::OpInfix, TokenSubType::None, " ".to_string()),
+                (TokenType::Paren, TokenSubType::Open, "(".to_string()),
+                (TokenType::Operand, TokenSubType::Range, "B1:B3".to_string()),
+                (TokenType::Paren, TokenSubType::Close, ")".to_string()),
+            ];
+            assert_eq!(classic_non_ws("=(A1:A3) (B1:B3)"), expected);
+            assert_eq!(span_non_ws("=(A1:A3) (B1:B3)"), expected);
+        }
+
+        #[test]
+        fn colon_after_close_bracket_is_op() {
+            // =Table1[Col]:B10 → table reference followed by colon op.
+            let classic = classic_non_ws("=Table1[Col]:B10");
+            assert_eq!(classic.len(), 3);
+            assert_eq!(classic[0].0, TokenType::Operand);
+            assert_eq!(classic[0].2, "Table1[Col]");
+            assert_eq!(
+                (classic[1].0, classic[1].1, classic[1].2.as_str()),
+                (TokenType::OpInfix, TokenSubType::None, ":")
+            );
+            assert_eq!(classic[2].2, "B10");
+            let span = span_non_ws("=Table1[Col]:B10");
+            assert_eq!(
+                (span[1].0, span[1].1, span[1].2.as_str()),
+                (TokenType::OpInfix, TokenSubType::None, ":")
+            );
+        }
+
+        #[test]
+        fn colon_after_postfix_hash_is_op() {
+            // =A1#:B10
+            let classic = classic_non_ws("=A1#:B10");
+            assert_eq!(
+                classic
+                    .iter()
+                    .find(|t| t.2 == ":" && t.0 == TokenType::OpInfix)
+                    .map(|t| t.0),
+                Some(TokenType::OpInfix)
+            );
+            let span = span_non_ws("=A1#:B10");
+            assert!(span.iter().any(|t| t.2 == ":" && t.0 == TokenType::OpInfix));
+        }
+
+        #[test]
+        fn space_with_newline_between_refs_is_intersection_op() {
+            // Whitespace runs (including \n) collapse to OpInfix(" ") when both
+            // sides are reference-producing.
+            let classic = classic_non_ws("=A1:A3\n B1:B3");
+            assert!(
+                classic
+                    .iter()
+                    .any(|t| t.0 == TokenType::OpInfix && t.2.contains(' '))
+                    || classic
+                        .iter()
+                        .any(|t| t.0 == TokenType::OpInfix && t.2 == " ")
+            );
+        }
+    }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -255,8 +255,10 @@ impl Token {
         //   &
         //   comparisons
         match op {
-            "#" => Some((9, Associativity::Left)),
-            ":" | " " | "," => Some((8, Associativity::Left)),
+            "#" => Some((11, Associativity::Left)),
+            ":" => Some((10, Associativity::Left)),
+            " " => Some((9, Associativity::Left)),
+            "," => Some((8, Associativity::Left)),
             "%" => Some((7, Associativity::Left)),
             "u" => Some((6, Associativity::Right)),
             "^" => Some((5, Associativity::Right)),
@@ -596,6 +598,93 @@ fn operand_subtype(value_str: &str) -> TokenSubType {
     }
 }
 
+fn is_cell_reference_like(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut i = 0;
+
+    if i < bytes.len() && bytes[i] == b'$' {
+        i += 1;
+    }
+
+    let col_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+        i += 1;
+    }
+    if i == col_start {
+        return false;
+    }
+
+    if i < bytes.len() && bytes[i] == b'$' {
+        i += 1;
+    }
+
+    let row_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+
+    i == bytes.len() && i > row_start
+}
+
+fn reference_value_contains_range_colon(value: &str) -> bool {
+    let value_part = value
+        .rsplit_once('!')
+        .map_or(value, |(_, value_part)| value_part);
+    value_part.contains(':')
+}
+
+fn is_reference_operand_value(value: &str) -> bool {
+    operand_subtype(value) == TokenSubType::Range
+        && (reference_value_contains_range_colon(value)
+            || value.contains('!')
+            || value.contains('[')
+            || is_cell_reference_like(value))
+}
+
+fn next_starts_reference_expression(formula: &str, mut offset: usize) -> bool {
+    let bytes = formula.as_bytes();
+    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\n') {
+        offset += 1;
+    }
+    if offset >= bytes.len() {
+        return false;
+    }
+
+    matches!(bytes[offset], b'(' | b'[' | b'\'' | b'$') || bytes[offset].is_ascii_alphabetic()
+}
+
+fn next_reference_has_sheet_qualifier(formula: &str, mut offset: usize) -> bool {
+    let bytes = formula.as_bytes();
+    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\n') {
+        offset += 1;
+    }
+
+    let mut in_quote = false;
+    while offset < bytes.len() {
+        match bytes[offset] {
+            b'\'' => {
+                if in_quote && offset + 1 < bytes.len() && bytes[offset + 1] == b'\'' {
+                    offset += 2;
+                    continue;
+                }
+                in_quote = !in_quote;
+            }
+            b'!' => return true,
+            b':' if !in_quote => return false,
+            b',' | b';' | b'}' | b')' | b' ' | b'\n' | b'+' | b'-' | b'*' | b'/' | b'^' | b'&'
+            | b'=' | b'>' | b'<' | b'%' | b'@'
+                if !in_quote =>
+            {
+                return false;
+            }
+            _ => {}
+        }
+        offset += 1;
+    }
+
+    false
+}
+
 struct SpanTokenizer<'a> {
     formula: &'a str,
     spans: Vec<TokenSpan>,
@@ -766,6 +855,19 @@ impl<'a> SpanTokenizer<'a> {
                     }
                 }
                 b' ' | b'\n' => self.parse_whitespace(),
+                b':' => {
+                    if self.should_emit_colon_infix() {
+                        self.emit_infix_operator(self.offset, self.offset + 1);
+                        Ok(())
+                    } else {
+                        if !self.has_token() {
+                            self.start_token();
+                        }
+                        self.offset += 1;
+                        self.extend_token();
+                        Ok(())
+                    }
+                }
                 b'+' | b'-' | b'*' | b'/' | b'^' | b'&' | b'=' | b'>' | b'<' | b'%' | b'@' => {
                     self.parse_operator()
                 }
@@ -1083,14 +1185,57 @@ impl<'a> SpanTokenizer<'a> {
             }
         }
 
-        self.push_span(
-            TokenType::Whitespace,
-            TokenSubType::None,
-            ws_start,
-            self.offset,
-        );
+        let token_type = if self.prev_is_reference_producing()
+            && next_starts_reference_expression(self.formula, self.offset)
+        {
+            TokenType::OpInfix
+        } else {
+            TokenType::Whitespace
+        };
+        self.push_span(token_type, TokenSubType::None, ws_start, self.offset);
         self.start_token();
         Ok(())
+    }
+
+    fn prev_is_reference_producing(&self) -> bool {
+        match self.prev_non_whitespace() {
+            Some(prev) => match prev.token_type {
+                TokenType::OpPostfix => true,
+                TokenType::Paren | TokenType::Func | TokenType::Array
+                    if prev.subtype == TokenSubType::Close =>
+                {
+                    true
+                }
+                TokenType::Operand if prev.subtype == TokenSubType::Range => self
+                    .formula
+                    .get(prev.start..prev.end)
+                    .is_some_and(is_reference_operand_value),
+                _ => false,
+            },
+            None => false,
+        }
+    }
+
+    fn should_emit_colon_infix(&self) -> bool {
+        if self.has_token() {
+            let value = &self.formula[self.token_start..self.token_end];
+            if value.ends_with('!') {
+                return false;
+            }
+            return reference_value_contains_range_colon(value)
+                || value.contains('[')
+                || (value.contains('!')
+                    && next_reference_has_sheet_qualifier(self.formula, self.offset + 1));
+        }
+        self.prev_is_reference_producing()
+    }
+
+    fn emit_infix_operator(&mut self, start: usize, end: usize) {
+        self.save_token();
+        self.start_token();
+        self.push_span(TokenType::OpInfix, TokenSubType::None, start, end);
+        self.offset = end;
+        self.start_token();
     }
 
     fn prev_non_whitespace(&self) -> Option<&TokenSpan> {
@@ -1447,6 +1592,17 @@ impl Tokenizer {
                     }
                 }
                 b' ' | b'\n' => self.parse_whitespace()?,
+                b':' => {
+                    if self.should_emit_colon_infix() {
+                        self.emit_infix_operator(self.offset, self.offset + 1);
+                    } else {
+                        if !self.has_token() {
+                            self.start_token();
+                        }
+                        self.offset += 1;
+                        self.extend_token();
+                    }
+                }
                 // operator characters
                 b'+' | b'-' | b'*' | b'/' | b'^' | b'&' | b'=' | b'>' | b'<' | b'%' | b'@' => {
                     self.parse_operator()?
@@ -1738,15 +1894,76 @@ impl Tokenizer {
             }
         }
 
+        let token_type = if self.prev_is_reference_producing()
+            && next_starts_reference_expression(&self.formula, self.offset)
+        {
+            TokenType::OpInfix
+        } else {
+            TokenType::Whitespace
+        };
+
         self.items.push(Token::from_slice(
             &self.formula,
-            TokenType::Whitespace,
+            token_type,
             TokenSubType::None,
             ws_start,
             self.offset,
         ));
         self.start_token();
         Ok(())
+    }
+
+    fn prev_non_whitespace(&self) -> Option<&Token> {
+        self.items
+            .iter()
+            .rev()
+            .find(|t| t.token_type != TokenType::Whitespace)
+    }
+
+    fn prev_is_reference_producing(&self) -> bool {
+        match self.prev_non_whitespace() {
+            Some(prev) => match prev.token_type {
+                TokenType::OpPostfix => true,
+                TokenType::Paren | TokenType::Func | TokenType::Array
+                    if prev.subtype == TokenSubType::Close =>
+                {
+                    true
+                }
+                TokenType::Operand if prev.subtype == TokenSubType::Range => {
+                    is_reference_operand_value(&prev.value)
+                }
+                _ => false,
+            },
+            None => false,
+        }
+    }
+
+    fn should_emit_colon_infix(&self) -> bool {
+        if self.has_token() {
+            let value = &self.formula[self.token_start..self.token_end];
+            if value.ends_with('!') {
+                return false;
+            }
+            return reference_value_contains_range_colon(value)
+                || value.contains('[')
+                || (value.contains('!')
+                    && next_reference_has_sheet_qualifier(&self.formula, self.offset + 1));
+        }
+        self.prev_is_reference_producing()
+    }
+
+    fn emit_infix_operator(&mut self, start: usize, end: usize) {
+        self.save_token();
+        self.start_token();
+        self.items.push(Token::from_slice(
+            &self.formula,
+            TokenType::OpInfix,
+            TokenSubType::None,
+            start,
+            end,
+        ));
+        self.offset = end;
+        self.start_token();
     }
 
     /// Parse an operator token.


### PR DESCRIPTION
## Summary

- Emits Excel reference operators for composed ranges: colon (`:`) and space intersection.
- Preserves the simple `A1:B2` / sheet-qualified range fast path as one `Operand:Range`.
- Adds distinct reference-operator precedence (`:` > space > comma) across tokenizer, SpanParser, and pretty-printer.
- Pretty-prints range operators tightly and intersection as a single space.
- Adds tokenizer/parser coverage for composed colon, cross-sheet range composition, chained colon, space intersection, precedence, and regression guards.

## Validation

- `cargo fmt --all`
- `cargo test -p formualizer-parse`
- `cargo clippy -p formualizer-parse --all-targets -- -D warnings`

Closes #69

Note: stacked on #88 / `parse/issue-71-spill-postfix` because reference-operator parsing shares precedence and token context with spill postfix support.