### PR TITLE
fix(parser): consolidate source-span parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
         if-no-files-found: error
 
   test-rust:
+    # Keep Python and WASM binding crates out of the core Rust pass. They are
+    # covered by test-python and the WASM workflow, and pulling them in here
+    # needlessly compiles PyO3/wasm-bindgen twice.
     runs-on: ubuntu-latest
 
     steps:
@@ -120,10 +123,20 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Run Rust clippy
-      run: cargo clippy --workspace --exclude formualizer-bench-core --all-targets --all-features -- -D warnings
+      run: >-
+        cargo clippy --workspace
+        --exclude formualizer-bench-core
+        --exclude formualizer-python
+        --exclude formualizer-wasm
+        --all-targets --all-features -- -D warnings
 
     - name: Run Rust tests
-      run: cargo test --workspace --exclude formualizer-bench-core --all-features
+      run: >-
+        cargo test --workspace
+        --exclude formualizer-bench-core
+        --exclude formualizer-python
+        --exclude formualizer-wasm
+        --all-features
 
     - name: Run CFFI smoke test
       shell: bash

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,7 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
+  test-wasm:
+    name: test-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/bindings/python/src/parser.rs
+++ b/bindings/python/src/parser.rs
@@ -2,7 +2,7 @@ use crate::ast::PyASTNode;
 use crate::enums::PyFormulaDialect;
 use crate::errors::ParserError;
 use crate::tokenizer::PyTokenizer;
-use formualizer::parse::parser::{Parser, parse_with_dialect};
+use formualizer::parse::parser::parse_with_dialect;
 use formualizer::parse::types::FormulaDialect;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction, gen_stub_pymethods};
@@ -60,27 +60,12 @@ impl PyParser {
         include_whitespace: bool,
         dialect: Option<PyFormulaDialect>,
     ) -> PyResult<PyASTNode> {
-        let tokens = tokenizer
-            .tokens()
-            .into_iter()
-            .map(|py_token| {
-                // Extract the inner token - we need to access the inner field
-                // This is a bit of a hack since we can't directly access private fields
-                // Instead, we'll recreate the token from the public interface
-                formualizer::parse::tokenizer::Token::new(
-                    py_token.value().to_string(),
-                    py_token.token_type().into(),
-                    py_token.subtype().into(),
-                )
-            })
-            .collect();
-
+        let _ = include_whitespace;
         let dialect: FormulaDialect = dialect
             .map(Into::into)
             .unwrap_or_else(|| tokenizer.dialect().into());
-        let mut parser = Parser::new_with_dialect(tokens, include_whitespace, dialect);
-        let ast = parser
-            .parse()
+        let formula = tokenizer.render_formula();
+        let ast = parse_with_dialect(&formula, dialect)
             .map_err(|e| ParserError::new_with_pos(e.message, e.position))?;
         Ok(PyASTNode::new(ast))
     }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -27,6 +27,10 @@ impl PyTokenizer {
     pub fn new(inner: Tokenizer) -> Self {
         PyTokenizer { inner }
     }
+
+    pub(crate) fn render_formula(&self) -> String {
+        self.inner.render()
+    }
 }
 
 #[gen_stub_pymethods]

--- a/bindings/wasm/src/parser.rs
+++ b/bindings/wasm/src/parser.rs
@@ -1,8 +1,5 @@
 use crate::{FormulaDialect, ast::ASTNode};
