### PR TITLE
fix(eval): tear down spill projections and region locks when stamping #CIRC

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -7823,9 +7823,7 @@ where
                     .with_message("Circular dependency detected".to_string()),
             );
             for &vertex_id in cycle {
-                self.graph
-                    .update_vertex_value(vertex_id, circ_error.clone());
-                self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                self.stamp_cycle_error(vertex_id, &circ_error, None);
             }
         }
 
@@ -7908,20 +7906,7 @@ where
         for cycle in &schedule.cycles {
             cycle_errors += 1;
             for &vertex_id in cycle {
-                if delta.mode != DeltaMode::Off
-                    && let Some(cell) = self.graph.get_cell_ref_for_vertex(vertex_id)
-                {
-                    let sheet_name = self.graph.sheet_name(cell.sheet_id);
-                    let old = self
-                        .read_cell_value(sheet_name, cell.coord.row() + 1, cell.coord.col() + 1)
-                        .unwrap_or(LiteralValue::Empty);
-                    if old != circ_error {
-                        delta.record_cell(cell.sheet_id, cell.coord.row(), cell.coord.col());
-                    }
-                }
-                self.graph
-                    .update_vertex_value(vertex_id, circ_error.clone());
-                self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                self.stamp_cycle_error(vertex_id, &circ_error, Some(delta));
             }
         }
 
@@ -8011,9 +7996,7 @@ where
                 cycle_errors += 1;
                 for &vertex_id in cycle {
                     if dirty_set.contains(&vertex_id) {
-                        self.graph
-                            .update_vertex_value(vertex_id, circ_error.clone());
-                        self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                        self.stamp_cycle_error(vertex_id, &circ_error, None);
                     }
                 }
             }
@@ -8445,9 +8428,7 @@ where
         );
         for cycle in &schedule.cycles {
             for &vertex_id in cycle {
-                self.graph
-                    .update_vertex_value(vertex_id, circ_error.clone());
-                self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                self.stamp_cycle_error(vertex_id, &circ_error, None);
             }
         }
         schedule.cycles.len()
@@ -8605,20 +8586,7 @@ where
             for cycle in &schedule.cycles {
                 cycle_errors += 1;
                 for &vertex_id in cycle {
-                    if delta.mode != DeltaMode::Off
-                        && let Some(cell) = self.graph.get_cell_ref_for_vertex(vertex_id)
-                    {
-                        let sheet_name = self.graph.sheet_name(cell.sheet_id);
-                        let old = self
-                            .read_cell_value(sheet_name, cell.coord.row() + 1, cell.coord.col() + 1)
-                            .unwrap_or(LiteralValue::Empty);
-                        if old != circ_error {
-                            delta.record_cell(cell.sheet_id, cell.coord.row(), cell.coord.col());
-                        }
-                    }
-                    self.graph
-                        .update_vertex_value(vertex_id, circ_error.clone());
-                    self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                    self.stamp_cycle_error(vertex_id, &circ_error, Some(delta));
                 }
             }
 
@@ -9307,9 +9275,7 @@ where
                         .with_message("Circular dependency detected".to_string()),
                 );
                 for &vertex_id in cycle {
-                    self.graph
-                        .update_vertex_value(vertex_id, circ_error.clone());
-                    self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                    self.stamp_cycle_error(vertex_id, &circ_error, None);
                 }
             }
 
@@ -9459,9 +9425,7 @@ where
                     .with_message("Circular dependency detected".to_string()),
             );
             for &vertex_id in cycle {
-                self.graph
-                    .update_vertex_value(vertex_id, circ_error.clone());
-                self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                self.stamp_cycle_error(vertex_id, &circ_error, None);
             }
         }
 
@@ -10340,6 +10304,17 @@ impl ShimSpillManager {
                 Ok(())
             }
             Err(e) => Err(e),
+        }
+    }
+
+    /// Release any in-flight region reservation still held for `owner`.
+    ///
+    /// Reservations are normally released on commit/rollback, but if an anchor is
+    /// abandoned without committing (e.g. cycle detection stamps it with #CIRC), a
+    /// stale reservation could remain. This is a no-op when nothing is held.
+    pub(crate) fn release_owner(&mut self, owner: VertexId) {
+        if let Some(id) = self.active_locks.remove(&owner) {
+            self.region_locks.release(id);
         }
     }
 
@@ -11646,6 +11621,53 @@ where
                 );
             }
         }
