### PR TITLE
chore(release): bump product to 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to Formualizer will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.7] - 2026-04-26
+
 ### Fixed
 
-- Fixed unary minus precedence to bind tighter than exponentiation, matching Excel semantics (`=-2^2` now evaluates to `4` instead of `-4`).
+- Fixed unary minus precedence to bind tighter than exponentiation, matching Excel semantics (`=-2^2` now evaluates to `4` instead of `-4`). (#65)
+
+### Performance
+
+- Fixed O(N²) bulk-ingest scaling for row-major formulas by introducing `CoordBuildHasher` for packed coordinate keys and applying it to the hot dependency-graph and spill-commit maps. (#67)
 
 ## [0.5.6] - 2026-04-14
 
@@ -102,7 +108,8 @@ All notable changes to Formualizer will be documented in this file.
 
 - Incomplete product release due to partial publication during the release workflow. Superseded by `0.5.1`.
 
-[Unreleased]: https://github.com/PSU3D0/formualizer/compare/v0.5.6...HEAD
+[Unreleased]: https://github.com/PSU3D0/formualizer/compare/v0.5.7...HEAD
+[0.5.7]: https://github.com/PSU3D0/formualizer/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/PSU3D0/formualizer/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/PSU3D0/formualizer/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/PSU3D0/formualizer/compare/v0.5.3...v0.5.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "formualizer-common",
  "formualizer-eval",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-common"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "chrono",
  "serde",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-eval"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-macros"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "formualizer-common",
  "proc-macro2",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-parse"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "formualizer-common",
  "once_cell",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-python"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "chrono",
  "formualizer",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-sheetport"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "chrono",
  "formualizer-common",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-wasm"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-workbook"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ documentation = "https://docs.rs/formualizer"
 
 [workspace.dependencies]
 
-formualizer-common = { version = "1.1.2", path = "crates/formualizer-common" }
-formualizer-macros = { version = "0.5.6", path = "crates/formualizer-macros" }
-formualizer-parse = { version = "1.1.2", path = "crates/formualizer-parse" }
-formualizer-eval = { version = "0.5.6", path = "crates/formualizer-eval" }
-formualizer-workbook = { version = "0.5.6", path = "crates/formualizer-workbook" }
+formualizer-common = { version = "1.1.3", path = "crates/formualizer-common" }
+formualizer-macros = { version = "0.5.7", path = "crates/formualizer-macros" }
+formualizer-parse = { version = "1.1.3", path = "crates/formualizer-parse" }
+formualizer-eval = { version = "0.5.7", path = "crates/formualizer-eval" }
+formualizer-workbook = { version = "0.5.7", path = "crates/formualizer-workbook" }
 
 chrono = { version = "0.4.41", default-features = false, features = ["std"] }
 serde = "1.0.228"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-python"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 homepage = "https://github.com/PSU3D0/formualizer"
 license = "MIT OR Apache-2.0"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "formualizer"
-version = "0.5.6"
+version = "0.5.7"
 description = "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks at native speed"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "formualizer"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-wasm"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 authors = ["Formualizer Contributors"]
 homepage = "https://github.com/PSU3D0/formualizer"

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formualizer",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks in the browser. 320+ functions, Arrow-powered.",
   "homepage": "https://github.com/psu3d0/formualizer",
   "type": "module",

--- a/crates/formualizer-common/Cargo.toml
+++ b/crates/formualizer-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-common"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2024"
 description = "Core value, reference, and error types shared across the Formualizer parser and engine"
 homepage.workspace = true

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-eval"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 description = "High-performance Arrow-backed Excel formula engine with dependency graph and incremental recalculation"
 homepage.workspace = true

--- a/crates/formualizer-macros/Cargo.toml
+++ b/crates/formualizer-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-macros"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 description = "Proc macros for authoring Formualizer built-ins (caps, schemas, and validation)"
 homepage.workspace = true

--- a/crates/formualizer-parse/Cargo.toml
+++ b/crates/formualizer-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-parse"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2024"
 description = "High-performance Excel/OpenFormula tokenizer + parser with a stable AST surface"
 homepage.workspace = true

--- a/crates/formualizer-sheetport/Cargo.toml
+++ b/crates/formualizer-sheetport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-sheetport"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 description = "SheetPort runtime: bind manifests to workbooks, validate IO, and run sessions deterministically"
 homepage.workspace = true
@@ -24,10 +24,10 @@ umya = ["formualizer-workbook/umya_integration"]
 
 [dependencies]
 sheetport-spec = { path = "../sheetport-spec", version = "0.3.0" }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.6", default-features = false }
-formualizer-common = { path = "../formualizer-common", version = "1.1.2" }
-formualizer-parse = { path = "../formualizer-parse", version = "1.1.2" }
-formualizer-eval = { path = "../formualizer-eval", version = "0.5.6", default-features = false }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.7", default-features = false }
+formualizer-common = { path = "../formualizer-common", version = "1.1.3" }
+formualizer-parse = { path = "../formualizer-parse", version = "1.1.3" }
+formualizer-eval = { path = "../formualizer-eval", version = "0.5.7", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/formualizer-sheetport/Cargo.toml
+++ b/crates/formualizer-sheetport/Cargo.toml
@@ -42,5 +42,5 @@ chrono = { workspace = true }
 chrono = { workspace = true }
 formualizer-testkit = { path = "../formualizer-testkit" }
 tempfile = { workspace = true }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.2", features = ["umya_integration"] }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.7", features = ["umya_integration"] }
 umya-spreadsheet = "=2.3.2"

--- a/crates/formualizer-workbook/Cargo.toml
+++ b/crates/formualizer-workbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-workbook"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 description = "Ergonomic workbook API over the Formualizer engine (sheets, loaders, staging, undo/redo)"
 homepage.workspace = true

--- a/crates/formualizer-workbook/Cargo.toml
+++ b/crates/formualizer-workbook/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["data-structures", "mathematics"]
 [dependencies]
 formualizer-parse = { workspace = true }
 formualizer-common = { workspace = true }
-formualizer-eval = { path = "../formualizer-eval", version = "0.5.2", default-features = false }
+formualizer-eval = { path = "../formualizer-eval", version = "0.5.7", default-features = false }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }

--- a/crates/formualizer/Cargo.toml
+++ b/crates/formualizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 description = "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks from Rust"
 homepage.workspace = true
@@ -57,9 +57,9 @@ portable-wasm = ["eval", "workbook", "sheetport", "parse", "common"]
 wasm-js = ["portable-wasm", "system-clock", "js-runtime"]
 
 [dependencies]
-formualizer-common = { path = "../formualizer-common", version = "1.1.2", optional = true }
-formualizer-parse = { path = "../formualizer-parse", version = "1.1.2", optional = true }
-formualizer-eval = { path = "../formualizer-eval", version = "0.5.6", optional = true, default-features = false }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.6", optional = true, default-features = false }
-formualizer-sheetport = { path = "../formualizer-sheetport", version = "0.5.6", optional = true, default-features = false }
+formualizer-common = { path = "../formualizer-common", version = "1.1.3", optional = true }
+formualizer-parse = { path = "../formualizer-parse", version = "1.1.3", optional = true }
+formualizer-eval = { path = "../formualizer-eval", version = "0.5.7", optional = true, default-features = false }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.5.7", optional = true, default-features = false }
+formualizer-sheetport = { path = "../formualizer-sheetport", version = "0.5.7", optional = true, default-features = false }
 sheetport-spec = { path = "../sheetport-spec", version = "0.3.0", optional = true }

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -66,7 +66,8 @@ PRODUCT_INTERNAL_DEPS = [
     ("crates/formualizer/Cargo.toml", "formualizer-eval"),
     ("crates/formualizer/Cargo.toml", "formualizer-workbook"),
     ("crates/formualizer/Cargo.toml", "formualizer-sheetport"),
-    # crates/formualizer-sheetport/Cargo.toml references
+    # product crate cross-dependencies
+    ("crates/formualizer-workbook/Cargo.toml", "formualizer-eval"),
     ("crates/formualizer-sheetport/Cargo.toml", "formualizer-eval"),
     ("crates/formualizer-sheetport/Cargo.toml", "formualizer-workbook"),
 ]


### PR DESCRIPTION
## Summary

- Bumps product track from `0.5.6` to `0.5.7` across Rust product crates, Python binding metadata, npm metadata, and internal dependency versions.
- Bumps parser/SDK track from `1.1.2` to `1.1.3` for `formualizer-common` + `formualizer-parse`, so `CoordBuildHasher` is published before the product crates depending on it.
- Updates `Cargo.lock`.
- Cuts `CHANGELOG.md` section for `0.5.7` with the unary precedence fix and bulk-ingest hasher performance fix.

## Validation

- `./scripts/bump-version.py --track parse --version 1.1.3 --dry-run`
- `./scripts/bump-version.py --track product --version 0.5.7 --dry-run`
- `./scripts/bump-version.py --track parse --version 1.1.3 --no-verify`
- `./scripts/bump-version.py --track product --version 0.5.7 --no-verify`
- `cargo check --workspace --exclude formualizer-bench-core --all-features`
- `cargo fmt --all -- --check`

Release tags after merge should be `parse-v1.1.3` and `v0.5.7`.