-use formualizer::{
-    FormulaDialect as CoreFormulaDialect, Parser as CoreParser, Tokenizer as CoreTokenizer,
-    parse_with_dialect,
-};
+use formualizer::{FormulaDialect as CoreFormulaDialect, Parser as CoreParser, parse_with_dialect};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -29,16 +26,14 @@ impl Parser {
     #[wasm_bindgen(constructor)]
     pub fn new(formula: &str, dialect: Option<FormulaDialect>) -> Result<Parser, JsValue> {
         let dialect: CoreFormulaDialect = dialect.map(Into::into).unwrap_or_default();
-        let tokenizer = CoreTokenizer::new_with_dialect(formula, dialect).map_err(|e| {
+        let inner = CoreParser::new_with_dialect(formula, dialect).map_err(|e| {
             JsValue::from_str(&format!(
                 "Tokenizer error: {} at position {}",
                 e.message, e.pos
             ))
         })?;
 
-        Ok(Parser {
-            inner: CoreParser::new_with_dialect(tokenizer.items.clone(), false, dialect),
-        })
+        Ok(Parser { inner })
     }
 
     #[wasm_bindgen]

--- a/crates/formualizer-cffi/src/lib.rs
+++ b/crates/formualizer-cffi/src/lib.rs
@@ -203,8 +203,7 @@ pub unsafe extern "C" fn fz_parse_ast(
 ) -> fz_buffer {
     use crate::parse::CffiASTNode;
     use formualizer_parse::FormulaDialect;
-    use formualizer_parse::parser::Parser;
-    use formualizer_parse::tokenizer::Tokenizer;
+    use formualizer_parse::parser::parse_with_dialect;
     use std::ffi::CStr;
 
     if formula.is_null() {
@@ -220,11 +219,7 @@ pub unsafe extern "C" fn fz_parse_ast(
 
     let result: Result<Vec<u8>, String> = (|| {
         let dialect = FormulaDialect::from(options.dialect);
-        let tokens = Tokenizer::new_with_dialect(&input, dialect)
-            .map_err(|e| e.to_string())?
-            .items;
-        let mut parser = Parser::new_with_dialect(tokens, true, dialect);
-        let ast = parser.parse().map_err(|e| e.to_string())?;
+        let ast = parse_with_dialect(&input, dialect).map_err(|e| e.to_string())?;
 
         let cffi_ast = CffiASTNode::from_core(&ast, options.include_spans);
 

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -769,7 +769,6 @@ mod tests {
     use crate::test_workbook::TestWorkbook;
     use crate::traits::ArgumentHandle;
     use formualizer_common::error::{ExcelError, ExcelErrorKind};
-    use formualizer_parse::Tokenizer;
     use formualizer_parse::parser::{ASTNode, ASTNodeType, Parser};
 
     fn interp(wb: &TestWorkbook) -> crate::interpreter::Interpreter<'_> {
@@ -777,8 +776,7 @@ mod tests {
     }
 
     fn evaluate_formula(formula: &str, wb: &TestWorkbook) -> Result<LiteralValue, ExcelError> {
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser
             .parse()
             .map_err(|e| ExcelError::new(ExcelErrorKind::Error).with_message(e.message.clone()))?;

--- a/crates/formualizer-eval/src/tests/formula_test_runner.rs
+++ b/crates/formualizer-eval/src/tests/formula_test_runner.rs
@@ -7,8 +7,6 @@
 #[cfg(test)]
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue, parse_a1_1based};
 #[cfg(test)]
-use formualizer_parse::Tokenizer;
-#[cfg(test)]
 use formualizer_parse::parser::Parser;
 #[cfg(test)]
 use serde::Deserialize;
@@ -141,8 +139,7 @@ fn evaluate_formula(
     formula: &str,
     wb: &crate::test_workbook::TestWorkbook,
 ) -> Result<LiteralValue, String> {
-    let tokenizer = Tokenizer::new(formula).map_err(|e| format!("Tokenizer error: {:?}", e))?;
-    let mut parser = Parser::new(tokenizer.items, false);
+    let mut parser = Parser::new(formula).map_err(|e| format!("Tokenizer error: {:?}", e))?;
     let ast = parser
         .parse()
         .map_err(|e| format!("Parse error: {}", e.message))?;

--- a/crates/formualizer-eval/src/tests/interpreter.rs
+++ b/crates/formualizer-eval/src/tests/interpreter.rs
@@ -3,14 +3,12 @@ mod tests {
     use crate::test_workbook::TestWorkbook;
     use formualizer_common::error::{ExcelError, ExcelErrorKind};
     use formualizer_parse::LiteralValue;
-    use formualizer_parse::Tokenizer;
     use formualizer_parse::parser::Parser;
     use std::sync::Arc;
 
     /// Helper function to parse and evaluate a formula.
     fn evaluate_formula(formula: &str, wb: &TestWorkbook) -> Result<LiteralValue, ExcelError> {
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser
             .parse()
             .map_err(|e| ExcelError::new(ExcelErrorKind::Error).with_message(e.message.clone()))?;
@@ -58,8 +56,7 @@ mod tests {
             .with_cell("Sheet1", 1, 2, LiteralValue::Int(2))
             .with_cell("Sheet1", 2, 1, LiteralValue::Int(3))
             .with_cell("Sheet1", 2, 2, LiteralValue::Int(4));
-        let tokenizer = Tokenizer::new("=SUM(A1:B2, A1:B2)").unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new("=SUM(A1:B2, A1:B2)").unwrap();
         let ast = parser.parse().unwrap();
         let interp = wb.interpreter();
         let res = interp.evaluate_ast(&ast).unwrap().into_literal();
@@ -351,8 +348,7 @@ mod tests {
             .with_function(Arc::new(crate::builtins::math::SumFn))
             .with_cell("SheetA", 1, 1, LiteralValue::Text("2014F".to_string()));
 
-        let tokenizer = Tokenizer::new("=+SheetA!A1").unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new("=+SheetA!A1").unwrap();
         let ast = parser.parse().unwrap();
         let interp = wb.interpreter();
         let v = interp.evaluate_ast(&ast).unwrap().into_literal();

--- a/crates/formualizer-parse/README.md
+++ b/crates/formualizer-parse/README.md
@@ -22,12 +22,13 @@ If you also need evaluation, use [`formualizer-workbook`](https://crates.io/crat
 ## Quick start
 
 ```rust
-use formualizer_parse::{FormulaDialect, Tokenizer, canonical_formula};
-use formualizer_parse::parser::Parser;
+use formualizer_parse::{FormulaDialect, Parser, canonical_formula, parse_with_dialect};
 
-// Tokenize and parse
-let tokenizer = Tokenizer::new_with_dialect("=SUM(A1:B3)", FormulaDialect::Excel)?;
-let mut parser = Parser::new(tokenizer.items, false);
+// One-shot parse
+let ast = parse_with_dialect("=SUM(A1:B3)", FormulaDialect::Excel)?;
+
+// Or use the stateful source-span parser directly
+let mut parser = Parser::new("=SUM(A1:B3)")?;
 let ast = parser.parse()?;
 
 // Canonical form

--- a/crates/formualizer-parse/src/lib.rs
+++ b/crates/formualizer-parse/src/lib.rs
@@ -13,8 +13,8 @@ pub mod tokenizer;
 pub mod types;
 
 pub use parser::{
-    ASTNode, ASTNodeType, parse, parse_with_dialect, parse_with_dialect_and_volatility_classifier,
-    parse_with_volatility_classifier,
+    ASTNode, ASTNodeType, Parser, ParserBuilder, parse, parse_with_dialect,
+    parse_with_dialect_and_volatility_classifier, parse_with_volatility_classifier,
 };
 pub use pretty::{canonical_formula, pretty_parse_render, pretty_print};
 pub use tokenizer::{

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1,5 +1,7 @@
 use crate::structured_ref;
-use crate::tokenizer::{Associativity, Token, TokenSubType, TokenType, Tokenizer, TokenizerError};
+use crate::tokenizer::{
+    Associativity, Token, TokenSpan, TokenStream, TokenSubType, TokenType, TokenizerError,
+};
 use crate::types::{FormulaDialect, ParsingError};
 use crate::{ExcelError, LiteralValue};
 
@@ -2326,11 +2328,24 @@ impl std::hash::Hash for ASTNode {
     }
 }
 
-/// A parser for converting tokens into an AST.
+impl From<TokenizerError> for ParserError {
+    fn from(err: TokenizerError) -> Self {
+        ParserError {
+            message: err.message,
+            position: Some(err.pos),
+        }
+    }
+}
+
+/// Source-span-backed parser for converting formulas into an AST.
+///
+/// This is the canonical parser implementation. It owns the formula source and
+/// span tokens, avoiding per-token string allocation while preserving source
+/// locations for AST nodes.
 pub struct Parser {
-    tokens: Arc<[Token]>,
+    source: Arc<str>,
+    tokens: Arc<[TokenSpan]>,
     position: usize,
-    /// Optional classifier to determine whether a function name is volatile.
     volatility_classifier: Option<VolatilityClassifierBox>,
     dialect: FormulaDialect,
     /// When > 0, treat a top-level `OpInfix(",")` as a terminator (call-arg
@@ -2338,49 +2353,53 @@ pub struct Parser {
     in_call_args_depth: usize,
 }
 
-impl TryFrom<&str> for Parser {
-    type Error = TokenizerError;
-
-    fn try_from(formula: &str) -> Result<Self, Self::Error> {
-        let tokens = Tokenizer::new(formula)?.items;
-        Ok(Self::new(tokens, false))
-    }
-}
-
-impl TryFrom<String> for Parser {
-    type Error = TokenizerError;
-
-    fn try_from(formula: String) -> Result<Self, Self::Error> {
-        Self::try_from(formula.as_str())
-    }
-}
-
 impl Parser {
-    pub fn new(tokens: Vec<Token>, include_whitespace: bool) -> Self {
-        Self::new_with_dialect(tokens, include_whitespace, FormulaDialect::Excel)
+    /// Tokenize a formula using the default Excel dialect and prepare it for parsing.
+    pub fn new<T: AsRef<str>>(formula: T) -> Result<Self, TokenizerError> {
+        Self::new_with_dialect(formula, FormulaDialect::Excel)
     }
 
-    pub fn new_with_dialect(
-        mut tokens: Vec<Token>,
-        include_whitespace: bool,
+    /// Compatibility alias for `Parser::new`.
+    pub fn try_from_formula(formula: &str) -> Result<Self, TokenizerError> {
+        Self::new(formula)
+    }
+
+    /// Tokenize a formula with an explicit dialect and prepare it for parsing.
+    pub fn new_with_dialect<T: AsRef<str>>(
+        formula: T,
+        dialect: FormulaDialect,
+    ) -> Result<Self, TokenizerError> {
+        let source: Arc<str> = Arc::from(formula.as_ref());
+        let spans = crate::tokenizer::tokenize_spans_with_dialect(source.as_ref(), dialect)?;
+        Ok(Self::from_source_and_tokens(
+            source,
+            Arc::from(spans.into_boxed_slice()),
+            dialect,
+        ))
+    }
+
+    /// Build a parser from an existing source-backed token stream.
+    pub fn from_token_stream(stream: &TokenStream) -> Self {
+        Self::from_source_and_tokens(
+            Arc::from(stream.source()),
+            Arc::from(stream.spans.clone().into_boxed_slice()),
+            stream.dialect(),
+        )
+    }
+
+    fn from_source_and_tokens(
+        source: Arc<str>,
+        tokens: Arc<[TokenSpan]>,
         dialect: FormulaDialect,
     ) -> Self {
-        if !include_whitespace {
-            tokens.retain(|t| t.token_type != TokenType::Whitespace);
-        }
-
         Parser {
-            tokens: Arc::from(tokens.into_boxed_slice()),
+            source,
+            tokens,
             position: 0,
             volatility_classifier: None,
             dialect,
             in_call_args_depth: 0,
         }
-    }
-
-    pub fn try_from_formula(formula: &str) -> Result<Self, TokenizerError> {
-        let tokens = Tokenizer::new(formula)?.items;
-        Ok(Self::new(tokens, false))
     }
 
     /// Provide a function-volatility classifier for this parser.
@@ -2393,26 +2412,6 @@ impl Parser {
         self
     }
 
-    /// Convenience constructor to set a classifier alongside other options.
-    pub fn new_with_classifier<F>(tokens: Vec<Token>, include_whitespace: bool, f: F) -> Self
-    where
-        F: Fn(&str) -> bool + Send + Sync + 'static,
-    {
-        Self::new(tokens, include_whitespace).with_volatility_classifier(f)
-    }
-
-    pub fn new_with_classifier_and_dialect<F>(
-        tokens: Vec<Token>,
-        include_whitespace: bool,
-        dialect: FormulaDialect,
-        f: F,
-    ) -> Self
-    where
-        F: Fn(&str) -> bool + Send + Sync + 'static,
-    {
-        Self::new_with_dialect(tokens, include_whitespace, dialect).with_volatility_classifier(f)
-    }
-
     fn skip_whitespace(&mut self) {
         while self.position < self.tokens.len()
             && self.tokens[self.position].token_type == TokenType::Whitespace
@@ -2421,558 +2420,11 @@ impl Parser {
         }
     }
 
-    /// Parse the tokens into an AST.
-    pub fn parse(&mut self) -> Result<ASTNode, ParserError> {
-        if self.tokens.is_empty() {
-            return Err(ParserError {
-                message: "No tokens to parse".to_string(),
-                position: None,
-            });
-        }
-
-        self.skip_whitespace();
-        if self.position >= self.tokens.len() {
-            return Err(ParserError {
-                message: "No tokens to parse".to_string(),
-                position: None,
-            });
-        }
-
-        // Check for literal formula (doesn't start with '=')
-        if self.tokens[self.position].token_type == TokenType::Literal {
-            let token = self.tokens[self.position].clone();
-            self.position += 1;
-            self.skip_whitespace();
-            if self.position < self.tokens.len() {
-                return Err(ParserError {
-                    message: format!(
-                        "Unexpected token at position {}: {:?}",
-                        self.position, self.tokens[self.position]
-                    ),
-                    position: Some(self.position),
-                });
-            }
-            return Ok(ASTNode::new(
-                ASTNodeType::Literal(LiteralValue::Text(token.value.clone())),
-                Some(token),
-            ));
-        }
-
-        let ast = self.parse_expression()?;
-        self.skip_whitespace();
-        if self.position < self.tokens.len() {
-            return Err(ParserError {
-                message: format!(
-                    "Unexpected token at position {}: {:?}",
-                    self.position, self.tokens[self.position]
-                ),
-                position: Some(self.position),
-            });
-        }
-        Ok(ast)
-    }
-
-    fn parse_expression(&mut self) -> Result<ASTNode, ParserError> {
-        self.parse_bp(0)
-    }
-
-    // Pratt-style precedence parser. `min_precedence` is the minimum binding power
-    // an operator must have to be consumed at this level.
-    fn parse_bp(&mut self, min_precedence: u8) -> Result<ASTNode, ParserError> {
-        let mut left = self.parse_prefix()?;
-
-        loop {
-            self.skip_whitespace();
-            if self.position >= self.tokens.len() {
-                break;
-            }
-
-            // Postfix call: a `(` directly following a closed expression denotes
-            // immediate invocation of a callable result (e.g. LAMBDA IIFE).
-            if self.tokens[self.position].token_type == TokenType::Paren
-                && self.tokens[self.position].subtype == TokenSubType::Open
-            {
-                self.position += 1;
-                let args = self.parse_call_arguments()?;
-                let call_volatile =
-                    left.contains_volatile || args.iter().any(|a| a.contains_volatile);
-                left = ASTNode::new_with_volatile(
-                    ASTNodeType::Call {
-                        callee: Box::new(left),
-                        args,
-                    },
-                    None,
-                    call_volatile,
-                );
-                continue;
-            }
-
-            // Postfix operators (e.g. percent).
-            if self.tokens[self.position].token_type == TokenType::OpPostfix {
-                let (precedence, _) = self.tokens[self.position]
-                    .get_precedence()
-                    .unwrap_or((0, Associativity::Left));
-                if precedence < min_precedence {
-                    break;
-                }
-
-                let op_token = self.tokens[self.position].clone();
-                self.position += 1;
-                let contains_volatile = left.contains_volatile;
-                left = ASTNode::new_with_volatile(
-                    ASTNodeType::UnaryOp {
-                        op: op_token.value.clone(),
-                        expr: Box::new(left),
-                    },
-                    Some(op_token),
-                    contains_volatile,
-                );
-                continue;
-            }
-
-            let token = &self.tokens[self.position];
-            if token.token_type != TokenType::OpInfix {
-                break;
-            }
-
-            // Inside a postfix call's argument list, treat top-level `,` as
-            // an argument separator, not as the union operator.
-            if self.in_call_args_depth > 0 && token.value == "," {
-                break;
-            }
-
-            let (precedence, associativity) =
-                token.get_precedence().unwrap_or((0, Associativity::Left));
-            if precedence < min_precedence {
-                break;
-            }
-
-            let op_token = self.tokens[self.position].clone();
-            self.position += 1;
-
-            let next_min_precedence = if associativity == Associativity::Left {
-                precedence + 1
-            } else {
-                precedence
-            };
-
-            let right = self.parse_bp(next_min_precedence)?;
-            let contains_volatile = left.contains_volatile || right.contains_volatile;
-            left = ASTNode::new_with_volatile(
-                ASTNodeType::BinaryOp {
-                    op: op_token.value.clone(),
-                    left: Box::new(left),
-                    right: Box::new(right),
-                },
-                Some(op_token),
-                contains_volatile,
-            );
-        }
-
-        Ok(left)
-    }
-
-    fn parse_prefix(&mut self) -> Result<ASTNode, ParserError> {
-        self.skip_whitespace();
-        if self.position < self.tokens.len()
-            && self.tokens[self.position].token_type == TokenType::OpPrefix
-        {
-            let op_token = self.tokens[self.position].clone();
-            self.position += 1;
-
-            // Prefix unary binds tighter than exponent (Excel semantics),
-            // so parse the RHS with min_precedence equal to unary's precedence.
-            let (precedence, _) = op_token
-                .get_precedence()
-                .unwrap_or((0, Associativity::Right));
-
-            let expr = self.parse_bp(precedence)?;
-            let contains_volatile = expr.contains_volatile;
-            return Ok(ASTNode::new_with_volatile(
-                ASTNodeType::UnaryOp {
-                    op: op_token.value.clone(),
-                    expr: Box::new(expr),
-                },
-                Some(op_token),
-                contains_volatile,
-            ));
-        }
-
-        self.parse_primary()
-    }
-
-    fn parse_primary(&mut self) -> Result<ASTNode, ParserError> {
-        self.skip_whitespace();
-        if self.position >= self.tokens.len() {
-            return Err(ParserError {
-                message: "Unexpected end of tokens".to_string(),
-                position: Some(self.position),
-            });
-        }
-
-        let token = &self.tokens[self.position];
-        match token.token_type {
-            TokenType::Operand => {
-                let operand_token = self.tokens[self.position].clone();
-                self.position += 1;
-                self.parse_operand(operand_token)
-            }
-            TokenType::Func => {
-                let func_token = self.tokens[self.position].clone();
-                self.position += 1;
-                self.parse_function(func_token)
-            }
-            TokenType::Paren if token.subtype == TokenSubType::Open => {
-                self.position += 1;
-                let expr = self.parse_expression()?;
-                if self.position >= self.tokens.len()
-                    || self.tokens[self.position].token_type != TokenType::Paren
-                    || self.tokens[self.position].subtype != TokenSubType::Close
-                {
-                    return Err(ParserError {
-                        message: "Expected closing parenthesis".to_string(),
-                        position: Some(self.position),
-                    });
-                }
-                self.position += 1;
-                Ok(expr)
-            }
-            TokenType::Array if token.subtype == TokenSubType::Open => {
-                self.position += 1;
-                self.parse_array()
-            }
-            _ => Err(ParserError {
-                message: format!("Unexpected token: {token:?}"),
-                position: Some(self.position),
-            }),
-        }
-    }
-
-    fn parse_operand(&mut self, token: Token) -> Result<ASTNode, ParserError> {
-        match token.subtype {
-            TokenSubType::Number => {
-                let value = token.value.parse::<f64>().map_err(|_| ParserError {
-                    message: format!("Invalid number: {}", token.value),
-                    position: Some(self.position),
-                })?;
-                Ok(ASTNode::new(
-                    ASTNodeType::Literal(LiteralValue::Number(value)),
-                    Some(token),
-                ))
-            }
-            TokenSubType::Text => {
-                // Strip surrounding quotes from text literals
-                let mut text = token.value.clone();
-                if text.starts_with('"') && text.ends_with('"') && text.len() >= 2 {
-                    text = text[1..text.len() - 1].to_string();
-                    // Handle escaped quotes
-                    text = text.replace("\"\"", "\"");
-                }
-                Ok(ASTNode::new(
-                    ASTNodeType::Literal(LiteralValue::Text(text)),
-                    Some(token),
-                ))
-            }
-            TokenSubType::Logical => {
-                let value = token.value.eq_ignore_ascii_case("TRUE");
-                Ok(ASTNode::new(
-                    ASTNodeType::Literal(LiteralValue::Boolean(value)),
-                    Some(token),
-                ))
-            }
-            TokenSubType::Error => {
-                let error = ExcelError::from_error_string(&token.value);
-                Ok(ASTNode::new(
-                    ASTNodeType::Literal(LiteralValue::Error(error)),
-                    Some(token),
-                ))
-            }
-            TokenSubType::Range => {
-                let reference = ReferenceType::from_string_with_dialect(&token.value, self.dialect)
-                    .map_err(|e| ParserError {
-                        message: format!("Invalid reference '{}': {}", token.value, e),
-                        position: Some(self.position),
-                    })?;
-                Ok(ASTNode::new(
-                    ASTNodeType::Reference {
-                        original: token.value.clone(),
-                        reference,
-                    },
-                    Some(token),
-                ))
-            }
-            _ => Err(ParserError {
-                message: format!("Unexpected operand subtype: {:?}", token.subtype),
-                position: Some(self.position),
-            }),
-        }
-    }
-
-    fn parse_function(&mut self, func_token: Token) -> Result<ASTNode, ParserError> {
-        let name = func_token.value[..func_token.value.len() - 1].to_string();
-        let args = self.parse_function_arguments()?;
-        // Determine volatility for this function
-        let this_is_volatile = self
-            .volatility_classifier
-            .as_ref()
-            .map(|f| f(name.as_str()))
-            .unwrap_or(false);
-        let args_volatile = args.iter().any(|a| a.contains_volatile);
-
-        Ok(ASTNode::new_with_volatile(
-            ASTNodeType::Function { name, args },
-            Some(func_token),
-            this_is_volatile || args_volatile,
-        ))
-    }
-
-    /// Parse arguments for a postfix call (immediate invocation), where the
-    /// opening `(` is a `Paren:Open` and the matching `)` is a `Paren:Close`.
-    /// Caller has already consumed the opening paren.
-    ///
-    /// Inside this region the tokenizer emits a top-level `,` as `OpInfix`
-    /// (Excel's union operator). For call arguments we want it to behave as a
-    /// separator, so we bump `in_call_args_depth` while parsing each argument.
-    fn parse_call_arguments(&mut self) -> Result<Vec<ASTNode>, ParserError> {
-        let mut args: Vec<ASTNode> = Vec::new();
-
-        self.skip_whitespace();
-        // Empty argument list: `f()`
-        if self.position < self.tokens.len()
-            && self.tokens[self.position].token_type == TokenType::Paren
-            && self.tokens[self.position].subtype == TokenSubType::Close
-        {
-            self.position += 1;
-            return Ok(args);
-        }
-
-        self.in_call_args_depth += 1;
-        let result = (|| -> Result<Vec<ASTNode>, ParserError> {
-            args.push(self.parse_expression()?);
-            loop {
-                self.skip_whitespace();
-                if self.position >= self.tokens.len() {
-                    return Err(ParserError {
-                        message: "Unterminated call argument list".to_string(),
-                        position: Some(self.position),
-                    });
-                }
-                let token = &self.tokens[self.position];
-                let is_separator = (token.token_type == TokenType::Sep
-                    && token.subtype == TokenSubType::Arg)
-                    || (token.token_type == TokenType::OpInfix && token.value == ",");
-                if is_separator {
-                    self.position += 1;
-                    args.push(self.parse_expression()?);
-                } else if token.token_type == TokenType::Paren
-                    && token.subtype == TokenSubType::Close
-                {
-                    self.position += 1;
-                    return Ok(std::mem::take(&mut args));
-                } else {
-                    return Err(ParserError {
-                        message: format!("Expected ',' or ')' in call arguments, got {token:?}"),
-                        position: Some(self.position),
-                    });
-                }
-            }
-        })();
-        self.in_call_args_depth -= 1;
-        result
-    }
-
-    /// Parse function arguments.
-    fn parse_function_arguments(&mut self) -> Result<Vec<ASTNode>, ParserError> {
-        let mut args = Vec::new();
-
-        // Check for closing parenthesis (empty arguments)
-        if self.position < self.tokens.len()
-            && self.tokens[self.position].token_type == TokenType::Func
-            && self.tokens[self.position].subtype == TokenSubType::Close
-        {
-            self.position += 1;
-            return Ok(args);
-        }
-
-        // Handle optional arguments (consecutive separators)
-        // Check if we start with a separator (empty first argument)
-        if self.position < self.tokens.len()
-            && self.tokens[self.position].token_type == TokenType::Sep
-            && self.tokens[self.position].subtype == TokenSubType::Arg
-        {
-            // Empty first argument - represented as empty text literal for compatibility
-            args.push(ASTNode::new(
-                ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                None,
-            ));
-            self.position += 1;
-        } else {
-            // Parse first argument
-            args.push(self.parse_expression()?);
-        }
-
-        // Parse remaining arguments
-        while self.position < self.tokens.len() {
-            let token = &self.tokens[self.position];
-
-            if token.token_type == TokenType::Sep && token.subtype == TokenSubType::Arg {
-                self.position += 1;
-                // Check for consecutive separators (empty argument)
-                if self.position < self.tokens.len() {
-                    let next_token = &self.tokens[self.position];
-                    if next_token.token_type == TokenType::Sep
-                        && next_token.subtype == TokenSubType::Arg
-                    {
-                        // Empty argument - represented as empty text literal for compatibility
-                        args.push(ASTNode::new(
-                            ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                            None,
-                        ));
-                    } else if next_token.token_type == TokenType::Func
-                        && next_token.subtype == TokenSubType::Close
-                    {
-                        // Empty last argument
-                        args.push(ASTNode::new(
-                            ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                            None,
-                        ));
-                        self.position += 1;
-                        break;
-                    } else {
-                        args.push(self.parse_expression()?);
-                    }
-                } else {
-                    // Trailing separator at end of formula
-                    args.push(ASTNode::new(
-                        ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                        None,
-                    ));
-                }
-            } else if token.token_type == TokenType::Func && token.subtype == TokenSubType::Close {
-                self.position += 1;
-                break;
-            } else {
-                return Err(ParserError {
-                    message: format!("Expected ',' or ')' in function arguments, got {token:?}"),
-                    position: Some(self.position),
-                });
-            }
-        }
-
-        Ok(args)
-    }
-
-    fn parse_array(&mut self) -> Result<ASTNode, ParserError> {
-        let mut rows = Vec::new();
-        let mut current_row = Vec::new();
-
-        // Check for empty array
-        if self.position < self.tokens.len()
-            && self.tokens[self.position].token_type == TokenType::Array
-            && self.tokens[self.position].subtype == TokenSubType::Close
-        {
-            self.position += 1;
-            return Ok(ASTNode::new(ASTNodeType::Array(rows), None));
-        }
-
-        // Parse first element
-        current_row.push(self.parse_expression()?);
-
-        while self.position < self.tokens.len() {
-            let token = &self.tokens[self.position];
-
-            if token.token_type == TokenType::Sep {
-                if token.subtype == TokenSubType::Arg {
-                    // Column separator
-                    self.position += 1;
-                    current_row.push(self.parse_expression()?);
-                } else if token.subtype == TokenSubType::Row {
-                    // Row separator
-                    self.position += 1;
-                    rows.push(current_row);
-                    current_row = vec![self.parse_expression()?];
-                }
-            } else if token.token_type == TokenType::Array && token.subtype == TokenSubType::Close {
-                self.position += 1;
-                rows.push(current_row);
-                break;
-            } else {
-                return Err(ParserError {
-                    message: format!("Unexpected token in array: {token:?}"),
-                    position: Some(self.position),
-                });
-            }
-        }
-
-        // Array volatility is the OR of element volatility
-        let contains_volatile = rows
-            .iter()
-            .flat_map(|r| r.iter())
-            .any(|n| n.contains_volatile);
-        Ok(ASTNode::new_with_volatile(
-            ASTNodeType::Array(rows),
-            None,
-            contains_volatile,
-        ))
-    }
-}
-
-impl From<TokenizerError> for ParserError {
-    fn from(err: TokenizerError) -> Self {
-        ParserError {
-            message: err.message,
-            position: Some(err.pos),
-        }
-    }
-}
-
-struct SpanParser<'a> {
-    source: &'a str,
-    tokens: &'a [crate::tokenizer::TokenSpan],
-    position: usize,
-    volatility_classifier: Option<VolatilityClassifierBox>,
-    dialect: FormulaDialect,
-    /// See `Parser::in_call_args_depth`.
-    in_call_args_depth: usize,
-}
-
-impl<'a> SpanParser<'a> {
-    fn new(
-        source: &'a str,
-        tokens: &'a [crate::tokenizer::TokenSpan],
-        dialect: FormulaDialect,
-    ) -> Self {
-        SpanParser {
-            source,
-            tokens,
-            position: 0,
-            volatility_classifier: None,
-            dialect,
-            in_call_args_depth: 0,
-        }
-    }
-
-    fn with_volatility_classifier<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&str) -> bool + Send + Sync + 'static,
-    {
-        self.volatility_classifier = Some(Box::new(f));
-        self
-    }
-
-    fn skip_whitespace(&mut self) {
-        while self.position < self.tokens.len()
-            && self.tokens[self.position].token_type == TokenType::Whitespace
-        {
-            self.position += 1;
-        }
-    }
-
-    fn span_value(&self, span: &crate::tokenizer::TokenSpan) -> &str {
+    fn span_value(&self, span: &TokenSpan) -> &str {
         &self.source[span.start..span.end]
     }
 
-    fn span_to_token(&self, span: &crate::tokenizer::TokenSpan) -> Token {
+    fn span_to_token(&self, span: &TokenSpan) -> Token {
         Token::new_with_span(
             self.span_value(span).to_string(),
             span.token_type,
@@ -2982,7 +2434,7 @@ impl<'a> SpanParser<'a> {
         )
     }
 
-    fn span_precedence(&self, span: &crate::tokenizer::TokenSpan) -> Option<(u8, Associativity)> {
+    fn span_precedence(&self, span: &TokenSpan) -> Option<(u8, Associativity)> {
         if !matches!(
             span.token_type,
             TokenType::OpPrefix | TokenType::OpInfix | TokenType::OpPostfix
@@ -3012,7 +2464,7 @@ impl<'a> SpanParser<'a> {
         }
     }
 
-    fn parse(&mut self) -> Result<ASTNode, ParserError> {
+    pub fn parse(&mut self) -> Result<ASTNode, ParserError> {
         if self.tokens.is_empty() {
             return Err(ParserError {
                 message: "No tokens to parse".to_string(),
@@ -3239,7 +2691,7 @@ impl<'a> SpanParser<'a> {
         }
     }
 
-    fn parse_operand(&mut self, span: crate::tokenizer::TokenSpan) -> Result<ASTNode, ParserError> {
+    fn parse_operand(&mut self, span: TokenSpan) -> Result<ASTNode, ParserError> {
         let value = self.span_value(&span);
         let token = self.span_to_token(&span);
 
@@ -3300,10 +2752,7 @@ impl<'a> SpanParser<'a> {
         }
     }
 
-    fn parse_function(
-        &mut self,
-        func_span: crate::tokenizer::TokenSpan,
-    ) -> Result<ASTNode, ParserError> {
+    fn parse_function(&mut self, func_span: TokenSpan) -> Result<ASTNode, ParserError> {
         let func_value = self.span_value(&func_span);
         if func_value.is_empty() {
             return Err(ParserError {
@@ -3401,7 +2850,6 @@ impl<'a> SpanParser<'a> {
                 ASTNodeType::Literal(LiteralValue::Text("".to_string())),
                 None,
             ));
-            self.position += 1;
         } else {
             args.push(self.parse_expression()?);
         }
@@ -3513,6 +2961,92 @@ impl<'a> SpanParser<'a> {
     }
 }
 
+impl TryFrom<&str> for Parser {
+    type Error = TokenizerError;
+
+    fn try_from(formula: &str) -> Result<Self, Self::Error> {
+        Self::new(formula)
+    }
+}
+
+impl TryFrom<String> for Parser {
+    type Error = TokenizerError;
+
+    fn try_from(formula: String) -> Result<Self, Self::Error> {
+        Self::new(formula)
+    }
+}
+
+impl From<&TokenStream> for Parser {
+    fn from(stream: &TokenStream) -> Self {
+        Self::from_token_stream(stream)
+    }
+}
+
+impl FromStr for ASTNode {
+    type Err = ParserError;
+
+    fn from_str(formula: &str) -> Result<Self, Self::Err> {
+        parse(formula)
+    }
+}
+
+impl TryFrom<&str> for ASTNode {
+    type Error = ParserError;
+
+    fn try_from(formula: &str) -> Result<Self, Self::Error> {
+        parse(formula)
+    }
+}
+
+impl TryFrom<String> for ASTNode {
+    type Error = ParserError;
+
+    fn try_from(formula: String) -> Result<Self, Self::Error> {
+        parse(formula)
+    }
+}
+
+impl Parser {
+    pub fn builder() -> ParserBuilder {
+        ParserBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct ParserBuilder {
+    dialect: FormulaDialect,
+    volatility_classifier: Option<VolatilityClassifierArc>,
+}
+
+impl ParserBuilder {
+    pub fn dialect(mut self, dialect: FormulaDialect) -> Self {
+        self.dialect = dialect;
+        self
+    }
+
+    pub fn with_volatility_classifier<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> bool + Send + Sync + 'static,
+    {
+        self.volatility_classifier = Some(Arc::new(f));
+        self
+    }
+
+    pub fn build<T: AsRef<str>>(self, formula: T) -> Result<Parser, TokenizerError> {
+        let mut parser = Parser::new_with_dialect(formula, self.dialect)?;
+        if let Some(classifier) = self.volatility_classifier {
+            parser = parser.with_volatility_classifier(move |name| classifier(name));
+        }
+        Ok(parser)
+    }
+
+    pub fn parse<T: AsRef<str>>(self, formula: T) -> Result<ASTNode, ParserError> {
+        let mut parser = self.build(formula)?;
+        parser.parse()
+    }
+}
+
 /// Normalise a reference string to its canonical form
 pub fn normalise_reference(reference: &str) -> Result<String, ParsingError> {
     let ref_type = ReferenceType::from_string(reference)?;
@@ -3527,13 +3061,12 @@ pub fn parse_with_dialect<T: AsRef<str>>(
     formula: T,
     dialect: FormulaDialect,
 ) -> Result<ASTNode, ParserError> {
-    let spans = crate::tokenizer::tokenize_spans_with_dialect(formula.as_ref(), dialect)?;
-    let mut parser = SpanParser::new(formula.as_ref(), &spans, dialect);
+    let mut parser = Parser::new_with_dialect(formula, dialect)?;
     parser.parse()
 }
 
 /// Parse a single formula and annotate volatility using the provided classifier.
-/// This is a convenience wrapper around `Parser::new_with_classifier`.
+/// This is a convenience wrapper around `Parser::with_volatility_classifier`.
 pub fn parse_with_volatility_classifier<T, F>(
     formula: T,
     classifier: F,
@@ -3554,9 +3087,8 @@ where
     T: AsRef<str>,
     F: Fn(&str) -> bool + Send + Sync + 'static,
 {
-    let spans = crate::tokenizer::tokenize_spans_with_dialect(formula.as_ref(), dialect)?;
     let mut parser =
-        SpanParser::new(formula.as_ref(), &spans, dialect).with_volatility_classifier(classifier);
+        Parser::new_with_dialect(formula, dialect)?.with_volatility_classifier(classifier);
     parser.parse()
 }
 
@@ -3567,7 +3099,7 @@ where
 pub struct BatchParser {
     include_whitespace: bool,
     volatility_classifier: Option<VolatilityClassifierArc>,
-    token_cache: std::collections::HashMap<String, Arc<[crate::tokenizer::TokenSpan]>>, // cached tokens
+    token_cache: std::collections::HashMap<String, (Arc<str>, Arc<[TokenSpan]>)>,
     dialect: FormulaDialect,
 }
 
@@ -3578,21 +3110,25 @@ impl BatchParser {
 
     /// Parse a formula using the internal cache and configured classifier.
     pub fn parse(&mut self, formula: &str) -> Result<ASTNode, ParserError> {
-        let spans = if let Some(tokens) = self.token_cache.get(formula) {
-            Arc::clone(tokens)
+        let (source, spans) = if let Some((source, tokens)) = self.token_cache.get(formula) {
+            (Arc::clone(source), Arc::clone(tokens))
         } else {
-            let mut spans = crate::tokenizer::tokenize_spans_with_dialect(formula, self.dialect)?;
+            let source: Arc<str> = Arc::from(formula);
+            let mut spans =
+                crate::tokenizer::tokenize_spans_with_dialect(source.as_ref(), self.dialect)?;
             if !self.include_whitespace {
                 spans.retain(|t| t.token_type != TokenType::Whitespace);
             }
 
-            let spans: Arc<[crate::tokenizer::TokenSpan]> = Arc::from(spans.into_boxed_slice());
-            self.token_cache
-                .insert(formula.to_string(), Arc::clone(&spans));
-            spans
+            let spans: Arc<[TokenSpan]> = Arc::from(spans.into_boxed_slice());
+            self.token_cache.insert(
+                formula.to_string(),
+                (Arc::clone(&source), Arc::clone(&spans)),
+            );
+            (source, spans)
         };
 
-        let mut parser = SpanParser::new(formula, spans.as_ref(), self.dialect);
+        let mut parser = Parser::from_source_and_tokens(source, spans, self.dialect);
         if let Some(classifier) = self.volatility_classifier.clone() {
             parser = parser.with_volatility_classifier(move |name| classifier(name));
         }

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -1,38 +1,30 @@
 #[cfg(test)]
 mod tests {
     use crate::FormulaDialect;
-    use crate::tokenizer::Tokenizer;
+    use crate::tokenizer::TokenStream;
     use formualizer_common::{ExcelError, LiteralValue};
 
-    use crate::parser::{ASTNode, ASTNodeType, Parser, ParserError, ReferenceType};
+    use crate::parser::{
+        ASTNode, ASTNodeType, Parser, ParserError, ReferenceType, parse, parse_with_dialect,
+    };
     use crate::parser::{CollectPolicy, RefView};
 
     // Helper function to parse a formula
     fn parse_formula(formula: &str) -> Result<ASTNode, ParserError> {
-        let tokenizer = Tokenizer::new(formula).map_err(|e| ParserError {
-            message: e.to_string(),
-            position: Some(e.pos),
-        })?;
-        let mut parser = Parser::new(tokenizer.items, false);
-        parser.parse()
+        parse(formula)
     }
 
     fn parse_formula_with_dialect(
         formula: &str,
         dialect: FormulaDialect,
     ) -> Result<ASTNode, ParserError> {
-        let tokenizer = Tokenizer::new_with_dialect(formula, dialect).map_err(|e| ParserError {
-            message: e.to_string(),
-            position: Some(e.pos),
-        })?;
-        let mut parser = Parser::new_with_dialect(tokenizer.items, false, dialect);
-        parser.parse()
+        parse_with_dialect(formula, dialect)
     }
 
     #[test]
     fn parser_rejects_best_effort_invalid_spans() {
-        let tokenizer = Tokenizer::new_best_effort("=A1+)");
-        let mut parser = Parser::new(tokenizer.items, false);
+        let stream = TokenStream::new_best_effort("=A1+)");
+        let mut parser = Parser::from_token_stream(&stream);
         let err = parser.parse().unwrap_err();
         assert!(err.message.contains("Unexpected"));
     }
@@ -63,8 +55,7 @@ mod tests {
 
     mod sheet_qualified_errors {
         use super::parse_formula;
-        use crate::parser::{ASTNode, ASTNodeType, Parser};
-        use crate::tokenizer::Tokenizer;
+        use crate::parser::{ASTNode, ASTNodeType};
         use formualizer_common::{ExcelErrorKind, LiteralValue};
 
         fn parse_span(formula: &str) -> Result<ASTNode, crate::parser::ParserError> {
@@ -195,21 +186,15 @@ mod tests {
                 "=[1]Sheet1!#REF!",
                 "=sheet1!#ref!",
             ] {
-                let classic = {
-                    let tok = Tokenizer::new(formula).expect("tokenize");
-                    let mut parser = Parser::new(tok.items, false);
-                    parser.parse().expect("classic parse")
-                };
-                let span = parse_span(formula).expect("span parse");
-                let classic_kind = match &classic.node_type {
+                let ast = parse_span(formula).expect("parse");
+                let kind = match &ast.node_type {
                     ASTNodeType::Literal(LiteralValue::Error(e)) => e.kind,
-                    other => panic!("classic non-error for {formula:?}: {other:?}"),
+                    other => panic!("non-error for {formula:?}: {other:?}"),
                 };
-                let span_kind = match &span.node_type {
-                    ASTNodeType::Literal(LiteralValue::Error(e)) => e.kind,
-                    other => panic!("span non-error for {formula:?}: {other:?}"),
-                };
-                assert_eq!(classic_kind, span_kind, "kind mismatch for {formula:?}");
+                assert!(
+                    kind.to_string().starts_with('#'),
+                    "kind mismatch for {formula:?}"
+                );
             }
         }
     }
@@ -236,17 +221,18 @@ mod tests {
 
     #[test]
     fn test_contains_volatile_with_classifier() {
-        let tokenizer = Tokenizer::new("=RAND()+A1").unwrap();
-        let mut parser = Parser::new(tokenizer.items, false).with_volatility_classifier(|name| {
-            name.eq_ignore_ascii_case("RAND")
-                || name.eq_ignore_ascii_case("NOW")
-                || name.eq_ignore_ascii_case("TODAY")
-        });
+        let mut parser = Parser::new("=RAND()+A1")
+            .unwrap()
+            .with_volatility_classifier(|name| {
+                name.eq_ignore_ascii_case("RAND")
+                    || name.eq_ignore_ascii_case("NOW")
+                    || name.eq_ignore_ascii_case("TODAY")
+            });
         let ast = parser.parse().unwrap();
         assert!(ast.contains_volatile());
 
-        let tokenizer = Tokenizer::new("=SUM(1,2,3)").unwrap();
-        let mut parser = Parser::new(tokenizer.items, false)
+        let mut parser = Parser::new("=SUM(1,2,3)")
+            .unwrap()
             .with_volatility_classifier(|name| name.eq_ignore_ascii_case("RAND"));
         let ast = parser.parse().unwrap();
         assert!(!ast.contains_volatile());
@@ -2373,8 +2359,7 @@ mod reference_tests {
     fn test_get_dependencies() {
         // Parse a formula and check its dependencies
         let formula = "=A1+B1*SUM(C1:D2)";
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser.parse().unwrap();
 
         let dependencies = ast.get_dependencies();
@@ -2399,8 +2384,7 @@ mod reference_tests {
     fn test_get_dependency_strings() {
         // Parse a formula and check its dependency strings
         let formula = "=A1+B1*SUM(C1:D2)";
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser.parse().unwrap();
 
         let dependencies = ast.get_dependency_strings();
@@ -2415,8 +2399,7 @@ mod reference_tests {
     #[test]
     fn test_complex_formula_dependencies() {
         let formula = "=IF(SUM(Sheet1!A1:A10)>100,MAX(Table1[Amount]),MIN('Data Sheet'!B1:B5))";
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser.parse().unwrap();
 
         let dependencies = ast.get_dependency_strings();
@@ -2433,7 +2416,7 @@ mod reference_tests {
         let formula = "=_xlfn.XLOOKUP(J7, 'GI XWALK'!$Q:$Q,'GI XWALK'!$R:$R,,0)";
         let tokenizer = Tokenizer::new(formula).unwrap();
         println!("tokenizer: {:?}", tokenizer.items);
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser.parse().unwrap();
         println!("ast: {ast:?}");
     }
@@ -2442,8 +2425,7 @@ mod reference_tests {
     fn test_dual_bracket_structured_reference_parsing() {
         use crate::parser::{SpecialItem, TableSpecifier};
         let formula = "=EffortDB[[#All],[NPI]:[JMG Group]]";
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser.parse().unwrap();
 
         let ASTNodeType::Reference {
@@ -2574,7 +2556,7 @@ mod reference_tests {
         let formula = "=EffortDB[#All]";
         let tokenizer = Tokenizer::new(formula).unwrap();
         println!("tokenizer: {:?}", tokenizer.items);
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser.parse().unwrap();
         println!("ast: {ast:?}");
     }
@@ -2765,10 +2747,8 @@ mod structured_references {
         TableSpecifier,
     };
     use crate::tokenizer::Tokenizer;
-
     fn parse_via_classic(formula: &str) -> Result<ReferenceType, String> {
-        let tokenizer = Tokenizer::new(formula).map_err(|e| e.to_string())?;
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).map_err(|e| e.to_string())?;
         let ast = parser.parse().map_err(|e| e.to_string())?;
         match ast.node_type {
             ASTNodeType::Reference { reference, .. } => Ok(reference),
@@ -3280,12 +3260,10 @@ mod sheet_ref_tests {
 #[cfg(test)]
 mod semantics_regressions {
     use crate::parser::{ASTNodeType, Parser, ReferenceType};
-    use crate::tokenizer::Tokenizer;
 
     #[test]
     fn exponent_is_right_associative() {
-        let t = Tokenizer::new("=2^3^2").unwrap();
-        let mut p = Parser::new(t.items, false);
+        let mut p = Parser::new("=2^3^2").unwrap();
         let ast = p.parse().unwrap();
 
         match ast.node_type {
@@ -3303,8 +3281,7 @@ mod semantics_regressions {
 
     #[test]
     fn unary_minus_binds_tighter_than_exponent() {
-        let t = Tokenizer::new("=-2^2").unwrap();
-        let mut p = Parser::new(t.items, false);
+        let mut p = Parser::new("=-2^2").unwrap();
         let ast = p.parse().unwrap();
 
         // Excel: =-2^2 means (-2)^2 = 4
@@ -3321,17 +3298,11 @@ mod semantics_regressions {
     }
 
     mod scientific_notation {
-        use crate::parser::{ASTNode, ASTNodeType, Parser, ParserError, ReferenceType, parse};
-        use crate::tokenizer::Tokenizer;
+        use crate::parser::{ASTNode, ASTNodeType, ParserError, ReferenceType, parse};
         use formualizer_common::LiteralValue;
 
         fn parse_formula(formula: &str) -> Result<ASTNode, ParserError> {
-            let tokenizer = Tokenizer::new(formula).map_err(|e| ParserError {
-                message: e.to_string(),
-                position: Some(e.pos),
-            })?;
-            let mut parser = Parser::new(tokenizer.items, false);
-            parser.parse()
+            parse(formula)
         }
 
         fn assert_parsers_agree(formula: &str) {
@@ -3457,13 +3428,11 @@ mod semantics_regressions {
         use crate::parser::parse as span_parse;
         use crate::parser::{ASTNode, ASTNodeType, Parser};
         use crate::pretty::canonical_formula;
-        use crate::tokenizer::Tokenizer;
         use formualizer_common::LiteralValue;
 
         fn parse_classic(formula: &str) -> ASTNode {
-            let tokenizer = Tokenizer::new(formula).expect("tokenize");
-            let mut parser = Parser::new(tokenizer.items, false);
-            parser.parse().expect("classic parser")
+            let mut parser = Parser::new(formula).unwrap();
+            parser.parse().expect("parser")
         }
 
         fn parse_both(formula: &str) -> ASTNode {
@@ -3716,14 +3685,8 @@ mod semantics_regressions {
         use crate::parser::{
             ASTNode, ASTNodeType, Parser, ParserError, ReferenceType, parse as parse_span,
         };
-        use crate::tokenizer::Tokenizer;
-
         fn parse_classic(formula: &str) -> Result<ASTNode, ParserError> {
-            let tokenizer = Tokenizer::new(formula).map_err(|e| ParserError {
-                message: e.to_string(),
-                position: Some(e.pos),
-            })?;
-            let mut parser = Parser::new(tokenizer.items, false);
+            let mut parser = Parser::new(formula)?;
             parser.parse()
         }
 
@@ -3916,8 +3879,6 @@ mod string_colon_interaction {
     //! the pending `A1:` prefix when followed by a double-quoted string.
 
     use crate::parser::{ASTNodeType, Parser, ReferenceType};
-    use crate::tokenizer::Tokenizer;
-
     fn extract_reference(ast: &crate::parser::ASTNode) -> ReferenceType {
         match &ast.node_type {
             ASTNodeType::Reference { reference, .. } => reference.clone(),
@@ -3932,8 +3893,7 @@ mod string_colon_interaction {
         // currently supported end-to-end by both parsers.
         let formula = "='Sheet 1:Sheet 3'!A1:C10";
 
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let ast = parser
             .parse()
             .expect("classic parser should accept formula");
@@ -3952,8 +3912,7 @@ mod string_colon_interaction {
     fn test_colon_string_raises() {
         let formula = "=A1:\"text\"";
 
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         let err = parser.parse().expect_err(
             "classic parser must reject `=A1:\"text\"` rather than silently discard the prefix",
         );
@@ -3971,8 +3930,7 @@ mod string_colon_interaction {
     fn test_colon_string_in_function() {
         let formula = "=SUM(A1:\"text\")";
 
-        let tokenizer = Tokenizer::new(formula).unwrap();
-        let mut parser = Parser::new(tokenizer.items, false);
+        let mut parser = Parser::new(formula).unwrap();
         assert!(
             parser.parse().is_err(),
             "classic parser must reject `=SUM(A1:\"text\")`"
@@ -3994,12 +3952,9 @@ mod r1c1_disambiguation {
     //! R1C1-shaped input are: existing `NamedRange` behaviour, or a clean
     //! `ParserError`. The forbidden outcome is `ReferenceType::Table(...)`.
     use crate::parser::{ASTNode, ASTNodeType, Parser, ReferenceType, TableReference, parse};
-    use crate::tokenizer::Tokenizer;
-
     fn parse_classic(formula: &str) -> ASTNode {
-        let tokenizer = Tokenizer::new(formula).expect("tokenize");
-        let mut parser = Parser::new(tokenizer.items, false);
-        parser.parse().expect("classic parse")
+        let mut parser = Parser::new(formula).unwrap();
+        parser.parse().expect("parse")
     }
 
     fn parse_span(formula: &str) -> ASTNode {

--- a/crates/formualizer-parse/tests/parser_differential.rs
+++ b/crates/formualizer-parse/tests/parser_differential.rs
@@ -1,56 +1,15 @@
-//! Differential harness for the two public parser implementations in
-//! `formualizer-parse`.
+//! Public parser entrypoint parity tests.
 //!
-//! See issue PSU3D0/formualizer#77 for context. The crate ships two
-//! parsers with subtly different behaviours:
-//!
-//! - the classic token-based `Parser` (`Parser::new(tokens, ...)`,
-//!   `Parser::try_from(&str)`); and
-//! - the source-span-backed `SpanParser`, exposed via the free
-//!   functions `parse`, `parse_with_dialect`,
-//!   `parse_with_volatility_classifier`, and `BatchParser`.
-//!
-//! This file exists so any drift between the two front-ends becomes
-//! visible in CI before a unification PR rewrites `Parser` as a thin
-//! forwarder. It deliberately:
-//!
-//! 1. asserts AST-equality on a corpus of formulas where both parsers
-//!    already agree (the bulk of the harness — these guard against
-//!    future regressions); and
-//! 2. pins the *currently-known* divergences as explicit expectations,
-//!    so future fixes can flip them to assertions of equality without
-//!    having to re-discover the cases.
-//!
-//! When a follow-up PR unifies the implementations, divergence cases
-//! should be migrated into the `agreeing` corpus.
-//!
-//! See also `docs/parser-divergences.md` (at the workspace root) for the
-//! human-readable catalog.
-use formualizer_parse::parse;
-use formualizer_parse::parser::{ASTNode, ASTNodeType, Parser, ParserError};
-use formualizer_parse::tokenizer::Tokenizer;
+//! Issue PSU3D0/formualizer#77 consolidated the old token-based parser and the
+//! source-span parser into a single canonical `Parser`. These tests make sure the
+//! supported public calling patterns continue to produce the same AST shape.
 
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
+use std::str::FromStr;
 
-fn classic(formula: &str, include_whitespace: bool) -> Result<ASTNode, ParserError> {
-    let tokenizer = Tokenizer::new(formula).map_err(|e| ParserError {
-        message: e.to_string(),
-        position: Some(e.pos),
-    })?;
-    let mut parser = Parser::new(tokenizer.items, include_whitespace);
-    parser.parse()
-}
+use formualizer_parse::parser::{ASTNode, ASTNodeType, BatchParser, Parser};
+use formualizer_parse::tokenizer::TokenStream;
+use formualizer_parse::{LiteralValue, parse};
 
-fn span(formula: &str) -> Result<ASTNode, ParserError> {
-    parse(formula)
-}
-
-/// Compare two ASTs for structural equality, ignoring `source_token`
-/// (which legitimately differs between the parsers because they build
-/// `Token` instances from different sources) and `contains_volatile`
-/// (set only when a classifier is supplied).
 fn ast_eq(a: &ASTNode, b: &ASTNode) -> bool {
     if a.node_type == b.node_type {
         return true;
@@ -89,23 +48,15 @@ fn ast_eq(a: &ASTNode, b: &ASTNode) -> bool {
 }
 
 fn assert_ast_eq(formula: &str, a: &ASTNode, b: &ASTNode, label_a: &str, label_b: &str) {
-    if !ast_eq(a, b) {
-        panic!(
-            "AST divergence for `{formula}`:\n  {label_a}: {:#?}\n  {label_b}: {:#?}",
-            a.node_type, b.node_type
-        );
-    }
+    assert!(
+        ast_eq(a, b),
+        "AST divergence for `{formula}`:\n  {label_a}: {:#?}\n  {label_b}: {:#?}",
+        a.node_type,
+        b.node_type
+    );
 }
 
-// ---------------------------------------------------------------------------
-// Corpus that BOTH parsers must agree on
-// ---------------------------------------------------------------------------
-
-/// Formulas where the classic and span parsers must produce structurally
-/// identical ASTs. Adding a formula here that fails will surface a real
-/// regression.
-const AGREEING_CORPUS: &[&str] = &[
-    // Literals
+const CORPUS: &[&str] = &[
     "=1",
     "=1.5",
     "=-1",
@@ -123,9 +74,8 @@ const AGREEING_CORPUS: &[&str] = &[
     "=#NUM!",
     "=#N/A",
     "=#GETTING_DATA",
-    "=#ref!",        // lowercase error literal (PR #65 region)
-    "=source!#ref!", // sheet-qualified lowercase error literal
-    // Simple references
+    "=#ref!",
+    "=source!#ref!",
     "=A1",
     "=$A$1",
     "=A1:B2",
@@ -136,7 +86,6 @@ const AGREEING_CORPUS: &[&str] = &[
     "=NamedRange",
     "=A:A",
     "=1:1",
-    // Arithmetic / boolean / comparison
     "=1+2",
     "=1-2",
     "=2*3",
@@ -159,7 +108,6 @@ const AGREEING_CORPUS: &[&str] = &[
     "=--A1",
     "=- -A1",
     "=- -1",
-    // Functions
     "=SUM(A1,B1)",
     "=SUM(A1:A10)",
     "=SUM(A1, B1, C1)",
@@ -168,243 +116,126 @@ const AGREEING_CORPUS: &[&str] = &[
     "=AVERAGE(A1:A10)",
     "=COUNTIF(A1:A10,\">0\")",
     "=VLOOKUP(A1,B1:C10,2,FALSE)",
+    "=VLOOKUP(,A1:C10,2,FALSE)",
     "=IFS(A1=1,\"a\",A1=2,\"b\",TRUE,\"c\")",
     "=LET(x,1,y,2,x+y)",
     "=LAMBDA(x,x+1)(2)",
-    "=SUM()", // no-arg function
-    // Whitespace tolerated by both
+    "=SUM()",
+    "=SUM(  )",
+    "=SUM(A1, )",
+    "=SUM(A1, B1, )",
+    "=FOO(,A1:C3,TRUE,A13)",
+    "=FOO(,A1:C3)",
+    "=FOO(A1,,B2)",
+    "=FOO(,,A1)",
+    "=FOO(,)",
     "= 1 + 2",
     "=  SUM(A1,B1)  ",
     "=SUM( A1 , B1 )",
     "=( A1 + B1 )",
     "= ( A1 + B1 ) ",
-    "=SUM(A1 )", // trailing space inside arg
+    "=SUM(A1 )",
     "=( A1 )",
     "= A1 + B1",
-    // Arrays
     "={1,2,3}",
     "={1,2;3,4}",
     "={\"a\",\"b\";\"c\",\"d\"}",
     "=SUM({1,2,3})",
-    // Mixed
     "=SUM(A1:A10)*COUNT(B1:B10)+IF(C1,1,0)",
     "=A1+SUM(B1:B5)",
     "=Sheet1!A1+Sheet2!B2",
     "='My Sheet'!A1+'Other Sheet'!$B$2",
     "=INDEX(A:A,MATCH(B1,C:C,0))",
-    "=A1#",  // spilled-range operator
-    "=A1:A", // partial range
-    // Unary precedence (post-#65)
+    "=A1#",
+    "=A1:A",
     "=-A1^2",
     "=-(A1^2)",
-    "=- -A1",
     "=---1",
-    // Comparison + arithmetic mixing
     "=A1+B1>=C1*D1",
-    // Concatenation
     "=\"a\"&\"b\"&\"c\"",
 ];
 
 #[test]
-fn classic_and_span_agree_on_corpus_no_whitespace_tokens() {
-    let mut failures: Vec<String> = Vec::new();
-    for formula in AGREEING_CORPUS {
-        let c = classic(formula, false);
-        let s = span(formula);
-        match (&c, &s) {
-            (Ok(a), Ok(b)) => {
-                if !ast_eq(a, b) {
-                    failures.push(format!(
-                        "{formula}: AST mismatch\n  classic: {:?}\n  span:    {:?}",
-                        a.node_type, b.node_type
-                    ));
-                }
-            }
-            (Err(ea), Err(eb)) => {
-                // Both errored — accept; specific error messages may differ.
-                let _ = (ea, eb);
-            }
-            (Ok(_), Err(e)) => {
-                failures.push(format!("{formula}: classic OK but span Err: {e}"));
-            }
-            (Err(e), Ok(_)) => {
-                failures.push(format!("{formula}: span OK but classic Err: {e}"));
-            }
-        }
+fn public_entrypoints_agree_on_corpus() {
+    let mut batch = BatchParser::builder().build();
+
+    for formula in CORPUS {
+        let direct = parse(formula).unwrap_or_else(|e| panic!("parse failed for {formula}: {e}"));
+
+        let mut parser = Parser::new(formula).unwrap_or_else(|e| panic!("Parser::new failed: {e}"));
+        let parser_ast = parser
+            .parse()
+            .unwrap_or_else(|e| panic!("Parser::parse failed: {e}"));
+        assert_ast_eq(formula, &direct, &parser_ast, "parse", "Parser::new");
+
+        let mut parser = Parser::try_from(*formula).expect("Parser::try_from");
+        let try_from_parser_ast = parser.parse().expect("Parser::try_from parse");
+        assert_ast_eq(
+            formula,
+            &direct,
+            &try_from_parser_ast,
+            "parse",
+            "Parser::try_from",
+        );
+
+        let from_str_ast = ASTNode::from_str(formula).expect("ASTNode::from_str");
+        assert_ast_eq(formula, &direct, &from_str_ast, "parse", "FromStr");
+
+        let try_from_ast = ASTNode::try_from(*formula).expect("ASTNode::try_from");
+        assert_ast_eq(
+            formula,
+            &direct,
+            &try_from_ast,
+            "parse",
+            "ASTNode::try_from",
+        );
+
+        let stream = TokenStream::new(formula).expect("TokenStream::new");
+        let mut stream_parser = Parser::from_token_stream(&stream);
+        let stream_ast = stream_parser.parse().expect("TokenStream parser");
+        assert_ast_eq(formula, &direct, &stream_ast, "parse", "TokenStream");
+
+        let batch_ast = batch.parse(formula).expect("BatchParser");
+        assert_ast_eq(formula, &direct, &batch_ast, "parse", "BatchParser");
     }
-    assert!(
-        failures.is_empty(),
-        "differential failures (classic vs span, include_whitespace=false):\n{}",
-        failures.join("\n")
-    );
 }
 
 #[test]
-fn classic_with_whitespace_tokens_agrees_with_span_on_corpus() {
-    // Most of the corpus also agrees when the classic parser is configured
-    // to keep whitespace tokens. The cases listed in
-    // `divergence::WS_BREAKS_CLASSIC_WITH_WS_TOKENS` are documented holes
-    // and excluded here.
-    let mut failures: Vec<String> = Vec::new();
-    for formula in AGREEING_CORPUS {
-        if divergence::WS_BREAKS_CLASSIC_WITH_WS_TOKENS.contains(formula) {
-            continue;
-        }
-        let c = classic(formula, true);
-        let s = span(formula);
-        match (&c, &s) {
-            (Ok(a), Ok(b)) => {
-                if !ast_eq(a, b) {
-                    failures.push(format!(
-                        "{formula}: AST mismatch (include_whitespace=true)\n  classic: {:?}\n  span:    {:?}",
-                        a.node_type, b.node_type
-                    ));
-                }
-            }
-            (Err(ea), Err(eb)) => {
-                let _ = (ea, eb);
-            }
-            (Ok(_), Err(e)) => {
-                failures.push(format!("{formula}: classic(ws) OK but span Err: {e}"));
-            }
-            (Err(e), Ok(_)) => {
-                failures.push(format!(
-                    "{formula}: span OK but classic(ws) Err: {e} — \
-                     if intentional, add to divergence::WS_BREAKS_CLASSIC_WITH_WS_TOKENS"
-                ));
-            }
-        }
-    }
-    assert!(
-        failures.is_empty(),
-        "differential failures (classic include_whitespace=true vs span):\n{}",
-        failures.join("\n")
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Public-API compatibility smoke tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn parser_try_from_str_still_works() {
-    let mut p = Parser::try_from("=A1+B1").unwrap();
-    let ast = p.parse().unwrap();
-    assert!(matches!(ast.node_type, ASTNodeType::BinaryOp { .. }));
+fn parser_builder_supports_dialect_and_volatility_classifier() {
+    let ast = Parser::builder()
+        .with_volatility_classifier(|name| name.eq_ignore_ascii_case("RAND"))
+        .parse("=RAND()+A1")
+        .unwrap();
+    assert!(ast.contains_volatile());
 }
 
 #[test]
-fn parser_new_with_whitespace_tokens_still_works() {
-    let tokenizer = Tokenizer::new("= 1 + 2").unwrap();
-    let mut p = Parser::new(tokenizer.items, true);
-    let ast = p.parse().unwrap();
+fn leading_empty_argument_followed_by_argument_parses() {
+    let ast = parse("=VLOOKUP(,A1:C10,2,FALSE)").unwrap();
     match ast.node_type {
-        ASTNodeType::BinaryOp { op, .. } => assert_eq!(op, "+"),
-        other => panic!("expected BinaryOp, got {other:?}"),
+        ASTNodeType::Function { name, args } => {
+            assert_eq!(name, "VLOOKUP");
+            assert_eq!(args.len(), 4);
+            assert!(matches!(
+                &args[0].node_type,
+                ASTNodeType::Literal(LiteralValue::Text(s)) if s.is_empty()
+            ));
+        }
+        other => panic!("expected Function, got {other:?}"),
     }
 }
 
 #[test]
-fn batch_parser_still_works() {
-    use formualizer_parse::parser::BatchParser;
-    let mut bp = BatchParser::builder().build();
-    let a = bp.parse("=A1+B1").unwrap();
-    let b = bp.parse("=A1+B1").unwrap(); // cached
-    assert!(ast_eq(&a, &b));
-    let s = parse("=A1+B1").unwrap();
-    assert_ast_eq("=A1+B1", &a, &s, "batch", "span");
-}
-
-// ---------------------------------------------------------------------------
-// Targeted regression guards (from issue body)
-// ---------------------------------------------------------------------------
-
-#[test]
-fn regression_sum_with_inner_whitespace() {
-    // The issue points out that whitespace before `)` in a function arg
-    // list is currently handled in SpanParser but not in classic Parser
-    // when whitespace tokens are kept. With include_whitespace=false the
-    // classic path filters whitespace before parsing, so both agree.
-    let formula = "=SUM( A1 , B1 )";
-    let c = classic(formula, false).expect("classic no_ws should parse");
-    let s = span(formula).expect("span should parse");
-    assert_ast_eq(formula, &c, &s, "classic no_ws", "span");
-}
-
-#[test]
-fn regression_paren_group_with_inner_and_trailing_whitespace() {
-    let formula = "=( A1 + B1 ) ";
-    let c = classic(formula, false).expect("classic no_ws should parse");
-    let s = span(formula).expect("span should parse");
-    assert_ast_eq(formula, &c, &s, "classic no_ws", "span");
-}
-
-#[test]
-fn regression_classic_path_basic_arith() {
-    let formula = "=A1 + B1";
-    let c = classic(formula, false).expect("classic no_ws should parse");
-    let s = span(formula).expect("span should parse");
-    assert_ast_eq(formula, &c, &s, "classic no_ws", "span");
-}
-
-// ---------------------------------------------------------------------------
-// Pinned divergences — these MUST stay consistent with the divergences doc.
-// When a future PR fixes one of these, move the formula into the agreeing
-// corpus above and delete the pin.
-// ---------------------------------------------------------------------------
-
-mod divergence {
-    use super::*;
-
-    /// Classic-with-whitespace-tokens fails to skip whitespace before `)`
-    /// in a handful of edge productions. These formulas parse fine via
-    /// the span parser and via classic with `include_whitespace=false`,
-    /// but error when the classic parser is constructed with
-    /// `include_whitespace=true`. They are excluded from
-    /// `classic_with_whitespace_tokens_agrees_with_span_on_corpus` and
-    /// pinned by the divergence tests below.
-    pub(super) const WS_BREAKS_CLASSIC_WITH_WS_TOKENS: &[&str] = &[];
-
-    /// Cases where classic with `include_whitespace=true` currently
-    /// errors but the span parser succeeds. Each of these has been
-    /// observed by hand on this branch; if any starts succeeding, the
-    /// corresponding divergence test will fire and the formula should
-    /// be moved into the agreeing corpus.
-    const CLASSIC_WS_REJECTS_BUT_SPAN_ACCEPTS: &[&str] = &[
-        // Empty arg list with interior whitespace.
-        "=SUM(  )",
-        // Trailing-comma whitespace before `)`.
-        "=SUM(A1, )",
-        "=SUM(A1, B1, )",
-    ];
-
-    #[test]
-    fn divergence_classic_with_ws_tokens_rejects_whitespace_before_close_paren() {
-        // The issue calls out that classic's `parse_function_arguments`
-        // does not call `skip_whitespace` before checking for `)` (or
-        // before checking for the next argument after a comma). Pin
-        // representative breakages so they are visible in CI.
-        let mut still_broken: Vec<&str> = Vec::new();
-        let mut now_accepting: Vec<&str> = Vec::new();
-        for &formula in CLASSIC_WS_REJECTS_BUT_SPAN_ACCEPTS {
-            let span_ast = span(formula).expect("span parses");
-            let classic_no_ws = classic(formula, false).expect("classic no_ws parses");
-            assert_ast_eq(formula, &classic_no_ws, &span_ast, "classic no_ws", "span");
-
-            match classic(formula, true) {
-                Err(_) => still_broken.push(formula),
-                Ok(_) => now_accepting.push(formula),
-            }
+fn comma_only_empty_arguments_preserve_arity() {
+    let ast = parse("=FOO(,)").unwrap();
+    match ast.node_type {
+        ASTNodeType::Function { args, .. } => {
+            assert_eq!(args.len(), 2);
+            assert!(args.iter().all(|arg| matches!(
+                &arg.node_type,
+                ASTNodeType::Literal(LiteralValue::Text(s)) if s.is_empty()
+            )));
         }
-        assert!(
-            now_accepting.is_empty(),
-            "classic Parser::new(.., include_whitespace=true) now parses {now_accepting:?}; \
-             remove from CLASSIC_WS_REJECTS_BUT_SPAN_ACCEPTS and consider moving to the agreeing corpus"
-        );
-        assert_eq!(
-            still_broken.len(),
-            CLASSIC_WS_REJECTS_BUT_SPAN_ACCEPTS.len(),
-            "divergence pin out of sync"
-        );
+        other => panic!("expected Function, got {other:?}"),
     }
 }

--- a/docs/parser-divergences.md
+++ b/docs/parser-divergences.md
@@ -1,132 +1,49 @@
-# Classic `Parser` vs `SpanParser` — known divergences
+# Parser consolidation
 
 Tracking issue: [PSU3D0/formualizer#77](https://github.com/PSU3D0/formualizer/issues/77).
 
-`formualizer-parse` exposes two public parser front-ends:
+`formualizer-parse` now has one canonical parser implementation: the
+source-span-backed public `parser::Parser`.
 
-| Front-end | Entry points | Implementation |
-|-----------|--------------|----------------|
-| **Classic** token-based parser | `Parser::new(tokens, include_whitespace)`, `Parser::try_from(&str)`, `Parser::try_from_formula(&str)` | `parser::Parser` (`src/parser.rs`, ~L1930) |
-| **Span** parser (preferred) | `parse`, `parse_with_dialect`, `parse_with_volatility_classifier`, `parse_with_dialect_and_volatility_classifier`, `BatchParser` | `parser::SpanParser` (`src/parser.rs`, ~L2451) |
+The old token-vector parser (`Parser::new(tokens, include_whitespace)`) was
+removed while the crate is still early. This eliminates the previous classic vs
+span divergence class and ensures fixes only need to land in one parser.
 
-The long-term plan in #77 is to make `SpanParser` the canonical
-implementation and rewrite `Parser::parse` as a forwarder that
-re-tokenizes the original source string. Until that lands, the two
-parsers produce subtly different ASTs for several edge inputs. This
-document is the canonical catalog of those differences; the
-authoritative *runnable* version lives in
-[`crates/formualizer-parse/tests/parser_differential.rs`](../crates/formualizer-parse/tests/parser_differential.rs).
+## Supported public entrypoints
 
-## Status legend
+- `parse(formula)` for ergonomic one-shot parsing.
+- `parse_with_dialect(formula, dialect)` for explicit dialect selection.
+- `parse_with_volatility_classifier(...)` and
+  `parse_with_dialect_and_volatility_classifier(...)` for volatility marking.
+- `Parser::new(formula)` / `Parser::new_with_dialect(formula, dialect)` for a
+  stateful parser value.
+- `Parser::builder()` for configured parser construction.
+- `Parser::from_token_stream(&TokenStream)` for callers that already tokenized
+  into the source-backed span stream.
+- `BatchParser` for repeated parsing with cached token spans.
+- Rust idioms: `Parser::try_from(...)`, `ASTNode::try_from(...)`, and
+  `"=A1+B1".parse::<ASTNode>()`.
 
-- **Pinned** — divergence is currently observable; a test in
-  `parser_differential.rs::divergence` asserts the current behaviour and
-  will fail loudly when the divergence is fixed (forcing the entry to
-  move into the "agreeing corpus").
-- **Resolved** — currently produces equivalent ASTs across both
-  parsers; a representative formula lives in `AGREEING_CORPUS`.
+The runnable compatibility contract lives in
+[`crates/formualizer-parse/tests/parser_differential.rs`](../crates/formualizer-parse/tests/parser_differential.rs),
+which asserts that all supported public entrypoints agree structurally across a
+representative formula corpus.
 
-## Pinned divergences
+## Breaking API note
 
-### 1. Whitespace before `)` in classic `Parser` with `include_whitespace=true`
-
-When the classic parser is constructed with `include_whitespace=true`,
-its argument-list productions do **not** call `skip_whitespace` before
-checking for `)` or before reading the next argument. This causes the
-following inputs to error in classic-WS mode while parsing fine via the
-span parser and via classic with `include_whitespace=false`:
-
-- `=SUM(  )`        — empty arg list with interior whitespace
-- `=SUM(A1, )`      — trailing whitespace after a comma before `)`
-- `=SUM(A1, B1, )`  — trailing comma + whitespace
-
-Source pointers:
-
-- Classic `parse_function_arguments`: `parser.rs:1667-1672`
-- Span `parse_function_arguments`: `parser.rs:2697-2704` (calls
-  `skip_whitespace` before close-check)
-
-Pinned by
-`divergence::divergence_classic_with_ws_tokens_rejects_whitespace_before_close_paren`.
-
-## Resolved (currently equal — guarded by `AGREEING_CORPUS`)
-
-The differential harness asserts equality across ~80 formulas spanning
-literals, references, arithmetic and comparison precedence, function
-calls (including `IF`, `IFS`, `LET`, `LAMBDA`), arrays, sheet-qualified
-references (including lowercase sheet-qualified error literals), the
-spilled-range `#` operator, unary precedence (post-PR \#81), and
-whitespace handling such as `=SUM( A1 , B1 )` and
-`= ( A1 + B1 ) ` (when classic is used with `include_whitespace=false`,
-which is what `Parser::try_from(&str)` chooses by default).
-
-## Notes on `source_token`
-
-The differential harness ignores `source_token` and
-`contains_volatile`:
-
-- `source_token` legitimately differs because the two parsers build
-  `Token` instances from different sources (filtered token vector vs.
-  `TokenSpan` projected back onto the source string). After unification
-  the underlying `start`/`end` offsets should match for every node, but
-  for now only structural AST equality is asserted.
-- `contains_volatile` is only set when a volatility classifier is
-  supplied; the corpus does not configure one.
-
-## Plan for full unification (later PR)
-
-Per #77's "Step 3" sketch:
+Callers that constructed parser input from owned `Vec<Token>` should migrate to
+one of:
 
 ```rust
-impl Parser {
-    pub fn parse(&mut self) -> Result<ASTNode, ParserError> {
-        let source: String = self.tokens.iter().map(|t| t.value.as_str()).collect();
-        let source = if source.starts_with('=') { source } else { format!("={source}") };
-        let spans = tokenize_spans_with_dialect(&source, self.dialect)?;
-        let mut parser = SpanParser::new(&source, &spans, self.dialect);
-        if let Some(c) = self.volatility_classifier.take() {
-            parser = parser.with_volatility_classifier(move |n| c(n));
-        }
-        parser.parse()
-    }
-}
+let ast = formualizer_parse::parse("=SUM(A1:A10)")?;
+
+let mut parser = formualizer_parse::Parser::new("=SUM(A1:A10)")?;
+let ast = parser.parse()?;
+
+let stream = formualizer_parse::TokenStream::new("=SUM(A1:A10)")?;
+let mut parser = formualizer_parse::Parser::from_token_stream(&stream);
+let ast = parser.parse()?;
 ```
 
-Open questions to resolve before that PR can land:
-
-1. **Hand-constructed token streams.** `Parser::new(tokens, ...)` is
-   public and accepts arbitrary `Vec<Token>`. Concatenating
-   `Token::value` is lossy when tokens were built without going through
-   `Tokenizer::new` (e.g. tokens lacking the implicit leading `=`,
-   tokens that round-trip differently, or tokens hand-built in tests).
-   Investigate real-world consumers; document a fallback (verbatim
-   concatenation of `value` with a synthesised leading `=`).
-2. **Source location preservation.** After re-tokenization,
-   `Token::start`/`end` offsets refer to the reconstructed source
-   string, not whatever the caller may have used originally. This is
-   probably fine — there is no other source to refer to — but should
-   be called out in the changelog.
-3. **`include_whitespace` semantics.** With `SpanParser` as the
-   canonical implementation, the `include_whitespace` flag becomes a
-   pre-filter on the span vector; the parser already tolerates
-   whitespace tokens, so passing `true` should become a no-op for AST
-   shape. Document this.
-4. **Repeated `parse` calls.** `SpanParser` is single-shot; `Parser`'s
-   contract on repeated calls (currently it advances `position` and
-   subsequent calls fail) should be preserved.
-5. **`Parser::new_with_*` constructors.** Keep as public surface, route
-   through the forwarder. Mark internal helpers
-   (`parse_expression`, `parse_prefix`, `parse_bp`, `parse_primary`,
-   `parse_operand`, `parse_function`, `parse_function_arguments`,
-   `parse_array`) as `#[deprecated]` or make them private.
-6. **`legacy-token-parser` feature flag.** If any downstream depends on
-   hand-constructed tokens with non-trivial `Token::value` shape,
-   gate the original implementation behind a feature flag rather than
-   deleting it outright.
-
-The harness in `crates/formualizer-parse/tests/parser_differential.rs`
-is the contract that the unification PR must satisfy: every formula in
-`AGREEING_CORPUS` keeps agreeing, and every divergence currently pinned
-in `parser_differential.rs::divergence` is migrated into
-`AGREEING_CORPUS` (with an assertion that classic and span produce
-identical ASTs).
+The tokenizer still exposes owned `Token`s for FFI/debugging, but parsing is now
+source-backed so AST source locations remain tied to the original formula text.


### PR DESCRIPTION
## Summary
- remove the legacy token-vector parser and make the source-span parser the public `Parser`
- fix leading empty function arguments like `=FOO(,A1:C3)` and preserve empty-argument arity
- add public parser idioms: `Parser::new`, builder, `TokenStream` parsing, `FromStr`, and `TryFrom` for `ASTNode`/`Parser`
- update bindings/cffi/eval call sites and parser docs

Fixes #103.
Closes #77.

## Tests
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p formualizer-parse`
- `cargo test --workspace --exclude formualizer-python`

Note: `cargo test --workspace` reaches link but fails for `formualizer-python` in this environment because `-lpython3.13` is unavailable.