### PR TITLE
fix(eval): harden formula-plane sheet operations

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1758,23 +1758,24 @@ where
     }
 
     pub fn add_sheet(&mut self, name: &str) -> Result<SheetId, ExcelError> {
-        self.demote_all_spans()
-            .map_err(Self::editor_error_to_excel)?;
         let id = self.graph.add_sheet(name)?;
         self.ensure_arrow_sheet(name);
-        self.clear_all_computed_overlays();
-        self.mark_all_formula_vertices_dirty();
-        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        // Adding a sheet does not invalidate existing SheetId-based FormulaPlane
+        // spans. `graph.add_sheet` handles legacy orphan-healing for formulas
+        // that were explicitly tombstoned for this sheet name; avoid a global
+        // FormulaPlane demotion/dirty mark for unrelated spans.
         self.mark_topology_edited();
         Ok(id)
     }
 
     pub fn duplicate_sheet(&mut self, source: &str, new_name: &str) -> Result<SheetId, ExcelError> {
-        self.demote_all_spans()
-            .map_err(Self::editor_error_to_excel)?;
         let source_id = self.graph.sheet_id(source).ok_or_else(|| {
             ExcelError::new(ExcelErrorKind::Value).with_message("Source sheet does not exist")
         })?;
+        // Materialize only spans on the source sheet so graph duplication sees
+        // the formulas being copied. Spans on unrelated sheets remain active.
+        self.demote_spans_preserving_computed_overlays(source_id, Region::whole_sheet(source_id))
+            .map_err(Self::editor_error_to_excel)?;
         let new_id = self.graph.duplicate_sheet(source_id, new_name)?;
 
         if let Some(source_sheet) = self.arrow_sheets.sheet(source).cloned() {
@@ -1787,7 +1788,6 @@ where
 
         self.clear_all_computed_overlays();
         self.mark_all_formula_vertices_dirty();
-        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
         self.mark_topology_edited();
         Ok(new_id)
     }
@@ -1809,7 +1809,10 @@ where
 
     pub fn remove_sheet(&mut self, sheet_id: SheetId) -> Result<(), ExcelError> {
         let name = self.graph.sheet_name(sheet_id).to_string();
-        self.demote_all_spans()
+        // Removing a sheet only affects spans on that sheet and spans reading
+        // from that sheet. Preserve spans on unrelated sheets so sheet
+        // lifecycle operations do not collapse the whole FormulaPlane.
+        self.demote_spans_preserving_computed_overlays(sheet_id, Region::whole_sheet(sheet_id))
             .map_err(Self::editor_error_to_excel)?;
         self.graph.remove_sheet(sheet_id)?;
         self.arrow_sheets.sheets.retain(|s| s.name.as_ref() != name);
@@ -3918,33 +3921,6 @@ where
             self.demote_spans_preserving_computed_overlays(
                 sheet_id,
                 Region::point(sheet_id, row0, col0),
-            )?;
-        }
-        Ok(())
-    }
-
-    fn demote_all_spans(&mut self) -> Result<(), crate::engine::EditorError> {
-        if self.config.formula_plane_mode == FormulaPlaneMode::Off {
-            return Ok(());
-        }
-        let sheet_ids: FxHashSet<SheetId> = {
-            let authority = self.graph.formula_authority();
-            authority
-                .active_span_refs()
-                .into_iter()
-                .filter_map(|span_ref| {
-                    authority
-                        .plane
-                        .spans
-                        .get(span_ref)
-                        .map(|span| span.sheet_id)
-                })
-                .collect()
-        };
-        for sheet_id in sheet_ids {
-            self.demote_spans_preserving_computed_overlays(
-                sheet_id,
-                Region::whole_sheet(sheet_id),
             )?;
         }
         Ok(())

--- a/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
@@ -195,7 +195,7 @@ impl DependencyGraph {
                                     SharedSheetLocator::Id(id) => id,
                                     SharedSheetLocator::Current => current_sheet_id,
                                     SharedSheetLocator::Name(name) => {
-                                        self.sheet_id_mut(name.as_ref())
+                                        self.resolve_existing_sheet_id(name.as_ref())?
                                     }
                                 };
                                 range_dependencies.push(SharedRangeRef {
@@ -207,10 +207,11 @@ impl DependencyGraph {
                                 });
                             }
                         } else {
-                            let sr = start_row.unwrap();
-                            let sc = start_col.unwrap();
-                            let er = end_row.unwrap();
-                            let ec = end_col.unwrap();
+                            let (Some(sr), Some(sc), Some(er), Some(ec)) =
+                                (*start_row, *start_col, *end_row, *end_col)
+                            else {
+                                return Err(ExcelError::new(ExcelErrorKind::Ref));
+                            };
 
                             if sr > er || sc > ec {
                                 return Err(ExcelError::new(ExcelErrorKind::Ref));
@@ -245,7 +246,7 @@ impl DependencyGraph {
                                         SharedSheetLocator::Id(id) => id,
                                         SharedSheetLocator::Current => current_sheet_id,
                                         SharedSheetLocator::Name(name) => {
-                                            self.sheet_id_mut(name.as_ref())
+                                            self.resolve_existing_sheet_id(name.as_ref())?
                                         }
                                     };
                                     range_dependencies.push(SharedRangeRef {
@@ -576,7 +577,9 @@ impl DependencyGraph {
                             let sheet_id = match owned.sheet {
                                 SharedSheetLocator::Id(id) => id,
                                 SharedSheetLocator::Current => current_sheet_id,
-                                SharedSheetLocator::Name(name) => self.sheet_id_mut(name.as_ref()),
+                                SharedSheetLocator::Name(name) => {
+                                    self.resolve_existing_sheet_id(name.as_ref())?
+                                }
                             };
                             range_dependencies.push(SharedRangeRef {
                                 sheet: SharedSheetLocator::Id(sheet_id),
@@ -587,10 +590,11 @@ impl DependencyGraph {
                             });
                         }
                     } else {
-                        let sr = start_row.unwrap();
-                        let sc = start_col.unwrap();
-                        let er = end_row.unwrap();
-                        let ec = end_col.unwrap();
+                        let (Some(sr), Some(sc), Some(er), Some(ec)) =
+                            (*start_row, *start_col, *end_row, *end_col)
+                        else {
+                            return Err(ExcelError::new(ExcelErrorKind::Ref));
+                        };
 
                         if sr > er || sc > ec {
                             return Err(ExcelError::new(ExcelErrorKind::Ref));
@@ -623,7 +627,7 @@ impl DependencyGraph {
                                     SharedSheetLocator::Id(id) => id,
                                     SharedSheetLocator::Current => current_sheet_id,
                                     SharedSheetLocator::Name(name) => {
-                                        self.sheet_id_mut(name.as_ref())
+                                        self.resolve_existing_sheet_id(name.as_ref())?
                                     }
                                 };
                                 range_dependencies.push(SharedRangeRef {

--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -473,10 +473,11 @@ impl<'a> IngestPipeline<'a> {
                     return Ok(());
                 }
 
-                let sr = start_row.unwrap();
-                let sc = start_col.unwrap();
-                let er = end_row.unwrap();
-                let ec = end_col.unwrap();
+                let (Some(sr), Some(sc), Some(er), Some(ec)) =
+                    (*start_row, *start_col, *end_row, *end_col)
+                else {
+                    return Err(ExcelError::new(ExcelErrorKind::Ref));
+                };
                 if sr > er || sc > ec {
                     return Err(ExcelError::new(ExcelErrorKind::Ref));
                 }
@@ -560,7 +561,12 @@ impl<'a> IngestPipeline<'a> {
         match sheet {
             SharedSheetLocator::Id(id) => Ok(id),
             SharedSheetLocator::Current => Ok(current_sheet_id),
-            SharedSheetLocator::Name(name) => Ok(self.sheet_registry.id_for(name.as_ref())),
+            SharedSheetLocator::Name(name) => {
+                self.sheet_registry.get_id(name.as_ref()).ok_or_else(|| {
+                    ExcelError::new(ExcelErrorKind::Ref)
+                        .with_message(format!("Sheet not found: {name}"))
+                })
+            }
         }
     }
 

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -47,20 +47,27 @@ fn build_three_formula_column_family(rows: u32) -> Engine<TestWorkbook> {
 
 fn build_single_formula_column_family(rows: u32) -> Engine<TestWorkbook> {
     let mut engine = authoritative_engine();
-    let mut formulas = Vec::new();
-    for row in 1..=rows {
-        engine
-            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
-            .unwrap();
-        formulas.push(record(&mut engine, row, 2, &format!("=A{row}*2")));
-    }
-    engine
-        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
-        .unwrap();
+    add_single_formula_column_family(&mut engine, "Sheet1", rows);
     assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
     assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
     engine.evaluate_all().unwrap();
     engine
+}
+
+fn add_single_formula_column_family(engine: &mut Engine<TestWorkbook>, sheet: &str, rows: u32) {
+    if engine.sheet_id(sheet).is_none() {
+        engine.add_sheet(sheet).unwrap();
+    }
+    let mut formulas = Vec::new();
+    for row in 1..=rows {
+        engine
+            .set_cell_value(sheet, row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(engine, row, 2, &format!("=A{row}*2")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(sheet, formulas)])
+        .unwrap();
 }
 
 fn only_active_span_is_constant(engine: &Engine<TestWorkbook>) -> bool {
@@ -728,6 +735,87 @@ fn formula_plane_delete_fully_contains_span_removes_it_and_clears_overlays() {
         Some(LiteralValue::Number(5.0))
     );
     assert_eq!(engine.get_cell_value("Sheet1", 5, 2), None);
+}
+
+#[test]
+fn formula_plane_ingest_rejects_unbounded_reference_to_unknown_sheet_without_creating_sheet() {
+    let mut engine = authoritative_engine();
+    let formula = record(&mut engine, 1, 1, "=SUM(MissingSheet!A:A)");
+
+    let result =
+        engine.ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", vec![formula])]);
+
+    assert!(result.is_err());
+    assert!(engine.sheet_id("MissingSheet").is_none());
+}
+
+#[test]
+fn formula_plane_add_sheet_preserves_existing_active_spans() {
+    let mut engine = build_single_formula_column_family(100);
+
+    engine.add_sheet("Added").unwrap();
+
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 50, 2),
+        Some(LiteralValue::Number(100.0))
+    );
+}
+
+#[test]
+fn formula_plane_remove_unrelated_sheet_preserves_existing_active_spans() {
+    let mut engine = authoritative_engine();
+    let unrelated = engine.add_sheet("Unrelated").unwrap();
+    add_single_formula_column_family(&mut engine, "Sheet1", 100);
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+
+    engine.remove_sheet(unrelated).unwrap();
+
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 50, 2),
+        Some(LiteralValue::Number(100.0))
+    );
+}
+
+#[test]
+fn formula_plane_rename_sheet_preserves_existing_active_spans() {
+    let mut engine = build_single_formula_column_family(100);
+    let sheet = engine.sheet_id("Sheet1").unwrap();
+
+    engine.rename_sheet(sheet, "Renamed").unwrap();
+
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Renamed", 50, 2),
+        Some(LiteralValue::Number(100.0))
+    );
+}
+
+#[test]
+fn formula_plane_duplicate_sheet_only_demotes_source_sheet_spans() {
+    let mut engine = authoritative_engine();
+    add_single_formula_column_family(&mut engine, "Sheet1", 100);
+    add_single_formula_column_family(&mut engine, "Other", 100);
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+
+    engine.duplicate_sheet("Sheet1", "Copy").unwrap();
+
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Other", 50, 2),
+        Some(LiteralValue::Number(100.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Copy", 50, 2),
+        Some(LiteralValue::Number(100.0))
+    );
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/infinite_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/infinite_ranges.rs
@@ -16,6 +16,17 @@ fn range_limit_config(limit: usize) -> EvalConfig {
 }
 
 #[test]
+fn unbounded_reference_to_unknown_sheet_errors_without_creating_sheet() {
+    let wb = TestWorkbook::new();
+    let mut engine = Engine::new(wb, range_limit_config(16));
+
+    let result = engine.set_cell_formula("Sheet1", 1, 1, parse("=SUM(MissingSheet!A:A)").unwrap());
+
+    assert!(result.is_err());
+    assert!(engine.sheet_id("MissingSheet").is_none());
+}
+
+#[test]
 fn infinite_column_empty_sheet_sum_count_are_zero() {
     let wb = TestWorkbook::new();
     let mut engine = Engine::new(wb, range_limit_config(16));

--- a/crates/formualizer-eval/src/engine/tests/structural_op_clears_computed_values.rs
+++ b/crates/formualizer-eval/src/engine/tests/structural_op_clears_computed_values.rs
@@ -114,7 +114,7 @@ fn delete_columns_clears_computed_values() {
 }
 
 #[test]
-fn add_sheet_clears_all_sheets_computed_values() {
+fn add_sheet_preserves_unaffected_computed_values() {
     let mut engine = off_engine();
     engine.add_sheet("Sheet2").unwrap();
     engine.set_cell_value(SHEET, 1, 1, number(2.0)).unwrap();
@@ -132,8 +132,8 @@ fn add_sheet_clears_all_sheets_computed_values() {
 
     engine.add_sheet("NewSheet").unwrap();
 
-    assert_empty(&engine, SHEET, 1, 2);
-    assert_empty(&engine, "Sheet2", 1, 2);
+    assert_number(&engine, SHEET, 1, 2, 6.0);
+    assert_number(&engine, "Sheet2", 1, 2, 20.0);
 }
 
 #[test]

--- a/crates/formualizer-eval/src/formula_plane/region_index.rs
+++ b/crates/formualizer-eval/src/formula_plane/region_index.rs
@@ -623,11 +623,13 @@ impl<T: Clone> SheetRegionIndex<T> {
                 };
                 self.whole_sheets.entry(sheet_id).or_default().push(id);
             }
-            _ => panic!(
-                "unsupported SheetRegionIndex insertion kind pair in Phase 2: ({:?}, {:?})",
-                rows.kind(),
-                cols.kind()
-            ),
+            _ => {
+                // Keep unsupported-but-valid region shapes conservative: index
+                // them as a whole-sheet candidate so supported point/range
+                // queries still exact-filter them instead of panicking or
+                // silently under-returning.
+                self.whole_sheets.entry(sheet_id).or_default().push(id);
+            }
         }
     }
 
@@ -866,11 +868,17 @@ impl<T: Clone> SheetRegionIndex<T> {
                 self.collect_whole_cols_matching(sheet_id, |_| true, out);
                 self.collect_whole_sheet(sheet_id, out);
             }
-            _ => panic!(
-                "unsupported SheetRegionIndex query kind pair in Phase 2: ({:?}, {:?})",
-                rows.kind(),
-                cols.kind()
-            ),
+            _ => {
+                // Unsupported query shapes are rare internal fallback cases.
+                // Scan same-sheet entries and let the exact intersection
+                // filter in `query` decide, preserving correctness without a
+                // production panic.
+                out.extend(
+                    self.entries.iter().enumerate().filter_map(|(id, entry)| {
+                        (entry.region.sheet_id() == sheet_id).then_some(id)
+                    }),
+                );
+            }
         }
     }
 
@@ -1867,6 +1875,41 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn sheet_region_index_unsupported_axis_pairs_do_not_panic_or_under_return() {
+        let mut index = SheetRegionIndex::with_rect_bucket_size(4, 4);
+        let unsupported_insert = Region {
+            sheet_id: 1,
+            rows: AxisRange::To(10),
+            cols: AxisRange::Point(3),
+        };
+        let point_query = Region::point(1, 5, 3);
+
+        index.insert(unsupported_insert, "unsupported_insert");
+        let point_values: FxHashSet<_> = index
+            .query(point_query)
+            .matches
+            .iter()
+            .map(|matched| matched.value)
+            .collect();
+        assert!(point_values.contains("unsupported_insert"));
+
+        index.insert(Region::whole_sheet(1), "whole_sheet");
+        let unsupported_query = Region {
+            sheet_id: 1,
+            rows: AxisRange::To(10),
+            cols: AxisRange::Point(3),
+        };
+        let query_values: FxHashSet<_> = index
+            .query(unsupported_query)
+            .matches
+            .iter()
+            .map(|matched| matched.value)
+            .collect();
+        assert!(query_values.contains("unsupported_insert"));
+        assert!(query_values.contains("whole_sheet"));
     }
 
     #[test]

--- a/crates/formualizer-eval/src/formula_plane/runtime.rs
+++ b/crates/formualizer-eval/src/formula_plane/runtime.rs
@@ -397,14 +397,19 @@ impl Iterator for PlacementDomainIter {
         if self.done {
             return (0, Some(0));
         }
-        let remaining = match self.mode {
-            PlacementDomainIterMode::RowRun => self.row_end.saturating_sub(self.row) + 1,
-            PlacementDomainIterMode::ColRun => self.col_end.saturating_sub(self.col) + 1,
+        let remaining_u64 = match self.mode {
+            PlacementDomainIterMode::RowRun => u64::from(self.row_end.saturating_sub(self.row)) + 1,
+            PlacementDomainIterMode::ColRun => u64::from(self.col_end.saturating_sub(self.col)) + 1,
             PlacementDomainIterMode::Rect => {
-                let width = self.col_end - self.col_start + 1;
-                (self.row_end - self.row) * width + (self.col_end - self.col + 1)
+                let width = u64::from(self.col_end.saturating_sub(self.col_start)) + 1;
+                let remaining_full_rows = u64::from(self.row_end.saturating_sub(self.row));
+                let remaining_in_row = u64::from(self.col_end.saturating_sub(self.col)) + 1;
+                remaining_full_rows
+                    .saturating_mul(width)
+                    .saturating_add(remaining_in_row)
             }
-        } as usize;
+        };
+        let remaining = usize::try_from(remaining_u64).unwrap_or(usize::MAX);
         (remaining, Some(remaining))
     }
 }
@@ -1427,6 +1432,14 @@ mod tests {
             .expect("overlay record")
             .kind
             .clone()
+    }
+
+    #[test]
+    fn placement_domain_rect_size_hint_uses_wide_arithmetic() {
+        let domain = PlacementDomain::rect(0, 0, 1_048_575, 0, 16_383);
+        let expected = 1_048_576usize * 16_384usize;
+
+        assert_eq!(domain.iter().size_hint(), (expected, Some(expected)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- avoid global FormulaPlane demotion for add/remove/duplicate sheet operations
- preserve unrelated spans across sheet lifecycle operations while demoting only affected/source spans
- reject unbounded references to unknown sheets without creating phantom sheet IDs
- harden range-bound handling, region-index unsupported axis pairs, and large rect size hints against panics/overflow

## Validation
- `CARGO_TARGET_DIR=/home/psu3d0/.cache/formualizer-target/release-audit-c5078ba0 cargo test -p formualizer-eval`
- `CARGO_TARGET_DIR=/home/psu3d0/.cache/formualizer-target/release-audit-c5078ba0 cargo test --workspace --exclude formualizer-bench-core --exclude formualizer-python --exclude formualizer-wasm --all-features`
- `CARGO_TARGET_DIR=/home/psu3d0/.cache/formualizer-target/release-audit-c5078ba0 cargo clippy --workspace --exclude formualizer-bench-core --exclude formualizer-python --exclude formualizer-wasm --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=/home/psu3d0/.cache/formualizer-target/release-audit-c5078ba0 cargo test -p formualizer-bench-core --features formualizer_runner`
