### PR TITLE
fix(eval): named-range pass-through vertices in demand subgraph + preserve edges through CSR rebuild

### DIFF
--- a/crates/formualizer-eval/src/engine/delta_edges.rs
+++ b/crates/formualizer-eval/src/engine/delta_edges.rs
@@ -417,6 +417,21 @@ impl DeltaEdgeSlab {
         self.coord_changed = false;
     }
 
+    /// Iterate over all (from, &additions) pairs in the delta. Used by
+    /// build_from_adjacency to carry forward delta-only edges that the
+    /// adjacency input does not cover.
+    pub fn additions_iter(&self) -> impl Iterator<Item = (&VertexId, &FxHashSet<VertexId>)> {
+        self.additions.iter()
+    }
+
+    /// Return removals scheduled for `from` (empty slice if none).
+    pub fn removals_for(&self, from: VertexId) -> impl Iterator<Item = VertexId> + '_ {
+        self.removals
+            .get(&from)
+            .into_iter()
+            .flat_map(|set| set.iter().copied())
+    }
+
     /// Apply delta to CSR, creating a new CSR structure
     pub fn apply_to_csr(
         &self,
@@ -660,10 +675,66 @@ impl CsrMutableEdges {
     /// This replaces the current base and clears the delta slab.
     pub fn build_from_adjacency(
         &mut self,
-        adjacency: Vec<(u32, Vec<u32>)>,
+        mut adjacency: Vec<(u32, Vec<u32>)>,
         coords: Vec<AbsCoord>,
         vertex_ids: Vec<u32>,
     ) {
+        // Carry forward any edges that exist in the current base or delta
+        // for vertices NOT covered by the input adjacency. Named-range
+        // pass-through vertices (NamedScalar/NamedArray) emit edges to
+        // their underlying cells via add_edge during load. Those edges
+        // live in base after the auto-rebuild that follows each add_vertex
+        // call. Bulk-ingest's finalize only hands us formula-target edges
+        // in the adjacency input, so without this carry-forward the
+        // named-range vertex's out-edges would be silently dropped and
+        // build_demand_subgraph would never reach the underlying cells.
+        let covered: rustc_hash::FxHashSet<u32> = adjacency.iter().map(|(vid, _)| *vid).collect();
+        // Carry forward base-only out-edges for ANY existing vertex not in
+        // the new adjacency input. Iterate over the current vertex_ids
+        // (which already track every vertex allocated so far, including
+        // named-range pass-through vertices) before we overwrite the field.
+        for &vid in &self.vertex_ids {
+            if covered.contains(&vid) {
+                continue;
+            }
+            let v = VertexId(vid);
+            // Merge with any pending delta edges for this vertex.
+            let merged = if self.delta.op_count() == 0 {
+                self.base.out_edges(v).to_vec()
+            } else {
+                self.delta.merged_view(&self.base, v)
+            };
+            if !merged.is_empty() {
+                adjacency.push((vid, merged.into_iter().map(|v| v.0).collect()));
+            }
+        }
+        // Also carry forward delta-only additions (additions to vertices
+        // that weren't in vertex_ids yet — e.g., freshly allocated names
+        // whose add_vertex didn't trigger a rebuild). Pure deltas should
+        // be rare here, but include them for completeness.
+        for (&from, adds) in self.delta.additions_iter() {
+            if covered.contains(&from.0) {
+                continue;
+            }
+            if adjacency.iter().any(|(v, _)| *v == from.0) {
+                continue;
+            }
+            let removals: rustc_hash::FxHashSet<u32> =
+                self.delta.removals_for(from).map(|v| v.0).collect();
+            let mut base_set: rustc_hash::FxHashSet<u32> =
+                self.base.out_edges(from).iter().map(|v| v.0).collect();
+            for r in &removals {
+                base_set.remove(r);
+            }
+            for &add in adds {
+                base_set.insert(add.0);
+            }
+            if !base_set.is_empty() {
+                let mut targets: Vec<u32> = base_set.into_iter().collect();
+                targets.sort_unstable();
+                adjacency.push((from.0, targets));
+            }
+        }
         self.base = CsrEdges::from_adjacency(adjacency, &coords);
         self.coords = coords;
         self.vertex_ids = vertex_ids;

--- a/crates/formualizer-eval/src/engine/delta_edges.rs
+++ b/crates/formualizer-eval/src/engine/delta_edges.rs
@@ -671,28 +671,28 @@ impl CsrMutableEdges {
         }
     }
 
-    /// Build underlying CSR directly from adjacency and provided coords/ids.
-    /// This replaces the current base and clears the delta slab.
-    pub fn build_from_adjacency(
-        &mut self,
+    /// Return a copy of `adjacency` extended with the current base+delta
+    /// out-edges of every existing vertex that the input does not cover.
+    ///
+    /// Named-range pass-through vertices (NamedScalar/NamedArray) emit edges
+    /// to their underlying cells via `add_edge` during load; those edges live
+    /// in `base`/`delta` but are not part of the formula-target adjacency that
+    /// bulk-ingest's finalize hands to [`build_from_adjacency`]. Feeding the
+    /// raw adjacency straight to that (pure) builder would therefore silently
+    /// drop the pass-through vertices' out-edges, and `build_demand_subgraph`
+    /// could never reach the underlying cells. Callers run this first to merge
+    /// those edges back in, then pass the result to `build_from_adjacency`.
+    ///
+    /// Must be called BEFORE `build_from_adjacency`, which overwrites
+    /// `base`/`delta`/`vertex_ids`.
+    pub fn adjacency_with_carried_forward_edges(
+        &self,
         mut adjacency: Vec<(u32, Vec<u32>)>,
-        coords: Vec<AbsCoord>,
-        vertex_ids: Vec<u32>,
-    ) {
-        // Carry forward any edges that exist in the current base or delta
-        // for vertices NOT covered by the input adjacency. Named-range
-        // pass-through vertices (NamedScalar/NamedArray) emit edges to
-        // their underlying cells via add_edge during load. Those edges
-        // live in base after the auto-rebuild that follows each add_vertex
-        // call. Bulk-ingest's finalize only hands us formula-target edges
-        // in the adjacency input, so without this carry-forward the
-        // named-range vertex's out-edges would be silently dropped and
-        // build_demand_subgraph would never reach the underlying cells.
-        let covered: rustc_hash::FxHashSet<u32> = adjacency.iter().map(|(vid, _)| *vid).collect();
-        // Carry forward base-only out-edges for ANY existing vertex not in
-        // the new adjacency input. Iterate over the current vertex_ids
-        // (which already track every vertex allocated so far, including
-        // named-range pass-through vertices) before we overwrite the field.
+    ) -> Vec<(u32, Vec<u32>)> {
+        let covered: FxHashSet<u32> = adjacency.iter().map(|(vid, _)| *vid).collect();
+        // Carry forward base+delta out-edges for ANY existing vertex not in
+        // the new adjacency input. `vertex_ids` already tracks every vertex
+        // allocated so far, including named-range pass-through vertices.
         for &vid in &self.vertex_ids {
             if covered.contains(&vid) {
                 continue;
@@ -708,10 +708,10 @@ impl CsrMutableEdges {
                 adjacency.push((vid, merged.into_iter().map(|v| v.0).collect()));
             }
         }
-        // Also carry forward delta-only additions (additions to vertices
-        // that weren't in vertex_ids yet — e.g., freshly allocated names
-        // whose add_vertex didn't trigger a rebuild). Pure deltas should
-        // be rare here, but include them for completeness.
+        // Also carry forward delta-only additions (additions to vertices that
+        // weren't in vertex_ids yet — e.g., freshly allocated names whose
+        // add_vertex didn't trigger a rebuild). Pure deltas should be rare
+        // here, but include them for completeness.
         for (&from, adds) in self.delta.additions_iter() {
             if covered.contains(&from.0) {
                 continue;
@@ -719,9 +719,8 @@ impl CsrMutableEdges {
             if adjacency.iter().any(|(v, _)| *v == from.0) {
                 continue;
             }
-            let removals: rustc_hash::FxHashSet<u32> =
-                self.delta.removals_for(from).map(|v| v.0).collect();
-            let mut base_set: rustc_hash::FxHashSet<u32> =
+            let removals: FxHashSet<u32> = self.delta.removals_for(from).map(|v| v.0).collect();
+            let mut base_set: FxHashSet<u32> =
                 self.base.out_edges(from).iter().map(|v| v.0).collect();
             for r in &removals {
                 base_set.remove(r);
@@ -735,6 +734,22 @@ impl CsrMutableEdges {
                 adjacency.push((from.0, targets));
             }
         }
+        adjacency
+    }
+
+    /// Build underlying CSR directly from adjacency and provided coords/ids.
+    /// This replaces the current base and clears the delta slab.
+    ///
+    /// Pure builder: it uses exactly the edges in `adjacency` and does not
+    /// consult the existing `base`/`delta`. To preserve edges for vertices
+    /// absent from `adjacency` (e.g. named-range pass-through vertices), run
+    /// [`adjacency_with_carried_forward_edges`] first and pass its result in.
+    pub fn build_from_adjacency(
+        &mut self,
+        adjacency: Vec<(u32, Vec<u32>)>,
+        coords: Vec<AbsCoord>,
+        vertex_ids: Vec<u32>,
+    ) {
         self.base = CsrEdges::from_adjacency(adjacency, &coords);
         self.coords = coords;
         self.vertex_ids = vertex_ids;

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -9145,12 +9145,24 @@ where
             if !self.graph.vertex_exists(v) {
                 continue;
             }
-            // Only schedule dirty/volatile formulas
+            // Schedule dirty/volatile formulas. Also schedule pass-through
+            // Named*/Range vertices so the scheduler honours the
+            // topological position of any formula cells that sit underneath
+            // them — without these in `vertex_set` the scheduler skips the
+            // edges that route a target through a named-range vertex into
+            // its underlying cells, and the underlying cells then end up
+            // in the same (or an earlier) layer as the target.
             match self.graph.get_vertex_kind(v) {
                 VertexKind::FormulaScalar | VertexKind::FormulaArray => {
                     if self.graph.is_dirty(v) || self.graph.is_volatile(v) {
                         to_evaluate.insert(v);
                     }
+                }
+                VertexKind::NamedScalar
+                | VertexKind::NamedArray
+                | VertexKind::Range
+                | VertexKind::InfiniteRange => {
+                    to_evaluate.insert(v);
                 }
                 _ => {}
             }

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -9155,31 +9155,26 @@ where
                 _ => {}
             }
 
-            // Explicit dependencies (graph edges)
+            // Explicit dependencies (graph edges). We push *every* dep onto
+            // the stack — not just formulas — because intermediate vertices
+            // (NamedScalar, NamedArray, Range) are pass-through nodes whose
+            // own dependencies point at the actual formula cells. Filtering
+            // by kind here previously caused DN-range refs to be dropped
+            // from the demand subgraph, so a target like
+            // ``=SUM(named_range_pointing_at_dirty_cells)`` would evaluate
+            // using stale values for those cells. The kind check at the top
+            // of the loop still gates which vertices end up in
+            // ``to_evaluate``; only Formula vertices are scheduled.
             if let Some(dependencies) = self.graph.dependencies_slice(v) {
                 for &dep in dependencies {
-                    if self.graph.vertex_exists(dep) {
-                        match self.graph.get_vertex_kind(dep) {
-                            VertexKind::FormulaScalar | VertexKind::FormulaArray => {
-                                if !visited.contains(&dep) {
-                                    stack.push(dep);
-                                }
-                            }
-                            _ => {}
-                        }
+                    if self.graph.vertex_exists(dep) && !visited.contains(&dep) {
+                        stack.push(dep);
                     }
                 }
             } else {
                 for dep in self.graph.get_dependencies(v) {
-                    if self.graph.vertex_exists(dep) {
-                        match self.graph.get_vertex_kind(dep) {
-                            VertexKind::FormulaScalar | VertexKind::FormulaArray => {
-                                if !visited.contains(&dep) {
-                                    stack.push(dep);
-                                }
-                            }
-                            _ => {}
-                        }
+                    if self.graph.vertex_exists(dep) && !visited.contains(&dep) {
+                        stack.push(dep);
                     }
                 }
             } // Virtual dependencies (compressed ranges + dynamic like INDIRECT)

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -2191,6 +2191,21 @@ impl DependencyGraph {
             return vertex_id;
         }
 
+        // During first-load bulk ingest the fast path populates
+        // ``load_packed_to_vertex`` but skips ``cell_to_vertex``. Promote
+        // the entry into ``cell_to_vertex`` so subsequent lookups are O(1)
+        // and consistent across the two maps.
+        if self.first_load_assume_new {
+            let packed = Self::packed_cell_key(
+                addr.sheet_id,
+                AbsCoord::new(addr.coord.row(), addr.coord.col()),
+            );
+            if let Some(&existing) = self.load_packed_to_vertex.get(&packed) {
+                self.cell_to_vertex.insert(*addr, existing);
+                return existing;
+            }
+        }
+
         created_placeholders.push(*addr);
         let packed_coord = AbsCoord::new(addr.coord.row(), addr.coord.col());
         let vertex_id = self.store.allocate(packed_coord, addr.sheet_id, 0x00);

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -873,6 +873,10 @@ impl DependencyGraph {
         coords: Vec<AbsCoord>,
         vertex_ids: Vec<u32>,
     ) {
+        // Merge in base/delta out-edges for vertices the formula-target
+        // adjacency doesn't cover (e.g. named-range pass-through vertices)
+        // before handing the final adjacency to the pure builder.
+        let adjacency = self.edges.adjacency_with_carried_forward_edges(adjacency);
         self.edges
             .build_from_adjacency(adjacency, coords, vertex_ids);
     }

--- a/crates/formualizer-eval/src/engine/tests/demand_subgraph_named_range.rs
+++ b/crates/formualizer-eval/src/engine/tests/demand_subgraph_named_range.rs
@@ -1,0 +1,80 @@
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{Engine, EvalConfig};
+use crate::reference::{CellRef, Coord, RangeRef};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn approx_eq(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-9
+}
+
+#[test]
+fn evaluate_cell_walks_named_range_deps_for_dirty_upstreams() {
+    // Reproduces the v0.5.x regression where build_demand_subgraph filtered
+    // dep walks by VertexKind::FormulaScalar|FormulaArray, dropping the
+    // pass-through NamedScalar/NamedArray vertices and never reaching the
+    // formula cells underneath. A target like
+    //   =SUM(direct_range, named_range_at_dirty_cells)
+    // would evaluate using stale values for the named-range cells when
+    // their upstream input was changed via set_value.
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.graph.add_sheet("Inputs").unwrap();
+    engine.graph.add_sheet("Model").unwrap();
+
+    // Define the named range FIRST so the target formula's NamedRange ref
+    // resolves at graph-build time.
+    let model_sheet = engine.graph.sheet_id_mut("Model");
+    let range_start = CellRef::new(model_sheet, Coord::from_excel(1, 2, true, true));
+    let range_end = CellRef::new(model_sheet, Coord::from_excel(1, 3, true, true));
+    engine
+        .define_name(
+            "RANGE_REF",
+            NamedDefinition::Range(RangeRef::new(range_start, range_end)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    // Inputs sheet: one driver cell that all downstream formulas depend on.
+    engine
+        .set_cell_value("Inputs", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+
+    // Model sheet formula cells. Model!B1:C1 are the cells inside RANGE_REF.
+    engine
+        .set_cell_formula("Model", 1, 1, parse("=Inputs!A1*1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 1, 2, parse("=Inputs!A1*2").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 1, 3, parse("=Inputs!A1*3").unwrap())
+        .unwrap();
+
+    // Target = direct ref to A1 + sum over the defined-name range.
+    // Baseline: 10 + (20 + 30) = 60.
+    engine
+        .set_cell_formula("Model", 2, 1, parse("=Model!A1+SUM(RANGE_REF)").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+    let baseline = engine.get_cell_value("Model", 2, 1).unwrap();
+    assert!(
+        matches!(baseline, LiteralValue::Number(n) if approx_eq(n, 60.0)),
+        "baseline expected 60, got {baseline:?}",
+    );
+
+    // Change the upstream input. Evaluate ONLY the target cell.
+    // The target's demand subgraph must transit through the NamedScalar
+    // vertex into the underlying B1/C1 formula cells; otherwise those
+    // cells stay at their baseline computed values (20, 30) and the
+    // target evaluates as 100 + 20 + 30 = 150 instead of 100 + 200 + 300.
+    engine
+        .set_cell_value("Inputs", 1, 1, LiteralValue::Number(100.0))
+        .unwrap();
+    let target = engine.evaluate_cell("Model", 2, 1).unwrap().unwrap();
+    assert!(
+        matches!(target, LiteralValue::Number(n) if approx_eq(n, 600.0)),
+        "after override, target should be 100 + 200 + 300 = 600; got {target:?}",
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/dn_range_xlsx_subgraph.rs
+++ b/crates/formualizer-eval/src/engine/tests/dn_range_xlsx_subgraph.rs
@@ -1,0 +1,92 @@
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{Engine, EvalConfig};
+use crate::reference::{CellRef, Coord, RangeRef};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn approx_eq(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-9
+}
+
+#[test]
+fn supermod_repro_evaluate_cell_with_dn_range_ref_after_set_value() {
+    // Mirrors the supermod test_sensitivity_table failure shape:
+    //   - "Inputs" sheet holds an init_revenue scalar cell
+    //   - "Model" sheet has three groups of profit cells (base / upside / down)
+    //     each computing init_revenue * factor
+    //   - A workbook-scoped defined name "UP_PROFIT" covers the upside group
+    //   - Target = SUM(base_cells, UP_PROFIT) — base via direct cell range,
+    //     upside via the defined name
+    //   - After set_value on init_revenue, evaluate_cell on the target must
+    //     re-evaluate the upside cells (reached only through the NamedArray
+    //     vertex) so the sum reflects the new input.
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.graph.add_sheet("Inputs").unwrap();
+    engine.graph.add_sheet("Model").unwrap();
+
+    // Inputs!A1 — the scalar driver.
+    engine
+        .set_cell_value("Inputs", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+
+    // Model!E1, F1, G1 — base profit cells (referenced directly by target).
+    engine
+        .set_cell_formula("Model", 1, 5, parse("=Inputs!A1*1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 1, 6, parse("=Inputs!A1*1.1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 1, 7, parse("=Inputs!A1*1.21").unwrap())
+        .unwrap();
+
+    // Model!E8, F8, G8 — upside profit cells (referenced via defined name).
+    engine
+        .set_cell_formula("Model", 8, 5, parse("=Inputs!A1*1*1.2").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 8, 6, parse("=Inputs!A1*1.1*1.2").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Model", 8, 7, parse("=Inputs!A1*1.21*1.2").unwrap())
+        .unwrap();
+
+    let model_sheet = engine.graph.sheet_id("Model").unwrap();
+    let range_start = CellRef::new(model_sheet, Coord::from_excel(8, 5, true, true));
+    let range_end = CellRef::new(model_sheet, Coord::from_excel(8, 7, true, true));
+    engine
+        .define_name(
+            "UP_PROFIT",
+            NamedDefinition::Range(RangeRef::new(range_start, range_end)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    // Target = SUM(direct base range, UP_PROFIT)
+    engine
+        .set_cell_formula("Model", 10, 1, parse("=SUM(E1:G1,UP_PROFIT)").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+    let baseline = engine.get_cell_value("Model", 10, 1).unwrap();
+    let base_sum = 10.0 + 11.0 + 12.1;
+    let up_sum = 12.0 + 13.2 + 14.52;
+    let expected_baseline = base_sum + up_sum;
+    assert!(
+        matches!(baseline, LiteralValue::Number(n) if approx_eq(n, expected_baseline)),
+        "baseline expected {expected_baseline}, got {baseline:?}",
+    );
+
+    // Change the input. Evaluate ONLY the target — the upside cells (Model!E8..G8)
+    // must be re-evaluated through the UP_PROFIT NamedArray pass-through.
+    engine
+        .set_cell_value("Inputs", 1, 1, LiteralValue::Number(100.0))
+        .unwrap();
+    let target = engine.evaluate_cell("Model", 10, 1).unwrap().unwrap();
+    let expected_after = (base_sum + up_sum) * 10.0;
+    assert!(
+        matches!(target, LiteralValue::Number(n) if approx_eq(n, expected_after)),
+        "after override expected {expected_after}, got {target:?}",
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -132,3 +132,4 @@ mod subtotal_visibility;
 mod visibility_mask_cache;
 
 mod demand_subgraph_named_range;
+mod dn_range_xlsx_subgraph;

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -130,3 +130,5 @@ mod row_visibility_state;
 mod row_visibility_transactions;
 mod subtotal_visibility;
 mod visibility_mask_cache;
+
+mod demand_subgraph_named_range;


### PR DESCRIPTION
Two related fixes for named-range dependency tracking during incremental evaluation.

## 1. Walk through Named/Range pass-through vertices in the demand subgraph
`evaluate_cell`'s demand subgraph did not walk *through* `Named`/`Range` pass-through vertices, so dirty upstream cells sitting behind a named range were not recomputed. After overriding an input, the target kept a stale value.

## 2. Preserve named-range edges through CSR rebuild + schedule named pass-through vertices
The CSR rebuild dropped named-range edges, and named pass-through vertices were not scheduled, so xlsx-ingested defined-name ranges produced wrong results after `set_value`.

## Tests
Adds `demand_subgraph_named_range` and `dn_range_xlsx_subgraph` regression tests. Verified both **fail on current `main`** (stale values after override) and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)