### PR TITLE
perf(eval-flush): coalesce computed overlay writes into fragments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "607e64bb911ee4f90483e044fe78f175989148c2892e659a2cd25429e782ec54"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -175,23 +175,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "e754319ed8a85d817fe7adf183227e0b5308b82790a737b426c1124626b48118"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -199,30 +199,34 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
- "num",
+ "hashbrown 0.17.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+checksum = "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -230,15 +234,15 @@ dependencies = [
  "chrono",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-csv"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
+checksum = "86c276756867fc8186ec380c72c290e6e3b23a1d4fb05df6b1d62d2e62666d48"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -251,21 +255,22 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3594dcddccc7f20fd069bc8e9828ce37220372680ff638c5e00dea427d88f5"
+checksum = "fd8907ddd8f9fbabf91ec2c85c1d81fe2874e336d2443eb36373595e28b98dd5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -277,31 +282,34 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
+checksum = "f4518c59acc501f10d7dcae397fe12b8db3d81bc7de94456f8a58f9165d6f502"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
+ "itoa",
  "lexical-core",
  "memchr",
- "num",
- "serde",
+ "num-traits",
+ "ryu",
+ "serde_core",
  "serde_json",
  "simdutf8",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -312,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "faec88a945338192beffbbd4be0def70135422930caa244ac3cec0cd213b26b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -325,29 +333,29 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "58.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -355,7 +363,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
@@ -1762,6 +1770,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,20 +2525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,28 +2555,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 

--- a/crates/formualizer-bench-core/src/bin/probe-finance-recalc.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-finance-recalc.rs
@@ -1,0 +1,309 @@
+#[cfg(feature = "formualizer_runner")]
+use std::time::Instant;
+
+#[cfg(feature = "formualizer_runner")]
+use anyhow::{Result, bail};
+#[cfg(feature = "formualizer_runner")]
+use clap::Parser;
+#[cfg(feature = "formualizer_runner")]
+use formualizer_workbook::{LiteralValue, Workbook, WorkbookConfig};
+#[cfg(feature = "formualizer_runner")]
+use serde::Serialize;
+
+#[cfg(not(feature = "formualizer_runner"))]
+fn main() {
+    eprintln!(
+        "This binary requires feature `formualizer_runner`: cargo run -p formualizer-bench-core --features formualizer_runner --bin probe-finance-recalc -- ..."
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let report = run_probe(&cli)?;
+    println!("{}", serde_json::to_string(&report)?);
+    Ok(())
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Parser)]
+#[command(about = "Finance-shaped repeated edit/recalc probe for Formualizer native runner")]
+struct Cli {
+    #[arg(long, default_value_t = 50_000)]
+    rows: usize,
+    #[arg(long, default_value_t = 10)]
+    cycles: usize,
+    #[arg(long, default_value_t = 16)]
+    dense_edit_len: usize,
+    #[arg(long, default_value_t = 16)]
+    sparse_edits: usize,
+    #[arg(long, default_value = "phase-candidate")]
+    label: String,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
+struct FinanceRecalcProbeReport {
+    label: String,
+    rows: usize,
+    cycles: usize,
+    dense_edit_len: usize,
+    sparse_edits: usize,
+    setup_ms: f64,
+    initial_eval_ms: f64,
+    total_recalc_ms: f64,
+    recalc_ms_p50: f64,
+    recalc_ms_p95: f64,
+    recalc_ms_max: f64,
+    final_rollup: f64,
+    expected_final_rollup: f64,
+    checksum: f64,
+    rss_current_mb: Option<f64>,
+    rss_peak_mb: Option<f64>,
+    cycles_detail: Vec<FinanceRecalcCycleReport>,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
+struct FinanceRecalcCycleReport {
+    cycle: usize,
+    edit_kind: &'static str,
+    edit_ms: f64,
+    recalc_ms: f64,
+    rollup: f64,
+    expected_rollup: f64,
+}
+
+#[cfg(feature = "formualizer_runner")]
+struct FinanceProbeWorkbook {
+    workbook: Workbook,
+    units: Vec<f64>,
+    prices: Vec<f64>,
+    multiplier: f64,
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn run_probe(cli: &Cli) -> Result<FinanceRecalcProbeReport> {
+    if cli.rows == 0 {
+        bail!("--rows must be > 0");
+    }
+    if cli.cycles == 0 {
+        bail!("--cycles must be > 0");
+    }
+
+    let setup_start = Instant::now();
+    let mut probe = FinanceProbeWorkbook::new(cli.rows)?;
+    let setup_ms = setup_start.elapsed().as_secs_f64() * 1000.0;
+
+    let initial_start = Instant::now();
+    probe
+        .workbook
+        .evaluate_all()
+        .map_err(|e| anyhow::anyhow!("initial evaluate_all: {e}"))?;
+    let initial_eval_ms = initial_start.elapsed().as_secs_f64() * 1000.0;
+    probe.assert_rollup("initial")?;
+
+    let mut cycles_detail = Vec::with_capacity(cli.cycles);
+    for cycle in 0..cli.cycles {
+        let edit_start = Instant::now();
+        let edit_kind = probe.apply_cycle_edit(cycle, cli.dense_edit_len, cli.sparse_edits)?;
+        let edit_ms = edit_start.elapsed().as_secs_f64() * 1000.0;
+
+        let recalc_start = Instant::now();
+        probe
+            .workbook
+            .evaluate_all()
+            .map_err(|e| anyhow::anyhow!("evaluate_all cycle {cycle}: {e}"))?;
+        let recalc_ms = recalc_start.elapsed().as_secs_f64() * 1000.0;
+
+        let expected_rollup = probe.expected_rollup();
+        let rollup = probe.rollup()?;
+        if (rollup - expected_rollup).abs() > 1e-6 {
+            bail!("cycle {cycle}: rollup mismatch: got {rollup}, expected {expected_rollup}");
+        }
+        cycles_detail.push(FinanceRecalcCycleReport {
+            cycle,
+            edit_kind,
+            edit_ms,
+            recalc_ms,
+            rollup,
+            expected_rollup,
+        });
+    }
+
+    let mut recalc_times: Vec<f64> = cycles_detail.iter().map(|cycle| cycle.recalc_ms).collect();
+    recalc_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let total_recalc_ms = recalc_times.iter().sum();
+    let recalc_ms_p50 = percentile(&recalc_times, 0.50);
+    let recalc_ms_p95 = percentile(&recalc_times, 0.95);
+    let recalc_ms_max = recalc_times.last().copied().unwrap_or(0.0);
+    let final_rollup = probe.rollup()?;
+    let expected_final_rollup = probe.expected_rollup();
+    let checksum = cycles_detail
+        .iter()
+        .map(|cycle| cycle.rollup)
+        .fold(final_rollup, |acc, value| acc + value);
+    let (rss_current_mb, rss_peak_mb) = linux_rss_mb();
+
+    Ok(FinanceRecalcProbeReport {
+        label: cli.label.clone(),
+        rows: cli.rows,
+        cycles: cli.cycles,
+        dense_edit_len: cli.dense_edit_len,
+        sparse_edits: cli.sparse_edits,
+        setup_ms,
+        initial_eval_ms,
+        total_recalc_ms,
+        recalc_ms_p50,
+        recalc_ms_p95,
+        recalc_ms_max,
+        final_rollup,
+        expected_final_rollup,
+        checksum,
+        rss_current_mb,
+        rss_peak_mb,
+        cycles_detail,
+    })
+}
+
+#[cfg(feature = "formualizer_runner")]
+impl FinanceProbeWorkbook {
+    fn new(rows: usize) -> Result<Self> {
+        let mut workbook = Workbook::new_with_config(WorkbookConfig::ephemeral());
+        let mut units = Vec::with_capacity(rows);
+        let mut prices = Vec::with_capacity(rows);
+
+        for row0 in 0..rows {
+            let row = row0 as u32 + 1;
+            let unit = (row0 + 1) as f64;
+            let price = 10.0 + (row0 % 17) as f64;
+            units.push(unit);
+            prices.push(price);
+            workbook
+                .set_value("Sheet1", row, 1, LiteralValue::Number(unit))
+                .map_err(|e| anyhow::anyhow!("set unit row {row}: {e}"))?;
+            workbook
+                .set_value("Sheet1", row, 2, LiteralValue::Number(price))
+                .map_err(|e| anyhow::anyhow!("set price row {row}: {e}"))?;
+            workbook
+                .set_formula("Sheet1", row, 3, &format!("=A{row}*B{row}*$F$1"))
+                .map_err(|e| anyhow::anyhow!("set formula row {row}: {e}"))?;
+        }
+        workbook
+            .set_value("Sheet1", 1, 6, LiteralValue::Number(1.0))
+            .map_err(|e| anyhow::anyhow!("set multiplier: {e}"))?;
+        workbook
+            .set_formula("Sheet1", 1, 7, &format!("=SUM(C1:C{rows})"))
+            .map_err(|e| anyhow::anyhow!("set rollup formula: {e}"))?;
+
+        Ok(Self {
+            workbook,
+            units,
+            prices,
+            multiplier: 1.0,
+        })
+    }
+
+    fn apply_cycle_edit(
+        &mut self,
+        cycle: usize,
+        dense_edit_len: usize,
+        sparse_edits: usize,
+    ) -> Result<&'static str> {
+        match cycle % 3 {
+            0 => {
+                self.multiplier = 1.0 + ((cycle % 5) as f64);
+                self.workbook
+                    .set_value("Sheet1", 1, 6, LiteralValue::Number(self.multiplier))
+                    .map_err(|e| anyhow::anyhow!("set multiplier cycle {cycle}: {e}"))?;
+                Ok("multiplier")
+            }
+            1 => {
+                let len = dense_edit_len.min(self.units.len()).max(1);
+                let start = (cycle * 37) % self.units.len();
+                for idx in 0..len {
+                    let row0 = (start + idx) % self.units.len();
+                    let value = 1000.0 + cycle as f64 + idx as f64;
+                    self.units[row0] = value;
+                    self.workbook
+                        .set_value("Sheet1", row0 as u32 + 1, 1, LiteralValue::Number(value))
+                        .map_err(|e| anyhow::anyhow!("set dense unit cycle {cycle}: {e}"))?;
+                }
+                Ok("dense_units")
+            }
+            _ => {
+                let edits = sparse_edits.min(self.prices.len()).max(1);
+                for idx in 0..edits {
+                    let row0 = (cycle * 53 + idx * 97) % self.prices.len();
+                    let value = 20.0 + ((cycle + idx) % 23) as f64;
+                    self.prices[row0] = value;
+                    self.workbook
+                        .set_value("Sheet1", row0 as u32 + 1, 2, LiteralValue::Number(value))
+                        .map_err(|e| anyhow::anyhow!("set sparse price cycle {cycle}: {e}"))?;
+                }
+                Ok("sparse_prices")
+            }
+        }
+    }
+
+    fn expected_rollup(&self) -> f64 {
+        self.units
+            .iter()
+            .zip(self.prices.iter())
+            .map(|(unit, price)| unit * price * self.multiplier)
+            .sum()
+    }
+
+    fn rollup(&self) -> Result<f64> {
+        match self.workbook.get_value("Sheet1", 1, 7) {
+            Some(LiteralValue::Number(value)) => Ok(value),
+            Some(other) => bail!("expected numeric rollup, got {other:?}"),
+            None => bail!("missing rollup"),
+        }
+    }
+
+    fn assert_rollup(&self, label: &str) -> Result<()> {
+        let rollup = self.rollup()?;
+        let expected = self.expected_rollup();
+        if (rollup - expected).abs() > 1e-6 {
+            bail!("{label}: rollup mismatch: got {rollup}, expected {expected}");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let idx = ((sorted.len().saturating_sub(1)) as f64 * p).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn linux_rss_mb() -> (Option<f64>, Option<f64>) {
+    let status = std::fs::read_to_string("/proc/self/status").ok();
+    let Some(status) = status else {
+        return (None, None);
+    };
+    let mut current = None;
+    let mut peak = None;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            current = parse_status_kb(rest).map(|kb| kb as f64 / 1024.0);
+        } else if let Some(rest) = line.strip_prefix("VmHWM:") {
+            peak = parse_status_kb(rest).map(|kb| kb as f64 / 1024.0);
+        }
+    }
+    (current, peak)
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn parse_status_kb(value: &str) -> Option<u64> {
+    value
+        .split_whitespace()
+        .next()
+        .and_then(|token| token.parse::<u64>().ok())
+}

--- a/crates/formualizer-bench-core/src/bin/probe-finance-recalc.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-finance-recalc.rs
@@ -1,12 +1,16 @@
 #[cfg(feature = "formualizer_runner")]
-use std::time::Instant;
+use std::{path::PathBuf, time::Instant};
 
 #[cfg(feature = "formualizer_runner")]
 use anyhow::{Result, bail};
 #[cfg(feature = "formualizer_runner")]
 use clap::Parser;
 #[cfg(feature = "formualizer_runner")]
-use formualizer_workbook::{LiteralValue, Workbook, WorkbookConfig};
+use formualizer_testkit::write_workbook;
+#[cfg(feature = "formualizer_runner")]
+use formualizer_workbook::{
+    LiteralValue, LoadStrategy, SpreadsheetReader, UmyaAdapter, Workbook, WorkbookConfig,
+};
 #[cfg(feature = "formualizer_runner")]
 use serde::Serialize;
 
@@ -40,6 +44,12 @@ struct Cli {
     sparse_edits: usize,
     #[arg(long, default_value = "phase-candidate")]
     label: String,
+    /// Optional XLSX fixture path. Defaults under target/finance-recalc-fixtures/.
+    #[arg(long)]
+    workbook_path: Option<PathBuf>,
+    /// Reuse --workbook-path if it already exists instead of regenerating it.
+    #[arg(long)]
+    reuse_workbook: bool,
 }
 
 #[cfg(feature = "formualizer_runner")]
@@ -50,6 +60,10 @@ struct FinanceRecalcProbeReport {
     cycles: usize,
     dense_edit_len: usize,
     sparse_edits: usize,
+    workbook_path: String,
+    reused_workbook: bool,
+    fixture_gen_ms: f64,
+    load_ms: f64,
     setup_ms: f64,
     initial_eval_ms: f64,
     total_recalc_ms: f64,
@@ -92,9 +106,23 @@ fn run_probe(cli: &Cli) -> Result<FinanceRecalcProbeReport> {
         bail!("--cycles must be > 0");
     }
 
-    let setup_start = Instant::now();
-    let mut probe = FinanceProbeWorkbook::new(cli.rows)?;
-    let setup_ms = setup_start.elapsed().as_secs_f64() * 1000.0;
+    let workbook_path = cli
+        .workbook_path
+        .clone()
+        .unwrap_or_else(|| default_workbook_path(&cli.label, cli.rows));
+
+    let (fixture_gen_ms, reused_workbook) = if cli.reuse_workbook && workbook_path.exists() {
+        (0.0, true)
+    } else {
+        let gen_start = Instant::now();
+        generate_finance_fixture(&workbook_path, cli.rows)?;
+        (gen_start.elapsed().as_secs_f64() * 1000.0, false)
+    };
+
+    let load_start = Instant::now();
+    let mut probe = FinanceProbeWorkbook::load(&workbook_path, cli.rows)?;
+    let load_ms = load_start.elapsed().as_secs_f64() * 1000.0;
+    let setup_ms = fixture_gen_ms + load_ms;
 
     let initial_start = Instant::now();
     probe
@@ -152,6 +180,10 @@ fn run_probe(cli: &Cli) -> Result<FinanceRecalcProbeReport> {
         cycles: cli.cycles,
         dense_edit_len: cli.dense_edit_len,
         sparse_edits: cli.sparse_edits,
+        workbook_path: workbook_path.display().to_string(),
+        reused_workbook,
+        fixture_gen_ms,
+        load_ms,
         setup_ms,
         initial_eval_ms,
         total_recalc_ms,
@@ -169,34 +201,13 @@ fn run_probe(cli: &Cli) -> Result<FinanceRecalcProbeReport> {
 
 #[cfg(feature = "formualizer_runner")]
 impl FinanceProbeWorkbook {
-    fn new(rows: usize) -> Result<Self> {
-        let mut workbook = Workbook::new_with_config(WorkbookConfig::ephemeral());
-        let mut units = Vec::with_capacity(rows);
-        let mut prices = Vec::with_capacity(rows);
-
-        for row0 in 0..rows {
-            let row = row0 as u32 + 1;
-            let unit = (row0 + 1) as f64;
-            let price = 10.0 + (row0 % 17) as f64;
-            units.push(unit);
-            prices.push(price);
-            workbook
-                .set_value("Sheet1", row, 1, LiteralValue::Number(unit))
-                .map_err(|e| anyhow::anyhow!("set unit row {row}: {e}"))?;
-            workbook
-                .set_value("Sheet1", row, 2, LiteralValue::Number(price))
-                .map_err(|e| anyhow::anyhow!("set price row {row}: {e}"))?;
-            workbook
-                .set_formula("Sheet1", row, 3, &format!("=A{row}*B{row}*$F$1"))
-                .map_err(|e| anyhow::anyhow!("set formula row {row}: {e}"))?;
-        }
-        workbook
-            .set_value("Sheet1", 1, 6, LiteralValue::Number(1.0))
-            .map_err(|e| anyhow::anyhow!("set multiplier: {e}"))?;
-        workbook
-            .set_formula("Sheet1", 1, 7, &format!("=SUM(C1:C{rows})"))
-            .map_err(|e| anyhow::anyhow!("set rollup formula: {e}"))?;
-
+    fn load(path: &PathBuf, rows: usize) -> Result<Self> {
+        let backend = UmyaAdapter::open_path(path)
+            .map_err(|e| anyhow::anyhow!("open fixture via umya {}: {e}", path.display()))?;
+        let workbook =
+            Workbook::from_reader(backend, LoadStrategy::EagerAll, WorkbookConfig::ephemeral())
+                .map_err(|e| anyhow::anyhow!("load fixture into workbook: {e}"))?;
+        let (units, prices) = deterministic_inputs(rows);
         Ok(Self {
             workbook,
             units,
@@ -271,6 +282,60 @@ impl FinanceProbeWorkbook {
         }
         Ok(())
     }
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn generate_finance_fixture(path: &PathBuf, rows: usize) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("create fixture dir {}: {e}", parent.display()))?;
+    }
+    write_workbook(path, |book| {
+        let sheet = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        for row0 in 0..rows {
+            let row = row0 as u32 + 1;
+            let unit = (row0 + 1) as f64;
+            let price = 10.0 + (row0 % 17) as f64;
+            sheet.get_cell_mut((1, row)).set_value_number(unit);
+            sheet.get_cell_mut((2, row)).set_value_number(price);
+            sheet
+                .get_cell_mut((3, row))
+                .set_formula(format!("=A{row}*B{row}*$F$1"));
+        }
+        sheet.get_cell_mut((6, 1)).set_value_number(1.0);
+        sheet
+            .get_cell_mut((7, 1))
+            .set_formula(format!("=SUM(C1:C{rows})"));
+    });
+    Ok(())
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn deterministic_inputs(rows: usize) -> (Vec<f64>, Vec<f64>) {
+    let mut units = Vec::with_capacity(rows);
+    let mut prices = Vec::with_capacity(rows);
+    for row0 in 0..rows {
+        units.push((row0 + 1) as f64);
+        prices.push(10.0 + (row0 % 17) as f64);
+    }
+    (units, prices)
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn default_workbook_path(label: &str, rows: usize) -> PathBuf {
+    let safe_label: String = label
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    PathBuf::from("target")
+        .join("finance-recalc-fixtures")
+        .join(format!("{safe_label}-{rows}.xlsx"))
 }
 
 #[cfg(feature = "formualizer_runner")]

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -41,13 +41,13 @@ smallvec = { workspace = true }
 # web-time is only needed for the js-runtime (browser/wasm-bindgen) profile.
 web-time = { workspace = true, optional = true }
 
-# Arrow (per-crate) — pinned to 56.x series
-arrow-array = "56"
-arrow-buffer = "56"
-arrow-schema = "56"
-arrow-select = "56"
-arrow-cast = "56"
-arrow = "56"
+# Arrow (per-crate) — pinned to 58.x series
+arrow-array = "58.2.0"
+arrow-buffer = "58.2.0"
+arrow-schema = "58.2.0"
+arrow-select = "58.2.0"
+arrow-cast = "58.2.0"
+arrow = "58.2.0"
 
 [dependencies.tracing]
 version = "0.1"

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -2079,6 +2079,20 @@ impl Overlay {
         }
         covered.len() == self.len()
     }
+
+    pub(crate) fn debug_recomputed_estimated_bytes(&self) -> usize {
+        let point_bytes = self
+            .points
+            .values()
+            .map(Self::point_estimate)
+            .fold(0usize, usize::saturating_add);
+        let fragment_bytes = self
+            .fragments
+            .iter()
+            .map(OverlayFragment::estimated_bytes)
+            .fold(0usize, usize::saturating_add);
+        point_bytes.saturating_add(fragment_bytes)
+    }
 }
 
 pub(crate) struct OverlayCascade<'a> {
@@ -3612,6 +3626,74 @@ mod tests {
     use arrow_array::Array;
     use arrow_schema::DataType;
 
+    fn add_overlay_stats(into: &mut OverlayDebugStats, next: OverlayDebugStats) {
+        into.points += next.points;
+        into.sparse_fragments += next.sparse_fragments;
+        into.dense_fragments += next.dense_fragments;
+        into.run_fragments += next.run_fragments;
+        into.covered_len += next.covered_len;
+    }
+
+    fn column_overlay_stats(
+        sheet: &ArrowSheet,
+        col_idx: usize,
+        computed: bool,
+    ) -> OverlayDebugStats {
+        let mut stats = OverlayDebugStats::default();
+        let Some(column) = sheet.columns.get(col_idx) else {
+            return stats;
+        };
+        for chunk in &column.chunks {
+            add_overlay_stats(
+                &mut stats,
+                if computed {
+                    chunk.computed_overlay.debug_stats()
+                } else {
+                    chunk.overlay.debug_stats()
+                },
+            );
+        }
+        for chunk in column.sparse_chunks.values() {
+            add_overlay_stats(
+                &mut stats,
+                if computed {
+                    chunk.computed_overlay.debug_stats()
+                } else {
+                    chunk.overlay.debug_stats()
+                },
+            );
+        }
+        stats
+    }
+
+    fn assert_column_overlays_normalized(sheet: &ArrowSheet, col_idx: usize) {
+        let column = &sheet.columns[col_idx];
+        for chunk in &column.chunks {
+            assert!(chunk.overlay.debug_is_normalized());
+            assert!(chunk.computed_overlay.debug_is_normalized());
+            assert_eq!(
+                chunk.overlay.estimated_bytes(),
+                chunk.overlay.debug_recomputed_estimated_bytes()
+            );
+            assert_eq!(
+                chunk.computed_overlay.estimated_bytes(),
+                chunk.computed_overlay.debug_recomputed_estimated_bytes()
+            );
+        }
+        for chunk in column.sparse_chunks.values() {
+            assert!(chunk.overlay.debug_is_normalized());
+            assert!(chunk.computed_overlay.debug_is_normalized());
+            assert_eq!(
+                chunk.overlay.estimated_bytes(),
+                chunk.overlay.debug_recomputed_estimated_bytes()
+            );
+            assert_eq!(
+                chunk.computed_overlay.estimated_bytes(),
+                chunk.computed_overlay.debug_recomputed_estimated_bytes()
+            );
+        }
+    }
+
     #[test]
     fn ingest_mixed_rows_into_lanes_and_tags() {
         let mut b = IngestBuilder::new("Sheet1", 1, 1024, crate::engine::DateSystem::Excel1900);
@@ -4272,6 +4354,113 @@ mod tests {
     }
 
     #[test]
+    fn overlay_fragment_estimates_follow_encoded_shapes() {
+        let mut points = Overlay::new();
+        for idx in 0..512 {
+            points.set_scalar(idx, OverlayValue::Number(idx as f64));
+        }
+
+        let mut dense = Overlay::new();
+        dense.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                (0..512)
+                    .map(|idx| OverlayValue::Number(idx as f64))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            dense.estimated_bytes(),
+            dense.debug_recomputed_estimated_bytes()
+        );
+        assert!(
+            dense.estimated_bytes() < points.estimated_bytes(),
+            "dense fragment should account like encoded lanes, not point-map entries"
+        );
+
+        let mut short_run = Overlay::new();
+        short_run.apply_fragment(
+            OverlayFragment::run_range(0, vec![OverlayValue::Number(1.0); 8]).unwrap(),
+        );
+        let mut long_run = Overlay::new();
+        long_run.apply_fragment(
+            OverlayFragment::run_range(0, vec![OverlayValue::Number(1.0); 4096]).unwrap(),
+        );
+        assert_eq!(
+            short_run.estimated_bytes(),
+            short_run.debug_recomputed_estimated_bytes()
+        );
+        assert_eq!(
+            long_run.estimated_bytes(),
+            long_run.debug_recomputed_estimated_bytes()
+        );
+        assert_eq!(
+            short_run.estimated_bytes(),
+            long_run.estimated_bytes(),
+            "single-run estimate should scale with run count, not covered rows"
+        );
+
+        let sparse10 = OverlayFragment::sparse_offsets(
+            (0..10)
+                .map(|idx| (idx * 3, OverlayValue::Number(idx as f64)))
+                .collect(),
+        )
+        .unwrap();
+        let sparse20 = OverlayFragment::sparse_offsets(
+            (0..20)
+                .map(|idx| (idx * 3, OverlayValue::Number(idx as f64)))
+                .collect(),
+        )
+        .unwrap();
+        assert!(sparse20.estimated_bytes() > sparse10.estimated_bytes());
+    }
+
+    #[test]
+    fn overlay_estimated_bytes_stay_consistent_after_split_and_clear() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                (0..16)
+                    .map(|idx| OverlayValue::Number(idx as f64))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            overlay.estimated_bytes(),
+            overlay.debug_recomputed_estimated_bytes()
+        );
+
+        overlay.set_scalar(8, OverlayValue::Text(Arc::from("split")));
+        assert!(overlay.debug_is_normalized());
+        assert_eq!(
+            overlay.estimated_bytes(),
+            overlay.debug_recomputed_estimated_bytes()
+        );
+
+        overlay.apply_fragment(
+            OverlayFragment::sparse_offsets(vec![
+                (0, OverlayValue::Empty),
+                (15, OverlayValue::Boolean(true)),
+            ])
+            .unwrap(),
+        );
+        assert!(overlay.debug_is_normalized());
+        assert_eq!(
+            overlay.estimated_bytes(),
+            overlay.debug_recomputed_estimated_bytes()
+        );
+
+        let freed = overlay.clear_all();
+        assert!(freed > 0);
+        assert_eq!(overlay.estimated_bytes(), 0);
+        assert_eq!(overlay.debug_recomputed_estimated_bytes(), 0);
+        assert!(overlay.is_empty());
+    }
+
+    #[test]
     fn overlay_segment_numbers_masks_base_for_non_numeric_overlays() {
         let mut user = Overlay::new();
         user.set(1, OverlayValue::Text(Arc::from("x")));
@@ -4526,6 +4715,118 @@ mod tests {
             .map(|c| c.type_tag.len())
             .unwrap_or(0);
         assert_eq!(last_start + last_len, sheet.nrows as usize);
+    }
+
+    #[test]
+    fn row_insert_delete_preserves_user_dense_fragments() {
+        let mut b = IngestBuilder::new("S", 1, 4, crate::engine::DateSystem::Excel1900);
+        for _ in 0..10 {
+            b.append_row(&[LiteralValue::Empty]).unwrap();
+        }
+        let mut sheet = b.finish();
+
+        let (ch_idx, off) = sheet.chunk_of_row(1).unwrap();
+        sheet.columns[0]
+            .chunk_mut(ch_idx)
+            .unwrap()
+            .overlay
+            .apply_fragment(
+                OverlayFragment::dense_range(
+                    off,
+                    vec![
+                        OverlayValue::Number(10.0),
+                        OverlayValue::Number(20.0),
+                        OverlayValue::Number(30.0),
+                    ],
+                )
+                .unwrap(),
+            );
+
+        let before = column_overlay_stats(&sheet, 0, false);
+        assert_eq!(before.dense_fragments, 1);
+        assert_eq!(before.sparse_fragments, 0);
+        assert_column_overlays_normalized(&sheet, 0);
+
+        sheet.insert_rows(2, 2);
+        assert_eq!(sheet.nrows, 12);
+        let av = sheet.range_view(0, 0, (sheet.nrows - 1) as usize, 0);
+        assert_eq!(av.get_cell(1, 0), LiteralValue::Number(10.0));
+        assert_eq!(av.get_cell(2, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(3, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(4, 0), LiteralValue::Number(20.0));
+        assert_eq!(av.get_cell(5, 0), LiteralValue::Number(30.0));
+        let after_insert = column_overlay_stats(&sheet, 0, false);
+        assert_eq!(after_insert.sparse_fragments, 0);
+        assert!(after_insert.dense_fragments >= 2);
+        assert_column_overlays_normalized(&sheet, 0);
+
+        sheet.delete_rows(2, 2);
+        assert_eq!(sheet.nrows, 10);
+        let av = sheet.range_view(0, 0, (sheet.nrows - 1) as usize, 0);
+        assert_eq!(av.get_cell(1, 0), LiteralValue::Number(10.0));
+        assert_eq!(av.get_cell(2, 0), LiteralValue::Number(20.0));
+        assert_eq!(av.get_cell(3, 0), LiteralValue::Number(30.0));
+        let after_delete = column_overlay_stats(&sheet, 0, false);
+        assert_eq!(after_delete.sparse_fragments, 0);
+        assert!(after_delete.dense_fragments >= 1);
+        assert_column_overlays_normalized(&sheet, 0);
+    }
+
+    #[test]
+    fn row_insert_delete_preserves_computed_empty_run_fragments() {
+        let mut b = IngestBuilder::new("S", 1, 4, crate::engine::DateSystem::Excel1900);
+        for row in 0..8 {
+            b.append_row(&[LiteralValue::Number((row + 1) as f64)])
+                .unwrap();
+        }
+        let mut sheet = b.finish();
+
+        let (ch_idx, off) = sheet.chunk_of_row(1).unwrap();
+        sheet.columns[0]
+            .chunk_mut(ch_idx)
+            .unwrap()
+            .computed_overlay
+            .apply_fragment(
+                OverlayFragment::run_range(
+                    off,
+                    vec![
+                        OverlayValue::Empty,
+                        OverlayValue::Empty,
+                        OverlayValue::Empty,
+                    ],
+                )
+                .unwrap(),
+            );
+
+        let before = column_overlay_stats(&sheet, 0, true);
+        assert_eq!(before.run_fragments, 1);
+        assert_eq!(before.sparse_fragments, 0);
+        assert_column_overlays_normalized(&sheet, 0);
+
+        sheet.insert_rows(2, 1);
+        assert_eq!(sheet.nrows, 9);
+        let av = sheet.range_view(0, 0, (sheet.nrows - 1) as usize, 0);
+        assert_eq!(av.get_cell(1, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(2, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(3, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(4, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(5, 0), LiteralValue::Number(5.0));
+        let after_insert = column_overlay_stats(&sheet, 0, true);
+        assert_eq!(after_insert.sparse_fragments, 0);
+        assert!(after_insert.run_fragments >= 2);
+        assert_column_overlays_normalized(&sheet, 0);
+
+        sheet.delete_rows(2, 1);
+        assert_eq!(sheet.nrows, 8);
+        let av = sheet.range_view(0, 0, (sheet.nrows - 1) as usize, 0);
+        assert_eq!(av.get_cell(1, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(2, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(3, 0), LiteralValue::Empty);
+        assert_eq!(av.get_cell(4, 0), LiteralValue::Number(5.0));
+        let after_delete = column_overlay_stats(&sheet, 0, true);
+        assert_eq!(after_delete.sparse_fragments, 0);
+        assert!(after_delete.run_fragments >= 1);
+        assert_column_overlays_normalized(&sheet, 0);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -844,6 +844,84 @@ impl OverlayValue {
             OverlayValue::Text(s) => s.len(),
         }
     }
+
+    #[inline]
+    pub(crate) fn type_tag(&self) -> TypeTag {
+        match self {
+            OverlayValue::Empty => TypeTag::Empty,
+            OverlayValue::Number(_) => TypeTag::Number,
+            OverlayValue::DateTime(_) => TypeTag::DateTime,
+            OverlayValue::Duration(_) => TypeTag::Duration,
+            OverlayValue::Boolean(_) => TypeTag::Boolean,
+            OverlayValue::Text(_) => TypeTag::Text,
+            OverlayValue::Error(_) => TypeTag::Error,
+            OverlayValue::Pending => TypeTag::Pending,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn numeric_lane_value(&self) -> Option<f64> {
+        match self {
+            OverlayValue::Number(n) | OverlayValue::DateTime(n) | OverlayValue::Duration(n) => {
+                Some(*n)
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn boolean_lane_value(&self) -> Option<bool> {
+        match self {
+            OverlayValue::Boolean(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn text_lane_value(&self) -> Option<&str> {
+        match self {
+            OverlayValue::Text(s) => Some(s.as_ref()),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn error_lane_value(&self) -> Option<u8> {
+        match self {
+            OverlayValue::Error(code) => Some(*code),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn lowered_text_value(&self) -> Option<String> {
+        match self {
+            OverlayValue::Text(s) => Some(s.to_lowercase()),
+            OverlayValue::Number(n) | OverlayValue::DateTime(n) | OverlayValue::Duration(n) => {
+                Some(n.to_string())
+            }
+            OverlayValue::Boolean(b) => Some(if *b { "true" } else { "false" }.to_string()),
+            OverlayValue::Empty | OverlayValue::Error(_) | OverlayValue::Pending => None,
+        }
+    }
+
+    pub(crate) fn to_literal(&self) -> LiteralValue {
+        match self {
+            OverlayValue::Empty => LiteralValue::Empty,
+            OverlayValue::Number(n) => LiteralValue::Number(*n),
+            OverlayValue::DateTime(serial) => LiteralValue::from_serial_number(*serial),
+            OverlayValue::Duration(serial) => {
+                let nanos_f = *serial * 86_400.0 * 1_000_000_000.0;
+                let nanos = nanos_f.round().clamp(i64::MIN as f64, i64::MAX as f64) as i64;
+                LiteralValue::Duration(chrono::Duration::nanoseconds(nanos))
+            }
+            OverlayValue::Boolean(b) => LiteralValue::Boolean(*b),
+            OverlayValue::Text(s) => LiteralValue::Text((**s).to_string()),
+            OverlayValue::Error(code) => {
+                LiteralValue::Error(ExcelError::new(unmap_error_code(*code)))
+            }
+            OverlayValue::Pending => LiteralValue::Pending,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -867,11 +945,17 @@ impl Overlay {
         }
     }
     #[inline]
-    pub fn get(&self, off: usize) -> Option<&OverlayValue> {
+    pub(crate) fn get_scalar(&self, off: usize) -> Option<&OverlayValue> {
         self.map.get(&off)
     }
+
     #[inline]
-    pub fn set(&mut self, off: usize, v: OverlayValue) -> isize {
+    pub fn get(&self, off: usize) -> Option<&OverlayValue> {
+        self.get_scalar(off)
+    }
+
+    #[inline]
+    pub(crate) fn set_scalar(&mut self, off: usize, v: OverlayValue) -> isize {
         let new_est = Self::ENTRY_BASE_BYTES + v.estimated_payload_bytes();
         let old_est = self
             .map
@@ -889,7 +973,12 @@ impl Overlay {
     }
 
     #[inline]
-    pub fn remove(&mut self, off: usize) -> isize {
+    pub fn set(&mut self, off: usize, v: OverlayValue) -> isize {
+        self.set_scalar(off, v)
+    }
+
+    #[inline]
+    pub(crate) fn remove_scalar(&mut self, off: usize) -> isize {
         let Some(old) = self.map.remove(&off) else {
             return 0;
         };
@@ -897,12 +986,23 @@ impl Overlay {
         self.estimated_bytes = self.estimated_bytes.saturating_sub(old_est);
         -(old_est as isize)
     }
+
     #[inline]
-    pub fn clear(&mut self) -> usize {
+    pub fn remove(&mut self, off: usize) -> isize {
+        self.remove_scalar(off)
+    }
+
+    #[inline]
+    pub(crate) fn clear_all(&mut self) -> usize {
         let freed = self.estimated_bytes;
         self.map.clear();
         self.estimated_bytes = 0;
         freed
+    }
+
+    #[inline]
+    pub fn clear(&mut self) -> usize {
+        self.clear_all()
     }
     #[inline]
     pub fn len(&self) -> usize {
@@ -918,13 +1018,323 @@ impl Overlay {
         self.map.is_empty()
     }
     #[inline]
-    pub fn any_in_range(&self, range: core::ops::Range<usize>) -> bool {
+    pub(crate) fn has_any_in_range(&self, range: core::ops::Range<usize>) -> bool {
         self.map.keys().any(|k| range.contains(k))
+    }
+
+    #[inline]
+    pub fn any_in_range(&self, range: core::ops::Range<usize>) -> bool {
+        self.has_any_in_range(range)
+    }
+
+    pub(crate) fn slice(&self, off: usize, len: usize) -> Overlay {
+        let mut out = Overlay::new();
+        let end = off.saturating_add(len);
+        for (k, v) in self.map.iter() {
+            if *k >= off && *k < end {
+                let _ = out.set_scalar(*k - off, v.clone());
+            }
+        }
+        out
     }
 
     /// Iterate over all `(offset, value)` pairs in the overlay.
     pub fn iter(&self) -> impl Iterator<Item = (&usize, &OverlayValue)> {
         self.map.iter()
+    }
+}
+
+pub(crate) struct OverlayCascade<'a> {
+    user: &'a Overlay,
+    computed: &'a Overlay,
+}
+
+impl<'a> OverlayCascade<'a> {
+    #[inline]
+    pub(crate) fn new(user: &'a Overlay, computed: &'a Overlay) -> Self {
+        Self { user, computed }
+    }
+
+    #[inline]
+    pub(crate) fn get_scalar(&self, off: usize) -> Option<&'a OverlayValue> {
+        self.user
+            .get_scalar(off)
+            .or_else(|| self.computed.get_scalar(off))
+    }
+
+    #[inline]
+    pub(crate) fn has_any_in_range(&self, range: core::ops::Range<usize>) -> bool {
+        self.user.has_any_in_range(range.clone()) || self.computed.has_any_in_range(range)
+    }
+
+    pub(crate) fn select_numbers(
+        &self,
+        range: core::ops::Range<usize>,
+        base: &Float64Array,
+    ) -> Arc<Float64Array> {
+        let len = range.end.saturating_sub(range.start);
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = Float64Builder::with_capacity(len);
+        for off in range {
+            if let Some(value) = self.get_scalar(off) {
+                mask_b.append_value(true);
+                if let Some(n) = value.numeric_lane_value() {
+                    values_b.append_value(n);
+                } else {
+                    values_b.append_null();
+                }
+            } else {
+                mask_b.append_value(false);
+                values_b.append_null();
+            }
+        }
+        let mask = mask_b.finish();
+        let values = values_b.finish();
+        let zipped =
+            crate::compute_prelude::zip_select(&mask, &values, base).expect("zip numeric overlay");
+        Arc::new(
+            zipped
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("numeric overlay zip type")
+                .clone(),
+        )
+    }
+
+    pub(crate) fn select_booleans(
+        &self,
+        range: core::ops::Range<usize>,
+        base: &BooleanArray,
+    ) -> Arc<BooleanArray> {
+        let len = range.end.saturating_sub(range.start);
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = BooleanBuilder::with_capacity(len);
+        for off in range {
+            if let Some(value) = self.get_scalar(off) {
+                mask_b.append_value(true);
+                if let Some(b) = value.boolean_lane_value() {
+                    values_b.append_value(b);
+                } else {
+                    values_b.append_null();
+                }
+            } else {
+                mask_b.append_value(false);
+                values_b.append_null();
+            }
+        }
+        let mask = mask_b.finish();
+        let values = values_b.finish();
+        let zipped =
+            crate::compute_prelude::zip_select(&mask, &values, base).expect("zip boolean overlay");
+        Arc::new(
+            zipped
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .expect("boolean overlay zip type")
+                .clone(),
+        )
+    }
+
+    pub(crate) fn select_text(
+        &self,
+        range: core::ops::Range<usize>,
+        base: &StringArray,
+    ) -> ArrayRef {
+        let len = range.end.saturating_sub(range.start);
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = StringBuilder::with_capacity(len, len * 8);
+        for off in range {
+            if let Some(value) = self.get_scalar(off) {
+                mask_b.append_value(true);
+                if let Some(s) = value.text_lane_value() {
+                    values_b.append_value(s);
+                } else {
+                    values_b.append_null();
+                }
+            } else {
+                mask_b.append_value(false);
+                values_b.append_null();
+            }
+        }
+        let mask = mask_b.finish();
+        let values = values_b.finish();
+        crate::compute_prelude::zip_select(&mask, &values, base).expect("zip text overlay")
+    }
+
+    pub(crate) fn select_errors(
+        &self,
+        range: core::ops::Range<usize>,
+        base: &UInt8Array,
+    ) -> Arc<UInt8Array> {
+        let len = range.end.saturating_sub(range.start);
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = UInt8Builder::with_capacity(len);
+        for off in range {
+            if let Some(value) = self.get_scalar(off) {
+                mask_b.append_value(true);
+                if let Some(code) = value.error_lane_value() {
+                    values_b.append_value(code);
+                } else {
+                    values_b.append_null();
+                }
+            } else {
+                mask_b.append_value(false);
+                values_b.append_null();
+            }
+        }
+        let mask = mask_b.finish();
+        let values = values_b.finish();
+        let zipped =
+            crate::compute_prelude::zip_select(&mask, &values, base).expect("zip error overlay");
+        Arc::new(
+            zipped
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("error overlay zip type")
+                .clone(),
+        )
+    }
+
+    pub(crate) fn select_type_tags(
+        &self,
+        range: core::ops::Range<usize>,
+        base: &UInt8Array,
+    ) -> Arc<UInt8Array> {
+        let len = range.end.saturating_sub(range.start);
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = UInt8Builder::with_capacity(len);
+        for off in range {
+            if let Some(value) = self.get_scalar(off) {
+                mask_b.append_value(true);
+                values_b.append_value(value.type_tag() as u8);
+            } else {
+                mask_b.append_value(false);
+                values_b.append_null();
+            }
+        }
+        let mask = mask_b.finish();
+        let values = values_b.finish();
+        let zipped =
+            crate::compute_prelude::zip_select(&mask, &values, base).expect("zip type-tag overlay");
+        Arc::new(
+            zipped
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("type-tag overlay zip type")
+                .clone(),
+        )
+    }
+
+    pub(crate) fn select_lowered_text(
+        &self,
+        range: core::ops::Range<usize>,
+        base: &StringArray,
+    ) -> Arc<StringArray> {
+        let len = range.end.saturating_sub(range.start);
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = StringBuilder::with_capacity(len, len * 8);
+        for off in range {
+            if let Some(value) = self.get_scalar(off) {
+                mask_b.append_value(true);
+                if let Some(s) = value.lowered_text_value() {
+                    values_b.append_value(&s);
+                } else {
+                    values_b.append_null();
+                }
+            } else {
+                mask_b.append_value(false);
+                values_b.append_null();
+            }
+        }
+        let mask = mask_b.finish();
+        let values = values_b.finish();
+        let zipped = crate::compute_prelude::zip_select(&mask, &values, base)
+            .expect("zip lowered text overlay");
+        Arc::new(
+            zipped
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("lowered text overlay zip type")
+                .clone(),
+        )
+    }
+}
+
+fn append_overlay_value_to_lane_builders(
+    ov: &OverlayValue,
+    tag_b: &mut UInt8Builder,
+    nb: &mut Float64Builder,
+    bb: &mut BooleanBuilder,
+    sb: &mut StringBuilder,
+    eb: &mut UInt8Builder,
+    non_num: &mut usize,
+    non_bool: &mut usize,
+    non_text: &mut usize,
+    non_err: &mut usize,
+) {
+    match ov {
+        OverlayValue::Empty => {
+            tag_b.append_value(TypeTag::Empty as u8);
+            nb.append_null();
+            bb.append_null();
+            sb.append_null();
+            eb.append_null();
+        }
+        OverlayValue::Number(n) => {
+            tag_b.append_value(TypeTag::Number as u8);
+            nb.append_value(*n);
+            *non_num += 1;
+            bb.append_null();
+            sb.append_null();
+            eb.append_null();
+        }
+        OverlayValue::DateTime(serial) => {
+            tag_b.append_value(TypeTag::DateTime as u8);
+            nb.append_value(*serial);
+            *non_num += 1;
+            bb.append_null();
+            sb.append_null();
+            eb.append_null();
+        }
+        OverlayValue::Duration(serial) => {
+            tag_b.append_value(TypeTag::Duration as u8);
+            nb.append_value(*serial);
+            *non_num += 1;
+            bb.append_null();
+            sb.append_null();
+            eb.append_null();
+        }
+        OverlayValue::Boolean(b) => {
+            tag_b.append_value(TypeTag::Boolean as u8);
+            nb.append_null();
+            bb.append_value(*b);
+            *non_bool += 1;
+            sb.append_null();
+            eb.append_null();
+        }
+        OverlayValue::Text(s) => {
+            tag_b.append_value(TypeTag::Text as u8);
+            nb.append_null();
+            bb.append_null();
+            sb.append_value(s);
+            *non_text += 1;
+            eb.append_null();
+        }
+        OverlayValue::Error(code) => {
+            tag_b.append_value(TypeTag::Error as u8);
+            nb.append_null();
+            bb.append_null();
+            sb.append_null();
+            eb.append_value(*code);
+            *non_err += 1;
+        }
+        OverlayValue::Pending => {
+            tag_b.append_value(TypeTag::Pending as u8);
+            nb.append_null();
+            bb.append_null();
+            sb.append_null();
+            eb.append_null();
+        }
     }
 }
 
@@ -995,28 +1405,9 @@ impl ArrowSheet {
         };
 
         // Overlay takes precedence: user edits over computed over base.
-        if let Some(ov) = ch
-            .overlay
-            .get(in_off)
-            .or_else(|| ch.computed_overlay.get(in_off))
-        {
-            return match ov {
-                OverlayValue::Empty => LiteralValue::Empty,
-                OverlayValue::Number(n) => LiteralValue::Number(*n),
-                OverlayValue::DateTime(serial) => LiteralValue::from_serial_number(*serial),
-                OverlayValue::Duration(serial) => {
-                    let nanos_f = *serial * 86_400.0 * 1_000_000_000.0;
-                    let nanos = nanos_f.round().clamp(i64::MIN as f64, i64::MAX as f64) as i64;
-                    LiteralValue::Duration(chrono::Duration::nanoseconds(nanos))
-                }
-                OverlayValue::Boolean(b) => LiteralValue::Boolean(*b),
-                OverlayValue::Text(s) => LiteralValue::Text((**s).to_string()),
-                OverlayValue::Error(code) => {
-                    let kind = unmap_error_code(*code);
-                    LiteralValue::Error(ExcelError::new(kind))
-                }
-                OverlayValue::Pending => LiteralValue::Pending,
-            };
+        let cascade = OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+        if let Some(ov) = cascade.get_scalar(in_off) {
+            return ov.to_literal();
         }
 
         // Read tag and route to lane.
@@ -1275,19 +1666,9 @@ impl ArrowSheet {
             let nn = len.saturating_sub(ea.null_count());
             if nn == 0 { None } else { Some(Arc::new(ea)) }
         });
-        // Split overlays for this slice
-        let mut overlay = Overlay::new();
-        for (k, v) in ch.overlay.map.iter() {
-            if *k >= off && *k < off + len {
-                let _ = overlay.set(*k - off, v.clone());
-            }
-        }
-        let mut computed_overlay = Overlay::new();
-        for (k, v) in ch.computed_overlay.map.iter() {
-            if *k >= off && *k < off + len {
-                let _ = computed_overlay.set(*k - off, v.clone());
-            }
-        }
+        // Split overlays for this slice.
+        let overlay = ch.overlay.slice(off, len);
+        let computed_overlay = ch.computed_overlay.slice(off, len);
         let non_null_num = numbers.as_ref().map(|a| len - a.null_count()).unwrap_or(0);
         let non_null_bool = booleans.as_ref().map(|a| len - a.null_count()).unwrap_or(0);
         let non_null_text = text.as_ref().map(|a| len - a.null_count()).unwrap_or(0);
@@ -1358,71 +1739,19 @@ impl ArrowSheet {
 
             for i in 0..len {
                 // If overlay present, use it. Otherwise, use base tag+lane.
-                if let Some(ov) = ch_ref.overlay.get(i) {
-                    match ov {
-                        OverlayValue::Empty => {
-                            tag_b.append_value(TypeTag::Empty as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Number(n) => {
-                            tag_b.append_value(TypeTag::Number as u8);
-                            nb.append_value(*n);
-                            non_num += 1;
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::DateTime(serial) => {
-                            tag_b.append_value(TypeTag::DateTime as u8);
-                            nb.append_value(*serial);
-                            non_num += 1;
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Duration(serial) => {
-                            tag_b.append_value(TypeTag::Duration as u8);
-                            nb.append_value(*serial);
-                            non_num += 1;
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Boolean(b) => {
-                            tag_b.append_value(TypeTag::Boolean as u8);
-                            nb.append_null();
-                            bb.append_value(*b);
-                            non_bool += 1;
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Text(s) => {
-                            tag_b.append_value(TypeTag::Text as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_value(s);
-                            non_text += 1;
-                            eb.append_null();
-                        }
-                        OverlayValue::Error(code) => {
-                            tag_b.append_value(TypeTag::Error as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_value(*code);
-                            non_err += 1;
-                        }
-                        OverlayValue::Pending => {
-                            tag_b.append_value(TypeTag::Pending as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                    }
+                if let Some(ov) = ch_ref.overlay.get_scalar(i) {
+                    append_overlay_value_to_lane_builders(
+                        ov,
+                        &mut tag_b,
+                        &mut nb,
+                        &mut bb,
+                        &mut sb,
+                        &mut eb,
+                        &mut non_num,
+                        &mut non_bool,
+                        &mut non_text,
+                        &mut non_err,
+                    );
                 } else {
                     let tag = TypeTag::from_u8(ch_ref.type_tag.value(i));
                     match tag {
@@ -1602,71 +1931,19 @@ impl ArrowSheet {
             let mut non_err = 0usize;
 
             for i in 0..len {
-                if let Some(ov) = ch_ref.computed_overlay.get(i) {
-                    match ov {
-                        OverlayValue::Empty => {
-                            tag_b.append_value(TypeTag::Empty as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Number(n) => {
-                            tag_b.append_value(TypeTag::Number as u8);
-                            nb.append_value(*n);
-                            non_num += 1;
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::DateTime(serial) => {
-                            tag_b.append_value(TypeTag::DateTime as u8);
-                            nb.append_value(*serial);
-                            non_num += 1;
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Duration(serial) => {
-                            tag_b.append_value(TypeTag::Duration as u8);
-                            nb.append_value(*serial);
-                            non_num += 1;
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Boolean(b) => {
-                            tag_b.append_value(TypeTag::Boolean as u8);
-                            nb.append_null();
-                            bb.append_value(*b);
-                            non_bool += 1;
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                        OverlayValue::Text(s) => {
-                            tag_b.append_value(TypeTag::Text as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_value(s);
-                            non_text += 1;
-                            eb.append_null();
-                        }
-                        OverlayValue::Error(code) => {
-                            tag_b.append_value(TypeTag::Error as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_value(*code);
-                            non_err += 1;
-                        }
-                        OverlayValue::Pending => {
-                            tag_b.append_value(TypeTag::Pending as u8);
-                            nb.append_null();
-                            bb.append_null();
-                            sb.append_null();
-                            eb.append_null();
-                        }
-                    }
+                if let Some(ov) = ch_ref.computed_overlay.get_scalar(i) {
+                    append_overlay_value_to_lane_builders(
+                        ov,
+                        &mut tag_b,
+                        &mut nb,
+                        &mut bb,
+                        &mut sb,
+                        &mut eb,
+                        &mut non_num,
+                        &mut non_bool,
+                        &mut non_text,
+                        &mut non_err,
+                    );
                 } else {
                     let tag = TypeTag::from_u8(ch_ref.type_tag.value(i));
                     match tag {
@@ -2407,6 +2684,92 @@ mod tests {
         let nums1: Vec<_> = rv1.numbers_slices().map(|r| r.unwrap()).collect();
         assert_eq!(nums1.len(), 1);
         assert_eq!(nums1[0].2[0].value(0), 3.0);
+    }
+
+    #[test]
+    fn overlay_slice_preserves_explicit_empty_and_offsets() {
+        let mut overlay = Overlay::new();
+        overlay.set(2, OverlayValue::Number(2.0));
+        overlay.set(4, OverlayValue::Empty);
+        overlay.set(6, OverlayValue::Text(Arc::from("outside")));
+
+        let sliced = overlay.slice(1, 4);
+        assert!(sliced.get_scalar(0).is_none());
+        assert_eq!(
+            sliced.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+        assert_eq!(
+            sliced.get_scalar(3).unwrap().to_literal(),
+            LiteralValue::Empty
+        );
+        assert!(sliced.get_scalar(5).is_none());
+    }
+
+    #[test]
+    fn overlay_cascade_user_empty_masks_computed_and_base() {
+        let mut user = Overlay::new();
+        let mut computed = Overlay::new();
+        computed.set(1, OverlayValue::Number(42.0));
+        user.set(1, OverlayValue::Empty);
+
+        let cascade = OverlayCascade::new(&user, &computed);
+        assert_eq!(
+            cascade.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Empty
+        );
+        assert!(cascade.has_any_in_range(1..2));
+    }
+
+    #[test]
+    fn overlay_segment_numbers_masks_base_for_non_numeric_overlays() {
+        let mut user = Overlay::new();
+        user.set(1, OverlayValue::Text(Arc::from("x")));
+        user.set(2, OverlayValue::Empty);
+        user.set(3, OverlayValue::Error(map_error_code(ExcelErrorKind::Div)));
+        user.set(4, OverlayValue::Pending);
+        let computed = Overlay::new();
+        let cascade = OverlayCascade::new(&user, &computed);
+
+        let base = Float64Array::from(vec![10.0, 20.0, 30.0, 40.0, 50.0]);
+        let selected = cascade.select_numbers(0..5, &base);
+        assert_eq!(selected.value(0), 10.0);
+        assert!(selected.is_null(1));
+        assert!(selected.is_null(2));
+        assert!(selected.is_null(3));
+        assert!(selected.is_null(4));
+    }
+
+    #[test]
+    fn overlay_segment_type_tags_preserve_temporal_tags() {
+        let mut computed = Overlay::new();
+        computed.set(0, OverlayValue::DateTime(45000.5));
+        computed.set(1, OverlayValue::Duration(0.25));
+        let user = Overlay::new();
+        let cascade = OverlayCascade::new(&user, &computed);
+
+        let base = UInt8Array::from(vec![TypeTag::Empty as u8; 2]);
+        let selected = cascade.select_type_tags(0..2, &base);
+        assert_eq!(selected.value(0), TypeTag::DateTime as u8);
+        assert_eq!(selected.value(1), TypeTag::Duration as u8);
+    }
+
+    #[test]
+    fn overlay_lowered_text_matches_existing_overlay_semantics() {
+        let mut user = Overlay::new();
+        user.set(0, OverlayValue::Text(Arc::from("HeLLo")));
+        user.set(1, OverlayValue::Number(1.5));
+        user.set(2, OverlayValue::Boolean(true));
+        user.set(3, OverlayValue::Empty);
+        let computed = Overlay::new();
+        let cascade = OverlayCascade::new(&user, &computed);
+
+        let base = StringArray::from(vec![Some("A"), Some("B"), Some("C"), Some("D")]);
+        let selected = cascade.select_lowered_text(0..4, &base);
+        assert_eq!(selected.value(0), "hello");
+        assert_eq!(selected.value(1), "1.5");
+        assert_eq!(selected.value(2), "true");
+        assert!(selected.is_null(3));
     }
 
     #[test]

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -1276,6 +1276,18 @@ impl OverlayFragment {
         }
     }
 
+    pub(crate) fn max_covered_offset(&self) -> usize {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => {
+                offsets.iter().copied().max().unwrap_or(0) as usize
+            }
+            OverlayFragment::DenseRange { start, len, .. }
+            | OverlayFragment::RunRange { start, len, .. } => (*start as usize)
+                .saturating_add(*len as usize)
+                .saturating_sub(1),
+        }
+    }
+
     fn interval_coverage(&self) -> Option<core::ops::Range<usize>> {
         match self {
             OverlayFragment::DenseRange { start, len, .. }

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -924,13 +924,66 @@ impl OverlayValue {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum OverlayScalar<'a> {
+    Borrowed(&'a OverlayValue),
+    Owned(OverlayValue),
+}
+
+impl<'a> OverlayScalar<'a> {
+    #[inline]
+    fn as_value(&self) -> &OverlayValue {
+        match self {
+            OverlayScalar::Borrowed(value) => value,
+            OverlayScalar::Owned(value) => value,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn to_overlay_value(&self) -> OverlayValue {
+        self.as_value().clone()
+    }
+
+    #[inline]
+    pub(crate) fn type_tag(&self) -> TypeTag {
+        self.as_value().type_tag()
+    }
+
+    #[inline]
+    pub(crate) fn numeric_lane_value(&self) -> Option<f64> {
+        self.as_value().numeric_lane_value()
+    }
+
+    #[inline]
+    pub(crate) fn boolean_lane_value(&self) -> Option<bool> {
+        self.as_value().boolean_lane_value()
+    }
+
+    #[inline]
+    pub(crate) fn text_lane_value(&self) -> Option<&str> {
+        self.as_value().text_lane_value()
+    }
+
+    #[inline]
+    pub(crate) fn error_lane_value(&self) -> Option<u8> {
+        self.as_value().error_lane_value()
+    }
+
+    pub(crate) fn lowered_text_value(&self) -> Option<String> {
+        self.as_value().lowered_text_value()
+    }
+
+    pub(crate) fn to_literal(&self) -> LiteralValue {
+        self.as_value().to_literal()
+    }
+}
+
 const OVERLAY_ENTRY_BASE_BYTES: usize = 32;
 const OVERLAY_FRAGMENT_BASE_BYTES: usize = 48;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct OverlayFragmentPayload {
-    values: Arc<[OverlayValue]>,
     type_tags: Arc<UInt8Array>,
     numbers: Option<Arc<Float64Array>>,
     booleans: Option<Arc<BooleanArray>>,
@@ -967,45 +1020,111 @@ impl OverlayFragmentPayload {
             );
         }
 
-        let payload_bytes = values
-            .iter()
-            .map(|value| value.estimated_payload_bytes())
-            .fold(0usize, usize::saturating_add);
-        let estimated_bytes = len
-            .saturating_mul(OVERLAY_ENTRY_BASE_BYTES)
-            .saturating_add(payload_bytes);
+        let type_tags = Arc::new(tag_b.finish());
+        let numbers = {
+            let a = nb.finish();
+            (non_num > 0).then(|| Arc::new(a))
+        };
+        let booleans = {
+            let a = bb.finish();
+            (non_bool > 0).then(|| Arc::new(a))
+        };
+        let text = {
+            let a = sb.finish();
+            (non_text > 0).then(|| Arc::new(a) as ArrayRef)
+        };
+        let errors = {
+            let a = eb.finish();
+            (non_err > 0).then(|| Arc::new(a))
+        };
+
+        let estimated_bytes = type_tags
+            .get_array_memory_size()
+            .saturating_add(
+                numbers
+                    .as_ref()
+                    .map(|a| a.get_array_memory_size())
+                    .unwrap_or(0),
+            )
+            .saturating_add(
+                booleans
+                    .as_ref()
+                    .map(|a| a.get_array_memory_size())
+                    .unwrap_or(0),
+            )
+            .saturating_add(
+                text.as_ref()
+                    .map(|a| a.get_array_memory_size())
+                    .unwrap_or(0),
+            )
+            .saturating_add(
+                errors
+                    .as_ref()
+                    .map(|a| a.get_array_memory_size())
+                    .unwrap_or(0),
+            );
 
         Self {
-            values: Arc::from(values.into_boxed_slice()),
-            type_tags: Arc::new(tag_b.finish()),
-            numbers: {
-                let a = nb.finish();
-                (non_num > 0).then(|| Arc::new(a))
-            },
-            booleans: {
-                let a = bb.finish();
-                (non_bool > 0).then(|| Arc::new(a))
-            },
-            text: {
-                let a = sb.finish();
-                (non_text > 0).then(|| Arc::new(a) as ArrayRef)
-            },
-            errors: {
-                let a = eb.finish();
-                (non_err > 0).then(|| Arc::new(a))
-            },
+            type_tags,
+            numbers,
+            booleans,
+            text,
+            errors,
             estimated_bytes,
         }
     }
 
+    fn overlay_value(&self, idx: usize) -> Option<OverlayValue> {
+        if idx >= self.type_tags.len() || self.type_tags.is_null(idx) {
+            return None;
+        }
+        match TypeTag::from_u8(self.type_tags.value(idx)) {
+            TypeTag::Empty => Some(OverlayValue::Empty),
+            TypeTag::Number => Some(OverlayValue::Number(self.number_at(idx)?)),
+            TypeTag::DateTime => Some(OverlayValue::DateTime(self.number_at(idx)?)),
+            TypeTag::Duration => Some(OverlayValue::Duration(self.number_at(idx)?)),
+            TypeTag::Boolean => Some(OverlayValue::Boolean(self.boolean_at(idx)?)),
+            TypeTag::Text => Some(OverlayValue::Text(Arc::from(self.text_at(idx)?))),
+            TypeTag::Error => Some(OverlayValue::Error(self.error_at(idx)?)),
+            TypeTag::Pending => Some(OverlayValue::Pending),
+        }
+    }
+
     #[inline]
-    fn get(&self, idx: usize) -> Option<&OverlayValue> {
-        self.values.get(idx)
+    fn get_scalar(&self, idx: usize) -> Option<OverlayScalar<'_>> {
+        self.overlay_value(idx).map(OverlayScalar::Owned)
+    }
+
+    #[inline]
+    fn number_at(&self, idx: usize) -> Option<f64> {
+        let arr = self.numbers.as_ref()?;
+        (!arr.is_null(idx)).then(|| arr.value(idx))
+    }
+
+    #[inline]
+    fn boolean_at(&self, idx: usize) -> Option<bool> {
+        let arr = self.booleans.as_ref()?;
+        (!arr.is_null(idx)).then(|| arr.value(idx))
+    }
+
+    #[inline]
+    fn text_at(&self, idx: usize) -> Option<&str> {
+        let arr = self.text.as_ref()?;
+        let arr = arr.as_any().downcast_ref::<StringArray>()?;
+        (!arr.is_null(idx)).then(|| arr.value(idx))
+    }
+
+    #[inline]
+    fn error_at(&self, idx: usize) -> Option<u8> {
+        let arr = self.errors.as_ref()?;
+        (!arr.is_null(idx)).then(|| arr.value(idx))
     }
 
     #[inline]
     fn values_slice(&self, start: usize, len: usize) -> Vec<OverlayValue> {
-        self.values[start..start.saturating_add(len)].to_vec()
+        (start..start.saturating_add(len))
+            .filter_map(|idx| self.overlay_value(idx))
+            .collect()
     }
 
     #[inline]
@@ -1013,7 +1132,6 @@ impl OverlayFragmentPayload {
         self.estimated_bytes
     }
 }
-
 #[derive(Debug, Clone)]
 pub(crate) enum OverlayFragment {
     SparseOffsets {
@@ -1259,12 +1377,12 @@ impl OverlayFragment {
         self.get_scalar(off).is_some()
     }
 
-    fn get_scalar(&self, off: usize) -> Option<&OverlayValue> {
+    fn get_scalar(&self, off: usize) -> Option<OverlayScalar<'_>> {
         match self {
             OverlayFragment::SparseOffsets { offsets, payload } => {
                 let off = u32::try_from(off).ok()?;
                 let idx = offsets.binary_search(&off).ok()?;
-                payload.get(idx)
+                payload.get_scalar(idx)
             }
             OverlayFragment::DenseRange {
                 start,
@@ -1276,7 +1394,7 @@ impl OverlayFragment {
                 if rel >= *len as usize {
                     return None;
                 }
-                payload.get(rel)
+                payload.get_scalar(rel)
             }
             OverlayFragment::RunRange {
                 start,
@@ -1291,7 +1409,7 @@ impl OverlayFragment {
                 }
                 let rel_u32 = u32::try_from(rel).ok()?;
                 let run_idx = run_ends.partition_point(|end| *end <= rel_u32);
-                payload.get(run_idx)
+                payload.get_scalar(run_idx)
             }
         }
     }
@@ -1333,7 +1451,7 @@ impl OverlayFragment {
                     .filter_map(|(idx, off)| {
                         let off_usize = *off as usize;
                         (!replacement.contains(&off_usize))
-                            .then(|| payload.get(idx).cloned().map(|value| (off_usize, value)))?
+                            .then(|| payload.overlay_value(idx).map(|value| (off_usize, value)))?
                     })
                     .collect();
                 OverlayFragment::sparse_offsets(cells).into_iter().collect()
@@ -1399,8 +1517,7 @@ impl OverlayFragment {
                     .filter_map(|(idx, off)| {
                         replacement_offsets.binary_search(off).is_err().then(|| {
                             payload
-                                .get(idx)
-                                .cloned()
+                                .overlay_value(idx)
                                 .map(|value| (*off as usize, value))
                         })?
                     })
@@ -1570,7 +1687,7 @@ impl OverlayFragment {
             let inter_end = run_end.min(rel_end);
             if inter_start < inter_end {
                 new_run_ends.push(inter_end - rel_start);
-                if let Some(value) = payload.get(run_idx).cloned() {
+                if let Some(value) = payload.overlay_value(run_idx) {
                     new_values.push(value);
                 }
             }
@@ -1595,8 +1712,7 @@ impl OverlayFragment {
                 .enumerate()
                 .filter_map(|(idx, off)| {
                     payload
-                        .get(idx)
-                        .cloned()
+                        .overlay_value(idx)
                         .map(|value| (*off as usize, value))
                 })
                 .collect(),
@@ -1609,8 +1725,7 @@ impl OverlayFragment {
                 (0..*len as usize)
                     .filter_map(|idx| {
                         payload
-                            .get(idx)
-                            .cloned()
+                            .overlay_value(idx)
                             .map(|value| (start.saturating_add(idx), value))
                     })
                     .collect()
@@ -1620,8 +1735,7 @@ impl OverlayFragment {
                 (0..*len as usize)
                     .filter_map(|idx| {
                         self.get_scalar(start.saturating_add(idx))
-                            .cloned()
-                            .map(|value| (start.saturating_add(idx), value))
+                            .map(|value| (start.saturating_add(idx), value.to_overlay_value()))
                     })
                     .collect()
             }
@@ -1642,7 +1756,7 @@ impl OverlayFragment {
                 let cells: Vec<_> = (lo..hi)
                     .filter_map(|idx| {
                         let rebased = (offsets[idx] as usize).saturating_sub(off);
-                        payload.get(idx).cloned().map(|value| (rebased, value))
+                        payload.overlay_value(idx).map(|value| (rebased, value))
                     })
                     .collect();
                 OverlayFragment::sparse_offsets(cells)
@@ -1706,15 +1820,16 @@ impl Overlay {
     }
 
     #[inline]
-    pub(crate) fn get_scalar(&self, off: usize) -> Option<&OverlayValue> {
+    pub(crate) fn get_scalar(&self, off: usize) -> Option<OverlayScalar<'_>> {
         self.points
             .get(&off)
+            .map(OverlayScalar::Borrowed)
             .or_else(|| self.fragments.iter().rev().find_map(|f| f.get_scalar(off)))
     }
 
     #[inline]
-    pub fn get(&self, off: usize) -> Option<&OverlayValue> {
-        self.get_scalar(off)
+    pub fn get(&self, off: usize) -> Option<OverlayValue> {
+        self.get_scalar(off).map(|value| value.to_overlay_value())
     }
 
     #[inline]
@@ -1900,8 +2015,22 @@ impl Overlay {
         out
     }
 
-    /// Iterate over point `(offset, value)` pairs in the overlay.
-    pub fn iter(&self) -> impl Iterator<Item = (&usize, &OverlayValue)> {
+    /// Iterate over logical `(offset, value)` pairs in the overlay.
+    pub fn iter(&self) -> impl Iterator<Item = (usize, OverlayValue)> {
+        let mut cells = BTreeMap::new();
+        for fragment in &self.fragments {
+            for (off, value) in fragment.cells() {
+                cells.insert(off, value);
+            }
+        }
+        for (off, value) in &self.points {
+            cells.insert(*off, value.clone());
+        }
+        cells.into_iter()
+    }
+
+    /// Iterate over physical point entries only.
+    pub(crate) fn iter_points(&self) -> impl Iterator<Item = (&usize, &OverlayValue)> {
         self.points.iter()
     }
 }
@@ -1964,7 +2093,7 @@ impl<'a> OverlayCascade<'a> {
     }
 
     #[inline]
-    pub(crate) fn get_scalar(&self, off: usize) -> Option<&'a OverlayValue> {
+    pub(crate) fn get_scalar(&self, off: usize) -> Option<OverlayScalar<'a>> {
         self.user
             .get_scalar(off)
             .or_else(|| self.computed.get_scalar(off))
@@ -2648,8 +2777,9 @@ impl ArrowSheet {
             for i in 0..len {
                 // If overlay present, use it. Otherwise, use base tag+lane.
                 if let Some(ov) = ch_ref.overlay.get_scalar(i) {
+                    let ov = ov.to_overlay_value();
                     append_overlay_value_to_lane_builders(
-                        ov,
+                        &ov,
                         &mut tag_b,
                         &mut nb,
                         &mut bb,
@@ -2840,8 +2970,9 @@ impl ArrowSheet {
 
             for i in 0..len {
                 if let Some(ov) = ch_ref.computed_overlay.get_scalar(i) {
+                    let ov = ov.to_overlay_value();
                     append_overlay_value_to_lane_builders(
-                        ov,
+                        &ov,
                         &mut tag_b,
                         &mut nb,
                         &mut bb,
@@ -4050,6 +4181,94 @@ mod tests {
         assert_eq!(sheet.get_cell_value(0, 0), LiteralValue::Empty);
         assert_eq!(sheet.get_cell_value(1, 0), LiteralValue::Empty);
         assert_eq!(sheet.get_cell_value(2, 0), LiteralValue::Empty);
+    }
+
+    #[test]
+    fn overlay_fragments_reconstruct_scalars_from_typed_lanes() {
+        let values = vec![
+            OverlayValue::Empty,
+            OverlayValue::Number(1.5),
+            OverlayValue::DateTime(45000.25),
+            OverlayValue::Duration(0.5),
+            OverlayValue::Boolean(true),
+            OverlayValue::Text(Arc::from("Hello")),
+            OverlayValue::Error(map_error_code(ExcelErrorKind::Div)),
+            OverlayValue::Pending,
+        ];
+
+        let mut dense = Overlay::new();
+        dense.apply_fragment(OverlayFragment::dense_range(0, values.clone()).unwrap());
+        for (idx, expected) in values.iter().enumerate() {
+            assert_eq!(
+                dense.get_scalar(idx).unwrap().to_overlay_value(),
+                expected.clone()
+            );
+        }
+
+        let mut sparse = Overlay::new();
+        sparse.apply_fragment(
+            OverlayFragment::sparse_offsets(
+                values
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(idx, value)| (idx * 2, value))
+                    .collect(),
+            )
+            .unwrap(),
+        );
+        for (idx, expected) in values.iter().enumerate() {
+            assert_eq!(
+                sparse.get_scalar(idx * 2).unwrap().to_overlay_value(),
+                expected.clone()
+            );
+        }
+
+        let mut run = Overlay::new();
+        run.apply_fragment(
+            OverlayFragment::run_range(
+                0,
+                vec![
+                    OverlayValue::Number(7.0),
+                    OverlayValue::Number(7.0),
+                    OverlayValue::Text(Arc::from("run")),
+                    OverlayValue::Text(Arc::from("run")),
+                ],
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            run.get_scalar(0).unwrap().to_overlay_value(),
+            OverlayValue::Number(7.0)
+        );
+        assert_eq!(
+            run.get_scalar(2).unwrap().to_overlay_value(),
+            OverlayValue::Text(Arc::from("run"))
+        );
+    }
+
+    #[test]
+    fn overlay_iter_returns_complete_logical_entries() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                2,
+                vec![OverlayValue::Number(2.0), OverlayValue::Number(3.0)],
+            )
+            .unwrap(),
+        );
+        overlay.set_scalar(5, OverlayValue::Text(Arc::from("point")));
+
+        let entries: Vec<_> = overlay.iter().collect();
+        assert_eq!(
+            entries,
+            vec![
+                (2, OverlayValue::Number(2.0)),
+                (3, OverlayValue::Number(3.0)),
+                (5, OverlayValue::Text(Arc::from("point"))),
+            ]
+        );
+        assert_eq!(overlay.iter_points().count(), 1);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -1004,8 +1004,8 @@ impl OverlayFragmentPayload {
     }
 
     #[inline]
-    fn len(&self) -> usize {
-        self.values.len()
+    fn values_slice(&self, start: usize, len: usize) -> Vec<OverlayValue> {
+        self.values[start..start.saturating_add(len)].to_vec()
     }
 
     #[inline]
@@ -1034,6 +1034,8 @@ pub(crate) enum OverlayFragment {
 }
 
 impl OverlayFragment {
+    const MAX_SPLIT_SEGMENTS_BEFORE_SPARSE_FALLBACK: usize = 128;
+
     pub(crate) fn sparse_offsets(items: Vec<(usize, OverlayValue)>) -> Option<Self> {
         let mut by_offset: BTreeMap<usize, OverlayValue> = BTreeMap::new();
         for (offset, value) in items {
@@ -1078,19 +1080,54 @@ impl OverlayFragment {
         let mut current = values[0].clone();
         for (idx, value) in values.iter().enumerate().skip(1) {
             if *value != current {
-                run_ends.push(u32::try_from(idx).expect("run end fits in u32"));
+                run_ends.push(idx);
                 run_values.push(current);
                 current = value.clone();
             }
         }
-        run_ends.push(u32::try_from(values.len()).expect("run end fits in u32"));
+        run_ends.push(values.len());
         run_values.push(current);
+
+        Self::run_range_from_parts(start, values.len(), run_ends, run_values)
+    }
+
+    fn run_range_from_parts(
+        start: usize,
+        len: usize,
+        run_ends: Vec<usize>,
+        values: Vec<OverlayValue>,
+    ) -> Option<Self> {
+        if len == 0 || run_ends.is_empty() || run_ends.len() != values.len() {
+            return None;
+        }
+
+        let mut merged_ends: Vec<u32> = Vec::with_capacity(run_ends.len());
+        let mut merged_values: Vec<OverlayValue> = Vec::with_capacity(values.len());
+        let mut prev_end = 0usize;
+        for (end, value) in run_ends.into_iter().zip(values.into_iter()) {
+            if end <= prev_end || end > len {
+                return None;
+            }
+            if merged_values.last().is_some_and(|last| *last == value) {
+                if let Some(last_end) = merged_ends.last_mut() {
+                    *last_end = u32::try_from(end).expect("run end fits in u32");
+                }
+            } else {
+                merged_ends.push(u32::try_from(end).expect("run end fits in u32"));
+                merged_values.push(value);
+            }
+            prev_end = end;
+        }
+
+        if prev_end != len || merged_ends.last().copied() != Some(len as u32) {
+            return None;
+        }
 
         Some(Self::RunRange {
             start: u32::try_from(start).expect("overlay start fits in u32"),
-            len: u32::try_from(values.len()).expect("overlay length fits in u32"),
-            run_ends,
-            payload: OverlayFragmentPayload::from_values(run_values),
+            len: u32::try_from(len).expect("overlay length fits in u32"),
+            run_ends: merged_ends,
+            payload: OverlayFragmentPayload::from_values(merged_values),
         })
     }
 
@@ -1121,18 +1158,21 @@ impl OverlayFragment {
         }
     }
 
-    fn covered_range(&self) -> Option<core::ops::Range<usize>> {
+    fn interval_coverage(&self) -> Option<core::ops::Range<usize>> {
         match self {
-            OverlayFragment::SparseOffsets { offsets, .. } => {
-                let start = *offsets.first()? as usize;
-                let end = (*offsets.last()? as usize).saturating_add(1);
-                Some(start..end)
-            }
             OverlayFragment::DenseRange { start, len, .. }
             | OverlayFragment::RunRange { start, len, .. } => {
                 let start = *start as usize;
                 Some(start..start.saturating_add(*len as usize))
             }
+            OverlayFragment::SparseOffsets { .. } => None,
+        }
+    }
+
+    fn sparse_offsets_slice(&self) -> Option<&[u32]> {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => Some(offsets.as_slice()),
+            _ => None,
         }
     }
 
@@ -1149,9 +1189,70 @@ impl OverlayFragment {
                     .is_some_and(|off| (*off as usize) < range.end)
             }
             OverlayFragment::DenseRange { .. } | OverlayFragment::RunRange { .. } => self
-                .covered_range()
+                .interval_coverage()
                 .is_some_and(|r| r.start < range.end && range.start < r.end),
         }
+    }
+
+    fn intersects_fragment_exact(&self, replacement: &OverlayFragment) -> bool {
+        if let Some(offsets) = replacement.sparse_offsets_slice() {
+            self.intersects_sparse_offsets(offsets)
+        } else if let Some(range) = replacement.interval_coverage() {
+            self.intersects_interval(range)
+        } else {
+            false
+        }
+    }
+
+    fn intersects_interval(&self, range: core::ops::Range<usize>) -> bool {
+        if range.is_empty() {
+            return false;
+        }
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => {
+                let start = u32::try_from(range.start).unwrap_or(u32::MAX);
+                let idx = offsets.partition_point(|off| *off < start);
+                offsets
+                    .get(idx)
+                    .is_some_and(|off| (*off as usize) < range.end)
+            }
+            OverlayFragment::DenseRange { .. } | OverlayFragment::RunRange { .. } => self
+                .interval_coverage()
+                .is_some_and(|own| own.start < range.end && range.start < own.end),
+        }
+    }
+
+    fn intersects_sparse_offsets(&self, replacement_offsets: &[u32]) -> bool {
+        if replacement_offsets.is_empty() {
+            return false;
+        }
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => {
+                Self::sorted_offsets_intersect(offsets, replacement_offsets)
+            }
+            OverlayFragment::DenseRange { .. } | OverlayFragment::RunRange { .. } => {
+                self.interval_coverage().is_some_and(|range| {
+                    let start = u32::try_from(range.start).unwrap_or(u32::MAX);
+                    let idx = replacement_offsets.partition_point(|off| *off < start);
+                    replacement_offsets
+                        .get(idx)
+                        .is_some_and(|off| (*off as usize) < range.end)
+                })
+            }
+        }
+    }
+
+    fn sorted_offsets_intersect(a: &[u32], b: &[u32]) -> bool {
+        let mut ai = 0usize;
+        let mut bi = 0usize;
+        while ai < a.len() && bi < b.len() {
+            match a[ai].cmp(&b[bi]) {
+                core::cmp::Ordering::Equal => return true,
+                core::cmp::Ordering::Less => ai += 1,
+                core::cmp::Ordering::Greater => bi += 1,
+            }
+        }
+        false
     }
 
     fn covers_offset(&self, off: usize) -> bool {
@@ -1195,17 +1296,296 @@ impl OverlayFragment {
         }
     }
 
-    fn covered_offsets(&self) -> Vec<usize> {
+    fn subtract_fragment(&self, replacement: &OverlayFragment) -> Vec<OverlayFragment> {
+        if let Some(offsets) = replacement.sparse_offsets_slice() {
+            self.subtract_sparse_offsets(offsets)
+        } else if let Some(range) = replacement.interval_coverage() {
+            self.subtract_interval(range)
+        } else {
+            vec![self.clone()]
+        }
+    }
+
+    fn subtract_offset(&self, off: usize) -> Vec<OverlayFragment> {
         match self {
-            OverlayFragment::SparseOffsets { offsets, .. } => {
-                offsets.iter().map(|off| *off as usize).collect()
+            OverlayFragment::SparseOffsets { .. } => {
+                let Ok(off) = u32::try_from(off) else {
+                    return vec![self.clone()];
+                };
+                self.subtract_sparse_offsets(core::slice::from_ref(&off))
             }
-            OverlayFragment::DenseRange { start, len, .. }
-            | OverlayFragment::RunRange { start, len, .. } => {
-                let start = *start as usize;
-                (start..start.saturating_add(*len as usize)).collect()
+            OverlayFragment::DenseRange { .. } | OverlayFragment::RunRange { .. } => {
+                self.subtract_interval(off..off.saturating_add(1))
             }
         }
+    }
+
+    fn subtract_interval(&self, replacement: core::ops::Range<usize>) -> Vec<OverlayFragment> {
+        if replacement.is_empty() {
+            return vec![self.clone()];
+        }
+
+        match self {
+            OverlayFragment::SparseOffsets { offsets, payload } => {
+                let cells: Vec<_> = offsets
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, off)| {
+                        let off_usize = *off as usize;
+                        (!replacement.contains(&off_usize))
+                            .then(|| payload.get(idx).cloned().map(|value| (off_usize, value)))?
+                    })
+                    .collect();
+                OverlayFragment::sparse_offsets(cells).into_iter().collect()
+            }
+            OverlayFragment::DenseRange { .. } => {
+                let Some(own) = self.interval_coverage() else {
+                    return vec![self.clone()];
+                };
+                if own.end <= replacement.start || replacement.end <= own.start {
+                    return vec![self.clone()];
+                }
+                let cut_start = replacement.start.max(own.start);
+                let cut_end = replacement.end.min(own.end);
+                let mut out = Vec::with_capacity(2);
+                if own.start < cut_start
+                    && let Some(left) =
+                        self.dense_segment_with_start(own.start, own.start, cut_start)
+                {
+                    out.push(left);
+                }
+                if cut_end < own.end
+                    && let Some(right) = self.dense_segment_with_start(cut_end, cut_end, own.end)
+                {
+                    out.push(right);
+                }
+                out
+            }
+            OverlayFragment::RunRange { .. } => {
+                let Some(own) = self.interval_coverage() else {
+                    return vec![self.clone()];
+                };
+                if own.end <= replacement.start || replacement.end <= own.start {
+                    return vec![self.clone()];
+                }
+                let cut_start = replacement.start.max(own.start);
+                let cut_end = replacement.end.min(own.end);
+                let mut out = Vec::with_capacity(2);
+                if own.start < cut_start
+                    && let Some(left) = self.run_segment_with_start(own.start, own.start, cut_start)
+                {
+                    out.push(left);
+                }
+                if cut_end < own.end
+                    && let Some(right) = self.run_segment_with_start(cut_end, cut_end, own.end)
+                {
+                    out.push(right);
+                }
+                out
+            }
+        }
+    }
+
+    fn subtract_sparse_offsets(&self, replacement_offsets: &[u32]) -> Vec<OverlayFragment> {
+        if replacement_offsets.is_empty() {
+            return vec![self.clone()];
+        }
+
+        match self {
+            OverlayFragment::SparseOffsets { offsets, payload } => {
+                let cells: Vec<_> = offsets
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, off)| {
+                        replacement_offsets.binary_search(off).is_err().then(|| {
+                            payload
+                                .get(idx)
+                                .cloned()
+                                .map(|value| (*off as usize, value))
+                        })?
+                    })
+                    .collect();
+                OverlayFragment::sparse_offsets(cells).into_iter().collect()
+            }
+            OverlayFragment::DenseRange { .. } => {
+                self.subtract_sparse_offsets_from_dense(replacement_offsets)
+            }
+            OverlayFragment::RunRange { .. } => {
+                self.subtract_sparse_offsets_from_run(replacement_offsets)
+            }
+        }
+    }
+
+    fn sparse_holes_in_interval(offsets: &[u32], range: core::ops::Range<usize>) -> Vec<usize> {
+        if range.is_empty() {
+            return Vec::new();
+        }
+        let start = u32::try_from(range.start).unwrap_or(u32::MAX);
+        let mut idx = offsets.partition_point(|off| *off < start);
+        let mut holes = Vec::new();
+        let mut last = None;
+        while let Some(off) = offsets.get(idx).copied() {
+            let off_usize = off as usize;
+            if off_usize >= range.end {
+                break;
+            }
+            if last != Some(off_usize) {
+                holes.push(off_usize);
+                last = Some(off_usize);
+            }
+            idx += 1;
+        }
+        holes
+    }
+
+    fn subtract_sparse_offsets_from_dense(
+        &self,
+        replacement_offsets: &[u32],
+    ) -> Vec<OverlayFragment> {
+        let Some(own) = self.interval_coverage() else {
+            return vec![self.clone()];
+        };
+        let holes = Self::sparse_holes_in_interval(replacement_offsets, own.clone());
+        if holes.is_empty() {
+            return vec![self.clone()];
+        }
+        if holes.len().saturating_add(1) > Self::MAX_SPLIT_SEGMENTS_BEFORE_SPARSE_FALLBACK {
+            return self.sparse_remainder_excluding_offsets(&holes);
+        }
+
+        let mut out = Vec::with_capacity(holes.len().saturating_add(1));
+        let mut seg_start = own.start;
+        for hole in holes {
+            if seg_start < hole
+                && let Some(segment) = self.dense_segment_with_start(seg_start, seg_start, hole)
+            {
+                out.push(segment);
+            }
+            seg_start = hole.saturating_add(1);
+        }
+        if seg_start < own.end
+            && let Some(segment) = self.dense_segment_with_start(seg_start, seg_start, own.end)
+        {
+            out.push(segment);
+        }
+        out
+    }
+
+    fn subtract_sparse_offsets_from_run(
+        &self,
+        replacement_offsets: &[u32],
+    ) -> Vec<OverlayFragment> {
+        let Some(own) = self.interval_coverage() else {
+            return vec![self.clone()];
+        };
+        let holes = Self::sparse_holes_in_interval(replacement_offsets, own.clone());
+        if holes.is_empty() {
+            return vec![self.clone()];
+        }
+        if holes.len().saturating_add(1) > Self::MAX_SPLIT_SEGMENTS_BEFORE_SPARSE_FALLBACK {
+            return self.sparse_remainder_excluding_offsets(&holes);
+        }
+
+        let mut out = Vec::with_capacity(holes.len().saturating_add(1));
+        let mut seg_start = own.start;
+        for hole in holes {
+            if seg_start < hole
+                && let Some(segment) = self.run_segment_with_start(seg_start, seg_start, hole)
+            {
+                out.push(segment);
+            }
+            seg_start = hole.saturating_add(1);
+        }
+        if seg_start < own.end
+            && let Some(segment) = self.run_segment_with_start(seg_start, seg_start, own.end)
+        {
+            out.push(segment);
+        }
+        out
+    }
+
+    fn sparse_remainder_excluding_offsets(&self, sorted_holes: &[usize]) -> Vec<OverlayFragment> {
+        let cells: Vec<_> = self
+            .cells()
+            .into_iter()
+            .filter(|(off, _)| sorted_holes.binary_search(off).is_err())
+            .collect();
+        OverlayFragment::sparse_offsets(cells).into_iter().collect()
+    }
+
+    fn dense_segment_with_start(
+        &self,
+        new_start: usize,
+        abs_start: usize,
+        abs_end: usize,
+    ) -> Option<OverlayFragment> {
+        match self {
+            OverlayFragment::DenseRange { start, payload, .. } => {
+                if abs_start >= abs_end {
+                    return None;
+                }
+                let base = *start as usize;
+                let rel_start = abs_start.checked_sub(base)?;
+                let len = abs_end.saturating_sub(abs_start);
+                OverlayFragment::dense_range(new_start, payload.values_slice(rel_start, len))
+            }
+            _ => None,
+        }
+    }
+
+    fn run_segment_with_start(
+        &self,
+        new_start: usize,
+        abs_start: usize,
+        abs_end: usize,
+    ) -> Option<OverlayFragment> {
+        let OverlayFragment::RunRange {
+            start,
+            len,
+            run_ends,
+            payload,
+        } = self
+        else {
+            return None;
+        };
+        if abs_start >= abs_end {
+            return None;
+        }
+        let base = *start as usize;
+        let frag_end = base.saturating_add(*len as usize);
+        if abs_start < base || abs_end > frag_end {
+            return None;
+        }
+
+        let rel_start = abs_start - base;
+        let rel_end = abs_end - base;
+        let mut new_run_ends = Vec::new();
+        let mut new_values = Vec::new();
+        let mut prev_end = 0usize;
+
+        for (run_idx, end) in run_ends.iter().enumerate() {
+            let run_start = prev_end;
+            let run_end = *end as usize;
+            let inter_start = run_start.max(rel_start);
+            let inter_end = run_end.min(rel_end);
+            if inter_start < inter_end {
+                new_run_ends.push(inter_end - rel_start);
+                if let Some(value) = payload.get(run_idx).cloned() {
+                    new_values.push(value);
+                }
+            }
+            prev_end = run_end;
+            if prev_end >= rel_end {
+                break;
+            }
+        }
+
+        OverlayFragment::run_range_from_parts(
+            new_start,
+            abs_end.saturating_sub(abs_start),
+            new_run_ends,
+            new_values,
+        )
     }
 
     fn cells(&self) -> Vec<(usize, OverlayValue)> {
@@ -1248,44 +1628,46 @@ impl OverlayFragment {
         }
     }
 
-    fn without_offset(&self, off: usize) -> Vec<OverlayFragment> {
-        let cells: Vec<_> = self
-            .cells()
-            .into_iter()
-            .filter(|(cell_off, _)| *cell_off != off)
-            .collect();
-        OverlayFragment::sparse_offsets(cells).into_iter().collect()
-    }
-
     fn slice(&self, off: usize, len: usize) -> Option<OverlayFragment> {
         let end = off.saturating_add(len);
-        let cells: Vec<_> = self
-            .cells()
-            .into_iter()
-            .filter(|(cell_off, _)| *cell_off >= off && *cell_off < end)
-            .map(|(cell_off, value)| (cell_off - off, value))
-            .collect();
-
-        if cells.is_empty() {
+        if len == 0 {
             return None;
         }
 
         match self {
-            OverlayFragment::SparseOffsets { .. } => OverlayFragment::sparse_offsets(cells),
+            OverlayFragment::SparseOffsets { offsets, payload } => {
+                let start = u32::try_from(off).unwrap_or(u32::MAX);
+                let lo = offsets.partition_point(|candidate| *candidate < start);
+                let hi = offsets.partition_point(|candidate| (*candidate as usize) < end);
+                let cells: Vec<_> = (lo..hi)
+                    .filter_map(|idx| {
+                        let rebased = (offsets[idx] as usize).saturating_sub(off);
+                        payload.get(idx).cloned().map(|value| (rebased, value))
+                    })
+                    .collect();
+                OverlayFragment::sparse_offsets(cells)
+            }
             OverlayFragment::DenseRange { .. } => {
-                let start = cells[0].0;
-                let values = cells.into_iter().map(|(_, value)| value).collect();
-                OverlayFragment::dense_range(start, values)
+                let own = self.interval_coverage()?;
+                let seg_start = own.start.max(off);
+                let seg_end = own.end.min(end);
+                if seg_start >= seg_end {
+                    return None;
+                }
+                self.dense_segment_with_start(seg_start - off, seg_start, seg_end)
             }
             OverlayFragment::RunRange { .. } => {
-                let start = cells[0].0;
-                let values = cells.into_iter().map(|(_, value)| value).collect();
-                OverlayFragment::run_range(start, values)
+                let own = self.interval_coverage()?;
+                let seg_start = own.start.max(off);
+                let seg_end = own.end.min(end);
+                if seg_start >= seg_end {
+                    return None;
+                }
+                self.run_segment_with_start(seg_start - off, seg_start, seg_end)
             }
         }
     }
 }
-
 #[derive(Debug, Default, Clone)]
 pub struct Overlay {
     points: HashMap<usize, OverlayValue>,
@@ -1361,9 +1743,28 @@ impl Overlay {
 
     fn remove_points_covered_by_fragment(&mut self, fragment: &OverlayFragment) -> isize {
         let mut removed = 0usize;
-        for off in fragment.covered_offsets() {
-            if let Some(old) = self.points.remove(&off) {
-                removed = removed.saturating_add(Self::point_estimate(&old));
+        match fragment {
+            OverlayFragment::SparseOffsets { offsets, .. } => {
+                for off in offsets.iter().copied() {
+                    if let Some(old) = self.points.remove(&(off as usize)) {
+                        removed = removed.saturating_add(Self::point_estimate(&old));
+                    }
+                }
+            }
+            OverlayFragment::DenseRange { .. } | OverlayFragment::RunRange { .. } => {
+                if let Some(range) = fragment.interval_coverage() {
+                    let keys: Vec<_> = self
+                        .points
+                        .keys()
+                        .copied()
+                        .filter(|off| range.contains(off))
+                        .collect();
+                    for off in keys {
+                        if let Some(old) = self.points.remove(&off) {
+                            removed = removed.saturating_add(Self::point_estimate(&old));
+                        }
+                    }
+                }
             }
         }
         self.estimated_bytes = self.estimated_bytes.saturating_sub(removed);
@@ -1378,26 +1779,18 @@ impl Overlay {
         let mut delta: isize = 0;
         let mut fragments = Vec::with_capacity(self.fragments.len());
         for fragment in self.fragments.drain(..) {
-            let Some(range) = replacement.covered_range() else {
-                fragments.push(fragment);
-                continue;
-            };
-            if !fragment.has_any_in_range(range) {
+            if !fragment.intersects_fragment_exact(replacement) {
                 fragments.push(fragment);
                 continue;
             }
 
             let old_est = fragment.estimated_bytes();
-            let remaining_cells: Vec<_> = fragment
-                .cells()
-                .into_iter()
-                .filter(|(off, _)| !replacement.covers_offset(*off))
-                .collect();
-            let mut new_est = 0usize;
-            if let Some(fragment) = OverlayFragment::sparse_offsets(remaining_cells) {
-                new_est = fragment.estimated_bytes();
-                fragments.push(fragment);
-            }
+            let replacements = fragment.subtract_fragment(replacement);
+            let new_est = replacements
+                .iter()
+                .map(OverlayFragment::estimated_bytes)
+                .fold(0usize, usize::saturating_add);
+            fragments.extend(replacements);
             delta = delta.saturating_add(new_est as isize - old_est as isize);
         }
         self.fragments = fragments;
@@ -1423,7 +1816,7 @@ impl Overlay {
                 }
 
                 let old_est = fragment.estimated_bytes();
-                let replacements = fragment.without_offset(off);
+                let replacements = fragment.subtract_offset(off);
                 let new_est = replacements
                     .iter()
                     .map(OverlayFragment::estimated_bytes)
@@ -1512,6 +1905,53 @@ impl Overlay {
         self.points.iter()
     }
 }
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub(crate) struct OverlayDebugStats {
+    pub(crate) points: usize,
+    pub(crate) sparse_fragments: usize,
+    pub(crate) dense_fragments: usize,
+    pub(crate) run_fragments: usize,
+    pub(crate) covered_len: usize,
+}
+
+#[cfg(test)]
+impl Overlay {
+    pub(crate) fn debug_stats(&self) -> OverlayDebugStats {
+        let mut stats = OverlayDebugStats {
+            points: self.points.len(),
+            covered_len: self.len(),
+            ..OverlayDebugStats::default()
+        };
+        for fragment in &self.fragments {
+            match fragment {
+                OverlayFragment::SparseOffsets { .. } => stats.sparse_fragments += 1,
+                OverlayFragment::DenseRange { .. } => stats.dense_fragments += 1,
+                OverlayFragment::RunRange { .. } => stats.run_fragments += 1,
+            }
+        }
+        stats
+    }
+
+    pub(crate) fn debug_is_normalized(&self) -> bool {
+        let mut covered = std::collections::HashSet::new();
+        for off in self.points.keys().copied() {
+            if !covered.insert(off) {
+                return false;
+            }
+        }
+        for fragment in &self.fragments {
+            for (off, _) in fragment.cells() {
+                if !covered.insert(off) {
+                    return false;
+                }
+            }
+        }
+        covered.len() == self.len()
+    }
+}
+
 pub(crate) struct OverlayCascade<'a> {
     user: &'a Overlay,
     computed: &'a Overlay,
@@ -3301,8 +3741,10 @@ mod tests {
             .unwrap(),
         );
 
-        assert!(overlay.points.is_empty());
-        assert_eq!(overlay.fragments.len(), 1);
+        let stats = overlay.debug_stats();
+        assert_eq!(stats.points, 0);
+        assert_eq!(stats.dense_fragments, 1);
+        assert!(overlay.debug_is_normalized());
         assert_eq!(
             overlay.get_scalar(0).unwrap().to_literal(),
             LiteralValue::Number(10.0)
@@ -3315,6 +3757,271 @@ mod tests {
             overlay.get_scalar(2).unwrap().to_literal(),
             LiteralValue::Number(30.0)
         );
+    }
+
+    #[test]
+    fn overlay_sparse_far_apart_replacement_does_not_rewrite_unrelated_dense_fragment() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(100, vec![OverlayValue::Number(1.0); 10]).unwrap(),
+        );
+
+        overlay.apply_fragment(
+            OverlayFragment::sparse_offsets(vec![
+                (0, OverlayValue::Empty),
+                (1000, OverlayValue::Number(1000.0)),
+            ])
+            .unwrap(),
+        );
+
+        let stats = overlay.debug_stats();
+        assert_eq!(stats.dense_fragments, 1);
+        assert_eq!(stats.sparse_fragments, 1);
+        assert_eq!(stats.run_fragments, 0);
+        assert!(overlay.debug_is_normalized());
+        assert_eq!(
+            overlay.get_scalar(105).unwrap().to_literal(),
+            LiteralValue::Number(1.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(0).unwrap().to_literal(),
+            LiteralValue::Empty
+        );
+        assert_eq!(
+            overlay.get_scalar(1000).unwrap().to_literal(),
+            LiteralValue::Number(1000.0)
+        );
+    }
+
+    #[test]
+    fn overlay_sparse_offsets_are_sorted_unique_last_write_wins() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::sparse_offsets(vec![
+                (3, OverlayValue::Number(3.0)),
+                (1, OverlayValue::Number(1.0)),
+                (3, OverlayValue::Number(33.0)),
+            ])
+            .unwrap(),
+        );
+
+        let stats = overlay.debug_stats();
+        assert_eq!(stats.sparse_fragments, 1);
+        assert_eq!(overlay.len(), 2);
+        assert_eq!(
+            overlay.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Number(1.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(3).unwrap().to_literal(),
+            LiteralValue::Number(33.0)
+        );
+        assert!(overlay.debug_is_normalized());
+    }
+
+    #[test]
+    fn overlay_dense_point_replacement_splits_dense_not_sparse() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                (0..6)
+                    .map(|i| OverlayValue::Number(i as f64))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap(),
+        );
+
+        overlay.set_scalar(3, OverlayValue::Number(99.0));
+
+        let stats = overlay.debug_stats();
+        assert_eq!(stats.points, 1);
+        assert_eq!(stats.dense_fragments, 2);
+        assert_eq!(stats.sparse_fragments, 0);
+        assert!(overlay.debug_is_normalized());
+        assert_eq!(
+            overlay.get_scalar(2).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(3).unwrap().to_literal(),
+            LiteralValue::Number(99.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(4).unwrap().to_literal(),
+            LiteralValue::Number(4.0)
+        );
+    }
+
+    #[test]
+    fn overlay_dense_fragment_replacement_splits_left_and_right_dense() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                (0..8)
+                    .map(|i| OverlayValue::Number(i as f64))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap(),
+        );
+
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                3,
+                vec![OverlayValue::Number(30.0), OverlayValue::Number(40.0)],
+            )
+            .unwrap(),
+        );
+
+        let stats = overlay.debug_stats();
+        assert_eq!(stats.points, 0);
+        assert_eq!(stats.dense_fragments, 3);
+        assert_eq!(stats.sparse_fragments, 0);
+        assert!(overlay.debug_is_normalized());
+        assert_eq!(
+            overlay.get_scalar(2).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(3).unwrap().to_literal(),
+            LiteralValue::Number(30.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(4).unwrap().to_literal(),
+            LiteralValue::Number(40.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(5).unwrap().to_literal(),
+            LiteralValue::Number(5.0)
+        );
+    }
+
+    #[test]
+    fn overlay_run_point_replacement_splits_run_not_sparse() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::run_range(0, vec![OverlayValue::Number(1.0); 10]).unwrap(),
+        );
+
+        overlay.set_scalar(5, OverlayValue::Number(99.0));
+
+        let stats = overlay.debug_stats();
+        assert_eq!(stats.points, 1);
+        assert_eq!(stats.run_fragments, 2);
+        assert_eq!(stats.sparse_fragments, 0);
+        assert!(overlay.debug_is_normalized());
+        assert_eq!(
+            overlay.get_scalar(4).unwrap().to_literal(),
+            LiteralValue::Number(1.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(5).unwrap().to_literal(),
+            LiteralValue::Number(99.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(6).unwrap().to_literal(),
+            LiteralValue::Number(1.0)
+        );
+    }
+
+    #[test]
+    fn overlay_run_fragment_replacement_splits_left_and_right_run() {
+        let mut overlay = Overlay::new();
+        let values = [
+            vec![OverlayValue::Number(1.0); 4],
+            vec![OverlayValue::Number(2.0); 4],
+            vec![OverlayValue::Number(3.0); 4],
+        ]
+        .concat();
+        overlay.apply_fragment(OverlayFragment::run_range(0, values).unwrap());
+
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                5,
+                vec![OverlayValue::Number(50.0), OverlayValue::Number(60.0)],
+            )
+            .unwrap(),
+        );
+
+        let stats = overlay.debug_stats();
+        assert_eq!(stats.run_fragments, 2);
+        assert_eq!(stats.dense_fragments, 1);
+        assert_eq!(stats.sparse_fragments, 0);
+        assert!(overlay.debug_is_normalized());
+        assert_eq!(
+            overlay.get_scalar(4).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(5).unwrap().to_literal(),
+            LiteralValue::Number(50.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(6).unwrap().to_literal(),
+            LiteralValue::Number(60.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(7).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+    }
+
+    #[test]
+    fn overlay_slice_preserves_dense_and_run_encodings() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                10,
+                (0..5)
+                    .map(|i| OverlayValue::Number(i as f64))
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap(),
+        );
+        overlay.apply_fragment(
+            OverlayFragment::run_range(
+                20,
+                [
+                    vec![OverlayValue::Number(1.0); 3],
+                    vec![OverlayValue::Number(2.0); 3],
+                ]
+                .concat(),
+            )
+            .unwrap(),
+        );
+
+        let dense_slice = overlay.slice(12, 2);
+        let dense_stats = dense_slice.debug_stats();
+        assert_eq!(dense_stats.dense_fragments, 1);
+        assert_eq!(dense_stats.sparse_fragments, 0);
+        assert_eq!(
+            dense_slice.get_scalar(0).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+        assert_eq!(
+            dense_slice.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Number(3.0)
+        );
+        assert!(dense_slice.debug_is_normalized());
+
+        let run_slice = overlay.slice(22, 3);
+        let run_stats = run_slice.debug_stats();
+        assert_eq!(run_stats.run_fragments, 1);
+        assert_eq!(run_stats.sparse_fragments, 0);
+        assert_eq!(
+            run_slice.get_scalar(0).unwrap().to_literal(),
+            LiteralValue::Number(1.0)
+        );
+        assert_eq!(
+            run_slice.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+        assert_eq!(
+            run_slice.get_scalar(2).unwrap().to_literal(),
+            LiteralValue::Number(2.0)
+        );
+        assert!(run_slice.debug_is_normalized());
     }
 
     #[test]

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -3046,8 +3046,8 @@ impl<'a> OverlayCascade<'a> {
                 let start = u32::try_from(range.start).unwrap_or(u32::MAX);
                 let lo = offsets.partition_point(|off| *off < start);
                 let hi = offsets.partition_point(|off| (*off as usize) < range.end);
-                for idx in lo..hi {
-                    let out_idx = (offsets[idx] as usize).saturating_sub(range.start);
+                for (idx, off) in offsets.iter().enumerate().take(hi).skip(lo) {
+                    let out_idx = (*off as usize).saturating_sub(range.start);
                     f(out_idx, payload, idx);
                 }
             }

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -1176,6 +1176,18 @@ impl OverlayFragment {
         })
     }
 
+    pub(crate) fn sparse_offsets_if_estimated_smaller_than_points(
+        items: Vec<(usize, OverlayValue)>,
+        point_estimate: usize,
+    ) -> Option<Result<Self, Vec<(usize, OverlayValue)>>> {
+        let fragment = Self::sparse_offsets(items)?;
+        if fragment.estimated_bytes() < point_estimate {
+            Some(Ok(fragment))
+        } else {
+            Some(Err(fragment.cells()))
+        }
+    }
+
     pub(crate) fn dense_range(start: usize, values: Vec<OverlayValue>) -> Option<Self> {
         let len = values.len();
         if len == 0 {

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -2095,6 +2095,84 @@ impl Overlay {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub(crate) struct OverlaySelectStats {
+    pub(crate) zip_select_calls: usize,
+    pub(crate) direct_dense_slices: usize,
+    pub(crate) direct_run_materializations: usize,
+    pub(crate) partial_sparse_intersections: usize,
+    pub(crate) partial_dense_intersections: usize,
+    pub(crate) partial_run_intersections: usize,
+    pub(crate) partial_overlay_builds: usize,
+    pub(crate) row_scalar_fallbacks: usize,
+    pub(crate) point_entries_applied: usize,
+    pub(crate) fragment_intersections: usize,
+}
+
+#[cfg(test)]
+thread_local! {
+    static OVERLAY_SELECT_STATS: std::cell::RefCell<OverlaySelectStats> =
+        std::cell::RefCell::new(OverlaySelectStats::default());
+}
+
+#[cfg(test)]
+pub(crate) fn reset_overlay_select_stats() {
+    OVERLAY_SELECT_STATS.with(|stats| *stats.borrow_mut() = OverlaySelectStats::default());
+}
+
+#[cfg(test)]
+pub(crate) fn snapshot_overlay_select_stats() -> OverlaySelectStats {
+    OVERLAY_SELECT_STATS.with(|stats| *stats.borrow())
+}
+
+#[cfg(test)]
+fn record_overlay_select_stats(f: impl FnOnce(&mut OverlaySelectStats)) {
+    OVERLAY_SELECT_STATS.with(|stats| f(&mut stats.borrow_mut()));
+}
+
+#[cfg(not(test))]
+#[inline]
+fn record_overlay_select_stats(_f: impl FnOnce(&mut OverlaySelectStats)) {}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum OverlayFragmentShape {
+    Sparse,
+    Dense,
+    Run,
+}
+
+struct OverlaySlots<T> {
+    present: Vec<bool>,
+    values: Vec<Option<T>>,
+    any_present: bool,
+}
+
+impl<T> OverlaySlots<T> {
+    fn new(len: usize) -> Self {
+        Self {
+            present: vec![false; len],
+            values: (0..len).map(|_| None).collect(),
+            any_present: false,
+        }
+    }
+
+    #[inline]
+    fn set(&mut self, idx: usize, value: Option<T>) {
+        if idx >= self.present.len() {
+            return;
+        }
+        self.present[idx] = true;
+        self.values[idx] = value;
+        self.any_present = true;
+    }
+
+    #[inline]
+    fn any_present(&self) -> bool {
+        self.any_present
+    }
+}
+
 pub(crate) struct OverlayCascade<'a> {
     user: &'a Overlay,
     computed: &'a Overlay,
@@ -2123,22 +2201,48 @@ impl<'a> OverlayCascade<'a> {
         range: core::ops::Range<usize>,
         base: &Float64Array,
     ) -> Arc<Float64Array> {
-        let len = range.end.saturating_sub(range.start);
-        let mut mask_b = BooleanBuilder::with_capacity(len);
-        let mut values_b = Float64Builder::with_capacity(len);
-        for off in range {
-            if let Some(value) = self.get_scalar(off) {
-                mask_b.append_value(true);
-                if let Some(n) = value.numeric_lane_value() {
-                    values_b.append_value(n);
-                } else {
-                    values_b.append_null();
-                }
-            } else {
-                mask_b.append_value(false);
-                values_b.append_null();
+        if let Some(fragment) = self.user.full_cover_dense_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+            return Self::dense_numbers(fragment, range);
+        }
+        if let Some(fragment) = self.user.full_cover_run_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+            return Self::run_numbers(fragment, range);
+        }
+        if !self.user.has_any_in_range(range.clone()) {
+            if let Some(fragment) = self.computed.full_cover_dense_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+                return Self::dense_numbers(fragment, range);
+            }
+            if let Some(fragment) = self.computed.full_cover_run_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+                return Self::run_numbers(fragment, range);
             }
         }
+
+        if !self.has_any_in_range(range.clone()) {
+            return Arc::new(base.clone());
+        }
+
+        record_overlay_select_stats(|stats| stats.partial_overlay_builds += 1);
+        let len = range.end.saturating_sub(range.start);
+        let mut slots = OverlaySlots::<f64>::new(len);
+        Self::apply_number_layer(self.computed, range.clone(), &mut slots);
+        Self::apply_number_layer(self.user, range.clone(), &mut slots);
+        if !slots.any_present() {
+            return Arc::new(base.clone());
+        }
+
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = Float64Builder::with_capacity(len);
+        for idx in 0..len {
+            mask_b.append_value(slots.present[idx]);
+            match slots.values[idx] {
+                Some(value) => values_b.append_value(value),
+                None => values_b.append_null(),
+            }
+        }
+        record_overlay_select_stats(|stats| stats.zip_select_calls += 1);
         let mask = mask_b.finish();
         let values = values_b.finish();
         let zipped =
@@ -2157,22 +2261,48 @@ impl<'a> OverlayCascade<'a> {
         range: core::ops::Range<usize>,
         base: &BooleanArray,
     ) -> Arc<BooleanArray> {
-        let len = range.end.saturating_sub(range.start);
-        let mut mask_b = BooleanBuilder::with_capacity(len);
-        let mut values_b = BooleanBuilder::with_capacity(len);
-        for off in range {
-            if let Some(value) = self.get_scalar(off) {
-                mask_b.append_value(true);
-                if let Some(b) = value.boolean_lane_value() {
-                    values_b.append_value(b);
-                } else {
-                    values_b.append_null();
-                }
-            } else {
-                mask_b.append_value(false);
-                values_b.append_null();
+        if let Some(fragment) = self.user.full_cover_dense_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+            return Self::dense_booleans(fragment, range);
+        }
+        if let Some(fragment) = self.user.full_cover_run_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+            return Self::run_booleans(fragment, range);
+        }
+        if !self.user.has_any_in_range(range.clone()) {
+            if let Some(fragment) = self.computed.full_cover_dense_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+                return Self::dense_booleans(fragment, range);
+            }
+            if let Some(fragment) = self.computed.full_cover_run_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+                return Self::run_booleans(fragment, range);
             }
         }
+
+        if !self.has_any_in_range(range.clone()) {
+            return Arc::new(base.clone());
+        }
+
+        record_overlay_select_stats(|stats| stats.partial_overlay_builds += 1);
+        let len = range.end.saturating_sub(range.start);
+        let mut slots = OverlaySlots::<bool>::new(len);
+        Self::apply_boolean_layer(self.computed, range.clone(), &mut slots);
+        Self::apply_boolean_layer(self.user, range.clone(), &mut slots);
+        if !slots.any_present() {
+            return Arc::new(base.clone());
+        }
+
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = BooleanBuilder::with_capacity(len);
+        for idx in 0..len {
+            mask_b.append_value(slots.present[idx]);
+            match slots.values[idx] {
+                Some(value) => values_b.append_value(value),
+                None => values_b.append_null(),
+            }
+        }
+        record_overlay_select_stats(|stats| stats.zip_select_calls += 1);
         let mask = mask_b.finish();
         let values = values_b.finish();
         let zipped =
@@ -2191,22 +2321,48 @@ impl<'a> OverlayCascade<'a> {
         range: core::ops::Range<usize>,
         base: &StringArray,
     ) -> ArrayRef {
-        let len = range.end.saturating_sub(range.start);
-        let mut mask_b = BooleanBuilder::with_capacity(len);
-        let mut values_b = StringBuilder::with_capacity(len, len * 8);
-        for off in range {
-            if let Some(value) = self.get_scalar(off) {
-                mask_b.append_value(true);
-                if let Some(s) = value.text_lane_value() {
-                    values_b.append_value(s);
-                } else {
-                    values_b.append_null();
-                }
-            } else {
-                mask_b.append_value(false);
-                values_b.append_null();
+        if let Some(fragment) = self.user.full_cover_dense_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+            return Self::dense_text(fragment, range);
+        }
+        if let Some(fragment) = self.user.full_cover_run_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+            return Self::run_text(fragment, range);
+        }
+        if !self.user.has_any_in_range(range.clone()) {
+            if let Some(fragment) = self.computed.full_cover_dense_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+                return Self::dense_text(fragment, range);
+            }
+            if let Some(fragment) = self.computed.full_cover_run_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+                return Self::run_text(fragment, range);
             }
         }
+
+        if !self.has_any_in_range(range.clone()) {
+            return Arc::new(base.clone()) as ArrayRef;
+        }
+
+        record_overlay_select_stats(|stats| stats.partial_overlay_builds += 1);
+        let len = range.end.saturating_sub(range.start);
+        let mut slots = OverlaySlots::<String>::new(len);
+        Self::apply_text_layer(self.computed, range.clone(), &mut slots);
+        Self::apply_text_layer(self.user, range.clone(), &mut slots);
+        if !slots.any_present() {
+            return Arc::new(base.clone()) as ArrayRef;
+        }
+
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = StringBuilder::with_capacity(len, len.saturating_mul(8));
+        for idx in 0..len {
+            mask_b.append_value(slots.present[idx]);
+            match &slots.values[idx] {
+                Some(value) => values_b.append_value(value),
+                None => values_b.append_null(),
+            }
+        }
+        record_overlay_select_stats(|stats| stats.zip_select_calls += 1);
         let mask = mask_b.finish();
         let values = values_b.finish();
         crate::compute_prelude::zip_select(&mask, &values, base).expect("zip text overlay")
@@ -2217,22 +2373,48 @@ impl<'a> OverlayCascade<'a> {
         range: core::ops::Range<usize>,
         base: &UInt8Array,
     ) -> Arc<UInt8Array> {
-        let len = range.end.saturating_sub(range.start);
-        let mut mask_b = BooleanBuilder::with_capacity(len);
-        let mut values_b = UInt8Builder::with_capacity(len);
-        for off in range {
-            if let Some(value) = self.get_scalar(off) {
-                mask_b.append_value(true);
-                if let Some(code) = value.error_lane_value() {
-                    values_b.append_value(code);
-                } else {
-                    values_b.append_null();
-                }
-            } else {
-                mask_b.append_value(false);
-                values_b.append_null();
+        if let Some(fragment) = self.user.full_cover_dense_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+            return Self::dense_errors(fragment, range);
+        }
+        if let Some(fragment) = self.user.full_cover_run_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+            return Self::run_errors(fragment, range);
+        }
+        if !self.user.has_any_in_range(range.clone()) {
+            if let Some(fragment) = self.computed.full_cover_dense_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+                return Self::dense_errors(fragment, range);
+            }
+            if let Some(fragment) = self.computed.full_cover_run_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+                return Self::run_errors(fragment, range);
             }
         }
+
+        if !self.has_any_in_range(range.clone()) {
+            return Arc::new(base.clone());
+        }
+
+        record_overlay_select_stats(|stats| stats.partial_overlay_builds += 1);
+        let len = range.end.saturating_sub(range.start);
+        let mut slots = OverlaySlots::<u8>::new(len);
+        Self::apply_error_layer(self.computed, range.clone(), &mut slots);
+        Self::apply_error_layer(self.user, range.clone(), &mut slots);
+        if !slots.any_present() {
+            return Arc::new(base.clone());
+        }
+
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = UInt8Builder::with_capacity(len);
+        for idx in 0..len {
+            mask_b.append_value(slots.present[idx]);
+            match slots.values[idx] {
+                Some(value) => values_b.append_value(value),
+                None => values_b.append_null(),
+            }
+        }
+        record_overlay_select_stats(|stats| stats.zip_select_calls += 1);
         let mask = mask_b.finish();
         let values = values_b.finish();
         let zipped =
@@ -2251,18 +2433,48 @@ impl<'a> OverlayCascade<'a> {
         range: core::ops::Range<usize>,
         base: &UInt8Array,
     ) -> Arc<UInt8Array> {
-        let len = range.end.saturating_sub(range.start);
-        let mut mask_b = BooleanBuilder::with_capacity(len);
-        let mut values_b = UInt8Builder::with_capacity(len);
-        for off in range {
-            if let Some(value) = self.get_scalar(off) {
-                mask_b.append_value(true);
-                values_b.append_value(value.type_tag() as u8);
-            } else {
-                mask_b.append_value(false);
-                values_b.append_null();
+        if let Some(fragment) = self.user.full_cover_dense_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+            return Self::dense_type_tags(fragment, range);
+        }
+        if let Some(fragment) = self.user.full_cover_run_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+            return Self::run_type_tags(fragment, range);
+        }
+        if !self.user.has_any_in_range(range.clone()) {
+            if let Some(fragment) = self.computed.full_cover_dense_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+                return Self::dense_type_tags(fragment, range);
+            }
+            if let Some(fragment) = self.computed.full_cover_run_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+                return Self::run_type_tags(fragment, range);
             }
         }
+
+        if !self.has_any_in_range(range.clone()) {
+            return Arc::new(base.clone());
+        }
+
+        record_overlay_select_stats(|stats| stats.partial_overlay_builds += 1);
+        let len = range.end.saturating_sub(range.start);
+        let mut slots = OverlaySlots::<u8>::new(len);
+        Self::apply_type_tag_layer(self.computed, range.clone(), &mut slots);
+        Self::apply_type_tag_layer(self.user, range.clone(), &mut slots);
+        if !slots.any_present() {
+            return Arc::new(base.clone());
+        }
+
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = UInt8Builder::with_capacity(len);
+        for idx in 0..len {
+            mask_b.append_value(slots.present[idx]);
+            match slots.values[idx] {
+                Some(value) => values_b.append_value(value),
+                None => values_b.append_null(),
+            }
+        }
+        record_overlay_select_stats(|stats| stats.zip_select_calls += 1);
         let mask = mask_b.finish();
         let values = values_b.finish();
         let zipped =
@@ -2281,22 +2493,51 @@ impl<'a> OverlayCascade<'a> {
         range: core::ops::Range<usize>,
         base: &StringArray,
     ) -> Arc<StringArray> {
-        let len = range.end.saturating_sub(range.start);
-        let mut mask_b = BooleanBuilder::with_capacity(len);
-        let mut values_b = StringBuilder::with_capacity(len, len * 8);
-        for off in range {
-            if let Some(value) = self.get_scalar(off) {
-                mask_b.append_value(true);
-                if let Some(s) = value.lowered_text_value() {
-                    values_b.append_value(&s);
-                } else {
-                    values_b.append_null();
-                }
-            } else {
-                mask_b.append_value(false);
-                values_b.append_null();
+        if let Some(fragment) = self.user.full_cover_dense_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+            return Self::dense_lowered_text(fragment, range);
+        }
+        if let Some(fragment) = self.user.full_cover_run_fragment(range.clone()) {
+            record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+            return Self::run_lowered_text(fragment, range);
+        }
+        if !self.user.has_any_in_range(range.clone()) {
+            if let Some(fragment) = self.computed.full_cover_dense_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_dense_slices += 1);
+                return Self::dense_lowered_text(fragment, range);
+            }
+            if let Some(fragment) = self.computed.full_cover_run_fragment(range.clone()) {
+                record_overlay_select_stats(|stats| stats.direct_run_materializations += 1);
+                return Self::run_lowered_text(fragment, range);
             }
         }
+
+        if !self.has_any_in_range(range.clone()) {
+            return Arc::new(base.clone());
+        }
+        if self.user.fragments.is_empty() && self.computed.fragments.is_empty() {
+            return self.select_lowered_text_point_scalar(range, base);
+        }
+
+        record_overlay_select_stats(|stats| stats.partial_overlay_builds += 1);
+        let len = range.end.saturating_sub(range.start);
+        let mut slots = OverlaySlots::<String>::new(len);
+        Self::apply_lowered_text_layer(self.computed, range.clone(), &mut slots);
+        Self::apply_lowered_text_layer(self.user, range.clone(), &mut slots);
+        if !slots.any_present() {
+            return Arc::new(base.clone());
+        }
+
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = StringBuilder::with_capacity(len, len.saturating_mul(8));
+        for idx in 0..len {
+            mask_b.append_value(slots.present[idx]);
+            match &slots.values[idx] {
+                Some(value) => values_b.append_value(value),
+                None => values_b.append_null(),
+            }
+        }
+        record_overlay_select_stats(|stats| stats.zip_select_calls += 1);
         let mask = mask_b.finish();
         let values = values_b.finish();
         let zipped = crate::compute_prelude::zip_select(&mask, &values, base)
@@ -2309,8 +2550,624 @@ impl<'a> OverlayCascade<'a> {
                 .clone(),
         )
     }
+
+    fn select_lowered_text_point_scalar(
+        &self,
+        range: core::ops::Range<usize>,
+        base: &StringArray,
+    ) -> Arc<StringArray> {
+        let len = range.end.saturating_sub(range.start);
+        let mut mask_b = BooleanBuilder::with_capacity(len);
+        let mut values_b = StringBuilder::with_capacity(len, len.saturating_mul(8));
+        record_overlay_select_stats(|stats| stats.row_scalar_fallbacks += len);
+        for off in range {
+            if let Some(value) = self.get_scalar(off) {
+                mask_b.append_value(true);
+                if let Some(s) = value.lowered_text_value() {
+                    values_b.append_value(&s);
+                } else {
+                    values_b.append_null();
+                }
+                record_overlay_select_stats(|stats| stats.point_entries_applied += 1);
+            } else {
+                mask_b.append_value(false);
+                values_b.append_null();
+            }
+        }
+        record_overlay_select_stats(|stats| stats.zip_select_calls += 1);
+        let mask = mask_b.finish();
+        let values = values_b.finish();
+        let zipped = crate::compute_prelude::zip_select(&mask, &values, base)
+            .expect("zip lowered text overlay");
+        Arc::new(
+            zipped
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("lowered text overlay zip type")
+                .clone(),
+        )
+    }
+
+    fn dense_numbers(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<Float64Array> {
+        let (rel_start, len, payload) = Self::dense_payload_window(fragment, range);
+        Self::payload_numbers_slice(payload, rel_start, len)
+    }
+
+    fn dense_booleans(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<BooleanArray> {
+        let (rel_start, len, payload) = Self::dense_payload_window(fragment, range);
+        Self::payload_booleans_slice(payload, rel_start, len)
+    }
+
+    fn dense_text(fragment: &OverlayFragment, range: core::ops::Range<usize>) -> ArrayRef {
+        let (rel_start, len, payload) = Self::dense_payload_window(fragment, range);
+        Self::payload_text_slice(payload, rel_start, len)
+    }
+
+    fn dense_errors(fragment: &OverlayFragment, range: core::ops::Range<usize>) -> Arc<UInt8Array> {
+        let (rel_start, len, payload) = Self::dense_payload_window(fragment, range);
+        Self::payload_errors_slice(payload, rel_start, len)
+    }
+
+    fn dense_type_tags(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<UInt8Array> {
+        let (rel_start, len, payload) = Self::dense_payload_window(fragment, range);
+        Self::payload_type_tags_slice(payload, rel_start, len)
+    }
+
+    fn dense_lowered_text(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<StringArray> {
+        let (rel_start, len, payload) = Self::dense_payload_window(fragment, range);
+        Self::payload_lowered_text_materialize(payload, rel_start, len)
+    }
+
+    fn dense_payload_window(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> (usize, usize, &OverlayFragmentPayload) {
+        let OverlayFragment::DenseRange { start, payload, .. } = fragment else {
+            unreachable!("dense payload window requires DenseRange")
+        };
+        let rel_start = range.start.saturating_sub(*start as usize);
+        (rel_start, range.end.saturating_sub(range.start), payload)
+    }
+
+    fn run_numbers(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<Float64Array> {
+        let mut b = Float64Builder::with_capacity(range.end.saturating_sub(range.start));
+        Self::for_each_run_payload_index(fragment, range, |payload, run_idx, repeat| {
+            if let Some(value) = payload.number_at(run_idx) {
+                for _ in 0..repeat {
+                    b.append_value(value);
+                }
+            } else {
+                for _ in 0..repeat {
+                    b.append_null();
+                }
+            }
+        });
+        Arc::new(b.finish())
+    }
+
+    fn run_booleans(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<BooleanArray> {
+        let mut b = BooleanBuilder::with_capacity(range.end.saturating_sub(range.start));
+        Self::for_each_run_payload_index(fragment, range, |payload, run_idx, repeat| {
+            if let Some(value) = payload.boolean_at(run_idx) {
+                for _ in 0..repeat {
+                    b.append_value(value);
+                }
+            } else {
+                for _ in 0..repeat {
+                    b.append_null();
+                }
+            }
+        });
+        Arc::new(b.finish())
+    }
+
+    fn run_text(fragment: &OverlayFragment, range: core::ops::Range<usize>) -> ArrayRef {
+        let mut b = StringBuilder::with_capacity(
+            range.end.saturating_sub(range.start),
+            range.end.saturating_sub(range.start).saturating_mul(8),
+        );
+        Self::for_each_run_payload_index(fragment, range, |payload, run_idx, repeat| {
+            if let Some(value) = payload.text_at(run_idx) {
+                for _ in 0..repeat {
+                    b.append_value(value);
+                }
+            } else {
+                for _ in 0..repeat {
+                    b.append_null();
+                }
+            }
+        });
+        Arc::new(b.finish()) as ArrayRef
+    }
+
+    fn run_errors(fragment: &OverlayFragment, range: core::ops::Range<usize>) -> Arc<UInt8Array> {
+        let mut b = UInt8Builder::with_capacity(range.end.saturating_sub(range.start));
+        Self::for_each_run_payload_index(fragment, range, |payload, run_idx, repeat| {
+            if let Some(value) = payload.error_at(run_idx) {
+                for _ in 0..repeat {
+                    b.append_value(value);
+                }
+            } else {
+                for _ in 0..repeat {
+                    b.append_null();
+                }
+            }
+        });
+        Arc::new(b.finish())
+    }
+
+    fn run_type_tags(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<UInt8Array> {
+        let mut b = UInt8Builder::with_capacity(range.end.saturating_sub(range.start));
+        Self::for_each_run_payload_index(fragment, range, |payload, run_idx, repeat| {
+            let tag = payload.type_tag_at(run_idx).unwrap_or(TypeTag::Empty) as u8;
+            for _ in 0..repeat {
+                b.append_value(tag);
+            }
+        });
+        Arc::new(b.finish())
+    }
+
+    fn run_lowered_text(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+    ) -> Arc<StringArray> {
+        let mut b = StringBuilder::with_capacity(
+            range.end.saturating_sub(range.start),
+            range.end.saturating_sub(range.start).saturating_mul(8),
+        );
+        Self::for_each_run_payload_index(fragment, range, |payload, run_idx, repeat| {
+            let value = Self::payload_lowered_text_at(payload, run_idx);
+            if let Some(value) = value {
+                for _ in 0..repeat {
+                    b.append_value(&value);
+                }
+            } else {
+                for _ in 0..repeat {
+                    b.append_null();
+                }
+            }
+        });
+        Arc::new(b.finish())
+    }
+
+    fn payload_numbers_slice(
+        payload: &OverlayFragmentPayload,
+        start: usize,
+        len: usize,
+    ) -> Arc<Float64Array> {
+        if let Some(array) = &payload.numbers {
+            let sliced = array.slice(start, len);
+            Arc::new(
+                sliced
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .unwrap()
+                    .clone(),
+            )
+        } else {
+            Self::null_numbers(len)
+        }
+    }
+
+    fn payload_booleans_slice(
+        payload: &OverlayFragmentPayload,
+        start: usize,
+        len: usize,
+    ) -> Arc<BooleanArray> {
+        if let Some(array) = &payload.booleans {
+            let sliced = array.slice(start, len);
+            Arc::new(
+                sliced
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .unwrap()
+                    .clone(),
+            )
+        } else {
+            Self::null_booleans(len)
+        }
+    }
+
+    fn payload_text_slice(payload: &OverlayFragmentPayload, start: usize, len: usize) -> ArrayRef {
+        if let Some(array) = &payload.text {
+            array.slice(start, len)
+        } else {
+            new_null_array(&DataType::Utf8, len)
+        }
+    }
+
+    fn payload_errors_slice(
+        payload: &OverlayFragmentPayload,
+        start: usize,
+        len: usize,
+    ) -> Arc<UInt8Array> {
+        if let Some(array) = &payload.errors {
+            let sliced = array.slice(start, len);
+            Arc::new(
+                sliced
+                    .as_any()
+                    .downcast_ref::<UInt8Array>()
+                    .unwrap()
+                    .clone(),
+            )
+        } else {
+            Self::null_errors(len)
+        }
+    }
+
+    fn payload_type_tags_slice(
+        payload: &OverlayFragmentPayload,
+        start: usize,
+        len: usize,
+    ) -> Arc<UInt8Array> {
+        let sliced = payload.type_tags.slice(start, len);
+        Arc::new(
+            sliced
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .unwrap()
+                .clone(),
+        )
+    }
+
+    fn payload_lowered_text_materialize(
+        payload: &OverlayFragmentPayload,
+        start: usize,
+        len: usize,
+    ) -> Arc<StringArray> {
+        let mut b = StringBuilder::with_capacity(len, len.saturating_mul(8));
+        for idx in start..start.saturating_add(len) {
+            if let Some(value) = Self::payload_lowered_text_at(payload, idx) {
+                b.append_value(&value);
+            } else {
+                b.append_null();
+            }
+        }
+        Arc::new(b.finish())
+    }
+
+    fn payload_lowered_text_at(payload: &OverlayFragmentPayload, idx: usize) -> Option<String> {
+        match payload.type_tag_at(idx)? {
+            TypeTag::Text => payload.text_at(idx).map(|value| value.to_lowercase()),
+            TypeTag::Number | TypeTag::DateTime | TypeTag::Duration => {
+                payload.number_at(idx).map(|value| value.to_string())
+            }
+            TypeTag::Boolean => payload
+                .boolean_at(idx)
+                .map(|value| if value { "true" } else { "false" }.to_string()),
+            TypeTag::Empty | TypeTag::Error | TypeTag::Pending => None,
+        }
+    }
+
+    fn null_numbers(len: usize) -> Arc<Float64Array> {
+        let arr = new_null_array(&DataType::Float64, len);
+        Arc::new(arr.as_any().downcast_ref::<Float64Array>().unwrap().clone())
+    }
+
+    fn null_booleans(len: usize) -> Arc<BooleanArray> {
+        let arr = new_null_array(&DataType::Boolean, len);
+        Arc::new(arr.as_any().downcast_ref::<BooleanArray>().unwrap().clone())
+    }
+
+    fn null_errors(len: usize) -> Arc<UInt8Array> {
+        let arr = new_null_array(&DataType::UInt8, len);
+        Arc::new(arr.as_any().downcast_ref::<UInt8Array>().unwrap().clone())
+    }
+
+    fn apply_number_layer(
+        layer: &Overlay,
+        range: core::ops::Range<usize>,
+        slots: &mut OverlaySlots<f64>,
+    ) {
+        Self::apply_fragment_layer(layer, range.clone(), slots, |payload, idx| {
+            payload.number_at(idx)
+        });
+        for (off, value) in layer.iter_points() {
+            if range.contains(off) {
+                slots.set(*off - range.start, value.numeric_lane_value());
+                record_overlay_select_stats(|stats| stats.point_entries_applied += 1);
+            }
+        }
+    }
+
+    fn apply_boolean_layer(
+        layer: &Overlay,
+        range: core::ops::Range<usize>,
+        slots: &mut OverlaySlots<bool>,
+    ) {
+        Self::apply_fragment_layer(layer, range.clone(), slots, |payload, idx| {
+            payload.boolean_at(idx)
+        });
+        for (off, value) in layer.iter_points() {
+            if range.contains(off) {
+                slots.set(*off - range.start, value.boolean_lane_value());
+                record_overlay_select_stats(|stats| stats.point_entries_applied += 1);
+            }
+        }
+    }
+
+    fn apply_text_layer(
+        layer: &Overlay,
+        range: core::ops::Range<usize>,
+        slots: &mut OverlaySlots<String>,
+    ) {
+        Self::apply_fragment_layer(layer, range.clone(), slots, |payload, idx| {
+            payload.text_at(idx).map(ToString::to_string)
+        });
+        for (off, value) in layer.iter_points() {
+            if range.contains(off) {
+                slots.set(
+                    *off - range.start,
+                    value.text_lane_value().map(ToString::to_string),
+                );
+                record_overlay_select_stats(|stats| stats.point_entries_applied += 1);
+            }
+        }
+    }
+
+    fn apply_error_layer(
+        layer: &Overlay,
+        range: core::ops::Range<usize>,
+        slots: &mut OverlaySlots<u8>,
+    ) {
+        Self::apply_fragment_layer(layer, range.clone(), slots, |payload, idx| {
+            payload.error_at(idx)
+        });
+        for (off, value) in layer.iter_points() {
+            if range.contains(off) {
+                slots.set(*off - range.start, value.error_lane_value());
+                record_overlay_select_stats(|stats| stats.point_entries_applied += 1);
+            }
+        }
+    }
+
+    fn apply_type_tag_layer(
+        layer: &Overlay,
+        range: core::ops::Range<usize>,
+        slots: &mut OverlaySlots<u8>,
+    ) {
+        Self::apply_fragment_layer(layer, range.clone(), slots, |payload, idx| {
+            payload.type_tag_at(idx).map(|tag| tag as u8)
+        });
+        for (off, value) in layer.iter_points() {
+            if range.contains(off) {
+                slots.set(*off - range.start, Some(value.type_tag() as u8));
+                record_overlay_select_stats(|stats| stats.point_entries_applied += 1);
+            }
+        }
+    }
+
+    fn apply_lowered_text_layer(
+        layer: &Overlay,
+        range: core::ops::Range<usize>,
+        slots: &mut OverlaySlots<String>,
+    ) {
+        Self::apply_fragment_layer(layer, range.clone(), slots, Self::payload_lowered_text_at);
+        for (off, value) in layer.iter_points() {
+            if range.contains(off) {
+                slots.set(*off - range.start, value.lowered_text_value());
+                record_overlay_select_stats(|stats| stats.point_entries_applied += 1);
+            }
+        }
+    }
+
+    fn apply_fragment_layer<T>(
+        layer: &Overlay,
+        range: core::ops::Range<usize>,
+        slots: &mut OverlaySlots<T>,
+        mut value_at: impl FnMut(&OverlayFragmentPayload, usize) -> Option<T>,
+    ) {
+        for fragment in &layer.fragments {
+            if !fragment.has_any_in_range(range.clone()) {
+                continue;
+            }
+            Self::record_fragment_intersection(fragment);
+            Self::for_each_fragment_payload_index(
+                fragment,
+                range.clone(),
+                |out_idx, payload, payload_idx| {
+                    slots.set(out_idx, value_at(payload, payload_idx));
+                },
+            );
+        }
+    }
+
+    fn record_fragment_intersection(fragment: &OverlayFragment) {
+        let shape = match fragment {
+            OverlayFragment::SparseOffsets { .. } => OverlayFragmentShape::Sparse,
+            OverlayFragment::DenseRange { .. } => OverlayFragmentShape::Dense,
+            OverlayFragment::RunRange { .. } => OverlayFragmentShape::Run,
+        };
+        record_overlay_select_stats(|stats| {
+            stats.fragment_intersections += 1;
+            match shape {
+                OverlayFragmentShape::Sparse => stats.partial_sparse_intersections += 1,
+                OverlayFragmentShape::Dense => stats.partial_dense_intersections += 1,
+                OverlayFragmentShape::Run => stats.partial_run_intersections += 1,
+            }
+        });
+    }
+
+    fn for_each_fragment_payload_index(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+        mut f: impl FnMut(usize, &OverlayFragmentPayload, usize),
+    ) {
+        if range.is_empty() {
+            return;
+        }
+        match fragment {
+            OverlayFragment::SparseOffsets { offsets, payload } => {
+                let start = u32::try_from(range.start).unwrap_or(u32::MAX);
+                let lo = offsets.partition_point(|off| *off < start);
+                let hi = offsets.partition_point(|off| (*off as usize) < range.end);
+                for idx in lo..hi {
+                    let out_idx = (offsets[idx] as usize).saturating_sub(range.start);
+                    f(out_idx, payload, idx);
+                }
+            }
+            OverlayFragment::DenseRange {
+                start,
+                len,
+                payload,
+            } => {
+                let frag_start = *start as usize;
+                let frag_end = frag_start.saturating_add(*len as usize);
+                let inter_start = frag_start.max(range.start);
+                let inter_end = frag_end.min(range.end);
+                if inter_start >= inter_end {
+                    return;
+                }
+                for abs in inter_start..inter_end {
+                    f(abs - range.start, payload, abs - frag_start);
+                }
+            }
+            OverlayFragment::RunRange {
+                start,
+                len,
+                run_ends,
+                payload,
+            } => {
+                let frag_start = *start as usize;
+                let frag_end = frag_start.saturating_add(*len as usize);
+                let inter_start = frag_start.max(range.start);
+                let inter_end = frag_end.min(range.end);
+                if inter_start >= inter_end {
+                    return;
+                }
+                let mut prev_end = 0usize;
+                for (run_idx, run_end) in run_ends.iter().enumerate() {
+                    let run_start_abs = frag_start.saturating_add(prev_end);
+                    let run_end_abs = frag_start.saturating_add(*run_end as usize);
+                    let start_abs = run_start_abs.max(inter_start);
+                    let end_abs = run_end_abs.min(inter_end);
+                    if start_abs < end_abs {
+                        for abs in start_abs..end_abs {
+                            f(abs - range.start, payload, run_idx);
+                        }
+                    }
+                    prev_end = *run_end as usize;
+                    if run_end_abs >= inter_end {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn for_each_run_payload_index(
+        fragment: &OverlayFragment,
+        range: core::ops::Range<usize>,
+        mut f: impl FnMut(&OverlayFragmentPayload, usize, usize),
+    ) {
+        let OverlayFragment::RunRange {
+            start,
+            len,
+            run_ends,
+            payload,
+        } = fragment
+        else {
+            unreachable!("run payload iteration requires RunRange")
+        };
+        let frag_start = *start as usize;
+        let frag_end = frag_start.saturating_add(*len as usize);
+        let inter_start = frag_start.max(range.start);
+        let inter_end = frag_end.min(range.end);
+        if inter_start >= inter_end {
+            return;
+        }
+        let mut prev_end = 0usize;
+        for (run_idx, run_end) in run_ends.iter().enumerate() {
+            let run_start_abs = frag_start.saturating_add(prev_end);
+            let run_end_abs = frag_start.saturating_add(*run_end as usize);
+            let start_abs = run_start_abs.max(inter_start);
+            let end_abs = run_end_abs.min(inter_end);
+            if start_abs < end_abs {
+                f(payload, run_idx, end_abs - start_abs);
+            }
+            prev_end = *run_end as usize;
+            if run_end_abs >= inter_end {
+                break;
+            }
+        }
+    }
 }
 
+impl OverlayFragmentPayload {
+    #[inline]
+    fn type_tag_at(&self, idx: usize) -> Option<TypeTag> {
+        if idx >= self.type_tags.len() || self.type_tags.is_null(idx) {
+            return None;
+        }
+        Some(TypeTag::from_u8(self.type_tags.value(idx)))
+    }
+}
+
+impl Overlay {
+    fn full_cover_dense_fragment(
+        &self,
+        range: core::ops::Range<usize>,
+    ) -> Option<&OverlayFragment> {
+        self.full_cover_single_fragment(range, OverlayFragmentShape::Dense)
+    }
+
+    fn full_cover_run_fragment(&self, range: core::ops::Range<usize>) -> Option<&OverlayFragment> {
+        self.full_cover_single_fragment(range, OverlayFragmentShape::Run)
+    }
+
+    fn full_cover_single_fragment(
+        &self,
+        range: core::ops::Range<usize>,
+        shape: OverlayFragmentShape,
+    ) -> Option<&OverlayFragment> {
+        if range.is_empty() || self.points.keys().any(|off| range.contains(off)) {
+            return None;
+        }
+        let mut found = None;
+        for fragment in &self.fragments {
+            if !fragment.has_any_in_range(range.clone()) {
+                continue;
+            }
+            let shape_matches = matches!(
+                (shape, fragment),
+                (
+                    OverlayFragmentShape::Dense,
+                    OverlayFragment::DenseRange { .. }
+                ) | (OverlayFragmentShape::Run, OverlayFragment::RunRange { .. })
+            );
+            let covers = fragment
+                .interval_coverage()
+                .is_some_and(|own| own.start <= range.start && range.end <= own.end);
+            if shape_matches && covers && found.is_none() {
+                found = Some(fragment);
+            } else {
+                return None;
+            }
+        }
+        found
+    }
+}
 fn append_overlay_value_to_lane_builders(
     ov: &OverlayValue,
     tag_b: &mut UInt8Builder,
@@ -3759,7 +4616,7 @@ mod tests {
         type_tags: Phase4ProbeOp,
         lowered_text: Phase4ProbeOp,
         get_cell_scan: Phase4ProbeOp,
-        expected_current_zip_select_calls: usize,
+        select_stats: OverlaySelectStats,
     }
 
     fn build_phase4_probe_sheet(rows: usize, fixture: Phase4ProbeFixture) -> ArrowSheet {
@@ -3977,12 +4834,12 @@ mod tests {
         let sheet = build_phase4_probe_sheet(rows, fixture);
         assert_column_overlays_normalized(&sheet, 0);
         let stats = column_overlay_stats(&sheet, 0, true);
+        reset_overlay_select_stats();
         let numbers = measure_probe_numbers(&sheet, rows);
         let type_tags = measure_probe_type_tags(&sheet, rows);
         let lowered_text = measure_probe_lowered_text(&sheet, rows);
+        let select_stats = snapshot_overlay_select_stats();
         let get_cell_scan = measure_probe_get_cell(&sheet, rows);
-        let expected_current_zip_select_calls =
-            numbers.segments + type_tags.segments + lowered_text.segments;
         Phase4ProbeRow {
             fixture: fixture.name(),
             rows,
@@ -3996,7 +4853,7 @@ mod tests {
             type_tags,
             lowered_text,
             get_cell_scan,
-            expected_current_zip_select_calls,
+            select_stats,
         }
     }
 
@@ -4836,6 +5693,288 @@ mod tests {
         assert_eq!(selected.value(1), "1.5");
         assert_eq!(selected.value(2), "true");
         assert!(selected.is_null(3));
+    }
+
+    fn numeric_sheet(rows: usize) -> ArrowSheet {
+        let mut b = IngestBuilder::new("S", 1, rows.max(1), crate::engine::DateSystem::Excel1900);
+        for row in 0..rows {
+            b.append_row(&[LiteralValue::Number((row + 1) as f64)])
+                .unwrap();
+        }
+        b.finish()
+    }
+
+    fn numbers_for_range(sheet: &ArrowSheet, sr: usize, er: usize) -> Arc<Float64Array> {
+        let view = sheet.range_view(sr, 0, er, 0);
+        let segments: Vec<_> = view.numbers_slices().map(|res| res.unwrap()).collect();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].2.len(), 1);
+        segments[0].2[0].clone()
+    }
+
+    fn type_tags_for_range(sheet: &ArrowSheet, sr: usize, er: usize) -> Arc<UInt8Array> {
+        let view = sheet.range_view(sr, 0, er, 0);
+        let segments: Vec<_> = view.type_tags_slices().map(|res| res.unwrap()).collect();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].2.len(), 1);
+        segments[0].2[0].clone()
+    }
+
+    fn lowered_for_range(sheet: &ArrowSheet, sr: usize, er: usize) -> Arc<StringArray> {
+        let view = sheet.range_view(sr, 0, er, 0);
+        let segments: Vec<_> = view.lowered_text_slices().map(|res| res.unwrap()).collect();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].2.len(), 1);
+        segments[0].2[0].clone()
+    }
+
+    #[test]
+    fn rangeview_dense_text_masks_base_numbers() {
+        let mut sheet = numeric_sheet(4);
+        sheet.columns[0].chunks[0].computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                vec![
+                    OverlayValue::Text(Arc::from("x")),
+                    OverlayValue::Text(Arc::from("y")),
+                    OverlayValue::Text(Arc::from("z")),
+                    OverlayValue::Text(Arc::from("w")),
+                ],
+            )
+            .unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 3);
+        assert_eq!(numbers.null_count(), 4);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 1);
+        assert_eq!(stats.zip_select_calls, 0);
+    }
+
+    #[test]
+    fn rangeview_empty_dense_masks_base_all_selectors() {
+        let mut sheet = numeric_sheet(3);
+        sheet.columns[0].chunks[0]
+            .computed_overlay
+            .apply_fragment(OverlayFragment::dense_range(0, vec![OverlayValue::Empty; 3]).unwrap());
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 2);
+        let type_tags = type_tags_for_range(&sheet, 0, 2);
+        let lowered = lowered_for_range(&sheet, 0, 2);
+        assert_eq!(numbers.null_count(), 3);
+        assert_eq!(lowered.null_count(), 3);
+        assert_eq!(type_tags.values(), &[TypeTag::Empty as u8; 3]);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 3);
+        assert_eq!(stats.zip_select_calls, 0);
+    }
+
+    #[test]
+    fn rangeview_pending_masks_base_type_tag_present_lanes_null() {
+        let mut sheet = numeric_sheet(2);
+        sheet.columns[0].chunks[0].computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(0, vec![OverlayValue::Pending; 2]).unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 1);
+        let type_tags = type_tags_for_range(&sheet, 0, 1);
+        let lowered = lowered_for_range(&sheet, 0, 1);
+        assert_eq!(numbers.null_count(), 2);
+        assert_eq!(lowered.null_count(), 2);
+        assert_eq!(type_tags.values(), &[TypeTag::Pending as u8; 2]);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 3);
+        assert_eq!(stats.zip_select_calls, 0);
+    }
+
+    #[test]
+    fn rangeview_subrange_inside_dense_fragment_uses_direct_path() {
+        let mut sheet = numeric_sheet(10);
+        sheet.columns[0].chunks[0].computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                (0..10)
+                    .map(|row| OverlayValue::Number((row + 10) as f64))
+                    .collect(),
+            )
+            .unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 2, 6);
+        assert_eq!(numbers.len(), 5);
+        assert_eq!(numbers.value(0), 12.0);
+        assert_eq!(numbers.value(4), 16.0);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 1);
+        assert_eq!(stats.zip_select_calls, 0);
+    }
+
+    #[test]
+    fn rangeview_subrange_inside_run_fragment_uses_direct_path() {
+        let mut sheet = numeric_sheet(10);
+        sheet.columns[0].chunks[0].computed_overlay.apply_fragment(
+            OverlayFragment::run_range(0, vec![OverlayValue::Number(7.0); 10]).unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 2, 6);
+        assert_eq!(numbers.len(), 5);
+        for idx in 0..numbers.len() {
+            assert_eq!(numbers.value(idx), 7.0);
+        }
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_run_materializations, 1);
+        assert_eq!(stats.zip_select_calls, 0);
+    }
+
+    #[test]
+    fn rangeview_user_partial_wrong_type_masks_computed_numeric() {
+        let mut sheet = numeric_sheet(5);
+        let chunk = &mut sheet.columns[0].chunks[0];
+        chunk.computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                (0..5)
+                    .map(|row| OverlayValue::Number((row + 10) as f64))
+                    .collect(),
+            )
+            .unwrap(),
+        );
+        chunk.overlay.apply_fragment(
+            OverlayFragment::dense_range(2, vec![OverlayValue::Text(Arc::from("mask"))]).unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 4);
+        assert_eq!(numbers.value(0), 10.0);
+        assert_eq!(numbers.value(1), 11.0);
+        assert!(numbers.is_null(2));
+        assert_eq!(numbers.value(3), 13.0);
+        assert_eq!(numbers.value(4), 14.0);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 0);
+        assert_eq!(stats.zip_select_calls, 1);
+        assert_eq!(stats.partial_dense_intersections, 2);
+    }
+
+    #[test]
+    fn rangeview_computed_full_cover_user_no_overlap_uses_computed_direct() {
+        let mut sheet = numeric_sheet(5);
+        let chunk = &mut sheet.columns[0].chunks[0];
+        chunk.computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(0, vec![OverlayValue::Number(3.0); 5]).unwrap(),
+        );
+        chunk
+            .overlay
+            .set_scalar(10, OverlayValue::Text(Arc::from("outside")));
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 4);
+        assert_eq!(numbers.value(0), 3.0);
+        assert_eq!(numbers.value(4), 3.0);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 1);
+        assert_eq!(stats.zip_select_calls, 0);
+    }
+
+    #[test]
+    fn rangeview_user_full_cover_ignores_computed() {
+        let mut sheet = numeric_sheet(4);
+        let chunk = &mut sheet.columns[0].chunks[0];
+        chunk.computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(0, vec![OverlayValue::Number(99.0); 4]).unwrap(),
+        );
+        chunk.overlay.apply_fragment(
+            OverlayFragment::dense_range(0, vec![OverlayValue::Text(Arc::from("user")); 4])
+                .unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 3);
+        assert_eq!(numbers.null_count(), 4);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 1);
+        assert_eq!(stats.zip_select_calls, 0);
+    }
+
+    #[test]
+    fn rangeview_point_overlay_still_matches_legacy_scalar_path() {
+        let mut sheet = numeric_sheet(3);
+        sheet.columns[0].chunks[0]
+            .computed_overlay
+            .set_scalar(1, OverlayValue::Text(Arc::from("point")));
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 2);
+        assert_eq!(numbers.value(0), 1.0);
+        assert!(numbers.is_null(1));
+        assert_eq!(numbers.value(2), 3.0);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.zip_select_calls, 1);
+        assert_eq!(stats.point_entries_applied, 1);
+        assert_eq!(stats.row_scalar_fallbacks, 0);
+    }
+
+    #[test]
+    fn rangeview_multi_fragment_full_union_does_not_use_direct_path() {
+        let mut sheet = numeric_sheet(4);
+        let chunk = &mut sheet.columns[0].chunks[0];
+        chunk.computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(0, vec![OverlayValue::Number(10.0); 2]).unwrap(),
+        );
+        chunk.computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(2, vec![OverlayValue::Number(20.0); 2]).unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let numbers = numbers_for_range(&sheet, 0, 3);
+        assert_eq!(numbers.value(0), 10.0);
+        assert_eq!(numbers.value(1), 10.0);
+        assert_eq!(numbers.value(2), 20.0);
+        assert_eq!(numbers.value(3), 20.0);
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 0);
+        assert_eq!(stats.zip_select_calls, 1);
+        assert_eq!(stats.partial_dense_intersections, 2);
+    }
+
+    #[test]
+    fn rangeview_lowered_text_fragment_semantics_match_scalar_semantics() {
+        let mut sheet = numeric_sheet(8);
+        sheet.columns[0].chunks[0].computed_overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                vec![
+                    OverlayValue::Text(Arc::from("HeLLo")),
+                    OverlayValue::Number(1.5),
+                    OverlayValue::DateTime(45000.25),
+                    OverlayValue::Duration(0.5),
+                    OverlayValue::Boolean(true),
+                    OverlayValue::Empty,
+                    OverlayValue::Error(map_error_code(ExcelErrorKind::Div)),
+                    OverlayValue::Pending,
+                ],
+            )
+            .unwrap(),
+        );
+
+        reset_overlay_select_stats();
+        let lowered = lowered_for_range(&sheet, 0, 7);
+        assert_eq!(lowered.value(0), "hello");
+        assert_eq!(lowered.value(1), "1.5");
+        assert_eq!(lowered.value(2), "45000.25");
+        assert_eq!(lowered.value(3), "0.5");
+        assert_eq!(lowered.value(4), "true");
+        assert!(lowered.is_null(5));
+        assert!(lowered.is_null(6));
+        assert!(lowered.is_null(7));
+        let stats = snapshot_overlay_select_stats();
+        assert_eq!(stats.direct_dense_slices, 1);
+        assert_eq!(stats.zip_select_calls, 0);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -3625,6 +3625,7 @@ mod tests {
     use super::*;
     use arrow_array::Array;
     use arrow_schema::DataType;
+    use chrono::Datelike;
 
     fn add_overlay_stats(into: &mut OverlayDebugStats, next: OverlayDebugStats) {
         into.points += next.points;
@@ -3691,6 +3692,332 @@ mod tests {
                 chunk.computed_overlay.estimated_bytes(),
                 chunk.computed_overlay.debug_recomputed_estimated_bytes()
             );
+        }
+    }
+
+    fn column_computed_overlay_estimated_bytes(sheet: &ArrowSheet, col_idx: usize) -> usize {
+        let Some(column) = sheet.columns.get(col_idx) else {
+            return 0;
+        };
+        column
+            .chunks
+            .iter()
+            .map(|chunk| chunk.computed_overlay.estimated_bytes())
+            .chain(
+                column
+                    .sparse_chunks
+                    .values()
+                    .map(|chunk| chunk.computed_overlay.estimated_bytes()),
+            )
+            .fold(0usize, usize::saturating_add)
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum Phase4ProbeFixture {
+        PointNumeric,
+        DenseNumeric,
+        RunNumeric,
+        SparseNumeric,
+        EmptyRun,
+        MixedDense,
+    }
+
+    impl Phase4ProbeFixture {
+        fn name(self) -> &'static str {
+            match self {
+                Phase4ProbeFixture::PointNumeric => "point_numeric",
+                Phase4ProbeFixture::DenseNumeric => "dense_numeric",
+                Phase4ProbeFixture::RunNumeric => "run_numeric",
+                Phase4ProbeFixture::SparseNumeric => "sparse_numeric",
+                Phase4ProbeFixture::EmptyRun => "empty_run",
+                Phase4ProbeFixture::MixedDense => "mixed_dense",
+            }
+        }
+    }
+
+    #[derive(Debug, serde::Serialize)]
+    struct Phase4ProbeOp {
+        ms: f64,
+        segments: usize,
+        arrays: usize,
+        rows_scanned: usize,
+        checksum: f64,
+        non_null: usize,
+    }
+
+    #[derive(Debug, serde::Serialize)]
+    struct Phase4ProbeRow {
+        fixture: &'static str,
+        rows: usize,
+        points: usize,
+        sparse_fragments: usize,
+        dense_fragments: usize,
+        run_fragments: usize,
+        covered_len: usize,
+        overlay_estimated_bytes: usize,
+        numbers: Phase4ProbeOp,
+        type_tags: Phase4ProbeOp,
+        lowered_text: Phase4ProbeOp,
+        get_cell_scan: Phase4ProbeOp,
+        expected_current_zip_select_calls: usize,
+    }
+
+    fn build_phase4_probe_sheet(rows: usize, fixture: Phase4ProbeFixture) -> ArrowSheet {
+        let mut builder =
+            IngestBuilder::new("S", 1, rows.max(1), crate::engine::DateSystem::Excel1900);
+        for row in 0..rows {
+            builder
+                .append_row(&[LiteralValue::Number((row + 1) as f64)])
+                .unwrap();
+        }
+        let mut sheet = builder.finish();
+        let chunk = sheet.columns[0].chunk_mut(0).unwrap();
+        match fixture {
+            Phase4ProbeFixture::PointNumeric => {
+                for row in 0..rows {
+                    chunk
+                        .computed_overlay
+                        .set_scalar(row, OverlayValue::Number((row + 1) as f64));
+                }
+            }
+            Phase4ProbeFixture::DenseNumeric => {
+                chunk.computed_overlay.apply_fragment(
+                    OverlayFragment::dense_range(
+                        0,
+                        (0..rows)
+                            .map(|row| OverlayValue::Number((row + 1) as f64))
+                            .collect(),
+                    )
+                    .unwrap(),
+                );
+            }
+            Phase4ProbeFixture::RunNumeric => {
+                chunk.computed_overlay.apply_fragment(
+                    OverlayFragment::run_range(0, vec![OverlayValue::Number(1.0); rows]).unwrap(),
+                );
+            }
+            Phase4ProbeFixture::SparseNumeric => {
+                chunk.computed_overlay.apply_fragment(
+                    OverlayFragment::sparse_offsets(
+                        (0..rows)
+                            .step_by(10)
+                            .map(|row| (row, OverlayValue::Number(10.0)))
+                            .collect(),
+                    )
+                    .unwrap(),
+                );
+            }
+            Phase4ProbeFixture::EmptyRun => {
+                chunk.computed_overlay.apply_fragment(
+                    OverlayFragment::run_range(0, vec![OverlayValue::Empty; rows]).unwrap(),
+                );
+            }
+            Phase4ProbeFixture::MixedDense => {
+                let pattern = [
+                    OverlayValue::Number(1.0),
+                    OverlayValue::Boolean(true),
+                    OverlayValue::Text(Arc::from("Alpha")),
+                    OverlayValue::Empty,
+                    OverlayValue::Error(map_error_code(ExcelErrorKind::Div)),
+                    OverlayValue::Pending,
+                    OverlayValue::DateTime(45000.25),
+                    OverlayValue::Duration(0.5),
+                ];
+                chunk.computed_overlay.apply_fragment(
+                    OverlayFragment::dense_range(
+                        0,
+                        (0..rows)
+                            .map(|row| pattern[row % pattern.len()].clone())
+                            .collect(),
+                    )
+                    .unwrap(),
+                );
+            }
+        }
+        sheet
+    }
+
+    fn measure_probe_numbers(sheet: &ArrowSheet, rows: usize) -> Phase4ProbeOp {
+        let view = sheet.range_view(0, 0, rows.saturating_sub(1), 0);
+        let start = std::time::Instant::now();
+        let mut segments = 0usize;
+        let mut arrays = 0usize;
+        let mut rows_scanned = 0usize;
+        let mut checksum = 0.0;
+        let mut non_null = 0usize;
+        for segment in view.numbers_slices() {
+            let (_row_start, row_len, cols) = segment.unwrap();
+            segments += 1;
+            rows_scanned += row_len;
+            for array in cols {
+                arrays += 1;
+                for idx in 0..array.len() {
+                    if array.is_valid(idx) {
+                        checksum += array.value(idx);
+                        non_null += 1;
+                    }
+                }
+            }
+        }
+        Phase4ProbeOp {
+            ms: start.elapsed().as_secs_f64() * 1000.0,
+            segments,
+            arrays,
+            rows_scanned,
+            checksum,
+            non_null,
+        }
+    }
+
+    fn measure_probe_type_tags(sheet: &ArrowSheet, rows: usize) -> Phase4ProbeOp {
+        let view = sheet.range_view(0, 0, rows.saturating_sub(1), 0);
+        let start = std::time::Instant::now();
+        let mut segments = 0usize;
+        let mut arrays = 0usize;
+        let mut rows_scanned = 0usize;
+        let mut checksum = 0.0;
+        let mut non_null = 0usize;
+        for segment in view.type_tags_slices() {
+            let (_row_start, row_len, cols) = segment.unwrap();
+            segments += 1;
+            rows_scanned += row_len;
+            for array in cols {
+                arrays += 1;
+                for idx in 0..array.len() {
+                    if array.is_valid(idx) {
+                        checksum += array.value(idx) as f64;
+                        non_null += 1;
+                    }
+                }
+            }
+        }
+        Phase4ProbeOp {
+            ms: start.elapsed().as_secs_f64() * 1000.0,
+            segments,
+            arrays,
+            rows_scanned,
+            checksum,
+            non_null,
+        }
+    }
+
+    fn measure_probe_lowered_text(sheet: &ArrowSheet, rows: usize) -> Phase4ProbeOp {
+        let view = sheet.range_view(0, 0, rows.saturating_sub(1), 0);
+        let start = std::time::Instant::now();
+        let mut segments = 0usize;
+        let mut arrays = 0usize;
+        let mut rows_scanned = 0usize;
+        let mut checksum = 0.0;
+        let mut non_null = 0usize;
+        for segment in view.lowered_text_slices() {
+            let (_row_start, row_len, cols) = segment.unwrap();
+            segments += 1;
+            rows_scanned += row_len;
+            for array in cols {
+                arrays += 1;
+                for idx in 0..array.len() {
+                    if array.is_valid(idx) {
+                        checksum += array.value(idx).len() as f64;
+                        non_null += 1;
+                    }
+                }
+            }
+        }
+        Phase4ProbeOp {
+            ms: start.elapsed().as_secs_f64() * 1000.0,
+            segments,
+            arrays,
+            rows_scanned,
+            checksum,
+            non_null,
+        }
+    }
+
+    fn literal_probe_weight(value: LiteralValue) -> f64 {
+        match value {
+            LiteralValue::Empty => 0.0,
+            LiteralValue::Int(value) => value as f64,
+            LiteralValue::Number(value) => value,
+            LiteralValue::Boolean(value) => {
+                if value {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            LiteralValue::Text(value) => value.len() as f64,
+            LiteralValue::Error(_) => -1.0,
+            LiteralValue::Date(value) => value.num_days_from_ce() as f64,
+            LiteralValue::DateTime(value) => value.and_utc().timestamp() as f64,
+            LiteralValue::Time(value) => value.num_seconds_from_midnight() as f64,
+            LiteralValue::Duration(value) => value.num_seconds() as f64,
+            LiteralValue::Array(values) => values.len() as f64,
+            LiteralValue::Pending => -2.0,
+        }
+    }
+
+    fn measure_probe_get_cell(sheet: &ArrowSheet, rows: usize) -> Phase4ProbeOp {
+        let view = sheet.range_view(0, 0, rows.saturating_sub(1), 0);
+        let start = std::time::Instant::now();
+        let mut checksum = 0.0;
+        for row in 0..rows {
+            checksum += literal_probe_weight(view.get_cell(row, 0));
+        }
+        Phase4ProbeOp {
+            ms: start.elapsed().as_secs_f64() * 1000.0,
+            segments: 1,
+            arrays: 0,
+            rows_scanned: rows,
+            checksum,
+            non_null: rows,
+        }
+    }
+
+    fn run_phase4_probe_fixture(rows: usize, fixture: Phase4ProbeFixture) -> Phase4ProbeRow {
+        let sheet = build_phase4_probe_sheet(rows, fixture);
+        assert_column_overlays_normalized(&sheet, 0);
+        let stats = column_overlay_stats(&sheet, 0, true);
+        let numbers = measure_probe_numbers(&sheet, rows);
+        let type_tags = measure_probe_type_tags(&sheet, rows);
+        let lowered_text = measure_probe_lowered_text(&sheet, rows);
+        let get_cell_scan = measure_probe_get_cell(&sheet, rows);
+        let expected_current_zip_select_calls =
+            numbers.segments + type_tags.segments + lowered_text.segments;
+        Phase4ProbeRow {
+            fixture: fixture.name(),
+            rows,
+            points: stats.points,
+            sparse_fragments: stats.sparse_fragments,
+            dense_fragments: stats.dense_fragments,
+            run_fragments: stats.run_fragments,
+            covered_len: stats.covered_len,
+            overlay_estimated_bytes: column_computed_overlay_estimated_bytes(&sheet, 0),
+            numbers,
+            type_tags,
+            lowered_text,
+            get_cell_scan,
+            expected_current_zip_select_calls,
+        }
+    }
+
+    #[test]
+    #[ignore = "manual Phase 4 observability probe; run with --ignored --nocapture"]
+    fn phase4_overlay_rangeview_observability_probe() {
+        let rows = std::env::var("FORMUALIZER_OVERLAY_PROBE_ROWS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(100_000)
+            .max(1);
+        for fixture in [
+            Phase4ProbeFixture::PointNumeric,
+            Phase4ProbeFixture::DenseNumeric,
+            Phase4ProbeFixture::RunNumeric,
+            Phase4ProbeFixture::SparseNumeric,
+            Phase4ProbeFixture::EmptyRun,
+            Phase4ProbeFixture::MixedDense,
+        ] {
+            let row = run_phase4_probe_fixture(rows, fixture);
+            println!("{}", serde_json::to_string(&row).unwrap());
         }
     }
 

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -10,7 +10,7 @@ use once_cell::sync::OnceCell;
 
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use rustc_hash::FxHashMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Compact type tag per row (UInt8 backing)
 #[repr(u8)]
@@ -924,9 +924,372 @@ impl OverlayValue {
     }
 }
 
+const OVERLAY_ENTRY_BASE_BYTES: usize = 32;
+const OVERLAY_FRAGMENT_BASE_BYTES: usize = 48;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) struct OverlayFragmentPayload {
+    values: Arc<[OverlayValue]>,
+    type_tags: Arc<UInt8Array>,
+    numbers: Option<Arc<Float64Array>>,
+    booleans: Option<Arc<BooleanArray>>,
+    text: Option<ArrayRef>,
+    errors: Option<Arc<UInt8Array>>,
+    estimated_bytes: usize,
+}
+
+impl OverlayFragmentPayload {
+    fn from_values(values: Vec<OverlayValue>) -> Self {
+        let len = values.len();
+        let mut tag_b = UInt8Builder::with_capacity(len);
+        let mut nb = Float64Builder::with_capacity(len);
+        let mut bb = BooleanBuilder::with_capacity(len);
+        let mut sb = StringBuilder::with_capacity(len, len.saturating_mul(8));
+        let mut eb = UInt8Builder::with_capacity(len);
+        let mut non_num = 0usize;
+        let mut non_bool = 0usize;
+        let mut non_text = 0usize;
+        let mut non_err = 0usize;
+
+        for value in &values {
+            append_overlay_value_to_lane_builders(
+                value,
+                &mut tag_b,
+                &mut nb,
+                &mut bb,
+                &mut sb,
+                &mut eb,
+                &mut non_num,
+                &mut non_bool,
+                &mut non_text,
+                &mut non_err,
+            );
+        }
+
+        let payload_bytes = values
+            .iter()
+            .map(|value| value.estimated_payload_bytes())
+            .fold(0usize, usize::saturating_add);
+        let estimated_bytes = len
+            .saturating_mul(OVERLAY_ENTRY_BASE_BYTES)
+            .saturating_add(payload_bytes);
+
+        Self {
+            values: Arc::from(values.into_boxed_slice()),
+            type_tags: Arc::new(tag_b.finish()),
+            numbers: {
+                let a = nb.finish();
+                (non_num > 0).then(|| Arc::new(a))
+            },
+            booleans: {
+                let a = bb.finish();
+                (non_bool > 0).then(|| Arc::new(a))
+            },
+            text: {
+                let a = sb.finish();
+                (non_text > 0).then(|| Arc::new(a) as ArrayRef)
+            },
+            errors: {
+                let a = eb.finish();
+                (non_err > 0).then(|| Arc::new(a))
+            },
+            estimated_bytes,
+        }
+    }
+
+    #[inline]
+    fn get(&self, idx: usize) -> Option<&OverlayValue> {
+        self.values.get(idx)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
+    fn estimated_bytes(&self) -> usize {
+        self.estimated_bytes
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum OverlayFragment {
+    SparseOffsets {
+        offsets: Vec<u32>,
+        payload: OverlayFragmentPayload,
+    },
+    DenseRange {
+        start: u32,
+        len: u32,
+        payload: OverlayFragmentPayload,
+    },
+    RunRange {
+        start: u32,
+        len: u32,
+        run_ends: Vec<u32>,
+        payload: OverlayFragmentPayload,
+    },
+}
+
+impl OverlayFragment {
+    pub(crate) fn sparse_offsets(items: Vec<(usize, OverlayValue)>) -> Option<Self> {
+        let mut by_offset: BTreeMap<usize, OverlayValue> = BTreeMap::new();
+        for (offset, value) in items {
+            by_offset.insert(offset, value);
+        }
+        if by_offset.is_empty() {
+            return None;
+        }
+
+        let mut offsets = Vec::with_capacity(by_offset.len());
+        let mut values = Vec::with_capacity(by_offset.len());
+        for (offset, value) in by_offset {
+            offsets.push(u32::try_from(offset).expect("overlay offset fits in u32"));
+            values.push(value);
+        }
+
+        Some(Self::SparseOffsets {
+            offsets,
+            payload: OverlayFragmentPayload::from_values(values),
+        })
+    }
+
+    pub(crate) fn dense_range(start: usize, values: Vec<OverlayValue>) -> Option<Self> {
+        let len = values.len();
+        if len == 0 {
+            return None;
+        }
+        Some(Self::DenseRange {
+            start: u32::try_from(start).expect("overlay start fits in u32"),
+            len: u32::try_from(len).expect("overlay length fits in u32"),
+            payload: OverlayFragmentPayload::from_values(values),
+        })
+    }
+
+    pub(crate) fn run_range(start: usize, values: Vec<OverlayValue>) -> Option<Self> {
+        if values.is_empty() {
+            return None;
+        }
+
+        let mut run_ends = Vec::new();
+        let mut run_values = Vec::new();
+        let mut current = values[0].clone();
+        for (idx, value) in values.iter().enumerate().skip(1) {
+            if *value != current {
+                run_ends.push(u32::try_from(idx).expect("run end fits in u32"));
+                run_values.push(current);
+                current = value.clone();
+            }
+        }
+        run_ends.push(u32::try_from(values.len()).expect("run end fits in u32"));
+        run_values.push(current);
+
+        Some(Self::RunRange {
+            start: u32::try_from(start).expect("overlay start fits in u32"),
+            len: u32::try_from(values.len()).expect("overlay length fits in u32"),
+            run_ends,
+            payload: OverlayFragmentPayload::from_values(run_values),
+        })
+    }
+
+    #[inline]
+    fn estimated_bytes(&self) -> usize {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, payload } => OVERLAY_FRAGMENT_BASE_BYTES
+                .saturating_add(offsets.len().saturating_mul(core::mem::size_of::<u32>()))
+                .saturating_add(payload.estimated_bytes()),
+            OverlayFragment::DenseRange { payload, .. } => {
+                OVERLAY_FRAGMENT_BASE_BYTES.saturating_add(payload.estimated_bytes())
+            }
+            OverlayFragment::RunRange {
+                run_ends, payload, ..
+            } => OVERLAY_FRAGMENT_BASE_BYTES
+                .saturating_add(run_ends.len().saturating_mul(core::mem::size_of::<u32>()))
+                .saturating_add(payload.estimated_bytes()),
+        }
+    }
+
+    #[inline]
+    fn coverage_len(&self) -> usize {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => offsets.len(),
+            OverlayFragment::DenseRange { len, .. } | OverlayFragment::RunRange { len, .. } => {
+                *len as usize
+            }
+        }
+    }
+
+    fn covered_range(&self) -> Option<core::ops::Range<usize>> {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => {
+                let start = *offsets.first()? as usize;
+                let end = (*offsets.last()? as usize).saturating_add(1);
+                Some(start..end)
+            }
+            OverlayFragment::DenseRange { start, len, .. }
+            | OverlayFragment::RunRange { start, len, .. } => {
+                let start = *start as usize;
+                Some(start..start.saturating_add(*len as usize))
+            }
+        }
+    }
+
+    fn has_any_in_range(&self, range: core::ops::Range<usize>) -> bool {
+        if range.is_empty() {
+            return false;
+        }
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => {
+                let start = u32::try_from(range.start).unwrap_or(u32::MAX);
+                let idx = offsets.partition_point(|off| *off < start);
+                offsets
+                    .get(idx)
+                    .is_some_and(|off| (*off as usize) < range.end)
+            }
+            OverlayFragment::DenseRange { .. } | OverlayFragment::RunRange { .. } => self
+                .covered_range()
+                .is_some_and(|r| r.start < range.end && range.start < r.end),
+        }
+    }
+
+    fn covers_offset(&self, off: usize) -> bool {
+        self.get_scalar(off).is_some()
+    }
+
+    fn get_scalar(&self, off: usize) -> Option<&OverlayValue> {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, payload } => {
+                let off = u32::try_from(off).ok()?;
+                let idx = offsets.binary_search(&off).ok()?;
+                payload.get(idx)
+            }
+            OverlayFragment::DenseRange {
+                start,
+                len,
+                payload,
+            } => {
+                let start = *start as usize;
+                let rel = off.checked_sub(start)?;
+                if rel >= *len as usize {
+                    return None;
+                }
+                payload.get(rel)
+            }
+            OverlayFragment::RunRange {
+                start,
+                len,
+                run_ends,
+                payload,
+            } => {
+                let start = *start as usize;
+                let rel = off.checked_sub(start)?;
+                if rel >= *len as usize {
+                    return None;
+                }
+                let rel_u32 = u32::try_from(rel).ok()?;
+                let run_idx = run_ends.partition_point(|end| *end <= rel_u32);
+                payload.get(run_idx)
+            }
+        }
+    }
+
+    fn covered_offsets(&self) -> Vec<usize> {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, .. } => {
+                offsets.iter().map(|off| *off as usize).collect()
+            }
+            OverlayFragment::DenseRange { start, len, .. }
+            | OverlayFragment::RunRange { start, len, .. } => {
+                let start = *start as usize;
+                (start..start.saturating_add(*len as usize)).collect()
+            }
+        }
+    }
+
+    fn cells(&self) -> Vec<(usize, OverlayValue)> {
+        match self {
+            OverlayFragment::SparseOffsets { offsets, payload } => offsets
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, off)| {
+                    payload
+                        .get(idx)
+                        .cloned()
+                        .map(|value| (*off as usize, value))
+                })
+                .collect(),
+            OverlayFragment::DenseRange {
+                start,
+                len,
+                payload,
+            } => {
+                let start = *start as usize;
+                (0..*len as usize)
+                    .filter_map(|idx| {
+                        payload
+                            .get(idx)
+                            .cloned()
+                            .map(|value| (start.saturating_add(idx), value))
+                    })
+                    .collect()
+            }
+            OverlayFragment::RunRange { start, len, .. } => {
+                let start = *start as usize;
+                (0..*len as usize)
+                    .filter_map(|idx| {
+                        self.get_scalar(start.saturating_add(idx))
+                            .cloned()
+                            .map(|value| (start.saturating_add(idx), value))
+                    })
+                    .collect()
+            }
+        }
+    }
+
+    fn without_offset(&self, off: usize) -> Vec<OverlayFragment> {
+        let cells: Vec<_> = self
+            .cells()
+            .into_iter()
+            .filter(|(cell_off, _)| *cell_off != off)
+            .collect();
+        OverlayFragment::sparse_offsets(cells).into_iter().collect()
+    }
+
+    fn slice(&self, off: usize, len: usize) -> Option<OverlayFragment> {
+        let end = off.saturating_add(len);
+        let cells: Vec<_> = self
+            .cells()
+            .into_iter()
+            .filter(|(cell_off, _)| *cell_off >= off && *cell_off < end)
+            .map(|(cell_off, value)| (cell_off - off, value))
+            .collect();
+
+        if cells.is_empty() {
+            return None;
+        }
+
+        match self {
+            OverlayFragment::SparseOffsets { .. } => OverlayFragment::sparse_offsets(cells),
+            OverlayFragment::DenseRange { .. } => {
+                let start = cells[0].0;
+                let values = cells.into_iter().map(|(_, value)| value).collect();
+                OverlayFragment::dense_range(start, values)
+            }
+            OverlayFragment::RunRange { .. } => {
+                let start = cells[0].0;
+                let values = cells.into_iter().map(|(_, value)| value).collect();
+                OverlayFragment::run_range(start, values)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct Overlay {
-    map: HashMap<usize, OverlayValue>,
+    points: HashMap<usize, OverlayValue>,
+    fragments: Vec<OverlayFragment>,
     // Deterministic (and intentionally approximate) accounting of overlay memory.
     // This is used for budget enforcement/observability; it does not attempt to reflect
     // the allocator's exact overhead.
@@ -936,17 +1299,35 @@ pub struct Overlay {
 impl Overlay {
     // Deterministic estimate per entry to keep budget enforcement stable across platforms.
     // Includes key + map/node overhead (approx) and value payload bytes.
-    const ENTRY_BASE_BYTES: usize = 32;
+    const ENTRY_BASE_BYTES: usize = OVERLAY_ENTRY_BASE_BYTES;
 
     pub fn new() -> Self {
         Self {
-            map: HashMap::new(),
+            points: HashMap::new(),
+            fragments: Vec::new(),
             estimated_bytes: 0,
         }
     }
+
+    #[inline]
+    fn point_estimate(v: &OverlayValue) -> usize {
+        Self::ENTRY_BASE_BYTES + v.estimated_payload_bytes()
+    }
+
+    #[inline]
+    fn adjust_estimated_bytes(&mut self, delta: isize) {
+        if delta >= 0 {
+            self.estimated_bytes = self.estimated_bytes.saturating_add(delta as usize);
+        } else {
+            self.estimated_bytes = self.estimated_bytes.saturating_sub((-delta) as usize);
+        }
+    }
+
     #[inline]
     pub(crate) fn get_scalar(&self, off: usize) -> Option<&OverlayValue> {
-        self.map.get(&off)
+        self.points
+            .get(&off)
+            .or_else(|| self.fragments.iter().rev().find_map(|f| f.get_scalar(off)))
     }
 
     #[inline]
@@ -956,20 +1337,11 @@ impl Overlay {
 
     #[inline]
     pub(crate) fn set_scalar(&mut self, off: usize, v: OverlayValue) -> isize {
-        let new_est = Self::ENTRY_BASE_BYTES + v.estimated_payload_bytes();
-        let old_est = self
-            .map
-            .get(&off)
-            .map(|old| Self::ENTRY_BASE_BYTES + old.estimated_payload_bytes())
-            .unwrap_or(0);
-        self.map.insert(off, v);
-        let delta = new_est as isize - old_est as isize;
-        if delta >= 0 {
-            self.estimated_bytes = self.estimated_bytes.saturating_add(delta as usize);
-        } else {
-            self.estimated_bytes = self.estimated_bytes.saturating_sub((-delta) as usize);
-        }
-        delta
+        let removed = self.remove_scalar(off);
+        let new_est = Self::point_estimate(&v);
+        self.points.insert(off, v);
+        self.adjust_estimated_bytes(new_est as isize);
+        removed.saturating_add(new_est as isize)
     }
 
     #[inline]
@@ -977,14 +1349,93 @@ impl Overlay {
         self.set_scalar(off, v)
     }
 
+    pub(crate) fn apply_fragment(&mut self, fragment: OverlayFragment) -> isize {
+        let mut delta = self.remove_points_covered_by_fragment(&fragment);
+        delta = delta.saturating_add(self.remove_fragments_covered_by_fragment(&fragment));
+
+        let fragment_est = fragment.estimated_bytes();
+        self.fragments.push(fragment);
+        self.adjust_estimated_bytes(fragment_est as isize);
+        delta.saturating_add(fragment_est as isize)
+    }
+
+    fn remove_points_covered_by_fragment(&mut self, fragment: &OverlayFragment) -> isize {
+        let mut removed = 0usize;
+        for off in fragment.covered_offsets() {
+            if let Some(old) = self.points.remove(&off) {
+                removed = removed.saturating_add(Self::point_estimate(&old));
+            }
+        }
+        self.estimated_bytes = self.estimated_bytes.saturating_sub(removed);
+        -(removed as isize)
+    }
+
+    fn remove_fragments_covered_by_fragment(&mut self, replacement: &OverlayFragment) -> isize {
+        if self.fragments.is_empty() {
+            return 0;
+        }
+
+        let mut delta: isize = 0;
+        let mut fragments = Vec::with_capacity(self.fragments.len());
+        for fragment in self.fragments.drain(..) {
+            let Some(range) = replacement.covered_range() else {
+                fragments.push(fragment);
+                continue;
+            };
+            if !fragment.has_any_in_range(range) {
+                fragments.push(fragment);
+                continue;
+            }
+
+            let old_est = fragment.estimated_bytes();
+            let remaining_cells: Vec<_> = fragment
+                .cells()
+                .into_iter()
+                .filter(|(off, _)| !replacement.covers_offset(*off))
+                .collect();
+            let mut new_est = 0usize;
+            if let Some(fragment) = OverlayFragment::sparse_offsets(remaining_cells) {
+                new_est = fragment.estimated_bytes();
+                fragments.push(fragment);
+            }
+            delta = delta.saturating_add(new_est as isize - old_est as isize);
+        }
+        self.fragments = fragments;
+        self.adjust_estimated_bytes(delta);
+        delta
+    }
+
     #[inline]
     pub(crate) fn remove_scalar(&mut self, off: usize) -> isize {
-        let Some(old) = self.map.remove(&off) else {
-            return 0;
-        };
-        let old_est = Self::ENTRY_BASE_BYTES + old.estimated_payload_bytes();
-        self.estimated_bytes = self.estimated_bytes.saturating_sub(old_est);
-        -(old_est as isize)
+        let mut delta = 0isize;
+        if let Some(old) = self.points.remove(&off) {
+            let old_est = Self::point_estimate(&old);
+            self.estimated_bytes = self.estimated_bytes.saturating_sub(old_est);
+            delta = delta.saturating_sub(old_est as isize);
+        }
+
+        if !self.fragments.is_empty() {
+            let mut fragments = Vec::with_capacity(self.fragments.len());
+            for fragment in self.fragments.drain(..) {
+                if fragment.get_scalar(off).is_none() {
+                    fragments.push(fragment);
+                    continue;
+                }
+
+                let old_est = fragment.estimated_bytes();
+                let replacements = fragment.without_offset(off);
+                let new_est = replacements
+                    .iter()
+                    .map(OverlayFragment::estimated_bytes)
+                    .fold(0usize, usize::saturating_add);
+                fragments.extend(replacements);
+                delta = delta.saturating_add(new_est as isize - old_est as isize);
+            }
+            self.fragments = fragments;
+            self.adjust_estimated_bytes(delta);
+        }
+
+        delta
     }
 
     #[inline]
@@ -995,7 +1446,8 @@ impl Overlay {
     #[inline]
     pub(crate) fn clear_all(&mut self) -> usize {
         let freed = self.estimated_bytes;
-        self.map.clear();
+        self.points.clear();
+        self.fragments.clear();
         self.estimated_bytes = 0;
         freed
     }
@@ -1004,22 +1456,34 @@ impl Overlay {
     pub fn clear(&mut self) -> usize {
         self.clear_all()
     }
+
     #[inline]
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.points.len().saturating_add(
+            self.fragments
+                .iter()
+                .map(OverlayFragment::coverage_len)
+                .sum(),
+        )
     }
 
     #[inline]
     pub fn estimated_bytes(&self) -> usize {
         self.estimated_bytes
     }
+
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.points.is_empty() && self.fragments.is_empty()
     }
+
     #[inline]
     pub(crate) fn has_any_in_range(&self, range: core::ops::Range<usize>) -> bool {
-        self.map.keys().any(|k| range.contains(k))
+        self.points.keys().any(|k| range.contains(k))
+            || self
+                .fragments
+                .iter()
+                .any(|fragment| fragment.has_any_in_range(range.clone()))
     }
 
     #[inline]
@@ -1030,7 +1494,12 @@ impl Overlay {
     pub(crate) fn slice(&self, off: usize, len: usize) -> Overlay {
         let mut out = Overlay::new();
         let end = off.saturating_add(len);
-        for (k, v) in self.map.iter() {
+        for fragment in &self.fragments {
+            if let Some(sliced) = fragment.slice(off, len) {
+                let _ = out.apply_fragment(sliced);
+            }
+        }
+        for (k, v) in self.points.iter() {
             if *k >= off && *k < end {
                 let _ = out.set_scalar(*k - off, v.clone());
             }
@@ -1038,12 +1507,11 @@ impl Overlay {
         out
     }
 
-    /// Iterate over all `(offset, value)` pairs in the overlay.
+    /// Iterate over point `(offset, value)` pairs in the overlay.
     pub fn iter(&self) -> impl Iterator<Item = (&usize, &OverlayValue)> {
-        self.map.iter()
+        self.points.iter()
     }
 }
-
 pub(crate) struct OverlayCascade<'a> {
     user: &'a Overlay,
     computed: &'a Overlay,
@@ -2719,6 +3187,162 @@ mod tests {
             LiteralValue::Empty
         );
         assert!(cascade.has_any_in_range(1..2));
+    }
+
+    #[test]
+    fn overlay_storage_pointmap_backward_compat_get_set_remove() {
+        let mut overlay = Overlay::new();
+        assert!(overlay.is_empty());
+
+        let delta = overlay.set_scalar(1, OverlayValue::Number(10.0));
+        assert!(delta > 0);
+        assert_eq!(overlay.len(), 1);
+        assert_eq!(
+            overlay.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Number(10.0)
+        );
+
+        let replace_delta = overlay.set_scalar(1, OverlayValue::Text(Arc::from("x")));
+        assert_ne!(replace_delta, 0);
+        assert_eq!(overlay.len(), 1);
+        assert_eq!(
+            overlay.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Text("x".into())
+        );
+
+        let remove_delta = overlay.remove_scalar(1);
+        assert!(remove_delta < 0);
+        assert!(overlay.is_empty());
+        assert!(overlay.get_scalar(1).is_none());
+    }
+
+    #[test]
+    fn overlay_storage_no_fragments_behavior_matches_old_map() {
+        let mut overlay = Overlay::new();
+        overlay.set_scalar(0, OverlayValue::Number(1.0));
+        overlay.set_scalar(3, OverlayValue::Empty);
+
+        assert!(overlay.has_any_in_range(0..1));
+        assert!(!overlay.has_any_in_range(1..3));
+        assert!(overlay.has_any_in_range(3..4));
+
+        let sliced = overlay.slice(2, 3);
+        assert!(sliced.get_scalar(0).is_none());
+        assert_eq!(
+            sliced.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Empty
+        );
+    }
+
+    #[test]
+    fn overlay_cascade_user_layer_masks_computed_fragment_regardless_of_sequence() {
+        let mut user = Overlay::new();
+        let mut computed = Overlay::new();
+
+        user.set_scalar(0, OverlayValue::Number(3.0));
+        computed.apply_fragment(
+            OverlayFragment::dense_range(0, vec![OverlayValue::Number(2.0)]).unwrap(),
+        );
+
+        let cascade = OverlayCascade::new(&user, &computed);
+        assert_eq!(
+            cascade.get_scalar(0).unwrap().to_literal(),
+            LiteralValue::Number(3.0)
+        );
+    }
+
+    #[test]
+    fn overlay_same_layer_later_point_replaces_fragment_cell() {
+        let mut overlay = Overlay::new();
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                vec![
+                    OverlayValue::Number(1.0),
+                    OverlayValue::Number(2.0),
+                    OverlayValue::Number(3.0),
+                ],
+            )
+            .unwrap(),
+        );
+
+        overlay.set_scalar(1, OverlayValue::Number(99.0));
+
+        assert_eq!(
+            overlay.get_scalar(0).unwrap().to_literal(),
+            LiteralValue::Number(1.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Number(99.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(2).unwrap().to_literal(),
+            LiteralValue::Number(3.0)
+        );
+    }
+
+    #[test]
+    fn overlay_same_layer_later_fragment_replaces_point_range() {
+        let mut overlay = Overlay::new();
+        overlay.set_scalar(0, OverlayValue::Number(1.0));
+        overlay.set_scalar(1, OverlayValue::Number(2.0));
+        overlay.set_scalar(2, OverlayValue::Number(3.0));
+
+        overlay.apply_fragment(
+            OverlayFragment::dense_range(
+                0,
+                vec![
+                    OverlayValue::Number(10.0),
+                    OverlayValue::Number(20.0),
+                    OverlayValue::Number(30.0),
+                ],
+            )
+            .unwrap(),
+        );
+
+        assert!(overlay.points.is_empty());
+        assert_eq!(overlay.fragments.len(), 1);
+        assert_eq!(
+            overlay.get_scalar(0).unwrap().to_literal(),
+            LiteralValue::Number(10.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(1).unwrap().to_literal(),
+            LiteralValue::Number(20.0)
+        );
+        assert_eq!(
+            overlay.get_scalar(2).unwrap().to_literal(),
+            LiteralValue::Number(30.0)
+        );
+    }
+
+    #[test]
+    fn overlay_computed_empty_run_masks_non_empty_base() {
+        let mut b = IngestBuilder::new("S", 1, 8, crate::engine::DateSystem::Excel1900);
+        b.append_row(&[LiteralValue::Number(1.0)]).unwrap();
+        b.append_row(&[LiteralValue::Number(2.0)]).unwrap();
+        b.append_row(&[LiteralValue::Number(3.0)]).unwrap();
+        let mut sheet = b.finish();
+
+        let (ch_i, _) = sheet.chunk_of_row(0).unwrap();
+        sheet.columns[0].chunks[ch_i]
+            .computed_overlay
+            .apply_fragment(
+                OverlayFragment::run_range(
+                    0,
+                    vec![
+                        OverlayValue::Empty,
+                        OverlayValue::Empty,
+                        OverlayValue::Empty,
+                    ],
+                )
+                .unwrap(),
+            );
+
+        assert_eq!(sheet.get_cell_value(0, 0), LiteralValue::Empty);
+        assert_eq!(sheet.get_cell_value(1, 0), LiteralValue::Empty);
+        assert_eq!(sheet.get_cell_value(2, 0), LiteralValue::Empty);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -816,7 +816,7 @@ pub enum CellIngest<'a> {
     Pending,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum OverlayValue {
     Empty,
     Number(f64),
@@ -832,7 +832,7 @@ pub enum OverlayValue {
 
 impl OverlayValue {
     #[inline]
-    fn estimated_payload_bytes(&self) -> usize {
+    pub(crate) fn estimated_payload_bytes(&self) -> usize {
         match self {
             OverlayValue::Empty | OverlayValue::Pending => 0,
             OverlayValue::Number(_) | OverlayValue::DateTime(_) | OverlayValue::Duration(_) => {

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -3920,11 +3920,25 @@ where
         &self,
         buffer: &ComputedWriteBuffer,
     ) -> ComputedWriteCoalescingPlan {
+        self.plan_computed_write_coalescing_from_writes(buffer.writes().iter().cloned())
+    }
+
+    fn plan_owned_computed_write_coalescing(
+        &self,
+        writes: Vec<ComputedWrite>,
+    ) -> ComputedWriteCoalescingPlan {
+        self.plan_computed_write_coalescing_from_writes(writes)
+    }
+
+    fn plan_computed_write_coalescing_from_writes(
+        &self,
+        writes: impl IntoIterator<Item = ComputedWrite>,
+    ) -> ComputedWriteCoalescingPlan {
         let mut groups: BTreeMap<ComputedWriteChunkKey, Vec<ComputedWriteChunkEntryPlan>> =
             BTreeMap::new();
         let mut input_cells = 0usize;
 
-        for write in buffer.writes() {
+        for write in writes {
             match write {
                 ComputedWrite::Cell {
                     seq,
@@ -3936,11 +3950,11 @@ where
                     input_cells = input_cells.saturating_add(1);
                     self.push_computed_write_plan_entry(
                         &mut groups,
-                        *seq,
-                        *sheet_id,
-                        *row0,
-                        *col0,
-                        value.clone(),
+                        seq,
+                        sheet_id,
+                        row0,
+                        col0,
+                        value,
                     );
                 }
                 ComputedWrite::Rect {
@@ -3950,16 +3964,16 @@ where
                     sc0,
                     values,
                 } => {
-                    for (r_off, row) in values.iter().enumerate() {
-                        for (c_off, value) in row.iter().enumerate() {
+                    for (r_off, row) in values.into_iter().enumerate() {
+                        for (c_off, value) in row.into_iter().enumerate() {
                             input_cells = input_cells.saturating_add(1);
                             self.push_computed_write_plan_entry(
                                 &mut groups,
-                                *seq,
-                                *sheet_id,
+                                seq,
+                                sheet_id,
                                 sr0.saturating_add(r_off as u32),
                                 sc0.saturating_add(c_off as u32),
-                                value.clone(),
+                                value,
                             );
                         }
                     }
@@ -4082,41 +4096,27 @@ where
             return Ok(());
         }
 
-        for write in buffer.take_writes() {
-            match write {
-                ComputedWrite::Cell {
-                    sheet_id,
-                    row0,
-                    col0,
-                    value,
-                    ..
-                } => {
-                    let sheet_name = self.graph.sheet_name(sheet_id).to_string();
-                    self.write_computed_overlay_value_0based(&sheet_name, row0, col0, value);
-                }
-                ComputedWrite::Rect {
-                    sheet_id,
-                    sr0,
-                    sc0,
-                    values,
-                    ..
-                } => {
-                    let sheet_name = self.graph.sheet_name(sheet_id).to_string();
-                    for (r_off, row) in values.into_iter().enumerate() {
-                        for (c_off, value) in row.into_iter().enumerate() {
-                            self.write_computed_overlay_value_0based(
-                                &sheet_name,
-                                sr0.saturating_add(r_off as u32),
-                                sc0.saturating_add(c_off as u32),
-                                value,
-                            );
-                        }
-                    }
-                }
-            }
-        }
+        let plan = self.plan_owned_computed_write_coalescing(buffer.take_writes());
+        self.flush_computed_write_plan_as_points(plan);
 
         Ok(())
+    }
+
+    fn flush_computed_write_plan_as_points(&mut self, plan: ComputedWriteCoalescingPlan) {
+        for chunk in plan.chunks {
+            let sheet_name = self.graph.sheet_name(chunk.sheet_id).to_string();
+            for entry in chunk.entries {
+                let row0 = chunk
+                    .chunk_start_row0
+                    .saturating_add(entry.row_in_chunk as u32);
+                self.write_computed_overlay_value_0based(
+                    &sheet_name,
+                    row0,
+                    chunk.col0,
+                    entry.value,
+                );
+            }
+        }
     }
 
     #[inline]

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1,5 +1,5 @@
 use crate::SheetId;
-use crate::arrow_store::SheetStore;
+use crate::arrow_store::{OverlayValue, SheetStore};
 use crate::engine::eval_delta::{DeltaCollector, DeltaMode, EvalDelta};
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::range_view::RangeView;
@@ -28,6 +28,128 @@ type ParsedFormulaEntry = (u32, u32, ASTNode);
 type StagedFormulaMap = std::collections::HashMap<String, Vec<StagedFormulaEntry>>;
 type PreparedFormulaBatches = Vec<(String, Vec<ParsedFormulaEntry>)>;
 type StagedFormulaBatches = Vec<(String, Vec<StagedFormulaEntry>)>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ComputedWrite {
+    Cell {
+        seq: u64,
+        sheet_id: SheetId,
+        row0: u32,
+        col0: u32,
+        value: OverlayValue,
+    },
+    Rect {
+        seq: u64,
+        sheet_id: SheetId,
+        sr0: u32,
+        sc0: u32,
+        values: Vec<Vec<OverlayValue>>,
+    },
+}
+
+impl ComputedWrite {
+    #[inline]
+    pub(crate) fn seq(&self) -> u64 {
+        match self {
+            ComputedWrite::Cell { seq, .. } | ComputedWrite::Rect { seq, .. } => *seq,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ComputedWriteBuffer {
+    writes: Vec<ComputedWrite>,
+    next_seq: u64,
+    estimated_bytes: usize,
+}
+
+impl ComputedWriteBuffer {
+    const ENTRY_BASE_BYTES: usize = 32;
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.writes.is_empty()
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.writes.len()
+    }
+
+    #[inline]
+    pub(crate) fn estimated_bytes(&self) -> usize {
+        self.estimated_bytes
+    }
+
+    #[inline]
+    pub(crate) fn writes(&self) -> &[ComputedWrite] {
+        &self.writes
+    }
+
+    pub(crate) fn push_cell(
+        &mut self,
+        sheet_id: SheetId,
+        row0: u32,
+        col0: u32,
+        value: OverlayValue,
+    ) {
+        let seq = self.next_sequence();
+        self.estimated_bytes = self
+            .estimated_bytes
+            .saturating_add(Self::estimate_value_bytes(&value));
+        self.writes.push(ComputedWrite::Cell {
+            seq,
+            sheet_id,
+            row0,
+            col0,
+            value,
+        });
+    }
+
+    pub(crate) fn push_rect(
+        &mut self,
+        sheet_id: SheetId,
+        sr0: u32,
+        sc0: u32,
+        values: Vec<Vec<OverlayValue>>,
+    ) {
+        let seq = self.next_sequence();
+        let added = values
+            .iter()
+            .flat_map(|row| row.iter())
+            .map(Self::estimate_value_bytes)
+            .fold(0usize, usize::saturating_add);
+        self.estimated_bytes = self.estimated_bytes.saturating_add(added);
+        self.writes.push(ComputedWrite::Rect {
+            seq,
+            sheet_id,
+            sr0,
+            sc0,
+            values,
+        });
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.writes.clear();
+        self.estimated_bytes = 0;
+    }
+
+    fn take_writes(&mut self) -> Vec<ComputedWrite> {
+        self.estimated_bytes = 0;
+        std::mem::take(&mut self.writes)
+    }
+
+    fn next_sequence(&mut self) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq = self.next_seq.wrapping_add(1);
+        seq
+    }
+
+    #[inline]
+    fn estimate_value_bytes(value: &OverlayValue) -> usize {
+        Self::ENTRY_BASE_BYTES.saturating_add(value.estimated_payload_bytes())
+    }
+}
 
 pub struct Engine<R> {
     pub(crate) graph: DependencyGraph,
@@ -3576,8 +3698,7 @@ where
     /// Mirror a value into the computed overlay (formula/spill outputs).
     ///
     /// This path is subject to `EvalConfig.max_overlay_memory_bytes`.
-    /// If the cap is exceeded, we deterministically stop mirroring additional computed overlay
-    /// values and force RangeView resolution to materialize from graph values for correctness.
+    /// If the cap is exceeded, computed overlays are compacted into base lanes.
     fn mirror_value_to_computed_overlay(
         &mut self,
         sheet: &str,
@@ -3595,21 +3716,36 @@ where
             return;
         }
 
-        if self.arrow_sheets.sheet(sheet).is_none() {
-            self.arrow_sheets
-                .sheets
-                .push(crate::arrow_store::ArrowSheet {
-                    name: std::sync::Arc::<str>::from(sheet),
-                    columns: Vec::new(),
-                    nrows: 0,
-                    chunk_starts: Vec::new(),
-                    chunk_rows: 32 * 1024,
-                });
+        let ov = self.literal_to_overlay_value(value);
+        self.write_computed_overlay_value_0based(
+            sheet,
+            row.saturating_sub(1),
+            col.saturating_sub(1),
+            ov,
+        );
+    }
+
+    fn write_computed_overlay_value_0based(
+        &mut self,
+        sheet: &str,
+        row0: u32,
+        col0: u32,
+        value: OverlayValue,
+    ) {
+        if !(self.config.arrow_storage_enabled
+            && self.config.delta_overlay_enabled
+            && self.config.write_formula_overlay_enabled)
+        {
+            return;
+        }
+        if self.computed_overlay_mirroring_disabled {
+            return;
         }
 
-        let row0 = row.saturating_sub(1) as usize;
-        let col0 = col.saturating_sub(1) as usize;
+        self.ensure_arrow_sheet(sheet);
 
+        let row0 = row0 as usize;
+        let col0 = col0 as usize;
         let asheet = self
             .arrow_sheets
             .sheet_mut(sheet)
@@ -3627,59 +3763,66 @@ where
             asheet.ensure_row_capacity(row0 + 1);
         }
 
-        if let Some((ch_idx, in_off)) = asheet.chunk_of_row(row0) {
-            use crate::arrow_store::OverlayValue;
-            let ov = match value {
-                LiteralValue::Empty => OverlayValue::Empty,
-                LiteralValue::Int(i) => OverlayValue::Number(*i as f64),
-                LiteralValue::Number(n) => OverlayValue::Number(*n),
-                LiteralValue::Boolean(b) => OverlayValue::Boolean(*b),
-                LiteralValue::Text(s) => OverlayValue::Text(std::sync::Arc::from(s.clone())),
-                LiteralValue::Error(e) => {
-                    OverlayValue::Error(crate::arrow_store::map_error_code(e.kind))
-                }
-                LiteralValue::Date(d) => {
-                    let dt = d.and_hms_opt(0, 0, 0).unwrap();
-                    let serial = crate::builtins::datetime::datetime_to_serial_for(
-                        self.config.date_system,
-                        &dt,
-                    );
-                    OverlayValue::DateTime(serial)
-                }
-                LiteralValue::DateTime(dt) => {
-                    let serial = crate::builtins::datetime::datetime_to_serial_for(
-                        self.config.date_system,
-                        dt,
-                    );
-                    OverlayValue::DateTime(serial)
-                }
-                LiteralValue::Time(t) => {
-                    let serial = t.num_seconds_from_midnight() as f64 / 86_400.0;
-                    OverlayValue::DateTime(serial)
-                }
-                LiteralValue::Duration(d) => {
-                    let serial = d.num_seconds() as f64 / 86_400.0;
-                    OverlayValue::Duration(serial)
-                }
-                LiteralValue::Pending => OverlayValue::Pending,
-                LiteralValue::Array(_) => OverlayValue::Error(crate::arrow_store::map_error_code(
-                    formualizer_common::ExcelErrorKind::Value,
-                )),
-            };
+        let Some((ch_idx, in_off)) = asheet.chunk_of_row(row0) else {
+            return;
+        };
+        let Some(ch) = asheet.ensure_column_chunk_mut(col0, ch_idx) else {
+            return;
+        };
 
-            let Some(ch) = asheet.ensure_column_chunk_mut(col0, ch_idx) else {
-                return;
-            };
+        let delta = ch.computed_overlay.set_scalar(in_off, value);
+        self.adjust_computed_overlay_bytes(delta);
 
-            let delta = ch.computed_overlay.set(in_off, ov);
-            self.adjust_computed_overlay_bytes(delta);
+        if let Some(cap) = self.config.max_overlay_memory_bytes
+            && self.computed_overlay_bytes_estimate > cap
+        {
+            self.disable_computed_overlay_mirroring_due_to_budget(cap);
+        }
+    }
 
-            if let Some(cap) = self.config.max_overlay_memory_bytes
-                && self.computed_overlay_bytes_estimate > cap
-            {
-                self.disable_computed_overlay_mirroring_due_to_budget(cap);
+    pub(crate) fn flush_computed_write_buffer(
+        &mut self,
+        buffer: &mut ComputedWriteBuffer,
+    ) -> Result<(), ExcelError> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
+        for write in buffer.take_writes() {
+            match write {
+                ComputedWrite::Cell {
+                    sheet_id,
+                    row0,
+                    col0,
+                    value,
+                    ..
+                } => {
+                    let sheet_name = self.graph.sheet_name(sheet_id).to_string();
+                    self.write_computed_overlay_value_0based(&sheet_name, row0, col0, value);
+                }
+                ComputedWrite::Rect {
+                    sheet_id,
+                    sr0,
+                    sc0,
+                    values,
+                    ..
+                } => {
+                    let sheet_name = self.graph.sheet_name(sheet_id).to_string();
+                    for (r_off, row) in values.into_iter().enumerate() {
+                        for (c_off, value) in row.into_iter().enumerate() {
+                            self.write_computed_overlay_value_0based(
+                                &sheet_name,
+                                sr0.saturating_add(r_off as u32),
+                                sc0.saturating_add(c_off as u32),
+                                value,
+                            );
+                        }
+                    }
+                }
             }
         }
+
+        Ok(())
     }
 
     #[inline]
@@ -3747,28 +3890,58 @@ where
     }
 
     fn mirror_vertex_value_to_overlay(&mut self, vertex_id: VertexId, value: &LiteralValue) {
+        let _ = self.record_vertex_value_to_overlay(vertex_id, value, None);
+    }
+
+    fn record_vertex_value_to_overlay(
+        &mut self,
+        vertex_id: VertexId,
+        value: &LiteralValue,
+        computed_writes: Option<&mut ComputedWriteBuffer>,
+    ) -> Result<(), ExcelError> {
         if !(self.config.arrow_storage_enabled
             && self.config.delta_overlay_enabled
             && self.config.write_formula_overlay_enabled)
         {
-            return;
+            return Ok(());
+        }
+        if self.computed_overlay_mirroring_disabled {
+            return Ok(());
         }
         if !matches!(
             self.graph.get_vertex_kind(vertex_id),
             VertexKind::FormulaScalar | VertexKind::FormulaArray
         ) {
-            return;
+            return Ok(());
         }
         let Some(cell) = self.graph.get_cell_ref(vertex_id) else {
-            return;
+            return Ok(());
         };
-        let sheet_name = self.graph.sheet_name(cell.sheet_id).to_string();
-        self.mirror_value_to_computed_overlay(
-            &sheet_name,
-            cell.coord.row() + 1,
-            cell.coord.col() + 1,
-            value,
-        );
+        let ov = self.literal_to_overlay_value(value);
+        if let Some(buffer) = computed_writes {
+            buffer.push_cell(cell.sheet_id, cell.coord.row(), cell.coord.col(), ov);
+            if self.should_flush_computed_write_buffer(buffer) {
+                self.flush_computed_write_buffer(buffer)?;
+            }
+        } else {
+            let sheet_name = self.graph.sheet_name(cell.sheet_id).to_string();
+            self.write_computed_overlay_value_0based(
+                &sheet_name,
+                cell.coord.row(),
+                cell.coord.col(),
+                ov,
+            );
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn should_flush_computed_write_buffer(&self, buffer: &ComputedWriteBuffer) -> bool {
+        self.config.max_overlay_memory_bytes.is_some_and(|cap| {
+            self.computed_overlay_bytes_estimate
+                .saturating_add(buffer.estimated_bytes())
+                > cap
+        })
     }
 
     /// Estimated memory usage for computed overlays (formula/spill mirroring).
@@ -8136,12 +8309,22 @@ where
         delta: Option<&mut DeltaCollector>,
         log: Option<&mut ChangeLog>,
     ) -> Result<(), ExcelError> {
+        self.apply_effect_with_computed_writes(effect, delta, log, None)
+    }
+
+    fn apply_effect_with_computed_writes(
+        &mut self,
+        effect: &Effect,
+        delta: Option<&mut DeltaCollector>,
+        log: Option<&mut ChangeLog>,
+        computed_writes: Option<&mut ComputedWriteBuffer>,
+    ) -> Result<(), ExcelError> {
         match effect {
             Effect::WriteCell { vertex_id, value } => {
-                self.apply_write_cell(*vertex_id, value, delta);
+                self.apply_write_cell(*vertex_id, value, delta, computed_writes)?;
             }
             Effect::SpillClear { anchor_vertex } => {
-                self.apply_spill_clear(*anchor_vertex, delta, log);
+                self.apply_spill_clear(*anchor_vertex, delta, log, computed_writes)?;
             }
             Effect::SpillCommit {
                 anchor_vertex,
@@ -8149,7 +8332,14 @@ where
                 target_cells,
                 values,
             } => {
-                self.apply_spill_commit(*anchor_vertex, target_cells, values.clone(), delta, log)?;
+                self.apply_spill_commit(
+                    *anchor_vertex,
+                    target_cells,
+                    values.clone(),
+                    delta,
+                    log,
+                    computed_writes,
+                )?;
             }
         }
         Ok(())
@@ -8160,22 +8350,28 @@ where
         &mut self,
         vertex_id: VertexId,
         value: &LiteralValue,
-        delta: Option<&mut DeltaCollector>,
-    ) {
-        if let Some(d) = delta
+        mut delta: Option<&mut DeltaCollector>,
+        mut computed_writes: Option<&mut ComputedWriteBuffer>,
+    ) -> Result<(), ExcelError> {
+        if let Some(d) = delta.as_deref_mut()
             && d.mode != DeltaMode::Off
-            && let Some(cell) = self.graph.get_cell_ref_for_vertex(vertex_id)
         {
-            let sheet_name = self.graph.sheet_name(cell.sheet_id);
-            let old = self
-                .read_cell_value(sheet_name, cell.coord.row() + 1, cell.coord.col() + 1)
-                .unwrap_or(LiteralValue::Empty);
-            if old != *value {
-                d.record_cell(cell.sheet_id, cell.coord.row(), cell.coord.col());
+            if let Some(buffer) = computed_writes.as_deref_mut() {
+                self.flush_computed_write_buffer(buffer)?;
+            }
+            if let Some(cell) = self.graph.get_cell_ref_for_vertex(vertex_id) {
+                let sheet_name = self.graph.sheet_name(cell.sheet_id);
+                let old = self
+                    .read_cell_value(sheet_name, cell.coord.row() + 1, cell.coord.col() + 1)
+                    .unwrap_or(LiteralValue::Empty);
+                if old != *value {
+                    d.record_cell(cell.sheet_id, cell.coord.row(), cell.coord.col());
+                }
             }
         }
         self.graph.update_vertex_value(vertex_id, value.clone());
-        self.mirror_vertex_value_to_overlay(vertex_id, value);
+        self.record_vertex_value_to_overlay(vertex_id, value, computed_writes)?;
+        Ok(())
     }
 
     /// Apply a SpillClear effect.
@@ -8184,14 +8380,19 @@ where
         anchor_vertex: VertexId,
         delta: Option<&mut DeltaCollector>,
         log: Option<&mut ChangeLog>,
-    ) {
+        computed_writes: Option<&mut ComputedWriteBuffer>,
+    ) -> Result<(), ExcelError> {
+        if let Some(buffer) = computed_writes {
+            self.flush_computed_write_buffer(buffer)?;
+        }
+
         let spill_cells = self
             .graph
             .spill_cells_for_anchor(anchor_vertex)
             .map(|cells| cells.to_vec())
             .unwrap_or_default();
         if spill_cells.is_empty() {
-            return;
+            return Ok(());
         }
 
         // Snapshot for ChangeLog before clearing.
@@ -8245,6 +8446,7 @@ where
                 old,
             });
         }
+        Ok(())
     }
 
     /// Apply a SpillCommit effect.
@@ -8255,7 +8457,12 @@ where
         values: Vec<Vec<LiteralValue>>,
         delta: Option<&mut DeltaCollector>,
         log: Option<&mut ChangeLog>,
+        computed_writes: Option<&mut ComputedWriteBuffer>,
     ) -> Result<(), ExcelError> {
+        if let Some(buffer) = computed_writes {
+            self.flush_computed_write_buffer(buffer)?;
+        }
+
         // Snapshot for ChangeLog before commit.
         let old_snapshot = if log.is_some() {
             self.snapshot_spill_for_anchor(anchor_vertex)
@@ -8341,6 +8548,30 @@ where
         })
     }
 
+    fn flush_before_range_dependent_vertex(
+        &mut self,
+        vertex_id: VertexId,
+        computed_writes: &mut ComputedWriteBuffer,
+    ) -> Result<(), ExcelError> {
+        if self.graph.get_range_dependencies(vertex_id).is_some() {
+            self.flush_computed_write_buffer(computed_writes)?;
+        }
+        Ok(())
+    }
+
+    fn plan_vertex_effects_with_computed_flush(
+        &mut self,
+        vertex_id: VertexId,
+        computed_value: LiteralValue,
+        overwritable_formulas: Option<&rustc_hash::FxHashSet<VertexId>>,
+        computed_writes: &mut ComputedWriteBuffer,
+    ) -> Result<Vec<Effect>, ExcelError> {
+        if matches!(&computed_value, LiteralValue::Array(_)) {
+            self.flush_computed_write_buffer(computed_writes)?;
+        }
+        self.plan_vertex_effects(vertex_id, computed_value, overwritable_formulas)
+    }
+
     // ── Layer evaluation via effects pipeline ──────────────────────────────
 
     /// Evaluate a layer sequentially using the effects pipeline.
@@ -8348,16 +8579,38 @@ where
         &mut self,
         layer: &super::scheduler::Layer,
     ) -> Result<usize, ExcelError> {
+        let mut computed_writes = ComputedWriteBuffer::default();
         for &vertex_id in &layer.vertices {
+            self.flush_before_range_dependent_vertex(vertex_id, &mut computed_writes)?;
             let value = match self.evaluate_vertex_immutable(vertex_id) {
                 Ok(v) => v,
                 Err(e) => LiteralValue::Error(e),
             };
-            let effects = self.plan_vertex_effects(vertex_id, value, None)?;
+            let effects = match self.plan_vertex_effects_with_computed_flush(
+                vertex_id,
+                value,
+                None,
+                &mut computed_writes,
+            ) {
+                Ok(effects) => effects,
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
+            };
             for effect in &effects {
-                self.apply_effect(effect, None, None)?;
+                if let Err(e) = self.apply_effect_with_computed_writes(
+                    effect,
+                    None,
+                    None,
+                    Some(&mut computed_writes),
+                ) {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
+        self.flush_computed_write_buffer(&mut computed_writes)?;
         Ok(layer.vertices.len())
     }
 
@@ -8367,16 +8620,38 @@ where
         layer: &super::scheduler::Layer,
         delta: &mut DeltaCollector,
     ) -> Result<usize, ExcelError> {
+        let mut computed_writes = ComputedWriteBuffer::default();
         for &vertex_id in &layer.vertices {
+            self.flush_before_range_dependent_vertex(vertex_id, &mut computed_writes)?;
             let value = match self.evaluate_vertex_immutable(vertex_id) {
                 Ok(v) => v,
                 Err(e) => LiteralValue::Error(e),
             };
-            let effects = self.plan_vertex_effects(vertex_id, value, None)?;
+            let effects = match self.plan_vertex_effects_with_computed_flush(
+                vertex_id,
+                value,
+                None,
+                &mut computed_writes,
+            ) {
+                Ok(effects) => effects,
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
+            };
             for effect in &effects {
-                self.apply_effect(effect, Some(delta), None)?;
+                if let Err(e) = self.apply_effect_with_computed_writes(
+                    effect,
+                    Some(delta),
+                    None,
+                    Some(&mut computed_writes),
+                ) {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
+        self.flush_computed_write_buffer(&mut computed_writes)?;
         Ok(layer.vertices.len())
     }
 
@@ -8386,20 +8661,43 @@ where
         layer: &super::scheduler::Layer,
         cancel_flag: &AtomicBool,
     ) -> Result<usize, ExcelError> {
+        let mut computed_writes = ComputedWriteBuffer::default();
         for (i, &vertex_id) in layer.vertices.iter().enumerate() {
             if i % 256 == 0 && cancel_flag.load(Ordering::Relaxed) {
+                self.flush_computed_write_buffer(&mut computed_writes)?;
                 return Err(ExcelError::new(ExcelErrorKind::Cancelled)
                     .with_message("Evaluation cancelled within layer".to_string()));
             }
+            self.flush_before_range_dependent_vertex(vertex_id, &mut computed_writes)?;
             let value = match self.evaluate_vertex_immutable(vertex_id) {
                 Ok(v) => v,
                 Err(e) => LiteralValue::Error(e),
             };
-            let effects = self.plan_vertex_effects(vertex_id, value, None)?;
+            let effects = match self.plan_vertex_effects_with_computed_flush(
+                vertex_id,
+                value,
+                None,
+                &mut computed_writes,
+            ) {
+                Ok(effects) => effects,
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
+            };
             for effect in &effects {
-                self.apply_effect(effect, None, None)?;
+                if let Err(e) = self.apply_effect_with_computed_writes(
+                    effect,
+                    None,
+                    None,
+                    Some(&mut computed_writes),
+                ) {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
+        self.flush_computed_write_buffer(&mut computed_writes)?;
         Ok(layer.vertices.len())
     }
 
@@ -8409,20 +8707,43 @@ where
         layer: &super::scheduler::Layer,
         cancel_flag: &AtomicBool,
     ) -> Result<usize, ExcelError> {
+        let mut computed_writes = ComputedWriteBuffer::default();
         for (i, &vertex_id) in layer.vertices.iter().enumerate() {
             if i % 128 == 0 && cancel_flag.load(Ordering::Relaxed) {
+                self.flush_computed_write_buffer(&mut computed_writes)?;
                 return Err(ExcelError::new(ExcelErrorKind::Cancelled)
                     .with_message("Demand-driven evaluation cancelled within layer".to_string()));
             }
+            self.flush_before_range_dependent_vertex(vertex_id, &mut computed_writes)?;
             let value = match self.evaluate_vertex_immutable(vertex_id) {
                 Ok(v) => v,
                 Err(e) => LiteralValue::Error(e),
             };
-            let effects = self.plan_vertex_effects(vertex_id, value, None)?;
+            let effects = match self.plan_vertex_effects_with_computed_flush(
+                vertex_id,
+                value,
+                None,
+                &mut computed_writes,
+            ) {
+                Ok(effects) => effects,
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
+            };
             for effect in &effects {
-                self.apply_effect(effect, None, None)?;
+                if let Err(e) = self.apply_effect_with_computed_writes(
+                    effect,
+                    None,
+                    None,
+                    Some(&mut computed_writes),
+                ) {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
+        self.flush_computed_write_buffer(&mut computed_writes)?;
         Ok(layer.vertices.len())
     }
 
@@ -8452,6 +8773,7 @@ where
             if group.is_empty() {
                 continue;
             }
+            let mut computed_writes = ComputedWriteBuffer::default();
 
             let results: Result<Vec<(VertexId, LiteralValue)>, ExcelError> =
                 thread_pool.install(|| {
@@ -8480,23 +8802,66 @@ where
                         }
                     }
                     for (vertex_id, result) in arrays {
-                        let effects =
-                            self.plan_vertex_effects(vertex_id, result, Some(&inflight))?;
+                        let effects = match self.plan_vertex_effects_with_computed_flush(
+                            vertex_id,
+                            result,
+                            Some(&inflight),
+                            &mut computed_writes,
+                        ) {
+                            Ok(effects) => effects,
+                            Err(e) => {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
+                        };
                         for effect in &effects {
-                            self.apply_effect(effect, None, None)?;
+                            if let Err(e) = self.apply_effect_with_computed_writes(
+                                effect,
+                                None,
+                                None,
+                                Some(&mut computed_writes),
+                            ) {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
                         }
                         applied = applied.saturating_add(1);
                     }
+                    // Make all array spill/top-left writes visible before scalar effects in this group.
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
                     for (vertex_id, result) in others {
-                        let effects =
-                            self.plan_vertex_effects(vertex_id, result, Some(&inflight))?;
+                        let effects = match self.plan_vertex_effects_with_computed_flush(
+                            vertex_id,
+                            result,
+                            Some(&inflight),
+                            &mut computed_writes,
+                        ) {
+                            Ok(effects) => effects,
+                            Err(e) => {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
+                        };
                         for effect in &effects {
-                            self.apply_effect(effect, None, None)?;
+                            if let Err(e) = self.apply_effect_with_computed_writes(
+                                effect,
+                                None,
+                                None,
+                                Some(&mut computed_writes),
+                            ) {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
                         }
                         applied = applied.saturating_add(1);
                     }
+                    // Flush at the group boundary; phase1 must be visible before phase2.
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
 
@@ -8530,6 +8895,7 @@ where
             if group.is_empty() {
                 continue;
             }
+            let mut computed_writes = ComputedWriteBuffer::default();
             let results: Result<Vec<(VertexId, LiteralValue)>, ExcelError> =
                 thread_pool.install(|| {
                     group
@@ -8555,23 +8921,64 @@ where
                         }
                     }
                     for (vertex_id, result) in arrays {
-                        let effects =
-                            self.plan_vertex_effects(vertex_id, result, Some(&inflight))?;
+                        let effects = match self.plan_vertex_effects_with_computed_flush(
+                            vertex_id,
+                            result,
+                            Some(&inflight),
+                            &mut computed_writes,
+                        ) {
+                            Ok(effects) => effects,
+                            Err(e) => {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
+                        };
                         for effect in &effects {
-                            self.apply_effect(effect, Some(delta), None)?;
+                            if let Err(e) = self.apply_effect_with_computed_writes(
+                                effect,
+                                Some(delta),
+                                None,
+                                Some(&mut computed_writes),
+                            ) {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
                         }
                         applied = applied.saturating_add(1);
                     }
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
                     for (vertex_id, result) in others {
-                        let effects =
-                            self.plan_vertex_effects(vertex_id, result, Some(&inflight))?;
+                        let effects = match self.plan_vertex_effects_with_computed_flush(
+                            vertex_id,
+                            result,
+                            Some(&inflight),
+                            &mut computed_writes,
+                        ) {
+                            Ok(effects) => effects,
+                            Err(e) => {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
+                        };
                         for effect in &effects {
-                            self.apply_effect(effect, Some(delta), None)?;
+                            if let Err(e) = self.apply_effect_with_computed_writes(
+                                effect,
+                                Some(delta),
+                                None,
+                                Some(&mut computed_writes),
+                            ) {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
                         }
                         applied = applied.saturating_add(1);
                     }
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
 
@@ -8610,6 +9017,7 @@ where
             if group.is_empty() {
                 continue;
             }
+            let mut computed_writes = ComputedWriteBuffer::default();
 
             let results: Result<Vec<(VertexId, LiteralValue)>, ExcelError> =
                 thread_pool.install(|| {
@@ -8643,23 +9051,64 @@ where
                         }
                     }
                     for (vertex_id, result) in arrays {
-                        let effects =
-                            self.plan_vertex_effects(vertex_id, result, Some(&inflight))?;
+                        let effects = match self.plan_vertex_effects_with_computed_flush(
+                            vertex_id,
+                            result,
+                            Some(&inflight),
+                            &mut computed_writes,
+                        ) {
+                            Ok(effects) => effects,
+                            Err(e) => {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
+                        };
                         for effect in &effects {
-                            self.apply_effect(effect, None, None)?;
+                            if let Err(e) = self.apply_effect_with_computed_writes(
+                                effect,
+                                None,
+                                None,
+                                Some(&mut computed_writes),
+                            ) {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
                         }
                         applied = applied.saturating_add(1);
                     }
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
                     for (vertex_id, result) in others {
-                        let effects =
-                            self.plan_vertex_effects(vertex_id, result, Some(&inflight))?;
+                        let effects = match self.plan_vertex_effects_with_computed_flush(
+                            vertex_id,
+                            result,
+                            Some(&inflight),
+                            &mut computed_writes,
+                        ) {
+                            Ok(effects) => effects,
+                            Err(e) => {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
+                        };
                         for effect in &effects {
-                            self.apply_effect(effect, None, None)?;
+                            if let Err(e) = self.apply_effect_with_computed_writes(
+                                effect,
+                                None,
+                                None,
+                                Some(&mut computed_writes),
+                            ) {
+                                self.flush_computed_write_buffer(&mut computed_writes)?;
+                                return Err(e);
+                            }
                         }
                         applied = applied.saturating_add(1);
                     }
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
 
@@ -8774,16 +9223,38 @@ where
         layer: &super::scheduler::Layer,
         log: &mut ChangeLog,
     ) -> Result<usize, ExcelError> {
+        let mut computed_writes = ComputedWriteBuffer::default();
         for &vertex_id in &layer.vertices {
+            self.flush_before_range_dependent_vertex(vertex_id, &mut computed_writes)?;
             let value = match self.evaluate_vertex_immutable(vertex_id) {
                 Ok(v) => v,
                 Err(e) => LiteralValue::Error(e),
             };
-            let effects = self.plan_vertex_effects(vertex_id, value, None)?;
+            let effects = match self.plan_vertex_effects_with_computed_flush(
+                vertex_id,
+                value,
+                None,
+                &mut computed_writes,
+            ) {
+                Ok(effects) => effects,
+                Err(e) => {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
+            };
             for effect in &effects {
-                self.apply_effect(effect, None, Some(log))?;
+                if let Err(e) = self.apply_effect_with_computed_writes(
+                    effect,
+                    None,
+                    Some(log),
+                    Some(&mut computed_writes),
+                ) {
+                    self.flush_computed_write_buffer(&mut computed_writes)?;
+                    return Err(e);
+                }
             }
         }
+        self.flush_computed_write_buffer(&mut computed_writes)?;
         Ok(layer.vertices.len())
     }
 }

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1,5 +1,5 @@
 use crate::SheetId;
-use crate::arrow_store::{OverlayValue, SheetStore};
+use crate::arrow_store::{OverlayFragment, OverlayValue, SheetStore};
 use crate::engine::eval_delta::{DeltaCollector, DeltaMode, EvalDelta};
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::range_view::RangeView;
@@ -4097,25 +4097,140 @@ where
         }
 
         let plan = self.plan_owned_computed_write_coalescing(buffer.take_writes());
-        self.flush_computed_write_plan_as_points(plan);
+        self.flush_computed_write_plan(plan);
 
         Ok(())
     }
 
-    fn flush_computed_write_plan_as_points(&mut self, plan: ComputedWriteCoalescingPlan) {
+    fn flush_computed_write_plan(&mut self, plan: ComputedWriteCoalescingPlan) {
         for chunk in plan.chunks {
-            let sheet_name = self.graph.sheet_name(chunk.sheet_id).to_string();
-            for entry in chunk.entries {
-                let row0 = chunk
-                    .chunk_start_row0
-                    .saturating_add(entry.row_in_chunk as u32);
-                self.write_computed_overlay_value_0based(
-                    &sheet_name,
-                    row0,
-                    chunk.col0,
-                    entry.value,
-                );
+            self.flush_computed_write_chunk_plan(chunk);
+        }
+    }
+
+    fn flush_computed_write_chunk_plan(&mut self, chunk: ComputedWriteChunkPlan) {
+        match &chunk.shape {
+            ComputedWriteChunkPlanShape::Point
+            | ComputedWriteChunkPlanShape::SparseOffsets { .. } => {
+                self.flush_computed_write_chunk_plan_as_points(chunk);
             }
+            ComputedWriteChunkPlanShape::DenseRange { .. } => {
+                self.flush_computed_write_chunk_plan_as_dense_fragment(chunk);
+            }
+            ComputedWriteChunkPlanShape::RunRange { len, runs, .. } => {
+                if Self::should_emit_computed_run_fragment(*len, *runs) {
+                    self.flush_computed_write_chunk_plan_as_run_fragment(chunk);
+                } else {
+                    self.flush_computed_write_chunk_plan_as_dense_fragment(chunk);
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn should_emit_computed_run_fragment(len: usize, runs: usize) -> bool {
+        runs <= len / 2
+    }
+
+    fn flush_computed_write_chunk_plan_as_points(&mut self, chunk: ComputedWriteChunkPlan) {
+        let sheet_name = self.graph.sheet_name(chunk.sheet_id).to_string();
+        for entry in chunk.entries {
+            let row0 = chunk
+                .chunk_start_row0
+                .saturating_add(entry.row_in_chunk as u32);
+            self.write_computed_overlay_value_0based(&sheet_name, row0, chunk.col0, entry.value);
+        }
+    }
+
+    fn flush_computed_write_chunk_plan_as_dense_fragment(&mut self, chunk: ComputedWriteChunkPlan) {
+        if chunk.entries.is_empty() {
+            return;
+        }
+        let start = chunk.entries[0].row_in_chunk;
+        let values: Vec<OverlayValue> =
+            chunk.entries.into_iter().map(|entry| entry.value).collect();
+        if let Some(fragment) = OverlayFragment::dense_range(start, values) {
+            self.apply_computed_overlay_fragment(
+                chunk.sheet_id,
+                chunk.col0,
+                chunk.chunk_idx,
+                fragment,
+            );
+        }
+    }
+
+    fn flush_computed_write_chunk_plan_as_run_fragment(&mut self, chunk: ComputedWriteChunkPlan) {
+        if chunk.entries.is_empty() {
+            return;
+        }
+        let start = chunk.entries[0].row_in_chunk;
+        let values: Vec<OverlayValue> =
+            chunk.entries.into_iter().map(|entry| entry.value).collect();
+        if let Some(fragment) = OverlayFragment::run_range(start, values) {
+            self.apply_computed_overlay_fragment(
+                chunk.sheet_id,
+                chunk.col0,
+                chunk.chunk_idx,
+                fragment,
+            );
+        }
+    }
+
+    fn apply_computed_overlay_fragment(
+        &mut self,
+        sheet_id: SheetId,
+        col0: u32,
+        chunk_idx: usize,
+        fragment: OverlayFragment,
+    ) {
+        if !(self.config.arrow_storage_enabled
+            && self.config.delta_overlay_enabled
+            && self.config.write_formula_overlay_enabled)
+        {
+            return;
+        }
+        if self.computed_overlay_mirroring_disabled {
+            return;
+        }
+
+        let sheet_name = self.graph.sheet_name(sheet_id).to_string();
+        self.ensure_arrow_sheet(&sheet_name);
+
+        let col0 = col0 as usize;
+        let asheet = self
+            .arrow_sheets
+            .sheet_mut(&sheet_name)
+            .expect("ArrowSheet must exist");
+
+        let cur_cols = asheet.columns.len();
+        if col0 >= cur_cols {
+            asheet.insert_columns(cur_cols, (col0 + 1) - cur_cols);
+        }
+
+        let start_row0 = asheet
+            .chunk_starts
+            .get(chunk_idx)
+            .copied()
+            .unwrap_or_else(|| chunk_idx.saturating_mul(asheet.chunk_rows.max(1)));
+        let required_rows =
+            start_row0.saturating_add(fragment.max_covered_offset().saturating_add(1));
+        if required_rows > asheet.nrows as usize {
+            if asheet.columns.is_empty() {
+                asheet.insert_columns(0, 1);
+            }
+            asheet.ensure_row_capacity(required_rows);
+        }
+
+        let Some(ch) = asheet.ensure_column_chunk_mut(col0, chunk_idx) else {
+            return;
+        };
+        let delta = ch.computed_overlay.apply_fragment(fragment);
+        self.adjust_computed_overlay_bytes(delta);
+
+        if let Some(cap) = self.config.max_overlay_memory_bytes
+            && self.computed_overlay_bytes_estimate > cap
+        {
+            self.disable_computed_overlay_mirroring_due_to_budget(cap);
         }
     }
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -20,6 +20,7 @@ use formualizer_parse::parser::ReferenceType;
 use formualizer_parse::{ASTNode, ASTNodeType, ExcelError, ExcelErrorKind, LiteralValue};
 use rayon::ThreadPoolBuilder;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -148,6 +149,140 @@ impl ComputedWriteBuffer {
     #[inline]
     fn estimate_value_bytes(value: &OverlayValue) -> usize {
         Self::ENTRY_BASE_BYTES.saturating_add(value.estimated_payload_bytes())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct ComputedWriteChunkKey {
+    sheet_id: SheetId,
+    col0: u32,
+    chunk_idx: usize,
+    chunk_start_row0: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ComputedWriteChunkEntryPlan {
+    pub(crate) row_in_chunk: usize,
+    pub(crate) seq: u64,
+    pub(crate) value: OverlayValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ComputedWriteChunkPlanShape {
+    Point,
+    SparseOffsets {
+        entries: usize,
+        span_len: usize,
+    },
+    DenseRange {
+        start: usize,
+        len: usize,
+    },
+    RunRange {
+        start: usize,
+        len: usize,
+        runs: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ComputedWriteChunkPlan {
+    pub(crate) sheet_id: SheetId,
+    pub(crate) col0: u32,
+    pub(crate) chunk_idx: usize,
+    pub(crate) chunk_start_row0: u32,
+    pub(crate) entries: Vec<ComputedWriteChunkEntryPlan>,
+    pub(crate) shape: ComputedWriteChunkPlanShape,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct ComputedWriteCoalescingPlan {
+    pub(crate) chunks: Vec<ComputedWriteChunkPlan>,
+    pub(crate) input_cells: usize,
+    pub(crate) coalesced_cells: usize,
+    pub(crate) overwritten_cells: usize,
+}
+
+impl ComputedWriteCoalescingPlan {
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.chunks.is_empty()
+    }
+}
+
+impl ComputedWriteChunkPlan {
+    fn from_group(
+        key: ComputedWriteChunkKey,
+        mut entries: Vec<ComputedWriteChunkEntryPlan>,
+    ) -> (Self, usize) {
+        entries.sort_by_key(|entry| (entry.row_in_chunk, entry.seq));
+        let input_len = entries.len();
+        let mut coalesced: Vec<ComputedWriteChunkEntryPlan> = Vec::with_capacity(input_len);
+        for entry in entries {
+            if let Some(prev) = coalesced.last_mut()
+                && prev.row_in_chunk == entry.row_in_chunk
+            {
+                *prev = entry;
+                continue;
+            }
+            coalesced.push(entry);
+        }
+        let overwritten = input_len.saturating_sub(coalesced.len());
+        let shape = Self::classify_shape(&coalesced);
+        (
+            Self {
+                sheet_id: key.sheet_id,
+                col0: key.col0,
+                chunk_idx: key.chunk_idx,
+                chunk_start_row0: key.chunk_start_row0,
+                entries: coalesced,
+                shape,
+            },
+            overwritten,
+        )
+    }
+
+    fn classify_shape(entries: &[ComputedWriteChunkEntryPlan]) -> ComputedWriteChunkPlanShape {
+        debug_assert!(!entries.is_empty());
+        if entries.len() == 1 {
+            return ComputedWriteChunkPlanShape::Point;
+        }
+
+        let start = entries[0].row_in_chunk;
+        let end = entries[entries.len() - 1].row_in_chunk;
+        let span_len = end.saturating_sub(start).saturating_add(1);
+        if span_len != entries.len() {
+            return ComputedWriteChunkPlanShape::SparseOffsets {
+                entries: entries.len(),
+                span_len,
+            };
+        }
+
+        let runs = Self::run_count(entries);
+        if runs < entries.len() {
+            ComputedWriteChunkPlanShape::RunRange {
+                start,
+                len: entries.len(),
+                runs,
+            }
+        } else {
+            ComputedWriteChunkPlanShape::DenseRange {
+                start,
+                len: entries.len(),
+            }
+        }
+    }
+
+    fn run_count(entries: &[ComputedWriteChunkEntryPlan]) -> usize {
+        let mut runs = 0usize;
+        let mut prev: Option<&OverlayValue> = None;
+        for entry in entries {
+            if prev != Some(&entry.value) {
+                runs = runs.saturating_add(1);
+                prev = Some(&entry.value);
+            }
+        }
+        runs
     }
 }
 
@@ -3779,6 +3914,164 @@ where
         {
             self.disable_computed_overlay_mirroring_due_to_budget(cap);
         }
+    }
+
+    pub(crate) fn plan_computed_write_coalescing(
+        &self,
+        buffer: &ComputedWriteBuffer,
+    ) -> ComputedWriteCoalescingPlan {
+        let mut groups: BTreeMap<ComputedWriteChunkKey, Vec<ComputedWriteChunkEntryPlan>> =
+            BTreeMap::new();
+        let mut input_cells = 0usize;
+
+        for write in buffer.writes() {
+            match write {
+                ComputedWrite::Cell {
+                    seq,
+                    sheet_id,
+                    row0,
+                    col0,
+                    value,
+                } => {
+                    input_cells = input_cells.saturating_add(1);
+                    self.push_computed_write_plan_entry(
+                        &mut groups,
+                        *seq,
+                        *sheet_id,
+                        *row0,
+                        *col0,
+                        value.clone(),
+                    );
+                }
+                ComputedWrite::Rect {
+                    seq,
+                    sheet_id,
+                    sr0,
+                    sc0,
+                    values,
+                } => {
+                    for (r_off, row) in values.iter().enumerate() {
+                        for (c_off, value) in row.iter().enumerate() {
+                            input_cells = input_cells.saturating_add(1);
+                            self.push_computed_write_plan_entry(
+                                &mut groups,
+                                *seq,
+                                *sheet_id,
+                                sr0.saturating_add(r_off as u32),
+                                sc0.saturating_add(c_off as u32),
+                                value.clone(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut plan = ComputedWriteCoalescingPlan {
+            chunks: Vec::with_capacity(groups.len()),
+            input_cells,
+            coalesced_cells: 0,
+            overwritten_cells: 0,
+        };
+        for (key, entries) in groups {
+            let (chunk_plan, overwritten) = ComputedWriteChunkPlan::from_group(key, entries);
+            plan.coalesced_cells = plan
+                .coalesced_cells
+                .saturating_add(chunk_plan.entries.len());
+            plan.overwritten_cells = plan.overwritten_cells.saturating_add(overwritten);
+            plan.chunks.push(chunk_plan);
+        }
+        debug_assert_eq!(
+            plan.input_cells,
+            plan.coalesced_cells.saturating_add(plan.overwritten_cells)
+        );
+        plan
+    }
+
+    fn push_computed_write_plan_entry(
+        &self,
+        groups: &mut BTreeMap<ComputedWriteChunkKey, Vec<ComputedWriteChunkEntryPlan>>,
+        seq: u64,
+        sheet_id: SheetId,
+        row0: u32,
+        col0: u32,
+        value: OverlayValue,
+    ) {
+        let (chunk_idx, chunk_start_row0, row_in_chunk) =
+            self.locate_computed_write_chunk(sheet_id, row0);
+        let key = ComputedWriteChunkKey {
+            sheet_id,
+            col0,
+            chunk_idx,
+            chunk_start_row0,
+        };
+        groups
+            .entry(key)
+            .or_default()
+            .push(ComputedWriteChunkEntryPlan {
+                row_in_chunk,
+                seq,
+                value,
+            });
+    }
+
+    fn locate_computed_write_chunk(&self, sheet_id: SheetId, row0: u32) -> (usize, u32, usize) {
+        let sheet_name = self.graph.sheet_name(sheet_id);
+        if let Some(sheet) = self.arrow_sheets.sheet(sheet_name) {
+            return Self::locate_row_in_sheet_for_computed_write_plan(sheet, row0 as usize);
+        }
+        Self::locate_row_in_empty_sheet_for_computed_write_plan(row0 as usize, 32 * 1024)
+    }
+
+    fn locate_row_in_sheet_for_computed_write_plan(
+        sheet: &crate::arrow_store::ArrowSheet,
+        row0: usize,
+    ) -> (usize, u32, usize) {
+        if row0 < sheet.nrows as usize
+            && let Some((chunk_idx, row_in_chunk)) = sheet.chunk_of_row(row0)
+        {
+            let chunk_start = sheet.chunk_starts.get(chunk_idx).copied().unwrap_or(0);
+            return (chunk_idx, chunk_start as u32, row_in_chunk);
+        }
+
+        let chunk_rows = sheet.chunk_rows.max(1);
+        if sheet.chunk_starts.is_empty() {
+            return Self::locate_row_in_empty_sheet_for_computed_write_plan(row0, chunk_rows);
+        }
+
+        let mut chunk_idx = sheet.chunk_starts.len().saturating_sub(1);
+        let mut chunk_start = sheet.chunk_starts[chunk_idx];
+        while chunk_start.saturating_add(chunk_rows) <= row0 {
+            chunk_idx = chunk_idx.saturating_add(1);
+            chunk_start = chunk_start.saturating_add(chunk_rows);
+        }
+        (
+            chunk_idx,
+            chunk_start as u32,
+            row0.saturating_sub(chunk_start),
+        )
+    }
+
+    fn locate_row_in_empty_sheet_for_computed_write_plan(
+        row0: usize,
+        chunk_rows: usize,
+    ) -> (usize, u32, usize) {
+        let chunk_rows = chunk_rows.max(1);
+        let chunk_idx = row0 / chunk_rows;
+        let chunk_start = chunk_idx.saturating_mul(chunk_rows);
+        (
+            chunk_idx,
+            chunk_start as u32,
+            row0.saturating_sub(chunk_start),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_plan_computed_write_coalescing(
+        &self,
+        buffer: &ComputedWriteBuffer,
+    ) -> ComputedWriteCoalescingPlan {
+        self.plan_computed_write_coalescing(buffer)
     }
 
     pub(crate) fn flush_computed_write_buffer(

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -3318,16 +3318,16 @@ where
                     formualizer_common::ExcelErrorKind::Value,
                 )),
             };
-            if let Some(ch) = asheet.ensure_column_chunk_mut(col0, ch_idx) {
+            let computed_delta = if let Some(ch) = asheet.ensure_column_chunk_mut(col0, ch_idx) {
                 let _ = ch.overlay.set(in_off, ov);
                 // A user edit must invalidate any computed (formula/spill) overlay entry at
                 // this cell. Otherwise, if the delta overlay later compacts into the base lanes
                 // (clearing `overlay`), a stale `computed_overlay=Empty` could incorrectly mask
                 // the edited base value under the read cascade.
-                let _ = ch.computed_overlay.remove(in_off);
+                ch.computed_overlay.remove(in_off)
             } else {
                 return;
-            }
+            };
             // Heuristic compaction: > len/50 or > 1024
             let abs_threshold = 1024usize;
             let frac_den = 50usize;
@@ -3335,6 +3335,7 @@ where
             if freed > 0 {
                 self.overlay_compactions = self.overlay_compactions.saturating_add(1);
             }
+            self.adjust_computed_overlay_bytes(computed_delta);
         }
     }
 
@@ -3947,6 +3948,23 @@ where
     /// Estimated memory usage for computed overlays (formula/spill mirroring).
     pub fn overlay_memory_usage(&self) -> usize {
         self.computed_overlay_bytes_estimate
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_recompute_computed_overlay_bytes(&mut self) -> usize {
+        let mut total = 0usize;
+        for sheet in &self.arrow_sheets.sheets {
+            for column in &sheet.columns {
+                for chunk in &column.chunks {
+                    total = total.saturating_add(chunk.computed_overlay.estimated_bytes());
+                }
+                for chunk in column.sparse_chunks.values() {
+                    total = total.saturating_add(chunk.computed_overlay.estimated_bytes());
+                }
+            }
+        }
+        self.computed_overlay_bytes_estimate = total;
+        total
     }
 
     fn resolve_sheet_locator_for_write(

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4405,6 +4405,9 @@ where
     #[inline]
     fn should_flush_computed_write_buffer(&self, buffer: &ComputedWriteBuffer) -> bool {
         self.config.max_overlay_memory_bytes.is_some_and(|cap| {
+            if cap == 0 {
+                return false;
+            }
             self.computed_overlay_bytes_estimate
                 .saturating_add(buffer.estimated_bytes())
                 > cap
@@ -4414,6 +4417,11 @@ where
     /// Estimated memory usage for computed overlays (formula/spill mirroring).
     pub fn overlay_memory_usage(&self) -> usize {
         self.computed_overlay_bytes_estimate
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_overlay_compactions(&self) -> u64 {
+        self.overlay_compactions
     }
 
     #[cfg(test)]

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -8842,10 +8842,10 @@ where
         &mut self,
         vertex_id: VertexId,
         value: &LiteralValue,
-        mut delta: Option<&mut DeltaCollector>,
+        delta: Option<&mut DeltaCollector>,
         mut computed_writes: Option<&mut ComputedWriteBuffer>,
     ) -> Result<(), ExcelError> {
-        if let Some(d) = delta.as_deref_mut()
+        if let Some(d) = delta
             && d.mode != DeltaMode::Off
         {
             if let Some(buffer) = computed_writes.as_deref_mut() {

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4110,9 +4110,11 @@ where
 
     fn flush_computed_write_chunk_plan(&mut self, chunk: ComputedWriteChunkPlan) {
         match &chunk.shape {
-            ComputedWriteChunkPlanShape::Point
-            | ComputedWriteChunkPlanShape::SparseOffsets { .. } => {
+            ComputedWriteChunkPlanShape::Point => {
                 self.flush_computed_write_chunk_plan_as_points(chunk);
+            }
+            ComputedWriteChunkPlanShape::SparseOffsets { .. } => {
+                self.flush_computed_write_chunk_plan_as_sparse_fragment_or_points(chunk);
             }
             ComputedWriteChunkPlanShape::DenseRange { .. } => {
                 self.flush_computed_write_chunk_plan_as_dense_fragment(chunk);
@@ -4139,6 +4141,62 @@ where
                 .chunk_start_row0
                 .saturating_add(entry.row_in_chunk as u32);
             self.write_computed_overlay_value_0based(&sheet_name, row0, chunk.col0, entry.value);
+        }
+    }
+
+    fn flush_computed_write_chunk_plan_as_sparse_fragment_or_points(
+        &mut self,
+        chunk: ComputedWriteChunkPlan,
+    ) {
+        let point_estimate = Self::computed_write_chunk_plan_point_estimate(&chunk);
+        let sheet_id = chunk.sheet_id;
+        let col0 = chunk.col0;
+        let chunk_idx = chunk.chunk_idx;
+        let chunk_start_row0 = chunk.chunk_start_row0;
+        let items: Vec<(usize, OverlayValue)> = chunk
+            .entries
+            .into_iter()
+            .map(|entry| (entry.row_in_chunk, entry.value))
+            .collect();
+        match OverlayFragment::sparse_offsets_if_estimated_smaller_than_points(
+            items,
+            point_estimate,
+        ) {
+            Some(Ok(fragment)) => {
+                self.apply_computed_overlay_fragment(sheet_id, col0, chunk_idx, fragment);
+            }
+            Some(Err(cells)) => {
+                self.flush_computed_overlay_cells_as_points(
+                    sheet_id,
+                    col0,
+                    chunk_start_row0,
+                    cells,
+                );
+            }
+            None => {}
+        }
+    }
+
+    #[inline]
+    fn computed_write_chunk_plan_point_estimate(chunk: &ComputedWriteChunkPlan) -> usize {
+        chunk
+            .entries
+            .iter()
+            .map(|entry| ComputedWriteBuffer::estimate_value_bytes(&entry.value))
+            .fold(0usize, usize::saturating_add)
+    }
+
+    fn flush_computed_overlay_cells_as_points(
+        &mut self,
+        sheet_id: SheetId,
+        col0: u32,
+        chunk_start_row0: u32,
+        cells: Vec<(usize, OverlayValue)>,
+    ) {
+        let sheet_name = self.graph.sheet_name(sheet_id).to_string();
+        for (row_in_chunk, value) in cells {
+            let row0 = chunk_start_row0.saturating_add(row_in_chunk as u32);
+            self.write_computed_overlay_value_0based(&sheet_name, row0, col0, value);
         }
     }
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -3244,28 +3244,6 @@ where
     }
 
     #[inline]
-    fn overlay_value_to_literal(&self, ov: &crate::arrow_store::OverlayValue) -> LiteralValue {
-        use crate::arrow_store::OverlayValue;
-        match ov {
-            OverlayValue::Empty => LiteralValue::Empty,
-            OverlayValue::Number(n) => LiteralValue::Number(*n),
-            OverlayValue::DateTime(serial) => LiteralValue::from_serial_number(*serial),
-            OverlayValue::Duration(serial) => {
-                let nanos_f = *serial * 86_400.0 * 1_000_000_000.0;
-                let nanos = nanos_f.round().clamp(i64::MIN as f64, i64::MAX as f64) as i64;
-                LiteralValue::Duration(chrono::Duration::nanoseconds(nanos))
-            }
-            OverlayValue::Boolean(b) => LiteralValue::Boolean(*b),
-            OverlayValue::Text(s) => LiteralValue::Text((**s).to_string()),
-            OverlayValue::Error(code) => {
-                let kind = crate::arrow_store::unmap_error_code(*code);
-                LiteralValue::Error(formualizer_common::ExcelError::new(kind))
-            }
-            OverlayValue::Pending => LiteralValue::Pending,
-        }
-    }
-
-    #[inline]
     fn literal_to_overlay_value(&self, value: &LiteralValue) -> crate::arrow_store::OverlayValue {
         use crate::arrow_store::OverlayValue;
         match value {
@@ -3317,9 +3295,7 @@ where
         }
         let (ch_idx, in_off) = asheet.chunk_of_row(row0)?;
         let ch = asheet.columns[col0].chunk(ch_idx)?;
-        ch.overlay
-            .get(in_off)
-            .map(|ov| self.overlay_value_to_literal(ov))
+        ch.overlay.get_scalar(in_off).map(|ov| ov.to_literal())
     }
 
     /// Read a single cell's computed overlay entry (if present), preserving the distinction
@@ -3340,8 +3316,8 @@ where
         let (ch_idx, in_off) = asheet.chunk_of_row(row0)?;
         let ch = asheet.columns[col0].chunk(ch_idx)?;
         ch.computed_overlay
-            .get(in_off)
-            .map(|ov| self.overlay_value_to_literal(ov))
+            .get_scalar(in_off)
+            .map(|ov| ov.to_literal())
     }
 
     fn set_delta_overlay_cell_raw(

--- a/crates/formualizer-eval/src/engine/range_view.rs
+++ b/crates/formualizer-eval/src/engine/range_view.rs
@@ -393,30 +393,9 @@ impl<'a> RangeView<'a> {
         let row_start = chunk_starts[ch_idx];
         let in_off = abs_row - row_start;
         // Overlay takes precedence: user edits over computed over base.
-        if let Some(ov) = ch
-            .overlay
-            .get(in_off)
-            .or_else(|| ch.computed_overlay.get(in_off))
-        {
-            return match ov {
-                arrow_store::OverlayValue::Empty => LiteralValue::Empty,
-                arrow_store::OverlayValue::Number(n) => LiteralValue::Number(*n),
-                arrow_store::OverlayValue::DateTime(serial) => {
-                    LiteralValue::from_serial_number(*serial)
-                }
-                arrow_store::OverlayValue::Duration(serial) => {
-                    let nanos_f = *serial * 86_400.0 * 1_000_000_000.0;
-                    let nanos = nanos_f.round().clamp(i64::MIN as f64, i64::MAX as f64) as i64;
-                    LiteralValue::Duration(chrono::Duration::nanoseconds(nanos))
-                }
-                arrow_store::OverlayValue::Boolean(b) => LiteralValue::Boolean(*b),
-                arrow_store::OverlayValue::Text(s) => LiteralValue::Text((**s).to_string()),
-                arrow_store::OverlayValue::Error(code) => {
-                    let kind = arrow_store::unmap_error_code(*code);
-                    LiteralValue::Error(ExcelError::new(kind))
-                }
-                arrow_store::OverlayValue::Pending => LiteralValue::Pending,
-            };
+        let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+        if let Some(ov) = cascade.get_scalar(in_off) {
+            return ov.to_literal();
         }
         // Read tag and route to lane
         let tag_u8 = ch.type_tag.value(in_off);
@@ -650,9 +629,6 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<Arc<arrow_array::Float64Array>>), ExcelError>> + '_
     {
-        use crate::compute_prelude::zip_select;
-        use arrow_array::builder::{BooleanBuilder, Float64Builder};
-
         self.iter_row_chunks().map(move |res| {
             let cs = res?;
             let mut out_cols: Vec<Arc<arrow_array::Float64Array>> =
@@ -691,43 +667,13 @@ impl<'a> RangeView<'a> {
                 };
                 let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
                 let seg_range = rel_off..(rel_off + cs.row_len);
-                let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                    || (!ch.computed_overlay.is_empty()
-                        && ch.computed_overlay.any_in_range(seg_range.clone()));
-                if has_overlay {
-                    let mut mask_b = BooleanBuilder::with_capacity(cs.row_len);
-                    let mut ob = Float64Builder::with_capacity(cs.row_len);
-                    for i in 0..cs.row_len {
-                        if let Some(ov) = ch
-                            .overlay
-                            .get(rel_off + i)
-                            .or_else(|| ch.computed_overlay.get(rel_off + i))
-                        {
-                            mask_b.append_value(true);
-                            match ov {
-                                arrow_store::OverlayValue::Number(n)
-                                | arrow_store::OverlayValue::DateTime(n)
-                                | arrow_store::OverlayValue::Duration(n) => ob.append_value(*n),
-                                _ => ob.append_null(),
-                            }
-                        } else {
-                            mask_b.append_value(false);
-                            ob.append_null();
-                        }
-                    }
-                    let mask = mask_b.finish();
-                    let overlay_vals = ob.finish();
+                let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                if cascade.has_any_in_range(seg_range.clone()) {
                     let base_fa = base
                         .as_any()
                         .downcast_ref::<arrow_array::Float64Array>()
                         .unwrap();
-                    let zipped = zip_select(&mask, &overlay_vals, base_fa).expect("zip overlay");
-                    let fa = zipped
-                        .as_any()
-                        .downcast_ref::<arrow_array::Float64Array>()
-                        .unwrap()
-                        .clone();
-                    out_cols.push(Arc::new(fa));
+                    out_cols.push(cascade.select_numbers(seg_range, base_fa));
                 } else {
                     out_cols.push(base_arc);
                 }
@@ -741,9 +687,6 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<Arc<arrow_array::BooleanArray>>), ExcelError>> + '_
     {
-        use crate::compute_prelude::zip_select;
-        use arrow_array::builder::BooleanBuilder;
-
         self.iter_row_chunks().map(move |res| {
             let cs = res?;
             let mut out_cols: Vec<Arc<arrow_array::BooleanArray>> =
@@ -782,42 +725,13 @@ impl<'a> RangeView<'a> {
                 };
                 let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
                 let seg_range = rel_off..(rel_off + cs.row_len);
-                let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                    || (!ch.computed_overlay.is_empty()
-                        && ch.computed_overlay.any_in_range(seg_range.clone()));
-                if has_overlay {
-                    let mut mask_b = BooleanBuilder::with_capacity(cs.row_len);
-                    let mut bb = BooleanBuilder::with_capacity(cs.row_len);
-                    for i in 0..cs.row_len {
-                        if let Some(ov) = ch
-                            .overlay
-                            .get(rel_off + i)
-                            .or_else(|| ch.computed_overlay.get(rel_off + i))
-                        {
-                            mask_b.append_value(true);
-                            match ov {
-                                arrow_store::OverlayValue::Boolean(b) => bb.append_value(*b),
-                                _ => bb.append_null(),
-                            }
-                        } else {
-                            mask_b.append_value(false);
-                            bb.append_null();
-                        }
-                    }
-                    let mask = mask_b.finish();
-                    let overlay_vals = bb.finish();
+                let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                if cascade.has_any_in_range(seg_range.clone()) {
                     let base_ba = base
                         .as_any()
                         .downcast_ref::<arrow_array::BooleanArray>()
                         .unwrap();
-                    let zipped =
-                        zip_select(&mask, &overlay_vals, base_ba).expect("zip boolean overlay");
-                    let ba = zipped
-                        .as_any()
-                        .downcast_ref::<arrow_array::BooleanArray>()
-                        .unwrap()
-                        .clone();
-                    out_cols.push(Arc::new(ba));
+                    out_cols.push(cascade.select_booleans(seg_range, base_ba));
                 } else {
                     out_cols.push(base_arc);
                 }
@@ -831,9 +745,6 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<arrow_array::ArrayRef>), ExcelError>> + '_
     {
-        use crate::compute_prelude::zip_select;
-        use arrow_array::builder::{BooleanBuilder, StringBuilder};
-
         self.iter_row_chunks().map(move |res| {
             let cs = res?;
             let mut out_cols: Vec<arrow_array::ArrayRef> = Vec::with_capacity(cs.cols.len());
@@ -863,37 +774,13 @@ impl<'a> RangeView<'a> {
                 };
                 let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
                 let seg_range = rel_off..(rel_off + cs.row_len);
-                let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                    || (!ch.computed_overlay.is_empty()
-                        && ch.computed_overlay.any_in_range(seg_range.clone()));
-                if has_overlay {
-                    let mut mask_b = BooleanBuilder::with_capacity(cs.row_len);
-                    let mut sb = StringBuilder::with_capacity(cs.row_len, cs.row_len * 8);
-                    for i in 0..cs.row_len {
-                        if let Some(ov) = ch
-                            .overlay
-                            .get(rel_off + i)
-                            .or_else(|| ch.computed_overlay.get(rel_off + i))
-                        {
-                            mask_b.append_value(true);
-                            match ov {
-                                arrow_store::OverlayValue::Text(s) => sb.append_value(s),
-                                _ => sb.append_null(),
-                            }
-                        } else {
-                            mask_b.append_value(false);
-                            sb.append_null();
-                        }
-                    }
-                    let mask = mask_b.finish();
-                    let overlay_vals = sb.finish();
+                let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                if cascade.has_any_in_range(seg_range.clone()) {
                     let base_sa = base
                         .as_any()
                         .downcast_ref::<arrow_array::StringArray>()
                         .unwrap();
-                    let zipped =
-                        zip_select(&mask, &overlay_vals, base_sa).expect("zip text overlay");
-                    out_cols.push(zipped);
+                    out_cols.push(cascade.select_text(seg_range, base_sa));
                 } else {
                     out_cols.push(base.clone());
                 }
@@ -907,9 +794,6 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<Arc<arrow_array::StringArray>>), ExcelError>> + '_
     {
-        use crate::compute_prelude::zip_select;
-        use arrow_array::builder::{BooleanBuilder, StringBuilder};
-
         self.iter_row_chunks().map(move |res| {
             let cs = res?;
             let mut out_cols: Vec<Arc<arrow_array::StringArray>> =
@@ -937,11 +821,6 @@ impl<'a> RangeView<'a> {
                 let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
                 let seg_range = rel_off..(rel_off + cs.row_len);
 
-                // Check overlay
-                let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                    || (!ch.computed_overlay.is_empty()
-                        && ch.computed_overlay.any_in_range(seg_range.clone()));
-
                 let base_lowered = ch.text_lower_or_null();
                 let base_seg = base_lowered.slice(rel_off, cs.row_len);
                 let base_sa = base_seg
@@ -949,52 +828,9 @@ impl<'a> RangeView<'a> {
                     .downcast_ref::<arrow_array::StringArray>()
                     .expect("lowered slice downcast");
 
-                if has_overlay {
-                    // Build lowered overlay values builder
-                    let mut sb = StringBuilder::with_capacity(cs.row_len, cs.row_len * 8);
-                    let mut mb = BooleanBuilder::with_capacity(cs.row_len);
-                    for i in 0..cs.row_len {
-                        if let Some(ov) = ch
-                            .overlay
-                            .get(rel_off + i)
-                            .or_else(|| ch.computed_overlay.get(rel_off + i))
-                        {
-                            mb.append_value(true);
-                            match ov {
-                                arrow_store::OverlayValue::Text(s) => {
-                                    sb.append_value(s.to_lowercase());
-                                }
-                                arrow_store::OverlayValue::Empty => {
-                                    sb.append_null();
-                                }
-                                arrow_store::OverlayValue::Number(n)
-                                | arrow_store::OverlayValue::DateTime(n)
-                                | arrow_store::OverlayValue::Duration(n) => {
-                                    sb.append_value(n.to_string());
-                                }
-                                arrow_store::OverlayValue::Boolean(b) => {
-                                    sb.append_value(if *b { "true" } else { "false" });
-                                }
-                                arrow_store::OverlayValue::Error(_)
-                                | arrow_store::OverlayValue::Pending => {
-                                    sb.append_null();
-                                }
-                            }
-                        } else {
-                            sb.append_null();
-                            mb.append_value(false);
-                        }
-                    }
-                    let overlay_vals = sb.finish();
-                    let mask = mb.finish();
-                    let zipped = zip_select(&mask, &overlay_vals, base_sa)
-                        .expect("zip lowered text overlay");
-                    let za = zipped
-                        .as_any()
-                        .downcast_ref::<arrow_array::StringArray>()
-                        .unwrap()
-                        .clone();
-                    out_cols.push(Arc::new(za));
+                let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                if cascade.has_any_in_range(seg_range.clone()) {
+                    out_cols.push(cascade.select_lowered_text(seg_range, base_sa));
                 } else {
                     out_cols.push(Arc::new(base_sa.clone()));
                 }
@@ -1008,9 +844,6 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<Arc<arrow_array::UInt8Array>>), ExcelError>> + '_
     {
-        use crate::compute_prelude::zip_select;
-        use arrow_array::builder::{BooleanBuilder, UInt8Builder};
-
         self.iter_row_chunks().map(move |res| {
             let cs = res?;
             let mut out_cols: Vec<Arc<arrow_array::UInt8Array>> = Vec::with_capacity(cs.cols.len());
@@ -1046,42 +879,13 @@ impl<'a> RangeView<'a> {
                 };
                 let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
                 let seg_range = rel_off..(rel_off + cs.row_len);
-                let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                    || (!ch.computed_overlay.is_empty()
-                        && ch.computed_overlay.any_in_range(seg_range.clone()));
-                if has_overlay {
-                    let mut mask_b = BooleanBuilder::with_capacity(cs.row_len);
-                    let mut eb = UInt8Builder::with_capacity(cs.row_len);
-                    for i in 0..cs.row_len {
-                        if let Some(ov) = ch
-                            .overlay
-                            .get(rel_off + i)
-                            .or_else(|| ch.computed_overlay.get(rel_off + i))
-                        {
-                            mask_b.append_value(true);
-                            match ov {
-                                arrow_store::OverlayValue::Error(code) => eb.append_value(*code),
-                                _ => eb.append_null(),
-                            }
-                        } else {
-                            mask_b.append_value(false);
-                            eb.append_null();
-                        }
-                    }
-                    let mask = mask_b.finish();
-                    let overlay_vals = eb.finish();
+                let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                if cascade.has_any_in_range(seg_range.clone()) {
                     let base_ea = base
                         .as_any()
                         .downcast_ref::<arrow_array::UInt8Array>()
                         .unwrap();
-                    let zipped =
-                        zip_select(&mask, &overlay_vals, base_ea).expect("zip err overlay");
-                    let ea = zipped
-                        .as_any()
-                        .downcast_ref::<arrow_array::UInt8Array>()
-                        .unwrap()
-                        .clone();
-                    out_cols.push(Arc::new(ea));
+                    out_cols.push(cascade.select_errors(seg_range, base_ea));
                 } else {
                     out_cols.push(base_arc);
                 }
@@ -1095,9 +899,6 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<Arc<arrow_array::UInt8Array>>), ExcelError>> + '_
     {
-        use crate::compute_prelude::zip_select;
-        use arrow_array::builder::{BooleanBuilder, UInt8Builder};
-
         self.iter_row_chunks().map(move |res| {
             let cs = res?;
             let mut out_cols: Vec<Arc<arrow_array::UInt8Array>> = Vec::with_capacity(cs.cols.len());
@@ -1130,57 +931,13 @@ impl<'a> RangeView<'a> {
                 };
                 let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
                 let seg_range = rel_off..(rel_off + cs.row_len);
-                let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                    || (!ch.computed_overlay.is_empty()
-                        && ch.computed_overlay.any_in_range(seg_range.clone()));
-                if has_overlay {
-                    let mut mask_b = BooleanBuilder::with_capacity(cs.row_len);
-                    let mut tb = UInt8Builder::with_capacity(cs.row_len);
-                    for i in 0..cs.row_len {
-                        if let Some(ov) = ch
-                            .overlay
-                            .get(rel_off + i)
-                            .or_else(|| ch.computed_overlay.get(rel_off + i))
-                        {
-                            mask_b.append_value(true);
-                            let tag = match ov {
-                                arrow_store::OverlayValue::Empty => arrow_store::TypeTag::Empty,
-                                arrow_store::OverlayValue::Number(_) => {
-                                    arrow_store::TypeTag::Number
-                                }
-                                arrow_store::OverlayValue::DateTime(_) => {
-                                    arrow_store::TypeTag::DateTime
-                                }
-                                arrow_store::OverlayValue::Duration(_) => {
-                                    arrow_store::TypeTag::Duration
-                                }
-                                arrow_store::OverlayValue::Boolean(_) => {
-                                    arrow_store::TypeTag::Boolean
-                                }
-                                arrow_store::OverlayValue::Text(_) => arrow_store::TypeTag::Text,
-                                arrow_store::OverlayValue::Error(_) => arrow_store::TypeTag::Error,
-                                arrow_store::OverlayValue::Pending => arrow_store::TypeTag::Pending,
-                            };
-                            tb.append_value(tag as u8);
-                        } else {
-                            mask_b.append_value(false);
-                            tb.append_null();
-                        }
-                    }
-                    let mask = mask_b.finish();
-                    let overlay_vals = tb.finish();
+                let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                if cascade.has_any_in_range(seg_range.clone()) {
                     let base_ta = base
                         .as_any()
                         .downcast_ref::<arrow_array::UInt8Array>()
                         .unwrap();
-                    let zipped =
-                        zip_select(&mask, &overlay_vals, base_ta).expect("zip tag overlay");
-                    let ta = zipped
-                        .as_any()
-                        .downcast_ref::<arrow_array::UInt8Array>()
-                        .unwrap()
-                        .clone();
-                    out_cols.push(Arc::new(ta));
+                    out_cols.push(cascade.select_type_tags(seg_range, base_ta));
                 } else {
                     out_cols.push(base_arc);
                 }
@@ -1192,8 +949,7 @@ impl<'a> RangeView<'a> {
     /// Build per-column concatenated lowered text arrays for this view.
     /// Uses per-chunk lowered cache for base text and merges overlays via zip_select.
     pub fn lowered_text_columns(&self) -> Vec<arrow_array::ArrayRef> {
-        use crate::compute_prelude::{concat_arrays, zip_select};
-        use arrow_array::builder::{BooleanBuilder, StringBuilder};
+        use crate::compute_prelude::concat_arrays;
 
         let mut out: Vec<arrow_array::ArrayRef> = Vec::with_capacity(self.cols);
         if self.rows == 0 || self.cols == 0 {
@@ -1237,61 +993,17 @@ impl<'a> RangeView<'a> {
                     let rel_off = is - start;
                     if let Some(ch) = col_ref.chunk(ci) {
                         // Overlay-aware lowered segment
-                        let has_overlay = ch.overlay.any_in_range(rel_off..(rel_off + seg_len))
-                            || (!ch.computed_overlay.is_empty()
-                                && ch
-                                    .computed_overlay
-                                    .any_in_range(rel_off..(rel_off + seg_len)));
-                        if has_overlay {
-                            // Build lowered overlay values builder
-                            let mut sb = StringBuilder::with_capacity(seg_len, seg_len * 8);
-                            // mask overlaid rows
-                            let mut mb = BooleanBuilder::with_capacity(seg_len);
-                            for i in 0..seg_len {
-                                if let Some(ov) = ch
-                                    .overlay
-                                    .get(rel_off + i)
-                                    .or_else(|| ch.computed_overlay.get(rel_off + i))
-                                {
-                                    mb.append_value(true);
-                                    match ov {
-                                        arrow_store::OverlayValue::Text(s) => {
-                                            sb.append_value(s.to_lowercase());
-                                        }
-                                        arrow_store::OverlayValue::Empty => {
-                                            sb.append_null();
-                                        }
-                                        arrow_store::OverlayValue::Number(n)
-                                        | arrow_store::OverlayValue::DateTime(n)
-                                        | arrow_store::OverlayValue::Duration(n) => {
-                                            sb.append_value(n.to_string());
-                                        }
-                                        arrow_store::OverlayValue::Boolean(b) => {
-                                            sb.append_value(if *b { "true" } else { "false" });
-                                        }
-                                        arrow_store::OverlayValue::Error(_)
-                                        | arrow_store::OverlayValue::Pending => {
-                                            sb.append_null();
-                                        }
-                                    }
-                                } else {
-                                    // not overlaid
-                                    sb.append_null();
-                                    mb.append_value(false);
-                                }
-                            }
-                            let overlay_vals = sb.finish();
-                            let mask = mb.finish();
-                            // base lowered segment
+                        let seg_range = rel_off..(rel_off + seg_len);
+                        let cascade =
+                            arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                        if cascade.has_any_in_range(seg_range.clone()) {
                             let base_lowered = ch.text_lower_or_null();
                             let base_seg = base_lowered.slice(rel_off, seg_len);
                             let base_sa = base_seg
                                 .as_any()
                                 .downcast_ref::<arrow_array::StringArray>()
                                 .expect("lowered slice downcast");
-                            let zipped = zip_select(&mask, &overlay_vals, base_sa)
-                                .expect("zip lowered text overlay");
-                            segs.push(zipped);
+                            segs.push(cascade.select_lowered_text(seg_range, base_sa));
                         } else {
                             // No overlay: slice from lowered base
                             let lowered = ch.text_lower_or_null();
@@ -1373,50 +1085,16 @@ impl<'a> RangeView<'a> {
                         let base_nums = base_nums_arc.as_ref();
 
                         let seg_range = rel_off_in_chunk..(rel_off_in_chunk + seg_len);
-                        let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                            || (!ch.computed_overlay.is_empty()
-                                && ch.computed_overlay.any_in_range(seg_range.clone()));
+                        let cascade =
+                            arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
 
-                        let final_arr = if has_overlay {
-                            let mut nb =
-                                arrow_array::builder::Float64Builder::with_capacity(seg_len);
-                            let mut mask_b =
-                                arrow_array::builder::BooleanBuilder::with_capacity(seg_len);
-                            for i in 0..seg_len {
-                                if let Some(ov) = ch
-                                    .overlay
-                                    .get(rel_off_in_chunk + i)
-                                    .or_else(|| ch.computed_overlay.get(rel_off_in_chunk + i))
-                                {
-                                    mask_b.append_value(true);
-                                    match ov {
-                                        arrow_store::OverlayValue::Number(n)
-                                        | arrow_store::OverlayValue::DateTime(n)
-                                        | arrow_store::OverlayValue::Duration(n) => {
-                                            nb.append_value(*n)
-                                        }
-                                        _ => nb.append_null(),
-                                    }
-                                } else {
-                                    mask_b.append_value(false);
-                                    nb.append_null();
-                                }
-                            }
-                            let mask = mask_b.finish();
-                            let overlay_vals = nb.finish();
+                        let final_arr = if cascade.has_any_in_range(seg_range.clone()) {
                             let base_slice = base_nums.slice(rel_off_in_chunk, seg_len);
                             let base_fa = base_slice
                                 .as_any()
                                 .downcast_ref::<arrow_array::Float64Array>()
                                 .unwrap();
-                            let zipped =
-                                crate::compute_prelude::zip_select(&mask, &overlay_vals, base_fa)
-                                    .expect("zip slice");
-                            zipped
-                                .as_any()
-                                .downcast_ref::<arrow_array::Float64Array>()
-                                .unwrap()
-                                .clone()
+                            cascade.select_numbers(seg_range, base_fa).as_ref().clone()
                         } else {
                             let sl = base_nums.slice(rel_off_in_chunk, seg_len);
                             sl.as_any()
@@ -1516,57 +1194,18 @@ impl<'a> RangeView<'a> {
                     if let Some(ch) = col.chunk(ch_idx) {
                         let base_lowered = ch.text_lower_or_null();
                         let seg_range = rel_off_in_chunk..(rel_off_in_chunk + seg_len);
-                        let has_overlay = ch.overlay.any_in_range(seg_range.clone())
-                            || (!ch.computed_overlay.is_empty()
-                                && ch.computed_overlay.any_in_range(seg_range.clone()));
+                        let cascade =
+                            arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
 
-                        let final_arr = if has_overlay {
-                            let mut sb = arrow_array::builder::StringBuilder::with_capacity(
-                                seg_len,
-                                seg_len * 8,
-                            );
-                            let mut mask_b =
-                                arrow_array::builder::BooleanBuilder::with_capacity(seg_len);
-                            for i in 0..seg_len {
-                                if let Some(ov) = ch
-                                    .overlay
-                                    .get(rel_off_in_chunk + i)
-                                    .or_else(|| ch.computed_overlay.get(rel_off_in_chunk + i))
-                                {
-                                    mask_b.append_value(true);
-                                    match ov {
-                                        arrow_store::OverlayValue::Text(s) => {
-                                            sb.append_value(s.to_lowercase())
-                                        }
-                                        arrow_store::OverlayValue::Number(n)
-                                        | arrow_store::OverlayValue::DateTime(n)
-                                        | arrow_store::OverlayValue::Duration(n) => {
-                                            sb.append_value(n.to_string())
-                                        }
-                                        arrow_store::OverlayValue::Boolean(b) => {
-                                            sb.append_value(if *b { "true" } else { "false" })
-                                        }
-                                        _ => sb.append_null(),
-                                    }
-                                } else {
-                                    mask_b.append_value(false);
-                                    sb.append_null();
-                                }
-                            }
-                            let mask = mask_b.finish();
-                            let overlay_vals = sb.finish();
+                        let final_arr = if cascade.has_any_in_range(seg_range.clone()) {
                             let base_slice = base_lowered.slice(rel_off_in_chunk, seg_len);
                             let base_sa = base_slice
                                 .as_any()
                                 .downcast_ref::<arrow_array::StringArray>()
                                 .unwrap();
-                            let zipped =
-                                crate::compute_prelude::zip_select(&mask, &overlay_vals, base_sa)
-                                    .expect("zip text");
-                            zipped
-                                .as_any()
-                                .downcast_ref::<arrow_array::StringArray>()
-                                .unwrap()
+                            cascade
+                                .select_lowered_text(seg_range, base_sa)
+                                .as_ref()
                                 .clone()
                         } else {
                             let sl = base_lowered.slice(rel_off_in_chunk, seg_len);

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -1,6 +1,8 @@
 use super::common::arrow_eval_config;
 use crate::arrow_store::{OverlayFragment, OverlayValue};
-use crate::engine::eval::{ComputedWrite, ComputedWriteBuffer, Engine};
+use crate::engine::eval::{
+    ComputedWrite, ComputedWriteBuffer, ComputedWriteChunkPlanShape, Engine,
+};
 use crate::test_workbook::TestWorkbook;
 use formualizer_common::LiteralValue;
 use formualizer_parse::parser::parse;
@@ -22,6 +24,130 @@ fn computed_write_buffer_records_sequence_order() {
     let seqs: Vec<u64> = buffer.writes().iter().map(ComputedWrite::seq).collect();
     assert_eq!(seqs, vec![0, 1, 2]);
     assert!(buffer.estimated_bytes() > 0);
+}
+
+#[test]
+fn computed_write_coalescing_plan_groups_sorts_and_applies_last_write_wins() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 2, 2);
+        for _ in 0..4 {
+            ab.append_row(sheet, &[LiteralValue::Empty, LiteralValue::Empty])
+                .unwrap();
+        }
+        ab.finish().unwrap();
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_cell(sheet_id, 3, 0, OverlayValue::Number(30.0));
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Number(10.0));
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Number(11.0));
+    buffer.push_rect(
+        sheet_id,
+        1,
+        0,
+        vec![
+            vec![OverlayValue::Number(20.0), OverlayValue::Text("a".into())],
+            vec![OverlayValue::Number(30.0), OverlayValue::Text("b".into())],
+        ],
+    );
+
+    let plan = engine.debug_plan_computed_write_coalescing(&buffer);
+    assert!(!plan.is_empty());
+    assert_eq!(plan.input_cells, 7);
+    assert_eq!(plan.coalesced_cells, 6);
+    assert_eq!(plan.overwritten_cells, 1);
+    assert_eq!(
+        buffer.len(),
+        4,
+        "debug planning must not consume the buffer"
+    );
+
+    let c0_ch0 = plan
+        .chunks
+        .iter()
+        .find(|chunk| chunk.col0 == 0 && chunk.chunk_idx == 0)
+        .expect("column 0 chunk 0");
+    assert_eq!(c0_ch0.chunk_start_row0, 0);
+    assert_eq!(
+        c0_ch0.shape,
+        ComputedWriteChunkPlanShape::DenseRange { start: 0, len: 2 }
+    );
+    assert_eq!(c0_ch0.entries.len(), 2);
+    assert_eq!(c0_ch0.entries[0].row_in_chunk, 0);
+    assert_eq!(c0_ch0.entries[0].seq, 2);
+    assert_eq!(c0_ch0.entries[0].value, OverlayValue::Number(11.0));
+    assert_eq!(c0_ch0.entries[1].row_in_chunk, 1);
+    assert_eq!(c0_ch0.entries[1].seq, 3);
+    assert_eq!(c0_ch0.entries[1].value, OverlayValue::Number(20.0));
+
+    let c0_ch1 = plan
+        .chunks
+        .iter()
+        .find(|chunk| chunk.col0 == 0 && chunk.chunk_idx == 1)
+        .expect("column 0 chunk 1");
+    assert_eq!(c0_ch1.chunk_start_row0, 2);
+    assert_eq!(
+        c0_ch1.shape,
+        ComputedWriteChunkPlanShape::RunRange {
+            start: 0,
+            len: 2,
+            runs: 1,
+        }
+    );
+    assert_eq!(c0_ch1.entries[0].row_in_chunk, 0);
+    assert_eq!(c0_ch1.entries[1].row_in_chunk, 1);
+
+    let c1_ch0 = plan
+        .chunks
+        .iter()
+        .find(|chunk| chunk.col0 == 1 && chunk.chunk_idx == 0)
+        .expect("column 1 chunk 0");
+    assert_eq!(c1_ch0.entries[0].row_in_chunk, 1);
+    assert_eq!(c1_ch0.shape, ComputedWriteChunkPlanShape::Point);
+
+    let c1_ch1 = plan
+        .chunks
+        .iter()
+        .find(|chunk| chunk.col0 == 1 && chunk.chunk_idx == 1)
+        .expect("column 1 chunk 1");
+    assert_eq!(c1_ch1.entries[0].row_in_chunk, 0);
+    assert_eq!(c1_ch1.shape, ComputedWriteChunkPlanShape::Point);
+}
+
+#[test]
+fn computed_write_coalescing_plan_preserves_sparse_gaps_and_empty_values() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Empty);
+    buffer.push_cell(sheet_id, 2, 0, OverlayValue::Empty);
+
+    let plan = engine.debug_plan_computed_write_coalescing(&buffer);
+    assert_eq!(plan.input_cells, 2);
+    assert_eq!(plan.coalesced_cells, 2);
+    assert_eq!(plan.overwritten_cells, 0);
+    assert_eq!(plan.chunks.len(), 1);
+
+    let chunk = &plan.chunks[0];
+    assert_eq!(chunk.col0, 0);
+    assert_eq!(chunk.chunk_idx, 0);
+    assert_eq!(chunk.entries[0].row_in_chunk, 0);
+    assert_eq!(chunk.entries[0].value, OverlayValue::Empty);
+    assert_eq!(chunk.entries[1].row_in_chunk, 2);
+    assert_eq!(chunk.entries[1].value, OverlayValue::Empty);
+    assert_eq!(
+        chunk.shape,
+        ComputedWriteChunkPlanShape::SparseOffsets {
+            entries: 2,
+            span_len: 3,
+        }
+    );
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -151,7 +151,7 @@ fn computed_write_coalescing_plan_preserves_sparse_gaps_and_empty_values() {
 }
 
 #[test]
-fn computed_write_buffer_flush_to_map_matches_immediate_cell_writes() {
+fn coalesced_flush_lww_matches_legacy_point_flush() {
     let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
     let sheet = "Sheet1";
     let sheet_id = engine.graph.sheet_id_mut(sheet);
@@ -179,7 +179,7 @@ fn computed_write_buffer_flush_to_map_matches_immediate_cell_writes() {
 }
 
 #[test]
-fn computed_write_buffer_rect_expands_row_major_correctly() {
+fn coalesced_flush_rect_expansion_matches_legacy() {
     let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
     let sheet = "Sheet1";
     let sheet_id = engine.graph.sheet_id_mut(sheet);
@@ -202,6 +202,84 @@ fn computed_write_buffer_rect_expands_row_major_correctly() {
     assert_eq!(asheet.get_cell_value(1, 3), LiteralValue::Number(2.0));
     assert_eq!(asheet.get_cell_value(2, 2), LiteralValue::Text("a".into()));
     assert_eq!(asheet.get_cell_value(2, 3), LiteralValue::Empty);
+}
+
+#[test]
+fn coalesced_flush_empty_masks_base() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 8);
+        ab.append_row(sheet, &[LiteralValue::Number(42.0)]).unwrap();
+        ab.finish().unwrap();
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Empty);
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Empty);
+}
+
+#[test]
+fn coalesced_flush_sparse_gaps_do_not_fill_base() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 8);
+        ab.append_row(sheet, &[LiteralValue::Number(1.0)]).unwrap();
+        ab.append_row(sheet, &[LiteralValue::Number(2.0)]).unwrap();
+        ab.append_row(sheet, &[LiteralValue::Number(3.0)]).unwrap();
+        ab.finish().unwrap();
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Number(10.0));
+    buffer.push_cell(sheet_id, 2, 0, OverlayValue::Empty);
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(10.0));
+    assert_eq!(asheet.get_cell_value(1, 0), LiteralValue::Number(2.0));
+    assert_eq!(asheet.get_cell_value(2, 0), LiteralValue::Empty);
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.points, 2);
+    assert_eq!(stats.covered_len, 2);
+}
+
+#[test]
+fn coalesced_flush_cap_zero_still_compacts_safely() {
+    let mut cfg = arrow_eval_config();
+    cfg.max_overlay_memory_bytes = Some(0);
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Number(7.0));
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    assert!(buffer.is_empty());
+    assert_eq!(engine.overlay_memory_usage(), 0);
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(7.0));
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.covered_len, 0);
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -137,6 +137,8 @@ fn user_edit_removes_same_cell_computed_fragment_before_compaction() {
         );
     }
 
+    assert!(engine.debug_recompute_computed_overlay_bytes() > 0);
+
     engine
         .set_cell_value(sheet, 1, 1, LiteralValue::Number(9.0))
         .unwrap();
@@ -151,4 +153,5 @@ fn user_edit_removes_same_cell_computed_fragment_before_compaction() {
         "user edit should remove same-cell computed fragment before user overlay compaction"
     );
     assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(9.0));
+    assert_eq!(engine.overlay_memory_usage(), 0);
 }

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -38,6 +38,17 @@ fn computed_write_buffer_flush_to_map_matches_immediate_cell_writes() {
 
     assert!(buffer.is_empty());
     let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, in_off) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.points, 1);
+    assert_eq!(stats.sparse_fragments, 0);
+    assert_eq!(stats.dense_fragments, 0);
+    assert_eq!(stats.run_fragments, 0);
+    assert_eq!(in_off, 0);
     assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(9.0));
 }
 

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -1,5 +1,5 @@
 use super::common::arrow_eval_config;
-use crate::arrow_store::OverlayValue;
+use crate::arrow_store::{OverlayFragment, OverlayValue};
 use crate::engine::eval::{ComputedWrite, ComputedWriteBuffer, Engine};
 use crate::test_workbook::TestWorkbook;
 use formualizer_common::LiteralValue;
@@ -105,4 +105,50 @@ fn computed_flush_parallel_scalar_group_flushes_before_return() {
             row0 + 1
         );
     }
+}
+
+#[test]
+fn user_edit_removes_same_cell_computed_fragment_before_compaction() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 8);
+        ab.append_row(sheet, &[LiteralValue::Empty]).unwrap();
+        ab.finish().unwrap();
+    }
+
+    {
+        let asheet = engine.sheet_store_mut().sheet_mut(sheet).unwrap();
+        let (ch_i, off) = asheet.chunk_of_row(0).unwrap();
+        asheet.columns[0].chunks[ch_i]
+            .computed_overlay
+            .apply_fragment(
+                OverlayFragment::run_range(0, vec![OverlayValue::Number(42.0)]).unwrap(),
+            );
+        assert_eq!(
+            asheet.columns[0].chunks[ch_i]
+                .computed_overlay
+                .get_scalar(off)
+                .unwrap()
+                .to_literal(),
+            LiteralValue::Number(42.0)
+        );
+    }
+
+    engine
+        .set_cell_value(sheet, 1, 1, LiteralValue::Number(9.0))
+        .unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).unwrap();
+    let (ch_i, off) = asheet.chunk_of_row(0).unwrap();
+    assert!(
+        asheet.columns[0].chunks[ch_i]
+            .computed_overlay
+            .get_scalar(off)
+            .is_none(),
+        "user edit should remove same-cell computed fragment before user overlay compaction"
+    );
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(9.0));
 }

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -1,11 +1,348 @@
 use super::common::arrow_eval_config;
-use crate::arrow_store::{OverlayFragment, OverlayValue};
+use crate::arrow_store::{
+    ArrowSheet, OverlayDebugStats, OverlayFragment, OverlaySelectStats, OverlayValue,
+    reset_overlay_select_stats, snapshot_overlay_select_stats,
+};
 use crate::engine::eval::{
     ComputedWrite, ComputedWriteBuffer, ComputedWriteChunkPlanShape, Engine,
 };
 use crate::test_workbook::TestWorkbook;
+use arrow_array::Array;
 use formualizer_common::LiteralValue;
+use formualizer_parse::ASTNode;
 use formualizer_parse::parser::parse;
+
+#[derive(Debug, Clone, Copy)]
+enum Phase5ComputedFlushProbeFixture {
+    ConstantCopied,
+    RowVarying,
+    AlternatingMostlyVaried,
+    SparseEveryOther,
+    CapZeroConstant,
+}
+
+impl Phase5ComputedFlushProbeFixture {
+    fn name(self) -> &'static str {
+        match self {
+            Phase5ComputedFlushProbeFixture::ConstantCopied => "constant_copied",
+            Phase5ComputedFlushProbeFixture::RowVarying => "row_varying",
+            Phase5ComputedFlushProbeFixture::AlternatingMostlyVaried => "alternating_mostly_varied",
+            Phase5ComputedFlushProbeFixture::SparseEveryOther => "sparse_every_other",
+            Phase5ComputedFlushProbeFixture::CapZeroConstant => "cap_zero_constant",
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct Phase5ComputedFlushProbeOp {
+    ms: f64,
+    segments: usize,
+    arrays: usize,
+    rows_scanned: usize,
+    checksum: f64,
+    non_null: usize,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct Phase5ComputedFlushProbeOverlayStats {
+    points: usize,
+    sparse_fragments: usize,
+    dense_fragments: usize,
+    run_fragments: usize,
+    covered_len: usize,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct Phase5ComputedFlushProbeRow {
+    fixture: &'static str,
+    rows: usize,
+    formulas: usize,
+    chunk_rows: usize,
+    eval_ms: f64,
+    overlay_memory_usage: usize,
+    computed_overlay_estimated_bytes: usize,
+    overlay_stats: Phase5ComputedFlushProbeOverlayStats,
+    numbers: Phase5ComputedFlushProbeOp,
+    type_tags: Phase5ComputedFlushProbeOp,
+    lowered_text: Phase5ComputedFlushProbeOp,
+    select_stats: OverlaySelectStats,
+}
+
+fn phase5_probe_overlay_stats(sheet: &ArrowSheet, col_idx: usize) -> OverlayDebugStats {
+    let mut total = OverlayDebugStats::default();
+    let Some(column) = sheet.columns.get(col_idx) else {
+        return total;
+    };
+    for chunk in &column.chunks {
+        let stats = chunk.computed_overlay.debug_stats();
+        total.points += stats.points;
+        total.sparse_fragments += stats.sparse_fragments;
+        total.dense_fragments += stats.dense_fragments;
+        total.run_fragments += stats.run_fragments;
+        total.covered_len += stats.covered_len;
+    }
+    for chunk in column.sparse_chunks.values() {
+        let stats = chunk.computed_overlay.debug_stats();
+        total.points += stats.points;
+        total.sparse_fragments += stats.sparse_fragments;
+        total.dense_fragments += stats.dense_fragments;
+        total.run_fragments += stats.run_fragments;
+        total.covered_len += stats.covered_len;
+    }
+    total
+}
+
+fn phase5_probe_computed_overlay_estimated_bytes(sheet: &ArrowSheet, col_idx: usize) -> usize {
+    let Some(column) = sheet.columns.get(col_idx) else {
+        return 0;
+    };
+    column
+        .chunks
+        .iter()
+        .map(|chunk| chunk.computed_overlay.estimated_bytes())
+        .chain(
+            column
+                .sparse_chunks
+                .values()
+                .map(|chunk| chunk.computed_overlay.estimated_bytes()),
+        )
+        .fold(0usize, usize::saturating_add)
+}
+
+fn phase5_seed_base_rows(
+    engine: &mut Engine<TestWorkbook>,
+    sheet: &str,
+    rows: usize,
+    chunk_rows: usize,
+) {
+    let mut ab = engine.begin_bulk_ingest_arrow();
+    ab.add_sheet(sheet, 1, chunk_rows.max(1));
+    for _ in 0..rows.max(1) {
+        ab.append_row(sheet, &[LiteralValue::Empty]).unwrap();
+    }
+    ab.finish().unwrap();
+}
+
+fn phase5_set_formula_rows(
+    engine: &mut Engine<TestWorkbook>,
+    sheet: &str,
+    rows: usize,
+    fixture: Phase5ComputedFlushProbeFixture,
+) -> usize {
+    let one = parse("=1").unwrap();
+    let two = parse("=2").unwrap();
+    let row_fn = parse("=ROW()").unwrap();
+    let mut formulas = 0usize;
+
+    let mut set_formula = |row0: usize, ast: &ASTNode| {
+        engine
+            .set_cell_formula(sheet, row0 as u32 + 1, 1, ast.clone())
+            .unwrap();
+        formulas += 1;
+    };
+
+    match fixture {
+        Phase5ComputedFlushProbeFixture::ConstantCopied
+        | Phase5ComputedFlushProbeFixture::CapZeroConstant => {
+            for row0 in 0..rows {
+                set_formula(row0, &one);
+            }
+        }
+        Phase5ComputedFlushProbeFixture::RowVarying => {
+            for row0 in 0..rows {
+                set_formula(row0, &row_fn);
+            }
+        }
+        Phase5ComputedFlushProbeFixture::AlternatingMostlyVaried => {
+            for row0 in 0..rows {
+                let ast = if row0 % 2 == 0 { &one } else { &two };
+                set_formula(row0, ast);
+            }
+        }
+        Phase5ComputedFlushProbeFixture::SparseEveryOther => {
+            for row0 in (0..rows).step_by(2) {
+                set_formula(row0, &row_fn);
+            }
+        }
+    }
+
+    formulas
+}
+
+fn phase5_measure_numbers(sheet: &ArrowSheet, rows: usize) -> Phase5ComputedFlushProbeOp {
+    let view = sheet.range_view(0, 0, rows.saturating_sub(1), 0);
+    let start = std::time::Instant::now();
+    let mut segments = 0usize;
+    let mut arrays = 0usize;
+    let mut rows_scanned = 0usize;
+    let mut checksum = 0.0;
+    let mut non_null = 0usize;
+    for segment in view.numbers_slices() {
+        let (_row_start, row_len, cols) = segment.unwrap();
+        segments += 1;
+        rows_scanned += row_len;
+        for array in cols {
+            arrays += 1;
+            for idx in 0..array.len() {
+                if array.is_valid(idx) {
+                    checksum += array.value(idx);
+                    non_null += 1;
+                }
+            }
+        }
+    }
+    Phase5ComputedFlushProbeOp {
+        ms: start.elapsed().as_secs_f64() * 1000.0,
+        segments,
+        arrays,
+        rows_scanned,
+        checksum,
+        non_null,
+    }
+}
+
+fn phase5_measure_type_tags(sheet: &ArrowSheet, rows: usize) -> Phase5ComputedFlushProbeOp {
+    let view = sheet.range_view(0, 0, rows.saturating_sub(1), 0);
+    let start = std::time::Instant::now();
+    let mut segments = 0usize;
+    let mut arrays = 0usize;
+    let mut rows_scanned = 0usize;
+    let mut checksum = 0.0;
+    let mut non_null = 0usize;
+    for segment in view.type_tags_slices() {
+        let (_row_start, row_len, cols) = segment.unwrap();
+        segments += 1;
+        rows_scanned += row_len;
+        for array in cols {
+            arrays += 1;
+            for idx in 0..array.len() {
+                if array.is_valid(idx) {
+                    checksum += array.value(idx) as f64;
+                    non_null += 1;
+                }
+            }
+        }
+    }
+    Phase5ComputedFlushProbeOp {
+        ms: start.elapsed().as_secs_f64() * 1000.0,
+        segments,
+        arrays,
+        rows_scanned,
+        checksum,
+        non_null,
+    }
+}
+
+fn phase5_measure_lowered_text(sheet: &ArrowSheet, rows: usize) -> Phase5ComputedFlushProbeOp {
+    let view = sheet.range_view(0, 0, rows.saturating_sub(1), 0);
+    let start = std::time::Instant::now();
+    let mut segments = 0usize;
+    let mut arrays = 0usize;
+    let mut rows_scanned = 0usize;
+    let mut checksum = 0.0;
+    let mut non_null = 0usize;
+    for segment in view.lowered_text_slices() {
+        let (_row_start, row_len, cols) = segment.unwrap();
+        segments += 1;
+        rows_scanned += row_len;
+        for array in cols {
+            arrays += 1;
+            for idx in 0..array.len() {
+                if array.is_valid(idx) {
+                    checksum += array.value(idx).len() as f64;
+                    non_null += 1;
+                }
+            }
+        }
+    }
+    Phase5ComputedFlushProbeOp {
+        ms: start.elapsed().as_secs_f64() * 1000.0,
+        segments,
+        arrays,
+        rows_scanned,
+        checksum,
+        non_null,
+    }
+}
+
+fn run_phase5_computed_flush_probe_fixture(
+    rows: usize,
+    chunk_rows: usize,
+    fixture: Phase5ComputedFlushProbeFixture,
+) -> Phase5ComputedFlushProbeRow {
+    let mut cfg = arrow_eval_config();
+    if matches!(fixture, Phase5ComputedFlushProbeFixture::CapZeroConstant) {
+        cfg.max_overlay_memory_bytes = Some(0);
+    }
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    let sheet = "Sheet1";
+    phase5_seed_base_rows(&mut engine, sheet, rows, chunk_rows);
+    let formulas = phase5_set_formula_rows(&mut engine, sheet, rows, fixture);
+
+    let eval_start = std::time::Instant::now();
+    engine.evaluate_all().unwrap();
+    let eval_ms = eval_start.elapsed().as_secs_f64() * 1000.0;
+
+    let overlay_memory_usage = engine.overlay_memory_usage();
+    let sheet_ref = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let raw_stats = phase5_probe_overlay_stats(sheet_ref, 0);
+    let overlay_stats = Phase5ComputedFlushProbeOverlayStats {
+        points: raw_stats.points,
+        sparse_fragments: raw_stats.sparse_fragments,
+        dense_fragments: raw_stats.dense_fragments,
+        run_fragments: raw_stats.run_fragments,
+        covered_len: raw_stats.covered_len,
+    };
+    let computed_overlay_estimated_bytes =
+        phase5_probe_computed_overlay_estimated_bytes(sheet_ref, 0);
+
+    reset_overlay_select_stats();
+    let numbers = phase5_measure_numbers(sheet_ref, rows);
+    let type_tags = phase5_measure_type_tags(sheet_ref, rows);
+    let lowered_text = phase5_measure_lowered_text(sheet_ref, rows);
+    let select_stats = snapshot_overlay_select_stats();
+
+    Phase5ComputedFlushProbeRow {
+        fixture: fixture.name(),
+        rows,
+        formulas,
+        chunk_rows,
+        eval_ms,
+        overlay_memory_usage,
+        computed_overlay_estimated_bytes,
+        overlay_stats,
+        numbers,
+        type_tags,
+        lowered_text,
+        select_stats,
+    }
+}
+
+#[test]
+#[ignore = "manual Phase 5 computed flush observability probe; run with --ignored --nocapture"]
+fn phase5_computed_flush_coalescing_observability_probe() {
+    let rows = std::env::var("FORMUALIZER_COMPUTED_FLUSH_PROBE_ROWS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(100_000)
+        .max(1);
+    let chunk_rows = std::env::var("FORMUALIZER_COMPUTED_FLUSH_PROBE_CHUNK_ROWS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(32 * 1024)
+        .max(1);
+
+    for fixture in [
+        Phase5ComputedFlushProbeFixture::ConstantCopied,
+        Phase5ComputedFlushProbeFixture::RowVarying,
+        Phase5ComputedFlushProbeFixture::AlternatingMostlyVaried,
+        Phase5ComputedFlushProbeFixture::SparseEveryOther,
+        Phase5ComputedFlushProbeFixture::CapZeroConstant,
+    ] {
+        let row = run_phase5_computed_flush_probe_fixture(rows, chunk_rows, fixture);
+        println!("{}", serde_json::to_string(&row).unwrap());
+    }
+}
 
 #[test]
 fn computed_write_buffer_records_sequence_order() {

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -783,6 +783,49 @@ fn coalesced_flush_cap_zero_still_compacts_safely() {
 }
 
 #[test]
+fn cap_zero_batches_computed_writes_before_compaction() {
+    let mut cfg = arrow_eval_config();
+    cfg.max_overlay_memory_bytes = Some(0);
+    cfg.enable_parallel = false;
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 8);
+        for _ in 0..32 {
+            ab.append_row(sheet, &[LiteralValue::Empty]).unwrap();
+        }
+        ab.finish().unwrap();
+    }
+
+    let formula = parse("=1").unwrap();
+    for row in 1..=32 {
+        engine
+            .set_cell_formula(sheet, row, 1, formula.clone())
+            .unwrap();
+    }
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(engine.overlay_memory_usage(), 0);
+    assert!(
+        engine.debug_overlay_compactions() <= 4,
+        "cap=0 should compact per coalesced chunk, not per formula; compactions={}",
+        engine.debug_overlay_compactions()
+    );
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let stats = asheet.columns[0]
+        .chunk(0)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.covered_len, 0);
+    for row0 in 0..32 {
+        assert_eq!(asheet.get_cell_value(row0, 0), LiteralValue::Number(1.0));
+    }
+}
+
+#[test]
 fn coalesced_flush_dense_range_creates_dense_fragment() {
     let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
     let sheet = "Sheet1";

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -283,6 +283,209 @@ fn coalesced_flush_cap_zero_still_compacts_safely() {
 }
 
 #[test]
+fn coalesced_flush_dense_range_creates_dense_fragment() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    for row0 in 0..4 {
+        buffer.push_cell(sheet_id, row0, 0, OverlayValue::Number((row0 + 1) as f64));
+    }
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.points, 0);
+    assert_eq!(stats.dense_fragments, 1);
+    assert_eq!(stats.run_fragments, 0);
+    assert_eq!(stats.sparse_fragments, 0);
+    assert_eq!(stats.covered_len, 4);
+    for row0 in 0..4 {
+        assert_eq!(
+            asheet.get_cell_value(row0 as usize, 0),
+            LiteralValue::Number((row0 + 1) as f64)
+        );
+    }
+}
+
+#[test]
+fn coalesced_flush_constant_range_creates_run_fragment() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    for row0 in 0..8 {
+        buffer.push_cell(sheet_id, row0, 0, OverlayValue::Number(7.0));
+    }
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.points, 0);
+    assert_eq!(stats.dense_fragments, 0);
+    assert_eq!(stats.run_fragments, 1);
+    assert_eq!(stats.covered_len, 8);
+    for row0 in 0..8 {
+        assert_eq!(asheet.get_cell_value(row0, 0), LiteralValue::Number(7.0));
+    }
+}
+
+#[test]
+fn coalesced_flush_mostly_varied_range_prefers_dense_not_run() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+    let values = [1.0, 2.0, 2.0, 3.0, 4.0, 5.0];
+
+    for (row0, value) in values.iter().copied().enumerate() {
+        buffer.push_cell(sheet_id, row0 as u32, 0, OverlayValue::Number(value));
+    }
+    let plan = engine.debug_plan_computed_write_coalescing(&buffer);
+    assert_eq!(
+        plan.chunks[0].shape,
+        ComputedWriteChunkPlanShape::RunRange {
+            start: 0,
+            len: 6,
+            runs: 5,
+        }
+    );
+
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.points, 0);
+    assert_eq!(stats.dense_fragments, 1);
+    assert_eq!(stats.run_fragments, 0);
+    assert_eq!(stats.covered_len, values.len());
+}
+
+#[test]
+fn coalesced_flush_user_overlay_still_masks_computed_fragment() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 8);
+        for _ in 0..3 {
+            ab.append_row(sheet, &[LiteralValue::Empty]).unwrap();
+        }
+        ab.finish().unwrap();
+    }
+    {
+        let asheet = engine.sheet_store_mut().sheet_mut(sheet).unwrap();
+        let (ch_i, off) = asheet.chunk_of_row(1).unwrap();
+        asheet.columns[0].chunks[ch_i]
+            .overlay
+            .set_scalar(off, OverlayValue::Text("user".into()));
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+    for row0 in 0..3 {
+        buffer.push_cell(sheet_id, row0, 0, OverlayValue::Number(10.0 + row0 as f64));
+    }
+
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(10.0));
+    assert_eq!(
+        asheet.get_cell_value(1, 0),
+        LiteralValue::Text("user".into())
+    );
+    assert_eq!(asheet.get_cell_value(2, 0), LiteralValue::Number(12.0));
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.dense_fragments, 1);
+}
+
+#[test]
+fn coalesced_flush_empty_run_masks_base() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 8);
+        for row0 in 0..4 {
+            ab.append_row(sheet, &[LiteralValue::Number((row0 + 1) as f64)])
+                .unwrap();
+        }
+        ab.finish().unwrap();
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+    for row0 in 0..4 {
+        buffer.push_cell(sheet_id, row0, 0, OverlayValue::Empty);
+    }
+
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.run_fragments, 1);
+    assert_eq!(stats.covered_len, 4);
+    for row0 in 0..4 {
+        assert_eq!(asheet.get_cell_value(row0, 0), LiteralValue::Empty);
+    }
+}
+
+#[test]
+fn coalesced_flush_cap_zero_compacts_fragment_safely() {
+    let mut cfg = arrow_eval_config();
+    cfg.max_overlay_memory_bytes = Some(0);
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    for row0 in 0..4 {
+        buffer.push_cell(sheet_id, row0, 0, OverlayValue::Number(7.0));
+    }
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    assert!(buffer.is_empty());
+    assert_eq!(engine.overlay_memory_usage(), 0);
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.covered_len, 0);
+    for row0 in 0..4 {
+        assert_eq!(asheet.get_cell_value(row0, 0), LiteralValue::Number(7.0));
+    }
+}
+
+#[test]
 fn computed_flush_sequential_scalar_layer_flushes_before_return() {
     let mut cfg = arrow_eval_config();
     cfg.enable_parallel = false;

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -1,0 +1,108 @@
+use super::common::arrow_eval_config;
+use crate::arrow_store::OverlayValue;
+use crate::engine::eval::{ComputedWrite, ComputedWriteBuffer, Engine};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+#[test]
+fn computed_write_buffer_records_sequence_order() {
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_cell(0, 0, 0, OverlayValue::Number(1.0));
+    buffer.push_cell(0, 0, 1, OverlayValue::Text("x".into()));
+    buffer.push_rect(
+        0,
+        1,
+        0,
+        vec![vec![OverlayValue::Boolean(true), OverlayValue::Empty]],
+    );
+
+    assert_eq!(buffer.len(), 3);
+    let seqs: Vec<u64> = buffer.writes().iter().map(ComputedWrite::seq).collect();
+    assert_eq!(seqs, vec![0, 1, 2]);
+    assert!(buffer.estimated_bytes() > 0);
+}
+
+#[test]
+fn computed_write_buffer_flush_to_map_matches_immediate_cell_writes() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Number(7.0));
+    buffer.push_cell(sheet_id, 0, 0, OverlayValue::Number(9.0));
+
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    assert!(buffer.is_empty());
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(9.0));
+}
+
+#[test]
+fn computed_write_buffer_rect_expands_row_major_correctly() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    buffer.push_rect(
+        sheet_id,
+        1,
+        2,
+        vec![
+            vec![OverlayValue::Number(1.0), OverlayValue::Number(2.0)],
+            vec![OverlayValue::Text("a".into()), OverlayValue::Empty],
+        ],
+    );
+
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    assert_eq!(asheet.get_cell_value(1, 2), LiteralValue::Number(1.0));
+    assert_eq!(asheet.get_cell_value(1, 3), LiteralValue::Number(2.0));
+    assert_eq!(asheet.get_cell_value(2, 2), LiteralValue::Text("a".into()));
+    assert_eq!(asheet.get_cell_value(2, 3), LiteralValue::Empty);
+}
+
+#[test]
+fn computed_flush_sequential_scalar_layer_flushes_before_return() {
+    let mut cfg = arrow_eval_config();
+    cfg.enable_parallel = false;
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=1+2").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    let asheet = engine.sheet_store().sheet("Sheet1").expect("arrow sheet");
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(3.0));
+}
+
+#[test]
+fn computed_flush_parallel_scalar_group_flushes_before_return() {
+    let mut cfg = arrow_eval_config();
+    cfg.enable_parallel = true;
+    cfg.max_threads = Some(4);
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+
+    for row in 1..=32 {
+        engine
+            .set_cell_formula("Sheet1", row, 1, parse("=ROW()").unwrap())
+            .unwrap();
+    }
+    engine.evaluate_all().unwrap();
+
+    let asheet = engine.sheet_store().sheet("Sheet1").expect("arrow sheet");
+    for row0 in 0..32 {
+        assert_eq!(
+            asheet.get_cell_value(row0, 0),
+            LiteralValue::Number((row0 + 1) as f64),
+            "row {}",
+            row0 + 1
+        );
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/computed_flush.rs
+++ b/crates/formualizer-eval/src/engine/tests/computed_flush.rs
@@ -254,7 +254,170 @@ fn coalesced_flush_sparse_gaps_do_not_fill_base() {
         .computed_overlay
         .debug_stats();
     assert_eq!(stats.points, 2);
+    assert_eq!(stats.sparse_fragments, 0);
     assert_eq!(stats.covered_len, 2);
+}
+
+#[test]
+fn coalesced_flush_sparse_offsets_creates_sparse_fragment() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 256);
+        for row0 in 0..128 {
+            ab.append_row(sheet, &[LiteralValue::Number((row0 + 1) as f64)])
+                .unwrap();
+        }
+        ab.finish().unwrap();
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+
+    for row0 in (0..128).step_by(2) {
+        buffer.push_cell(
+            sheet_id,
+            row0,
+            0,
+            OverlayValue::Number(1000.0 + row0 as f64),
+        );
+    }
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.points, 0);
+    assert_eq!(stats.sparse_fragments, 1);
+    assert_eq!(stats.dense_fragments, 0);
+    assert_eq!(stats.run_fragments, 0);
+    assert_eq!(stats.covered_len, 64);
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(1000.0));
+    assert_eq!(asheet.get_cell_value(1, 0), LiteralValue::Number(2.0));
+    assert_eq!(asheet.get_cell_value(126, 0), LiteralValue::Number(1126.0));
+    assert_eq!(asheet.get_cell_value(127, 0), LiteralValue::Number(128.0));
+}
+
+#[test]
+fn coalesced_flush_sparse_empty_masks_base_only_at_offsets() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 256);
+        for row0 in 0..128 {
+            ab.append_row(sheet, &[LiteralValue::Number((row0 + 1) as f64)])
+                .unwrap();
+        }
+        ab.finish().unwrap();
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+
+    for row0 in (0..128).step_by(2) {
+        buffer.push_cell(sheet_id, row0, 0, OverlayValue::Empty);
+    }
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.sparse_fragments, 1);
+    assert_eq!(stats.covered_len, 64);
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Empty);
+    assert_eq!(asheet.get_cell_value(1, 0), LiteralValue::Number(2.0));
+    assert_eq!(asheet.get_cell_value(126, 0), LiteralValue::Empty);
+    assert_eq!(asheet.get_cell_value(127, 0), LiteralValue::Number(128.0));
+}
+
+#[test]
+fn coalesced_flush_sparse_user_overlay_precedence() {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let sheet = "Sheet1";
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet(sheet, 1, 256);
+        for _ in 0..128 {
+            ab.append_row(sheet, &[LiteralValue::Empty]).unwrap();
+        }
+        ab.finish().unwrap();
+    }
+    {
+        let asheet = engine.sheet_store_mut().sheet_mut(sheet).unwrap();
+        let (ch_i, off) = asheet.chunk_of_row(10).unwrap();
+        asheet.columns[0].chunks[ch_i]
+            .overlay
+            .set_scalar(off, OverlayValue::Text("user".into()));
+    }
+    let sheet_id = engine.sheet_id(sheet).unwrap();
+    let mut buffer = ComputedWriteBuffer::default();
+
+    for row0 in (0..128).step_by(2) {
+        buffer.push_cell(
+            sheet_id,
+            row0,
+            0,
+            OverlayValue::Number(1000.0 + row0 as f64),
+        );
+    }
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.sparse_fragments, 1);
+    assert_eq!(asheet.get_cell_value(8, 0), LiteralValue::Number(1008.0));
+    assert_eq!(
+        asheet.get_cell_value(10, 0),
+        LiteralValue::Text("user".into())
+    );
+    assert_eq!(asheet.get_cell_value(11, 0), LiteralValue::Empty);
+}
+
+#[test]
+fn coalesced_flush_sparse_cap_zero_compacts_fragment_safely() {
+    let mut cfg = arrow_eval_config();
+    cfg.max_overlay_memory_bytes = Some(0);
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    let sheet = "Sheet1";
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    let mut buffer = ComputedWriteBuffer::default();
+
+    for row0 in (0..128).step_by(2) {
+        buffer.push_cell(
+            sheet_id,
+            row0,
+            0,
+            OverlayValue::Number(1000.0 + row0 as f64),
+        );
+    }
+    engine.flush_computed_write_buffer(&mut buffer).unwrap();
+
+    assert!(buffer.is_empty());
+    assert_eq!(engine.overlay_memory_usage(), 0);
+    let asheet = engine.sheet_store().sheet(sheet).expect("arrow sheet");
+    let (ch_i, _) = asheet.chunk_of_row(0).unwrap();
+    let stats = asheet.columns[0]
+        .chunk(ch_i)
+        .unwrap()
+        .computed_overlay
+        .debug_stats();
+    assert_eq!(stats.covered_len, 0);
+    assert_eq!(asheet.get_cell_value(0, 0), LiteralValue::Number(1000.0));
+    assert_eq!(asheet.get_cell_value(1, 0), LiteralValue::Empty);
+    assert_eq!(asheet.get_cell_value(126, 0), LiteralValue::Number(1126.0));
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/eval_flush_recalc_probe.rs
+++ b/crates/formualizer-eval/src/engine/tests/eval_flush_recalc_probe.rs
@@ -1,0 +1,281 @@
+use super::common::arrow_eval_config;
+use crate::arrow_store::OverlayDebugStats;
+use crate::engine::eval::Engine;
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+#[derive(Debug, Clone, Copy)]
+enum RecalcEditKind {
+    Multiplier,
+    DenseUnits,
+    SparsePrices,
+}
+
+impl RecalcEditKind {
+    fn name(self) -> &'static str {
+        match self {
+            RecalcEditKind::Multiplier => "multiplier",
+            RecalcEditKind::DenseUnits => "dense_units",
+            RecalcEditKind::SparsePrices => "sparse_prices",
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct RepeatedEditRecalcProbeRow {
+    cycle: usize,
+    edit_kind: &'static str,
+    rows: usize,
+    eval_ms: f64,
+    overlay_memory_usage: usize,
+    recomputed_overlay_memory_usage: usize,
+    compactions: u64,
+    formula_points: usize,
+    formula_sparse_fragments: usize,
+    formula_dense_fragments: usize,
+    formula_run_fragments: usize,
+    formula_covered_len: usize,
+    rollup: f64,
+    expected_rollup: f64,
+}
+
+struct FinanceRecalcFixture {
+    engine: Engine<TestWorkbook>,
+    units: Vec<f64>,
+    prices: Vec<f64>,
+    multiplier: f64,
+}
+
+impl FinanceRecalcFixture {
+    fn new(rows: usize, chunk_rows: usize) -> Self {
+        let mut cfg = arrow_eval_config();
+        cfg.enable_parallel = false;
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        let mut units = Vec::with_capacity(rows);
+        let mut prices = Vec::with_capacity(rows);
+        let sheet = "Sheet1";
+
+        {
+            let mut ab = engine.begin_bulk_ingest_arrow();
+            ab.add_sheet(sheet, 7, chunk_rows.max(1));
+            for row0 in 0..rows {
+                let unit = (row0 + 1) as f64;
+                let price = 10.0 + (row0 % 17) as f64;
+                units.push(unit);
+                prices.push(price);
+                ab.append_row(
+                    sheet,
+                    &[
+                        LiteralValue::Number(unit),
+                        LiteralValue::Number(price),
+                        LiteralValue::Empty,
+                        LiteralValue::Empty,
+                        LiteralValue::Empty,
+                        if row0 == 0 {
+                            LiteralValue::Number(1.0)
+                        } else {
+                            LiteralValue::Empty
+                        },
+                        LiteralValue::Empty,
+                    ],
+                )
+                .unwrap();
+            }
+            ab.finish().unwrap();
+        }
+
+        for row in 1..=rows {
+            let formula = parse(&format!("=A{row}*B{row}*$F$1")).unwrap();
+            engine
+                .set_cell_formula(sheet, row as u32, 3, formula)
+                .unwrap();
+        }
+        engine
+            .set_cell_formula(sheet, 1, 7, parse(&format!("=SUM(C1:C{rows})")).unwrap())
+            .unwrap();
+
+        Self {
+            engine,
+            units,
+            prices,
+            multiplier: 1.0,
+        }
+    }
+
+    fn apply_edit_cycle(&mut self, cycle: usize) -> RecalcEditKind {
+        match cycle % 3 {
+            0 => {
+                self.multiplier = 1.0 + ((cycle % 5) as f64);
+                self.engine
+                    .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(self.multiplier))
+                    .unwrap();
+                RecalcEditKind::Multiplier
+            }
+            1 => {
+                let start = (cycle * 37) % self.units.len().max(1);
+                let len = self.units.len().min(16);
+                for idx in 0..len {
+                    let row0 = (start + idx) % self.units.len();
+                    let value = 1000.0 + cycle as f64 + idx as f64;
+                    self.units[row0] = value;
+                    self.engine
+                        .set_cell_value("Sheet1", row0 as u32 + 1, 1, LiteralValue::Number(value))
+                        .unwrap();
+                }
+                RecalcEditKind::DenseUnits
+            }
+            _ => {
+                let stride = 97usize;
+                let edits = self.prices.len().min(16);
+                for idx in 0..edits {
+                    let row0 = (cycle * 53 + idx * stride) % self.prices.len();
+                    let value = 20.0 + ((cycle + idx) % 23) as f64;
+                    self.prices[row0] = value;
+                    self.engine
+                        .set_cell_value("Sheet1", row0 as u32 + 1, 2, LiteralValue::Number(value))
+                        .unwrap();
+                }
+                RecalcEditKind::SparsePrices
+            }
+        }
+    }
+
+    fn expected_rollup(&self) -> f64 {
+        self.units
+            .iter()
+            .zip(self.prices.iter())
+            .map(|(unit, price)| unit * price * self.multiplier)
+            .sum()
+    }
+
+    fn rollup(&self) -> f64 {
+        match self.engine.get_cell_value("Sheet1", 1, 7) {
+            Some(LiteralValue::Number(value)) => value,
+            Some(other) => panic!("expected numeric rollup, got {other:?}"),
+            None => panic!("missing rollup"),
+        }
+    }
+
+    fn formula_overlay_stats(&self) -> OverlayDebugStats {
+        let sheet = self.engine.sheet_store().sheet("Sheet1").unwrap();
+        let column = &sheet.columns[2];
+        let mut total = OverlayDebugStats::default();
+        for chunk in &column.chunks {
+            let stats = chunk.computed_overlay.debug_stats();
+            total.points += stats.points;
+            total.sparse_fragments += stats.sparse_fragments;
+            total.dense_fragments += stats.dense_fragments;
+            total.run_fragments += stats.run_fragments;
+            total.covered_len += stats.covered_len;
+        }
+        for chunk in column.sparse_chunks.values() {
+            let stats = chunk.computed_overlay.debug_stats();
+            total.points += stats.points;
+            total.sparse_fragments += stats.sparse_fragments;
+            total.dense_fragments += stats.dense_fragments;
+            total.run_fragments += stats.run_fragments;
+            total.covered_len += stats.covered_len;
+        }
+        total
+    }
+
+    fn evaluate_cycle(
+        &mut self,
+        cycle: usize,
+        edit_kind: RecalcEditKind,
+    ) -> RepeatedEditRecalcProbeRow {
+        let start = std::time::Instant::now();
+        self.engine.evaluate_all().unwrap();
+        let eval_ms = start.elapsed().as_secs_f64() * 1000.0;
+        let expected_rollup = self.expected_rollup();
+        let rollup = self.rollup();
+        assert!(
+            (rollup - expected_rollup).abs() < 1e-6,
+            "cycle {cycle}: rollup {rollup} != expected {expected_rollup}"
+        );
+        let overlay_memory_usage = self.engine.overlay_memory_usage();
+        let recomputed_overlay_memory_usage = self.engine.debug_recompute_computed_overlay_bytes();
+        assert_eq!(overlay_memory_usage, recomputed_overlay_memory_usage);
+        let stats = self.formula_overlay_stats();
+
+        RepeatedEditRecalcProbeRow {
+            cycle,
+            edit_kind: edit_kind.name(),
+            rows: self.units.len(),
+            eval_ms,
+            overlay_memory_usage,
+            recomputed_overlay_memory_usage,
+            compactions: self.engine.debug_overlay_compactions(),
+            formula_points: stats.points,
+            formula_sparse_fragments: stats.sparse_fragments,
+            formula_dense_fragments: stats.dense_fragments,
+            formula_run_fragments: stats.run_fragments,
+            formula_covered_len: stats.covered_len,
+            rollup,
+            expected_rollup,
+        }
+    }
+}
+
+#[test]
+fn repeated_edit_recalc_keeps_computed_overlays_bounded_and_correct() {
+    let rows = 256usize;
+    let mut fixture = FinanceRecalcFixture::new(rows, 64);
+    fixture.engine.evaluate_all().unwrap();
+
+    for cycle in 0..8 {
+        let edit_kind = fixture.apply_edit_cycle(cycle);
+        let row = fixture.evaluate_cycle(cycle, edit_kind);
+        assert!(
+            row.formula_points <= 32,
+            "cycle {cycle}: sparse incremental edits should not degrade into a large point map: {row:?}"
+        );
+        assert_eq!(row.formula_covered_len, rows, "cycle {cycle}");
+        assert!(
+            row.formula_dense_fragments > 0
+                || row.formula_run_fragments > 0
+                || row.formula_sparse_fragments > 0,
+            "cycle {cycle}: expected coalesced fragments, got {row:?}"
+        );
+        assert!(
+            row.overlay_memory_usage < 8 * 1024 * 1024,
+            "cycle {cycle}: overlay memory unexpectedly high: {}",
+            row.overlay_memory_usage
+        );
+    }
+}
+
+#[test]
+#[ignore = "manual repeated edit/recalc overlay probe; run with --ignored --nocapture"]
+fn repeated_edit_recalc_overlay_observability_probe() {
+    let rows = std::env::var("FORMUALIZER_RECALC_PROBE_ROWS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10_000)
+        .max(1);
+    let cycles = std::env::var("FORMUALIZER_RECALC_PROBE_CYCLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10)
+        .max(1);
+    let chunk_rows = std::env::var("FORMUALIZER_RECALC_PROBE_CHUNK_ROWS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(32 * 1024)
+        .max(1);
+
+    let mut fixture = FinanceRecalcFixture::new(rows, chunk_rows);
+    let initial = std::time::Instant::now();
+    fixture.engine.evaluate_all().unwrap();
+    eprintln!(
+        "initial_evaluate_ms={:.3}",
+        initial.elapsed().as_secs_f64() * 1000.0
+    );
+
+    for cycle in 0..cycles {
+        let edit_kind = fixture.apply_edit_cycle(cycle);
+        let row = fixture.evaluate_cycle(cycle, edit_kind);
+        println!("{}", serde_json::to_string(&row).unwrap());
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/eval_flush_recalc_probe.rs
+++ b/crates/formualizer-eval/src/engine/tests/eval_flush_recalc_probe.rs
@@ -86,13 +86,13 @@ impl FinanceRecalcFixture {
         }
 
         for row in 1..=rows {
-            let formula = parse(&format!("=A{row}*B{row}*$F$1")).unwrap();
+            let formula = parse(format!("=A{row}*B{row}*$F$1")).unwrap();
             engine
                 .set_cell_formula(sheet, row as u32, 3, formula)
                 .unwrap();
         }
         engine
-            .set_cell_formula(sheet, 1, 7, parse(&format!("=SUM(C1:C{rows})")).unwrap())
+            .set_cell_formula(sheet, 1, 7, parse(format!("=SUM(C1:C{rows})")).unwrap())
             .unwrap();
 
         Self {

--- a/crates/formualizer-eval/src/engine/tests/hardening_503.rs
+++ b/crates/formualizer-eval/src/engine/tests/hardening_503.rs
@@ -62,7 +62,7 @@ fn bulk_spill_clear_dirties_dependents_without_delta_scan_fallback() {
                 let col0 = &asheet.columns[0];
 
                 // Chunking-agnostic: locate the chunk for a given absolute row.
-                let at_row = |row0: usize| -> Option<&crate::arrow_store::OverlayValue> {
+                let at_row = |row0: usize| -> Option<crate::arrow_store::OverlayValue> {
                     let (ch_idx, in_off) = asheet.chunk_of_row(row0)?;
                     let ch = col0.chunk(ch_idx)?;
                     ch.computed_overlay.get(in_off)
@@ -70,19 +70,19 @@ fn bulk_spill_clear_dirties_dependents_without_delta_scan_fallback() {
 
                 match at_row(0) {
                     Some(crate::arrow_store::OverlayValue::Number(n)) => {
-                        assert!((*n - 1.0).abs() < 1e-6)
+                        assert!((n - 1.0).abs() < 1e-6)
                     }
                     other => panic!("expected computed overlay number at row0=0, got {other:?}"),
                 }
                 match at_row(9) {
                     Some(crate::arrow_store::OverlayValue::Number(n)) => {
-                        assert!((*n - 10.0).abs() < 1e-6)
+                        assert!((n - 10.0).abs() < 1e-6)
                     }
                     other => panic!("expected computed overlay number at row0=9, got {other:?}"),
                 }
                 match at_row(4999) {
                     Some(crate::arrow_store::OverlayValue::Number(n)) => {
-                        assert!((*n - 5000.0).abs() < 1e-6)
+                        assert!((n - 5000.0).abs() < 1e-6)
                     }
                     other => {
                         panic!("expected computed overlay number at row0=4999, got {other:?}")

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -78,6 +78,7 @@ mod arrow_sparse_extension;
 mod arrow_sparse_structural_ops;
 mod arrow_sparse_used_bounds;
 mod compressed_range_scheduler;
+mod computed_flush;
 mod config_defaults;
 mod context_default_noops;
 mod countifs_arrow_overlay;

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -89,6 +89,7 @@ mod criteria_overlay_parity;
 mod custom_function_registry_compat;
 mod dynamic_lookup_arrow;
 mod eval_delta;
+mod eval_flush_recalc_probe;
 mod formula_edit_propagation;
 mod formula_error_propagation;
 mod formula_overlay_writeback;


### PR DESCRIPTION
## Summary

This PR lands the eval-flush substrate for fragment-backed computed results:

- adds a unified overlay cascade seam for user/computed/base reads;
- introduces buffered computed writes;
- adds encoded overlay fragments: `SparseOffsets`, `DenseRange`, and `RunRange`;
- makes `RangeView` selectors consume overlay fragments directly;
- changes normal computed flush to coalesce writes by sheet/column/chunk and emit `DenseRange` / `RunRange` / `SparseOffsets` fragments where appropriate;
- preserves explicit `Empty` masking, `user overlay > computed overlay > base` priority, sparse gap behavior, and cap=0 budget safety.

## Why

FormulaPlane-style copied formula runs need result storage that does not degrade into N point HashMap writes. This PR makes the value/result plane ready for run-level FormulaPlane evaluation while preserving current public/default formula semantics.

## Notes

- The Arrow dependency bump to `58.2.0` is intentional for this Arrow-adjacent substrate work.
- The new perf/observability probes are bounded/manual and live behind ignored tests or bench binaries.
- This does not implement FormulaPlane scheduling, run-level dirty propagation, loader shared-formula preservation, or public API changes.

## Local validation

```bash
cargo fmt --all -- --check
cargo test -p formualizer-eval computed_flush --quiet
cargo test -p formualizer-eval eval_flush_recalc --quiet
cargo test -p formualizer-eval overlay_ --quiet
cargo test -p formualizer-eval rangeview_ --quiet
cargo test -p formualizer-eval arrow_sparse_structural_ops --quiet
cargo test -p formualizer-eval arrow_sparse_compaction --quiet
cargo test -p formualizer-eval hardening_503 --quiet
cargo test -p formualizer-eval arrow_canonical_606 --quiet
cargo test -p formualizer-eval --quiet
cargo test -p formualizer-bench-core --features formualizer_runner --quiet
cargo test -p formualizer-workbook --features umya,calamine --quiet
```

Full `formualizer-eval` result locally:

```text
1226 passed; 0 failed; 7 ignored
doctests passed
```

## Local/manual perf characterization

Manual, non-claim-grade characterization on a 50k finance-shaped recalc fixture showed:

```text
initial eval: -25.15%
total recalc: -23.67%
p50 recalc:  -40.63%
p95 recalc:  -16.82%
```

These are included only as a sanity signal; CI correctness gates remain the merge criteria.
