### PR TITLE
fix(eval): don't leak unqualified refs to the default sheet

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -10656,7 +10656,21 @@ where
         row: u32,
         col: u32,
     ) -> Result<LiteralValue, ExcelError> {
-        let sheet_name = sheet.unwrap_or_else(|| self.default_sheet_name()); // FIXME: should use formula current-sheet context
+        // This context-free trait method has no knowledge of the formula's
+        // current sheet, so an unqualified (`None`) reference cannot be resolved
+        // here. Previously this fell back to `default_sheet_name()`, which leaked
+        // the reference onto an unrelated sheet (issue #110). Interpreter paths
+        // already qualify references with the current sheet before reaching this
+        // method (see `Interpreter::implicit_intersection_from_reference`), and
+        // the sheet-aware scalar path goes through `resolve_cell_reference_value`
+        // with an explicit `current_sheet`. Returning #REF! for an unqualified
+        // reference here surfaces the missing context instead of silently
+        // returning data from the wrong sheet.
+        let Some(sheet_name) = sheet else {
+            return Err(ExcelError::new(ExcelErrorKind::Ref).with_message(
+                "Unqualified cell reference resolved without sheet context".to_string(),
+            ));
+        };
         // Prefer engine's unified accessor which consults Arrow store for base values
         // and falls back to graph for formulas and stored values.
         if let Some(v) = self.get_cell_value(sheet_name, row, col) {

--- a/crates/formualizer-workbook/tests/unqualified_ref_sheet_context.rs
+++ b/crates/formualizer-workbook/tests/unqualified_ref_sheet_context.rs
@@ -1,0 +1,181 @@
+//! Regression tests for issue #110: an unqualified reference inside a formula
+//! must resolve against the *formula's* sheet, not the workbook default sheet.
+//!
+//! Setup mirrors the issue repro:
+//!   Sheet1!A1 = 10, Sheet2!A1 = 99
+//!   A formula on Sheet2 that references unqualified `A1` must read 99 (Sheet2),
+//!   not 10 (Sheet1, the default sheet).
+
+use formualizer_common::LiteralValue;
+use formualizer_workbook::Workbook;
+
+fn num(v: LiteralValue) -> f64 {
+    match v {
+        LiteralValue::Number(n) => n,
+        LiteralValue::Int(i) => i as f64,
+        other => panic!("expected numeric, got {other:?}"),
+    }
+}
+
+/// Build a workbook where the default sheet (Sheet1) and a second sheet (Sheet2)
+/// both have data at A1/A2/B-area, so an unqualified ref that leaks to the default
+/// sheet produces an observably different value than the correct one.
+fn fixture() -> Workbook {
+    let mut wb = Workbook::new();
+    // Sheet1 is the implicit default ("Sheet1").
+    wb.add_sheet("Sheet1").ok(); // may already exist; ignore
+    wb.add_sheet("Sheet2").unwrap();
+
+    wb.set_value("Sheet1", 1, 1, LiteralValue::Int(10)).unwrap(); // Sheet1!A1
+    wb.set_value("Sheet1", 2, 1, LiteralValue::Int(20)).unwrap(); // Sheet1!A2
+
+    wb.set_value("Sheet2", 1, 1, LiteralValue::Int(99)).unwrap(); // Sheet2!A1
+    wb.set_value("Sheet2", 2, 1, LiteralValue::Int(88)).unwrap(); // Sheet2!A2
+    wb
+}
+
+/// Scalar unqualified reference `=A1` on Sheet2 must equal Sheet2!A1 (99).
+#[test]
+fn unqualified_scalar_ref_uses_formula_sheet() {
+    let mut wb = fixture();
+    wb.set_formula("Sheet2", 1, 2, "=A1").unwrap(); // Sheet2!B1
+    let v = wb.evaluate_cell("Sheet2", 1, 2).unwrap();
+    assert_eq!(
+        num(v),
+        99.0,
+        "unqualified =A1 on Sheet2 should read Sheet2!A1"
+    );
+}
+
+/// Unqualified range reference `=SUM(A1:A2)` on Sheet2 must sum Sheet2 (99+88=187),
+/// not Sheet1 (10+20=30).
+#[test]
+fn unqualified_range_ref_uses_formula_sheet() {
+    let mut wb = fixture();
+    wb.set_formula("Sheet2", 1, 2, "=SUM(A1:A2)").unwrap(); // Sheet2!B1
+    let v = wb.evaluate_cell("Sheet2", 1, 2).unwrap();
+    assert_eq!(
+        num(v),
+        187.0,
+        "unqualified =SUM(A1:A2) on Sheet2 should sum Sheet2 cells"
+    );
+}
+
+/// Implicit intersection via the `@` operator on an unqualified ref must use the
+/// formula's sheet. `=@A1:A2` evaluated on Sheet2 row 2 should pick Sheet2!A2 (88).
+#[test]
+fn unqualified_implicit_intersection_uses_formula_sheet() {
+    let mut wb = fixture();
+    // On row 2: implicit intersection of column A range picks the row-2 element.
+    wb.set_formula("Sheet2", 2, 2, "=@A1:A2").unwrap(); // Sheet2!B2
+    let v = wb.evaluate_cell("Sheet2", 2, 2).unwrap();
+    assert_eq!(
+        num(v),
+        88.0,
+        "implicit intersection on Sheet2 should pick Sheet2!A2"
+    );
+}
+
+/// A SUMIF-style criteria function that materializes a range/cell through the
+/// `resolve_range_like` path must also honor the formula's sheet. Here the
+/// criteria range and sum range are both unqualified column-A references.
+#[test]
+fn unqualified_sumif_uses_formula_sheet() {
+    let mut wb = fixture();
+    // SUMIF(A1:A2, ">90") on Sheet2 -> only Sheet2!A1 (99) qualifies => 99.
+    // If it leaked to Sheet1 (10,20) nothing qualifies => 0.
+    wb.set_formula("Sheet2", 1, 2, "=SUMIF(A1:A2,\">90\")")
+        .unwrap();
+    let v = wb.evaluate_cell("Sheet2", 1, 2).unwrap();
+    assert_eq!(
+        num(v),
+        99.0,
+        "unqualified SUMIF on Sheet2 should evaluate against Sheet2 cells"
+    );
+}
+
+/// Control: a *qualified* cross-sheet reference must be unchanged by the fix.
+/// `=Sheet1!A1` on Sheet2 must still read Sheet1!A1 (10).
+#[test]
+fn qualified_cross_sheet_ref_unchanged() {
+    let mut wb = fixture();
+    wb.set_formula("Sheet2", 1, 3, "=Sheet1!A1").unwrap(); // Sheet2!C1
+    let v = wb.evaluate_cell("Sheet2", 1, 3).unwrap();
+    assert_eq!(num(v), 10.0, "qualified =Sheet1!A1 must read Sheet1");
+}
+
+/// Control: a qualified range reference across sheets is unchanged.
+#[test]
+fn qualified_cross_sheet_range_unchanged() {
+    let mut wb = fixture();
+    wb.set_formula("Sheet2", 1, 3, "=SUM(Sheet1!A1:A2)")
+        .unwrap();
+    let v = wb.evaluate_cell("Sheet2", 1, 3).unwrap();
+    assert_eq!(num(v), 30.0, "qualified =SUM(Sheet1!A1:A2) must sum Sheet1");
+}
+
+/// Direct trait-level regression for the *latent* bug in
+/// `ReferenceResolver::resolve_cell_reference` / `Resolver::resolve_range_like`.
+///
+/// These trait methods carry no current-sheet context. The buggy implementation
+/// silently fell back to the workbook *default* sheet for an unqualified
+/// (`sheet == None`) reference, which can read a totally unrelated cell. After
+/// the fix, an unqualified reference reaching this context-free path must NOT be
+/// silently mapped to the default sheet (it returns a #REF! error instead),
+/// while a *qualified* reference keeps working.
+#[test]
+fn resolver_trait_does_not_leak_unqualified_ref_to_default_sheet() {
+    use formualizer_common::error::ExcelErrorKind;
+    use formualizer_eval::traits::{ReferenceResolver, Resolver};
+    use formualizer_parse::parser::ReferenceType;
+
+    let wb = fixture(); // default sheet is Sheet1; Sheet1!A1 = 10, Sheet2!A1 = 99
+    let engine = wb.engine();
+
+    // Qualified ref via the context-free trait still works.
+    let qualified = engine
+        .resolve_cell_reference(Some("Sheet2"), 1, 1)
+        .expect("qualified resolve should succeed");
+    assert_eq!(num(qualified), 99.0, "qualified Sheet2!A1 should be 99");
+
+    // Unqualified ref must NOT silently read Sheet1!A1 (10). With no sheet
+    // context available at this layer, the only correct answers are an error
+    // or Empty -- crucially never the default-sheet value.
+    let unqualified = engine.resolve_cell_reference(None, 1, 1);
+    match unqualified {
+        Err(e) => assert_eq!(e.kind, ExcelErrorKind::Ref),
+        Ok(LiteralValue::Number(n)) => {
+            assert_ne!(n, 10.0, "unqualified ref leaked to default Sheet1!A1")
+        }
+        Ok(LiteralValue::Int(i)) => {
+            assert_ne!(i, 10, "unqualified ref leaked to default Sheet1!A1")
+        }
+        Ok(other) => panic!("unexpected unqualified result: {other:?}"),
+    }
+
+    // Same expectation through the generic `resolve_range_like` cell branch.
+    let cell_ref = ReferenceType::Cell {
+        sheet: None,
+        row: 1,
+        col: 1,
+        row_abs: true,
+        col_abs: true,
+    };
+    let via_range_like = engine.resolve_range_like(&cell_ref);
+    match via_range_like {
+        Err(e) => assert_eq!(e.kind, ExcelErrorKind::Ref),
+        Ok(range) => {
+            let v = range.get(0, 0).unwrap_or(LiteralValue::Empty);
+            match v {
+                LiteralValue::Number(n) => {
+                    assert_ne!(n, 10.0, "resolve_range_like leaked to default Sheet1!A1")
+                }
+                LiteralValue::Int(i) => {
+                    assert_ne!(i, 10, "resolve_range_like leaked to default Sheet1!A1")
+                }
+                LiteralValue::Error(_) | LiteralValue::Empty => {}
+                other => panic!("unexpected resolve_range_like result: {other:?}"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #110.

## What was actually broken

Investigation showed the user-visible repro from the issue was already mitigated on every live evaluation path: the interpreter threads the formula's `current_sheet` through `resolve_cell_reference_value` (scalar), `resolve_shared_ref`/`resolve_range_view` (ranges), and the implicit-intersection paths qualify with `self.current_sheet` before calling the trait. The surviving defect was latent: the context-free `ReferenceResolver::resolve_cell_reference` trait method (the `FIXME` site, also reachable via `Resolver::resolve_range_like`'s cell branch) silently fell back to `default_sheet_name()` for an unqualified reference — returning data from an unrelated sheet to any caller that lacks sheet context.

## The fix

An unqualified (`None`) reference at this context-free layer now returns `#REF!` instead of guessing the default sheet — missing context surfaces as an error rather than wrong data. All real callers already pass `Some(sheet)`, so qualified resolution is unchanged. This deliberately avoids a trait-signature change (no ripple into external `Resolver` implementations).

## Tests

New integration matrix in `crates/formualizer-workbook/tests/unqualified_ref_sheet_context.rs` (7 tests): unqualified scalar/range/SUMIF/implicit-intersection references evaluated from a non-default sheet, qualified cross-sheet controls, and a direct trait-level regression test for the default-sheet leak (failed pre-fix by returning the wrong sheet's value; passes post-fix).

Validated locally with the CI commands: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo test --workspace --all-features` (CI exclusions) → 2392 passed, 0 failed.

Pre-work for the runtime-cycle-verdicts RFC (#112), where cross-sheet SCC evaluation would amplify any sheet-context misrouting.
