### PR TITLE
fix(eval): treat unary `+` as a pass-through to match Excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Formualizer will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Treated unary `+` as a pass-through (identity) operator to match Excel/LibreOffice semantics. Previously, `=+A1` returned `#VALUE!` when `A1` held a non-numeric string such as `"2014F"`; the leading-`=+` idiom is common in finance models carried over from Lotus 1-2-3 and now preserves text, booleans, and other non-numeric operand types. Unary `-` and `%` retain their numeric-coercion semantics.
+
 ## [0.5.8] - 2026-04-27
 
 ### Breaking changes

--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -696,7 +696,11 @@ impl<'a> Interpreter<'a> {
 
     fn eval_unary_scalar(&self, op: &str, v: LiteralValue) -> Result<LiteralValue, ExcelError> {
         match op {
-            "+" => self.apply_number_unary(v, |n| n),
+            // Excel/LibreOffice treat unary `+` as a pass-through (identity) operator,
+            // not as a numeric coercion. `=+"2014F"` returns the text "2014F"; only the
+            // unary `-` form coerces operands to numbers. The `=+A1` idiom is common in
+            // finance models (Lotus 1-2-3 carry-over) and must preserve text labels.
+            "+" => Ok(v),
             "-" => self.apply_number_unary(v, |n| -n),
             "%" => self.apply_number_unary(v, |n| n / 100.0),
             _ => {

--- a/crates/formualizer-eval/src/tests/interpreter.rs
+++ b/crates/formualizer-eval/src/tests/interpreter.rs
@@ -142,6 +142,223 @@ mod tests {
         );
     }
 
+    /// Unary `+` is a pass-through (identity) operator in Excel/LibreOffice,
+    /// not a numeric coercion. The `=+A1` idiom is a Lotus 1-2-3 carry-over
+    /// that is common in finance models, and must not turn text labels into
+    /// `#VALUE!`. Unary `-` and `%` retain their numeric-coercion semantics.
+    ///
+    /// Ground truth was captured by writing the same formulas to an .xlsx,
+    /// having LibreOffice recalculate them, and reading back cached values.
+    #[test]
+    fn test_unary_plus_is_passthrough_excel_parity() {
+        let wb = create_workbook()
+            .with_cell("Sheet1", 1, 1, LiteralValue::Text("2014F".to_string()))
+            .with_cell("Sheet1", 2, 1, LiteralValue::Text("hello".to_string()))
+            .with_cell("Sheet1", 3, 1, LiteralValue::Text("5".to_string()))
+            .with_cell("Sheet1", 4, 1, LiteralValue::Number(42.0))
+            .with_cell("Sheet1", 5, 1, LiteralValue::Number(-3.5))
+            .with_cell("Sheet1", 6, 1, LiteralValue::Boolean(true))
+            .with_cell("Sheet1", 7, 1, LiteralValue::Boolean(false))
+            .with_cell("Sheet1", 8, 1, LiteralValue::Empty)
+            .with_cell(
+                "Sheet1",
+                9,
+                1,
+                LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div)),
+            );
+
+        // Reference operand: text passes through unchanged. Pre-fix this returned #VALUE!.
+        assert_eq!(
+            evaluate_formula("=+A1", &wb).unwrap(),
+            LiteralValue::Text("2014F".to_string()),
+        );
+        assert_eq!(
+            evaluate_formula("=+A2", &wb).unwrap(),
+            LiteralValue::Text("hello".to_string()),
+        );
+        // Numeric-looking text stays text (Excel: `=+"5"` cached as "5", not 5).
+        assert_eq!(
+            evaluate_formula("=+A3", &wb).unwrap(),
+            LiteralValue::Text("5".to_string()),
+        );
+        // Numbers pass through.
+        assert_eq!(
+            evaluate_formula("=+A4", &wb).unwrap(),
+            LiteralValue::Number(42.0),
+        );
+        assert_eq!(
+            evaluate_formula("=+A5", &wb).unwrap(),
+            LiteralValue::Number(-3.5),
+        );
+        // Booleans stay booleans (LibreOffice cached value confirms this).
+        assert_eq!(
+            evaluate_formula("=+A6", &wb).unwrap(),
+            LiteralValue::Boolean(true),
+        );
+        assert_eq!(
+            evaluate_formula("=+A7", &wb).unwrap(),
+            LiteralValue::Boolean(false),
+        );
+        // Empty operand: identity preserves Empty (matches `=A8`).
+        assert_eq!(evaluate_formula("=+A8", &wb).unwrap(), LiteralValue::Empty);
+        // Errors propagate unchanged.
+        match evaluate_formula("=+A9", &wb).unwrap() {
+            LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Div),
+            other => panic!("expected #DIV/0! got {other:?}"),
+        }
+
+        // String literals.
+        assert_eq!(
+            evaluate_formula("=+\"hello\"", &wb).unwrap(),
+            LiteralValue::Text("hello".to_string()),
+        );
+        assert_eq!(
+            evaluate_formula("=+\"5\"", &wb).unwrap(),
+            LiteralValue::Text("5".to_string()),
+        );
+
+        // Numeric literals (regression guard: must remain numeric).
+        assert_eq!(
+            evaluate_formula("=+5", &wb).unwrap(),
+            LiteralValue::Number(5.0),
+        );
+        assert_eq!(
+            evaluate_formula("=+5.5", &wb).unwrap(),
+            LiteralValue::Number(5.5),
+        );
+        // Double unary plus on a number stays numeric.
+        assert_eq!(
+            evaluate_formula("=++5", &wb).unwrap(),
+            LiteralValue::Number(5.0),
+        );
+    }
+
+    /// Unary `-` must continue to coerce. `=-A1` on a non-numeric string
+    /// must still return #VALUE! to stay Excel-compatible. Guards against an
+    /// overzealous fix that pass-throughs both `+` and `-`.
+    #[test]
+    fn test_unary_minus_still_coerces_strings() {
+        let wb = create_workbook()
+            .with_cell("Sheet1", 1, 1, LiteralValue::Text("2014F".to_string()))
+            .with_cell("Sheet1", 2, 1, LiteralValue::Text("5".to_string()))
+            .with_cell("Sheet1", 3, 1, LiteralValue::Boolean(true))
+            .with_cell("Sheet1", 4, 1, LiteralValue::Empty);
+
+        match evaluate_formula("=-A1", &wb).unwrap() {
+            LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Value),
+            other => panic!("expected #VALUE! got {other:?}"),
+        }
+        assert_eq!(
+            evaluate_formula("=-A2", &wb).unwrap(),
+            LiteralValue::Number(-5.0),
+        );
+        assert_eq!(
+            evaluate_formula("=-A3", &wb).unwrap(),
+            LiteralValue::Number(-1.0),
+        );
+        assert_eq!(
+            evaluate_formula("=-A4", &wb).unwrap(),
+            LiteralValue::Number(0.0),
+        );
+        match evaluate_formula("=-\"hello\"", &wb).unwrap() {
+            LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Value),
+            other => panic!("expected #VALUE! got {other:?}"),
+        }
+    }
+
+    /// Percent operator must continue to coerce just like unary `-`.
+    #[test]
+    fn test_unary_percent_still_coerces_strings() {
+        let wb = create_workbook()
+            .with_cell("Sheet1", 1, 1, LiteralValue::Text("2014F".to_string()))
+            .with_cell("Sheet1", 2, 1, LiteralValue::Text("50".to_string()));
+
+        match evaluate_formula("=A1%", &wb).unwrap() {
+            LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Value),
+            other => panic!("expected #VALUE! got {other:?}"),
+        }
+        assert_eq!(
+            evaluate_formula("=A2%", &wb).unwrap(),
+            LiteralValue::Number(0.5),
+        );
+    }
+
+    /// Unary `+` inside a larger expression: the surrounding arithmetic
+    /// still coerces its operands, so `=1++"hello"` and `=1++A_text` remain
+    /// #VALUE!. Pass-through only changes the value produced by the `+` node
+    /// itself. Matches Excel: `=1++"hello"` -> #VALUE!, `=1++"5"` -> 6.
+    #[test]
+    fn test_inner_unary_plus_on_text_still_errors_in_arithmetic() {
+        let wb =
+            create_workbook().with_cell("Sheet1", 1, 1, LiteralValue::Text("2014F".to_string()));
+
+        match evaluate_formula("=1++\"hello\"", &wb).unwrap() {
+            LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Value),
+            other => panic!("expected #VALUE! got {other:?}"),
+        }
+        match evaluate_formula("=1++A1", &wb).unwrap() {
+            LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Value),
+            other => panic!("expected #VALUE! got {other:?}"),
+        }
+        assert_eq!(
+            evaluate_formula("=1++\"5\"", &wb).unwrap(),
+            LiteralValue::Number(6.0),
+        );
+    }
+
+    /// Unary `+` applied to an array operates element-wise as pass-through.
+    /// `=+{"a","b","c"}` returns an array of text, not an error.
+    #[test]
+    fn test_unary_plus_array_passthrough() {
+        let wb = create_workbook();
+
+        match evaluate_formula("=+{\"a\",\"b\",\"c\"}", &wb).unwrap() {
+            LiteralValue::Array(rows) => {
+                assert_eq!(rows.len(), 1);
+                assert_eq!(
+                    rows[0],
+                    vec![
+                        LiteralValue::Text("a".to_string()),
+                        LiteralValue::Text("b".to_string()),
+                        LiteralValue::Text("c".to_string()),
+                    ]
+                );
+            }
+            other => panic!("expected array, got {other:?}"),
+        }
+
+        match evaluate_formula("=+{1,2,3}", &wb).unwrap() {
+            LiteralValue::Array(rows) => {
+                assert_eq!(rows.len(), 1);
+                assert_eq!(
+                    rows[0],
+                    vec![
+                        LiteralValue::Number(1.0),
+                        LiteralValue::Number(2.0),
+                        LiteralValue::Number(3.0),
+                    ]
+                );
+            }
+            other => panic!("expected array, got {other:?}"),
+        }
+    }
+
+    /// Original bug-report scenario: leading `=+SheetRef!Cell` on a text
+    /// label must pass through, not become #VALUE!.
+    #[test]
+    fn test_unary_plus_on_cross_sheet_text_reference() {
+        let wb = TestWorkbook::new()
+            .with_function(Arc::new(crate::builtins::math::SumFn))
+            .with_cell("SheetA", 1, 1, LiteralValue::Text("2014F".to_string()));
+
+        let tokenizer = Tokenizer::new("=+SheetA!A1").unwrap();
+        let mut parser = Parser::new(tokenizer.items, false);
+        let ast = parser.parse().unwrap();
+        let interp = wb.interpreter();
+        let v = interp.evaluate_ast(&ast).unwrap().into_literal();
+        assert_eq!(v, LiteralValue::Text("2014F".to_string()));
+    }
+
     #[test]
     fn test_value_coercion() {
         let wb = create_workbook();


### PR DESCRIPTION
## Summary

Fix a parser/eval parity bug: unary `+` was numerically coercing its operand instead of acting as a pass-through identity operator like Excel and LibreOffice do. As a result, `=+A1` returned `#VALUE!` when `A1` held a non-numeric string such as `"2014F"`. This breaks the `=+SheetA!Cell` idiom that's very common in finance models carried over from Lotus 1-2-3.

| Operand | Excel/LibreOffice `=+X` | Formualizer 0.5.8 before | After this PR |
|---|---|---|---|
| Text `"2014F"` | `"2014F"` | `#VALUE!` | `"2014F"` |
| Text `"hello"` | `"hello"` | `#VALUE!` | `"hello"` |
| Text `"5"` | `"5"` (still text) | `Number(5)` | `"5"` |
| Number `42` | `42` | `42` | `42` |
| Boolean `TRUE` | `TRUE` (boolean) | `Number(1)` | `TRUE` |
| Empty cell | `0` (cached) | `Number(0)` | `Empty` |
| Error | propagate | propagate | propagate |

Unary `-` and `%` retain their numeric-coercion semantics. Only `+` becomes pass-through.

## Why this is correct

Excel's unary `+` is a no-op (a Lotus 1-2-3 carry-over). Ground truth was captured by writing the same probe formulas to an `.xlsx`, having LibreOffice recalculate them, and reading back cached values:

- `B1="2014F"`, `C1=+B1` → cached `"2014F"`
- `B6=TRUE`, `C6=+B6` → cached `TRUE` (boolean, not number)
- `B3="5"`, `C3=+B3` → cached `"5"` (string, not 5)
- `=-"2014F"` → `#VALUE!` (`-` still coerces)
- `=1++"hello"` → `#VALUE!` (outer `+` still coerces)
- `=1++"5"` → `6` (outer `+` lenient-coerces text-number)
- `=+{"a","b","c"}` → element-wise pass-through

## Implementation

Single-site change in `crates/formualizer-eval/src/interpreter.rs::eval_unary_scalar`:

```rust
"+" => Ok(v),                              // pass-through identity
"-" => self.apply_number_unary(v, |n| -n), // still coerces
"%" => self.apply_number_unary(v, |n| n / 100.0), // still coerces
```

This is local to the unary-`+` AST node. Downstream arithmetic still coerces normally, so behavior of mixed expressions (e.g. `=1++text`) is unchanged.

## Tests

Six new parity tests in `crates/formualizer-eval/src/tests/interpreter.rs`:

1. `test_unary_plus_is_passthrough_excel_parity` — text/numeric-text/number/boolean/empty/error operands, both reference and literal forms; numeric-literal regression (`=+5` still numeric).
2. `test_unary_minus_still_coerces_strings` — guards against an overzealous fix that pass-throughs `-` too.
3. `test_unary_percent_still_coerces_strings` — same guard for `%`.
4. `test_inner_unary_plus_on_text_still_errors_in_arithmetic` — `=1++"hello"` is still `#VALUE!`; `=1++"5"` is still `6`. Matches Excel.
5. `test_unary_plus_array_passthrough` — element-wise pass-through over array literals.
6. `test_unary_plus_on_cross_sheet_text_reference` — the exact `=+SheetA!A1` idiom from the bug report.

The pre-existing `test_unary_operators` continues to pass.

## Validation

```shell
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p formualizer-eval --lib            # 1232 passed
cargo test -p formualizer-eval --tests
cargo test -p formualizer-parse
cargo test -p formualizer-workbook --features json,umya
```

All green.

## Risk

Behavioral change is intentional and tightly scoped:

- Only unary `+` semantics change.
- Numeric operands and numeric literals are unaffected (`=+5` still returns `Number(5.0)`).
- Boolean operands of `=+X` now preserve booleans instead of converting to numbers; downstream operators still coerce normally so arithmetic chains behave the same as before.
- Searched the workspace for tests that depended on the old coercion behavior; only one (`=+5 -> Number(5.0)`) exists and still passes.

## Changelog

Added an `Unreleased` entry to `CHANGELOG.md` under `### Fixed`.