+    }
+
+    /// Stamp a vertex with `#CIRC!` as part of cycle handling.
+    ///
+    /// Unlike a bare `update_vertex_value`, this first tears down any spill the
+    /// vertex previously anchored: it clears the spilled cells, releases the graph
+    /// spill registry, drops any lingering region reservation, and mirrors the
+    /// cleared cells into the computed overlay — the same teardown a normal scalar/
+    /// error result performs (see `apply_non_array_result_from_parallel` /
+    /// `clear_spill_projection_and_mirror`). Without this, a #CIRC stamp on a former
+    /// spill anchor would leave stale spilled values and a reserved region behind
+    /// (issue #111).
+    ///
+    /// When `delta` is provided, the cleared spill cells are recorded (by
+    /// `clear_spill_projection_and_mirror`) and the anchor's own #CIRC change is
+    /// recorded here, matching how other result paths emit deltas.
+    fn stamp_cycle_error(
+        &mut self,
+        vertex_id: VertexId,
+        circ_error: &LiteralValue,
+        mut delta: Option<&mut DeltaCollector>,
+    ) {
+        // Tear down any previous spill projection/region before overwriting the anchor.
+        if self.graph.spill_registry_has_anchor(vertex_id) {
+            self.clear_spill_projection_and_mirror(vertex_id, delta.as_deref_mut());
+        }
+        // Drop any reservation that was never committed (defensive; normally released
+        // on the prior successful commit).
+        self.spill_mgr.release_owner(vertex_id);
+
+        // Record the anchor's own #CIRC delta, like other result paths.
+        if let Some(d) = delta
+            && d.mode != DeltaMode::Off
+            && let Some(cell) = self.graph.get_cell_ref_for_vertex(vertex_id)
+        {
+            let sheet_name = self.graph.sheet_name(cell.sheet_id);
+            let old = self
+                .read_cell_value(sheet_name, cell.coord.row() + 1, cell.coord.col() + 1)
+                .unwrap_or(LiteralValue::Empty);
+            if old != *circ_error {
+                d.record_cell(cell.sheet_id, cell.coord.row(), cell.coord.col());
+            }
+        }
+
+        self.graph
+            .update_vertex_value(vertex_id, circ_error.clone());
+        self.mirror_vertex_value_to_overlay(vertex_id, circ_error);
     }
 
     /// Helper: commit spill via shim and mirror resulting cells into Arrow overlay when enabled.
@@ -12979,9 +13001,7 @@ where
             for cycle in &schedule.cycles {
                 cycle_errors += 1;
                 for &vertex_id in cycle {
-                    self.graph
-                        .update_vertex_value(vertex_id, circ_error.clone());
-                    self.mirror_vertex_value_to_overlay(vertex_id, &circ_error);
+                    self.stamp_cycle_error(vertex_id, &circ_error, None);
                 }
             }
 

--- a/crates/formualizer-workbook/tests/spill_circ_teardown.rs
+++ b/crates/formualizer-workbook/tests/spill_circ_teardown.rs
@@ -1,0 +1,121 @@
+//! Regression tests for issue #111.
+//!
+//! When cycle detection stamps a spill anchor (a `FormulaArray` vertex) with
+//! `#CIRC!`, the engine must tear down the previous spill projection and release
+//! the region reservation. Before the fix the `#CIRC!` value was written directly
+//! to the anchor while the spilled cells (and the graph's spill registry) were left
+//! untouched, leaving stale values behind and blocking new spills into the region.
+
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_workbook::Workbook;
+
+fn is_circ(v: &Option<LiteralValue>) -> bool {
+    matches!(v, Some(LiteralValue::Error(e)) if e.kind == ExcelErrorKind::Circ)
+}
+
+fn is_empty(v: &Option<LiteralValue>) -> bool {
+    matches!(v, None | Some(LiteralValue::Empty))
+}
+
+/// Drive a spilling anchor into a dependency cycle, then re-evaluate via the full
+/// `evaluate_all` legacy pass.
+///
+/// A1 first spills `=SEQUENCE(3)` (A1:A3 = 1,2,3), then is switched to
+/// `=SEQUENCE(C1)` (still A1:A3) while C1 holds the constant 3. Finally C1 becomes
+/// `=A1+1`, forming the cycle A1 -> C1 -> A1. Cycle detection stamps A1 (and C1)
+/// with `#CIRC!`; A1's former spill (A2, A3) must be cleared and the region freed.
+#[test]
+fn circ_on_spill_anchor_tears_down_projection_and_region() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    // Prime: A1 spills a fixed SEQUENCE(3) -> A1:A3 = 1,2,3.
+    wb.set_formula("S", 1, 1, "=SEQUENCE(3)").unwrap();
+    wb.evaluate_all().unwrap();
+
+    // Re-point the anchor at C1 (a constant) so it still spills 3 rows.
+    wb.set_value("S", 1, 3, LiteralValue::Number(3.0)).unwrap();
+    wb.set_formula("S", 1, 1, "=SEQUENCE(C1)").unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(wb.get_value("S", 1, 1), Some(LiteralValue::Number(1.0)));
+    assert_eq!(wb.get_value("S", 2, 1), Some(LiteralValue::Number(2.0)));
+    assert_eq!(wb.get_value("S", 3, 1), Some(LiteralValue::Number(3.0)));
+
+    // Introduce the cycle: C1 = A1 + 1  =>  A1 -> C1 -> A1.
+    wb.set_formula("S", 1, 3, "=A1+1").unwrap();
+    wb.evaluate_all().unwrap();
+
+    // Anchor is #CIRC.
+    assert!(
+        is_circ(&wb.get_value("S", 1, 1)),
+        "anchor A1 should be #CIRC, got {:?}",
+        wb.get_value("S", 1, 1)
+    );
+
+    // Formerly-spilled cells must be cleared (not stale 2.0 / 3.0).
+    assert!(
+        is_empty(&wb.get_value("S", 2, 1)),
+        "spilled A2 should be cleared, got {:?}",
+        wb.get_value("S", 2, 1)
+    );
+    assert!(
+        is_empty(&wb.get_value("S", 3, 1)),
+        "spilled A3 should be cleared, got {:?}",
+        wb.get_value("S", 3, 1)
+    );
+
+    // Region-lock release proof: a NEW unrelated spill into the formerly-reserved
+    // region must succeed. A2 anchors SEQUENCE(2) -> A2:A3 = 1,2.
+    wb.set_formula("S", 2, 1, "=SEQUENCE(2)").unwrap();
+    wb.evaluate_all().unwrap();
+
+    assert_eq!(
+        wb.get_value("S", 2, 1),
+        Some(LiteralValue::Number(1.0)),
+        "new spill anchor A2 should spill (region must be free); got {:?}",
+        wb.get_value("S", 2, 1)
+    );
+    assert_eq!(
+        wb.get_value("S", 3, 1),
+        Some(LiteralValue::Number(2.0)),
+        "new spill should fill A3; got {:?}",
+        wb.get_value("S", 3, 1)
+    );
+}
+
+/// Same scenario but the cycle-introducing edit is recalculated through the
+/// targeted, delta-collecting path (`evaluate_cell`) instead of `evaluate_all`,
+/// exercising a different cycle-stamping site.
+#[test]
+fn circ_on_spill_anchor_tears_down_via_targeted_recalc() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    wb.set_formula("S", 1, 1, "=SEQUENCE(3)").unwrap();
+    wb.evaluate_all().unwrap();
+    wb.set_value("S", 1, 3, LiteralValue::Number(3.0)).unwrap();
+    wb.set_formula("S", 1, 1, "=SEQUENCE(C1)").unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(wb.get_value("S", 2, 1), Some(LiteralValue::Number(2.0)));
+    assert_eq!(wb.get_value("S", 3, 1), Some(LiteralValue::Number(3.0)));
+
+    // Edit C1 into the cycle and recalc through the demand-driven path.
+    wb.set_formula("S", 1, 3, "=A1+1").unwrap();
+    let _ = wb.evaluate_cell("S", 1, 1).unwrap();
+
+    assert!(
+        is_circ(&wb.get_value("S", 1, 1)),
+        "anchor A1 should be #CIRC, got {:?}",
+        wb.get_value("S", 1, 1)
+    );
+    assert!(
+        is_empty(&wb.get_value("S", 2, 1)),
+        "spilled A2 should be cleared, got {:?}",
+        wb.get_value("S", 2, 1)
+    );
+    assert!(
+        is_empty(&wb.get_value("S", 3, 1)),
+        "spilled A3 should be cleared, got {:?}",
+        wb.get_value("S", 3, 1)
+    );
+}


### PR DESCRIPTION
Fixes #111.

## What was broken

When cycle detection stamped a `FormulaArray` (spill anchor) vertex with `#CIRC`, the error was written directly via `update_vertex_value` + `mirror_vertex_value_to_overlay`, bypassing the spill machinery. Spilled values from a previous successful evaluation stayed readable, and the graph spill registry (`spill_anchor_to_cells` — which `plan_spill_region` consults) kept the region reserved, blocking new spills into it. Investigation found **eight** cycle-stamping sites, not the five listed in the issue; all had the bug.

## The fix

One helper, `Engine::stamp_cycle_error(vertex_id, &circ_error, Option<&mut DeltaCollector>)`, used by all eight sites. Before writing `#CIRC` it tears down any spill projection via the canonical `clear_spill_projection_and_mirror` (the same teardown the normal scalar/error result path uses — including cleared-cell delta recording and the formula-plane structural change), plus a defensive `ShimSpillManager::release_owner` for any uncommitted reservation.

Each site's existing behavior is preserved exactly: the recalc-plan path still stamps only cycle members in the dirty set, the cancellable paths keep their interleaved cancellation checks, and the delta-collector paths still record the anchor's `#CIRC` change. This is deliberately a bug fix, not the stamping-site consolidation refactor — though the shared helper now gives that future work (needed for #112) a single application point.

## Tests

New integration tests in `crates/formualizer-workbook/tests/spill_circ_teardown.rs`: spill via `=SEQUENCE`, introduce a cycle through the anchor, re-evaluate — asserts the anchor is `#CIRC`, formerly-spilled cells are cleared (not stale), and a **new unrelated spill into the freed region succeeds** (proves the reservation was released). Covered on both the full `evaluate_all` path and the demand-driven `evaluate_cell` path. Both failed pre-fix for the right reason (stale spilled values persisted).

Validated locally with the CI commands: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo test --workspace --all-features` (CI exclusions) → 2387 passed, 0 failed.

Pre-work for the runtime-cycle-verdicts RFC (#112).
