### PR TITLE
refactor(engine): condensation-ordered schedule units + per-SCC cycle outcome

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -14,8 +14,8 @@ use crate::engine::spill::{RegionLockManager, SpillMeta, SpillShape};
 use crate::engine::virtual_deps::VirtualDepBuilder;
 use crate::engine::{
     DependencyGraph, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaIngestReport,
-    FormulaParseDiagnostic, FormulaParsePolicy, FormulaPlaneMode, RowVisibilitySource, Scheduler,
-    VertexId, VertexKind, VisibilityMaskMode,
+    FormulaParseDiagnostic, FormulaParsePolicy, FormulaPlaneMode, RowVisibilitySource,
+    ScheduleUnit, Scheduler, VertexId, VertexKind, VisibilityMaskMode,
 };
 use crate::formula_plane::placement::{
     CandidateAnalysis, FormulaPlacementCandidate, FormulaPlacementResult, PlacementFallbackReason,
@@ -7814,26 +7814,24 @@ where
         #[cfg(feature = "tracing")]
         drop(_span_sched);
 
-        // Handle cycles first
+        // Walk schedule units in condensation order: stamp each cyclic SCC at
+        // its position, evaluate layers (parallel when enabled, mirroring
+        // evaluate_all).
         let mut cycle_errors = 0;
-        for cycle in &schedule.cycles {
-            cycle_errors += 1;
-            let circ_error = LiteralValue::Error(
-                ExcelError::new(ExcelErrorKind::Circ)
-                    .with_message("Circular dependency detected".to_string()),
-            );
-            for &vertex_id in cycle {
-                self.stamp_cycle_error(vertex_id, &circ_error, None);
-            }
-        }
-
-        // Evaluate layers (parallel when enabled, mirroring evaluate_all)
         let mut computed_vertices = 0;
-        for layer in &schedule.layers {
-            if self.thread_pool.is_some() && layer.vertices.len() > 1 {
-                computed_vertices += self.evaluate_layer_parallel(layer)?;
-            } else {
-                computed_vertices += self.evaluate_layer_sequential(layer)?;
+        for unit in &schedule.units {
+            match unit {
+                ScheduleUnit::Cycle(cycle) => {
+                    self.apply_cycle_outcome(cycle, None, None);
+                    cycle_errors += 1;
+                }
+                ScheduleUnit::Layer(layer) => {
+                    if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                        computed_vertices += self.evaluate_layer_parallel(layer)?;
+                    } else {
+                        computed_vertices += self.evaluate_layer_sequential(layer)?;
+                    }
+                }
             }
         }
 
@@ -7899,23 +7897,22 @@ where
         let schedule = scheduler.create_schedule_with_virtual(&precedents_to_eval, &vdeps)?;
 
         let mut cycle_errors = 0;
-        let circ_error = LiteralValue::Error(
-            ExcelError::new(ExcelErrorKind::Circ)
-                .with_message("Circular dependency detected".to_string()),
-        );
-        for cycle in &schedule.cycles {
-            cycle_errors += 1;
-            for &vertex_id in cycle {
-                self.stamp_cycle_error(vertex_id, &circ_error, Some(delta));
-            }
-        }
-
         let mut computed_vertices = 0;
-        for layer in &schedule.layers {
-            if self.thread_pool.is_some() && layer.vertices.len() > 1 {
-                computed_vertices += self.evaluate_layer_parallel_with_delta(layer, delta)?;
-            } else {
-                computed_vertices += self.evaluate_layer_sequential_with_delta(layer, delta)?;
+        for unit in &schedule.units {
+            match unit {
+                ScheduleUnit::Cycle(cycle) => {
+                    self.apply_cycle_outcome(cycle, Some(delta), None);
+                    cycle_errors += 1;
+                }
+                ScheduleUnit::Layer(layer) => {
+                    if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                        computed_vertices +=
+                            self.evaluate_layer_parallel_with_delta(layer, delta)?;
+                    } else {
+                        computed_vertices +=
+                            self.evaluate_layer_sequential_with_delta(layer, delta)?;
+                    }
+                }
             }
         }
 
@@ -7985,39 +7982,33 @@ where
         let mut computed_vertices = 0;
         let mut cycle_errors = 0;
 
-        if !plan.schedule.cycles.is_empty() {
-            let circ_error = LiteralValue::Error(
-                ExcelError::new(ExcelErrorKind::Circ)
-                    .with_message("Circular dependency detected".to_string()),
-            );
-            for cycle in &plan.schedule.cycles {
-                if !cycle.iter().any(|v| dirty_set.contains(v)) {
-                    continue;
-                }
-                cycle_errors += 1;
-                for &vertex_id in cycle {
-                    if dirty_set.contains(&vertex_id) {
-                        self.stamp_cycle_error(vertex_id, &circ_error, None);
+        for unit in &plan.schedule.units {
+            match unit {
+                ScheduleUnit::Cycle(cycle) => {
+                    // Recalc-plan quirk: stamp only the DIRTY members of the
+                    // cycle, and count the cycle only when it had any.
+                    let stamped = self.apply_cycle_outcome(cycle, None, Some(&dirty_set));
+                    if stamped > 0 {
+                        cycle_errors += 1;
                     }
                 }
-            }
-        }
-
-        for layer in &plan.schedule.layers {
-            let work: Vec<VertexId> = layer
-                .vertices
-                .iter()
-                .copied()
-                .filter(|v| dirty_set.contains(v))
-                .collect();
-            if work.is_empty() {
-                continue;
-            }
-            let temp_layer = crate::engine::scheduler::Layer { vertices: work };
-            if self.thread_pool.is_some() && temp_layer.vertices.len() > 1 {
-                computed_vertices += self.evaluate_layer_parallel(&temp_layer)?;
-            } else {
-                computed_vertices += self.evaluate_layer_sequential(&temp_layer)?;
+                ScheduleUnit::Layer(layer) => {
+                    let work: Vec<VertexId> = layer
+                        .vertices
+                        .iter()
+                        .copied()
+                        .filter(|v| dirty_set.contains(v))
+                        .collect();
+                    if work.is_empty() {
+                        continue;
+                    }
+                    let temp_layer = crate::engine::scheduler::Layer { vertices: work };
+                    if self.thread_pool.is_some() && temp_layer.vertices.len() > 1 {
+                        computed_vertices += self.evaluate_layer_parallel(&temp_layer)?;
+                    } else {
+                        computed_vertices += self.evaluate_layer_sequential(&temp_layer)?;
+                    }
+                }
             }
         }
 
@@ -8422,32 +8413,33 @@ where
         self.evaluate_all_legacy_impl()
     }
 
-    fn legacy_pass_apply_cycles(&mut self, schedule: &crate::engine::scheduler::Schedule) -> usize {
-        let circ_error = LiteralValue::Error(
-            ExcelError::new(ExcelErrorKind::Circ)
-                .with_message("Circular dependency detected".to_string()),
-        );
-        for cycle in &schedule.cycles {
-            for &vertex_id in cycle {
-                self.stamp_cycle_error(vertex_id, &circ_error, None);
-            }
-        }
-        schedule.cycles.len()
-    }
-
-    fn legacy_pass_run_layers(
+    /// Walk a schedule's units in condensation order: stamp each cyclic SCC
+    /// at its position and evaluate each layer (parallel when enabled).
+    ///
+    /// Returns `(computed_vertices, cycle_count)` where `cycle_count` is the
+    /// number of Cycle units walked (the former `schedule.cycles.len()`).
+    fn legacy_pass_run_units(
         &mut self,
         schedule: &crate::engine::scheduler::Schedule,
-    ) -> Result<usize, ExcelError> {
+    ) -> Result<(usize, usize), ExcelError> {
         let mut computed_vertices = 0;
-        for layer in &schedule.layers {
-            if self.thread_pool.is_some() && layer.vertices.len() > 1 {
-                computed_vertices += self.evaluate_layer_parallel(layer)?;
-            } else {
-                computed_vertices += self.evaluate_layer_sequential(layer)?;
+        let mut cycle_count = 0;
+        for unit in &schedule.units {
+            match unit {
+                ScheduleUnit::Cycle(cycle) => {
+                    self.apply_cycle_outcome(cycle, None, None);
+                    cycle_count += 1;
+                }
+                ScheduleUnit::Layer(layer) => {
+                    if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                        computed_vertices += self.evaluate_layer_parallel(layer)?;
+                    } else {
+                        computed_vertices += self.evaluate_layer_sequential(layer)?;
+                    }
+                }
             }
         }
-        Ok(computed_vertices)
+        Ok((computed_vertices, cycle_count))
     }
 
     /// Legacy `evaluate_all` body, reachable from the FormulaPlane coordinator
@@ -8484,8 +8476,9 @@ where
                 Self::accumulate_schedule_meta(t, &meta);
             }
 
-            cycle_errors += self.legacy_pass_apply_cycles(&schedule);
-            computed_vertices += self.legacy_pass_run_layers(&schedule)?;
+            let (pass_computed, pass_cycles) = self.legacy_pass_run_units(&schedule)?;
+            computed_vertices += pass_computed;
+            cycle_errors += pass_cycles;
 
             // Check if dynamic dependencies changed
             let changed_vertices = self.changed_virtual_dep_vertices(&to_evaluate, &old_vdeps);
@@ -8580,22 +8573,21 @@ where
                 Self::accumulate_schedule_meta(t, &meta);
             }
 
-            let circ_error = LiteralValue::Error(
-                ExcelError::new(ExcelErrorKind::Circ)
-                    .with_message("Circular dependency detected".to_string()),
-            );
-            for cycle in &schedule.cycles {
-                cycle_errors += 1;
-                for &vertex_id in cycle {
-                    self.stamp_cycle_error(vertex_id, &circ_error, Some(delta));
-                }
-            }
-
-            for layer in &schedule.layers {
-                if self.thread_pool.is_some() && layer.vertices.len() > 1 {
-                    computed_vertices += self.evaluate_layer_parallel_with_delta(layer, delta)?;
-                } else {
-                    computed_vertices += self.evaluate_layer_sequential_with_delta(layer, delta)?;
+            for unit in &schedule.units {
+                match unit {
+                    ScheduleUnit::Cycle(cycle) => {
+                        self.apply_cycle_outcome(cycle, Some(delta), None);
+                        cycle_errors += 1;
+                    }
+                    ScheduleUnit::Layer(layer) => {
+                        if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                            computed_vertices +=
+                                self.evaluate_layer_parallel_with_delta(layer, delta)?;
+                        } else {
+                            computed_vertices +=
+                                self.evaluate_layer_sequential_with_delta(layer, delta)?;
+                        }
+                    }
                 }
             }
 
@@ -9257,49 +9249,47 @@ where
                 Self::accumulate_schedule_meta(t, &meta);
             }
 
-            // Handle cycles first by marking them with #CIRC!
-            for cycle in &schedule.cycles {
-                // Check cancellation between cycles
-                if cancel_flag.load(Ordering::Relaxed) {
-                    if let Some(mut t) = telemetry {
-                        t.bailout_reason = Some("cancelled");
-                        t.replan_iterations = replan_iterations;
-                        self.last_virtual_dep_telemetry = t;
+            // Walk units in condensation order, checking cancellation between
+            // units (formerly between cycles and between layers).
+            for unit in &schedule.units {
+                match unit {
+                    ScheduleUnit::Cycle(cycle) => {
+                        // Check cancellation between cycles
+                        if cancel_flag.load(Ordering::Relaxed) {
+                            if let Some(mut t) = telemetry {
+                                t.bailout_reason = Some("cancelled");
+                                t.replan_iterations = replan_iterations;
+                                self.last_virtual_dep_telemetry = t;
+                            }
+                            return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
+                                "Evaluation cancelled during cycle handling".to_string(),
+                            ));
+                        }
+
+                        self.apply_cycle_outcome(cycle, None, None);
+                        cycle_errors += 1;
                     }
-                    return Err(ExcelError::new(ExcelErrorKind::Cancelled)
-                        .with_message("Evaluation cancelled during cycle handling".to_string()));
-                }
+                    ScheduleUnit::Layer(layer) => {
+                        // Check cancellation between layers
+                        if cancel_flag.load(Ordering::Relaxed) {
+                            if let Some(mut t) = telemetry {
+                                t.bailout_reason = Some("cancelled");
+                                t.replan_iterations = replan_iterations;
+                                self.last_virtual_dep_telemetry = t;
+                            }
+                            return Err(ExcelError::new(ExcelErrorKind::Cancelled)
+                                .with_message("Evaluation cancelled between layers".to_string()));
+                        }
 
-                cycle_errors += 1;
-                let circ_error = LiteralValue::Error(
-                    ExcelError::new(ExcelErrorKind::Circ)
-                        .with_message("Circular dependency detected".to_string()),
-                );
-                for &vertex_id in cycle {
-                    self.stamp_cycle_error(vertex_id, &circ_error, None);
-                }
-            }
-
-            // Evaluate acyclic layers sequentially with cancellation checks
-            for layer in &schedule.layers {
-                // Check cancellation between layers
-                if cancel_flag.load(Ordering::Relaxed) {
-                    if let Some(mut t) = telemetry {
-                        t.bailout_reason = Some("cancelled");
-                        t.replan_iterations = replan_iterations;
-                        self.last_virtual_dep_telemetry = t;
+                        // Evaluate vertices in this layer (parallel or sequential)
+                        if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                            computed_vertices +=
+                                self.evaluate_layer_parallel_cancellable(layer, cancel_flag)?;
+                        } else {
+                            computed_vertices +=
+                                self.evaluate_layer_sequential_cancellable(layer, cancel_flag)?;
+                        }
                     }
-                    return Err(ExcelError::new(ExcelErrorKind::Cancelled)
-                        .with_message("Evaluation cancelled between layers".to_string()));
-                }
-
-                // Evaluate vertices in this layer (parallel or sequential)
-                if self.thread_pool.is_some() && layer.vertices.len() > 1 {
-                    computed_vertices +=
-                        self.evaluate_layer_parallel_cancellable(layer, cancel_flag)?;
-                } else {
-                    computed_vertices +=
-                        self.evaluate_layer_sequential_cancellable(layer, cancel_flag)?;
                 }
             }
 
@@ -9410,43 +9400,43 @@ where
         let scheduler = Scheduler::new(&self.graph);
         let schedule = scheduler.create_schedule_with_virtual(&precedents_to_eval, &vdeps)?;
 
-        // Handle cycles first
+        // Walk units in condensation order with cancellation checks between
+        // units (formerly between cycles and between layers).
         let mut cycle_errors = 0;
-        for cycle in &schedule.cycles {
-            // Check cancellation between cycles
-            if cancel_flag.load(Ordering::Relaxed) {
-                return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
-                    "Demand-driven evaluation cancelled during cycle handling".to_string(),
-                ));
-            }
-
-            cycle_errors += 1;
-            let circ_error = LiteralValue::Error(
-                ExcelError::new(ExcelErrorKind::Circ)
-                    .with_message("Circular dependency detected".to_string()),
-            );
-            for &vertex_id in cycle {
-                self.stamp_cycle_error(vertex_id, &circ_error, None);
-            }
-        }
-
-        // Evaluate layers with cancellation checks
         let mut computed_vertices = 0;
-        for layer in &schedule.layers {
-            // Check cancellation between layers
-            if cancel_flag.load(Ordering::Relaxed) {
-                return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
-                    "Demand-driven evaluation cancelled between layers".to_string(),
-                ));
-            }
+        for unit in &schedule.units {
+            match unit {
+                ScheduleUnit::Cycle(cycle) => {
+                    // Check cancellation between cycles
+                    if cancel_flag.load(Ordering::Relaxed) {
+                        return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
+                            "Demand-driven evaluation cancelled during cycle handling".to_string(),
+                        ));
+                    }
 
-            // Evaluate vertices in this layer (parallel or sequential)
-            if self.thread_pool.is_some() && layer.vertices.len() > 1 {
-                computed_vertices +=
-                    self.evaluate_layer_parallel_cancellable(layer, cancel_flag)?;
-            } else {
-                computed_vertices +=
-                    self.evaluate_layer_sequential_cancellable_demand_driven(layer, cancel_flag)?;
+                    self.apply_cycle_outcome(cycle, None, None);
+                    cycle_errors += 1;
+                }
+                ScheduleUnit::Layer(layer) => {
+                    // Check cancellation between layers
+                    if cancel_flag.load(Ordering::Relaxed) {
+                        return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
+                            "Demand-driven evaluation cancelled between layers".to_string(),
+                        ));
+                    }
+
+                    // Evaluate vertices in this layer (parallel or sequential)
+                    if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                        computed_vertices +=
+                            self.evaluate_layer_parallel_cancellable(layer, cancel_flag)?;
+                    } else {
+                        computed_vertices += self
+                            .evaluate_layer_sequential_cancellable_demand_driven(
+                                layer,
+                                cancel_flag,
+                            )?;
+                    }
+                }
             }
         }
 
@@ -11638,6 +11628,42 @@ where
         }
     }
 
+    /// Apply the evaluation outcome for one cyclic SCC: stamp `#CIRC!` on its
+    /// (optionally filtered) members via `stamp_cycle_error`.
+    ///
+    /// This is the single per-SCC application point used by every schedule
+    /// consumer walking `Schedule::units` (pre-work for #112, where cyclic
+    /// SCCs will gain runtime verdicts instead of an unconditional stamp).
+    ///
+    /// `dirty_filter` preserves the recalc-plan quirk: when `Some(dirty)`,
+    /// only members present in the set are stamped.
+    ///
+    /// Returns the number of vertices stamped (0 when a filter excludes every
+    /// member), so callers can keep their site-specific `cycle_errors`
+    /// accounting.
+    fn apply_cycle_outcome(
+        &mut self,
+        cycle: &[VertexId],
+        mut delta: Option<&mut DeltaCollector>,
+        dirty_filter: Option<&FxHashSet<VertexId>>,
+    ) -> usize {
+        let circ_error = LiteralValue::Error(
+            ExcelError::new(ExcelErrorKind::Circ)
+                .with_message("Circular dependency detected".to_string()),
+        );
+        let mut stamped = 0usize;
+        for &vertex_id in cycle {
+            if let Some(filter) = dirty_filter
+                && !filter.contains(&vertex_id)
+            {
+                continue;
+            }
+            self.stamp_cycle_error(vertex_id, &circ_error, delta.as_deref_mut());
+            stamped += 1;
+        }
+        stamped
+    }
+
     /// Stamp a vertex with `#CIRC!` as part of cycle handling.
     ///
     /// Unlike a bare `update_vertex_value`, this first tears down any spill the
@@ -13008,21 +13034,18 @@ where
                 Self::accumulate_schedule_meta(t, &meta);
             }
 
-            // Handle cycles.
-            let circ_error = LiteralValue::Error(
-                ExcelError::new(ExcelErrorKind::Circ)
-                    .with_message("Circular dependency detected".to_string()),
-            );
-            for cycle in &schedule.cycles {
-                cycle_errors += 1;
-                for &vertex_id in cycle {
-                    self.stamp_cycle_error(vertex_id, &circ_error, None);
+            // Walk units in condensation order: stamp cycles at their
+            // position, evaluate layers with ChangeLog recording.
+            for unit in &schedule.units {
+                match unit {
+                    ScheduleUnit::Cycle(cycle) => {
+                        self.apply_cycle_outcome(cycle, None, None);
+                        cycle_errors += 1;
+                    }
+                    ScheduleUnit::Layer(layer) => {
+                        computed_vertices += self.evaluate_layer_logged(layer, log)?;
+                    }
                 }
-            }
-
-            // Evaluate layers.
-            for layer in &schedule.layers {
-                computed_vertices += self.evaluate_layer_logged(layer, log)?;
             }
 
             let changed_vertices = self.changed_virtual_dep_vertices(&to_evaluate, &old_vdeps);

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -7936,6 +7936,7 @@ where
         if vertices.is_empty() {
             return Ok(RecalcPlan {
                 schedule: crate::engine::Schedule {
+                    units: Vec::new(),
                     layers: Vec::new(),
                     cycles: Vec::new(),
                 },

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -55,7 +55,7 @@ pub use graph::{
     StripeType, block_index,
 };
 pub use row_visibility::{RowVisibilitySource, VisibilityMaskMode};
-pub use scheduler::{Layer, Schedule, Scheduler};
+pub use scheduler::{Layer, Schedule, ScheduleUnit, Scheduler};
 pub use vertex::{VertexId, VertexKind};
 
 pub use graph::editor::{

--- a/crates/formualizer-eval/src/engine/scheduler.rs
+++ b/crates/formualizer-eval/src/engine/scheduler.rs
@@ -12,10 +12,43 @@ pub struct Layer {
     pub vertices: Vec<VertexId>,
 }
 
+/// One step of the canonical schedule walk: either an acyclic Kahn wave
+/// (`Layer`) or a cyclic SCC treated as a single super-node (`Cycle`).
+#[derive(Debug, Clone)]
+pub enum ScheduleUnit {
+    Layer(Layer),
+    Cycle(Vec<VertexId>),
+}
+
 #[derive(Debug, Clone)]
 pub struct Schedule {
-    pub layers: Vec<Layer>,
+    /// Canonical walk order: condensation order over the dependency graph.
+    /// Every `Cycle` unit appears after all units containing its external
+    /// dependencies and before all units containing its external dependents.
+    pub units: Vec<ScheduleUnit>,
+    /// All cyclic SCCs (same contents as before `units` existed), for
+    /// consumers that only need the set of cycles.
     pub cycles: Vec<Vec<VertexId>>,
+    /// The `Layer` units in order, for consumers that only walk layers.
+    pub layers: Vec<Layer>,
+}
+
+impl Schedule {
+    fn from_parts(layers: Vec<Layer>, cycles: Vec<Vec<VertexId>>) -> Self {
+        debug_assert!(
+            cycles.is_empty(),
+            "Schedule::from_parts is the cycle-free fast path"
+        );
+        let units = layers
+            .iter()
+            .map(|l| ScheduleUnit::Layer(l.clone()))
+            .collect();
+        Schedule {
+            units,
+            cycles,
+            layers,
+        }
+    }
 }
 
 impl<'a> Scheduler<'a> {
@@ -37,20 +70,47 @@ impl<'a> Scheduler<'a> {
         let (cycles, acyclic_sccs) = self.separate_cycles(sccs);
 
         // 3. Topologically sort acyclic components into layers
-        let layers = if self.graph.dynamic_topo_enabled() {
+        if self.graph.dynamic_topo_enabled() {
+            // Dynamic-topo (PK) branch: pk_layers_for orders only the acyclic
+            // subset, so we cannot interleave Cycle units by condensation
+            // position here. Stay conservative on this experimental path and
+            // emit ALL Cycle units first (matching today's stamp-cycles-first
+            // semantics), then the pk layers as Layer units.
             let subset: Vec<VertexId> = acyclic_sccs.into_iter().flatten().collect();
-            if subset.is_empty() {
+            let layers = if subset.is_empty() {
                 Vec::new()
             } else {
                 self.graph
                     .pk_layers_for(&subset)
                     .unwrap_or(self.build_layers(vec![subset])?)
+            };
+            let mut units = Vec::with_capacity(cycles.len() + layers.len());
+            let mut cycle_order: Vec<usize> = (0..cycles.len()).collect();
+            cycle_order.sort_by_key(|&i| cycles[i].iter().copied().min());
+            for i in cycle_order {
+                units.push(ScheduleUnit::Cycle(cycles[i].clone()));
             }
-        } else {
-            self.build_layers(acyclic_sccs)?
-        };
+            units.extend(layers.iter().map(|l| ScheduleUnit::Layer(l.clone())));
+            return Ok(Schedule {
+                units,
+                cycles,
+                layers,
+            });
+        }
 
-        Ok(Schedule { layers, cycles })
+        if cycles.is_empty() {
+            // Fast path: byte-for-byte today's layer construction.
+            let layers = self.build_layers(acyclic_sccs)?;
+            return Ok(Schedule::from_parts(layers, cycles));
+        }
+
+        // Cycle path: Kahn over the condensation (SCC-as-node).
+        let (units, layers) = self.build_condensation_units(&cycles, acyclic_sccs, None)?;
+        Ok(Schedule {
+            units,
+            cycles,
+            layers,
+        })
     }
 
     /// Create a schedule considering additional ephemeral (virtual) dependencies just for this pass.
@@ -78,10 +138,19 @@ impl<'a> Scheduler<'a> {
         // 3. Build layers over combined adjacency (graph + vdeps)
         #[cfg(feature = "tracing")]
         let _layers_span = tracing::info_span!("build_layers_with_virtual").entered();
-        let layers = self.build_layers_with_virtual(acyclic_sccs, vdeps)?;
-        #[cfg(feature = "tracing")]
-        drop(_layers_span);
-        Ok(Schedule { layers, cycles })
+        if cycles.is_empty() {
+            // Fast path: byte-for-byte today's layer construction.
+            let layers = self.build_layers_with_virtual(acyclic_sccs, vdeps)?;
+            return Ok(Schedule::from_parts(layers, cycles));
+        }
+        // Cycle path: Kahn over the condensation (SCC-as-node), honoring
+        // virtual deps as extra edges.
+        let (units, layers) = self.build_condensation_units(&cycles, acyclic_sccs, Some(vdeps))?;
+        Ok(Schedule {
+            units,
+            cycles,
+            layers,
+        })
     }
 
     /// Tarjan's strongly connected components algorithm
@@ -480,6 +549,132 @@ impl<'a> Scheduler<'a> {
         }
 
         Ok(layers)
+    }
+
+    /// Kahn's algorithm over the condensation of the scheduled subgraph:
+    /// each cyclic SCC is a super-node, each acyclic vertex a singleton node.
+    ///
+    /// Per Kahn wave we emit first the wave's `Cycle` units (ordered by
+    /// smallest member `VertexId` for determinism), then one `Layer` unit with
+    /// the wave's singleton vertices (sorted, as in `build_layers`). Within a
+    /// wave there are no inter-node edges, so this ordering is semantically
+    /// free. The result guarantees every `Cycle` unit appears after all units
+    /// containing its external dependencies and before all units containing
+    /// its external dependents (pinned by tests in
+    /// `engine/tests/schedule_units.rs`).
+    ///
+    /// Returns the unit walk plus the `Layer` units in order (the
+    /// compatibility `Schedule::layers` view).
+    fn build_condensation_units(
+        &self,
+        cycles: &[Vec<VertexId>],
+        acyclic_sccs: Vec<Vec<VertexId>>,
+        vdeps: Option<&FxHashMap<VertexId, Vec<VertexId>>>,
+    ) -> Result<(Vec<ScheduleUnit>, Vec<Layer>), ExcelError> {
+        let singletons: Vec<VertexId> = acyclic_sccs.into_iter().flatten().collect();
+        let cycle_node_count = cycles.len();
+        let node_count = cycle_node_count + singletons.len();
+
+        // Map every scheduled vertex to its condensation node.
+        let mut node_of: FxHashMap<VertexId, usize> = FxHashMap::default();
+        for (i, cycle) in cycles.iter().enumerate() {
+            for &v in cycle {
+                node_of.insert(v, i);
+            }
+        }
+        for (j, &v) in singletons.iter().enumerate() {
+            node_of.insert(v, cycle_node_count + j);
+        }
+
+        // Build in-degrees and the dependents adjacency from a single scan of
+        // the dependency direction, so both sides are guaranteed consistent.
+        // Edges to vertices outside the scheduled set are ignored
+        // (membership == presence in `node_of`); intra-node edges are ignored.
+        let mut in_degrees: Vec<usize> = vec![0; node_count];
+        let mut node_dependents: Vec<Vec<usize>> = vec![Vec::new(); node_count];
+        let scan_dep = |from_node: usize,
+                        dep: VertexId,
+                        in_degrees: &mut Vec<usize>,
+                        node_dependents: &mut Vec<Vec<usize>>| {
+            if let Some(&dep_node) = node_of.get(&dep)
+                && dep_node != from_node
+            {
+                in_degrees[from_node] += 1;
+                node_dependents[dep_node].push(from_node);
+            }
+        };
+        for (&v, &n_v) in node_of.iter() {
+            if let Some(deps) = self.graph.dependencies_slice(v) {
+                for &dep in deps {
+                    scan_dep(n_v, dep, &mut in_degrees, &mut node_dependents);
+                }
+            } else {
+                for dep in self.graph.get_dependencies(v) {
+                    scan_dep(n_v, dep, &mut in_degrees, &mut node_dependents);
+                }
+            }
+            if let Some(extra) = vdeps.and_then(|m| m.get(&v)) {
+                for &dep in extra {
+                    scan_dep(n_v, dep, &mut in_degrees, &mut node_dependents);
+                }
+            }
+        }
+
+        // Kahn by waves over condensation nodes.
+        let mut current: Vec<usize> = (0..node_count).filter(|&n| in_degrees[n] == 0).collect();
+        let mut units = Vec::new();
+        let mut layers = Vec::new();
+        let mut processed_count = 0usize;
+        while !current.is_empty() {
+            let mut wave_cycles: Vec<usize> = current
+                .iter()
+                .copied()
+                .filter(|&n| n < cycle_node_count)
+                .collect();
+            wave_cycles.sort_by_key(|&n| cycles[n].iter().copied().min());
+            for n in wave_cycles {
+                units.push(ScheduleUnit::Cycle(cycles[n].clone()));
+            }
+
+            let mut wave_vertices: Vec<VertexId> = current
+                .iter()
+                .copied()
+                .filter(|&n| n >= cycle_node_count)
+                .map(|n| singletons[n - cycle_node_count])
+                .collect();
+            if !wave_vertices.is_empty() {
+                // Sort for deterministic output, as in build_layers.
+                wave_vertices.sort();
+                let layer = Layer {
+                    vertices: wave_vertices,
+                };
+                layers.push(layer.clone());
+                units.push(ScheduleUnit::Layer(layer));
+            }
+
+            processed_count += current.len();
+            let mut next = Vec::new();
+            for &n in &current {
+                for &dependent in &node_dependents[n] {
+                    in_degrees[dependent] -= 1;
+                    if in_degrees[dependent] == 0 {
+                        next.push(dependent);
+                    }
+                }
+            }
+            current = next;
+        }
+
+        if processed_count != node_count {
+            return Err(
+                ExcelError::new(formualizer_common::ExcelErrorKind::Circ).with_message(
+                    "Unexpected cycle detected in condensation during unit construction"
+                        .to_string(),
+                ),
+            );
+        }
+
+        Ok((units, layers))
     }
 
     pub(crate) fn build_layers_with_virtual(

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -23,6 +23,7 @@ mod range_property_tests;
 mod recalc_plan;
 mod schedule_cache;
 mod schedule_integration;
+mod schedule_units;
 mod sheet_index_integration;
 //mod streaming_evaluation;
 mod bulk_ingest;

--- a/crates/formualizer-eval/src/engine/tests/schedule_units.rs
+++ b/crates/formualizer-eval/src/engine/tests/schedule_units.rs
@@ -1,0 +1,362 @@
+//! Tests for condensation-ordered `Schedule::units` (Stage 0 of the
+//! cycle-evaluation work; pre-work for RFC #112).
+//!
+//! `Schedule::units` is the canonical walk order: each cyclic SCC is a
+//! `ScheduleUnit::Cycle` super-node positioned after all units containing its
+//! external dependencies and before all units containing its external
+//! dependents. Acyclic vertices are grouped into `ScheduleUnit::Layer` waves
+//! exactly as before.
+
+use super::common::get_vertex_ids_in_order;
+use crate::engine::scheduler::ScheduleUnit;
+use crate::engine::{DependencyGraph, Scheduler, VertexId};
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
+use rustc_hash::FxHashSet;
+
+/// Helper to create a cell reference AST node (row/col are 1-based).
+fn ref_ast(row: u32, col: u32) -> ASTNode {
+    ASTNode {
+        node_type: ASTNodeType::Reference {
+            original: format!("R{row}C{col}"),
+            reference: ReferenceType::cell(None, row, col),
+        },
+        source_token: None,
+        contains_volatile: false,
+    }
+}
+
+/// Build `=ref1 + ref2 + ...` as a chain of binary ops.
+fn sum_refs_ast(refs: &[(u32, u32)]) -> ASTNode {
+    assert!(!refs.is_empty());
+    let mut iter = refs.iter();
+    let first = iter.next().unwrap();
+    let mut ast = ref_ast(first.0, first.1);
+    for &(r, c) in iter {
+        ast = ASTNode {
+            node_type: ASTNodeType::BinaryOp {
+                op: "+".to_string(),
+                left: Box::new(ast),
+                right: Box::new(ref_ast(r, c)),
+            },
+            source_token: None,
+            contains_volatile: false,
+        };
+    }
+    ast
+}
+
+fn vertex_id_at(graph: &DependencyGraph, row: u32, col: u32) -> VertexId {
+    *graph
+        .cell_to_vertex()
+        .get(&super::common::abs_cell_ref(0, row, col))
+        .unwrap()
+}
+
+/// Map each scheduled vertex to the index of the unit that contains it.
+fn unit_positions(units: &[ScheduleUnit]) -> rustc_hash::FxHashMap<VertexId, usize> {
+    let mut pos = rustc_hash::FxHashMap::default();
+    for (i, unit) in units.iter().enumerate() {
+        let members: &[VertexId] = match unit {
+            ScheduleUnit::Layer(layer) => &layer.vertices,
+            ScheduleUnit::Cycle(cycle) => cycle,
+        };
+        for &v in members {
+            let prev = pos.insert(v, i);
+            assert!(prev.is_none(), "vertex {v:?} appears in more than one unit");
+        }
+    }
+    pos
+}
+
+/// U -> SCC{A,B} -> D: the cycle unit must sit between its upstream layer and
+/// its dependent's layer.
+#[test]
+fn units_position_cycle_between_upstream_and_dependent() {
+    let mut graph = DependencyGraph::new();
+
+    // U: A1 = 42 (value, upstream of the cycle)
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(42))
+        .unwrap();
+    // SCC: B1 = A1 + C1, C1 = B1
+    graph
+        .set_cell_formula("Sheet1", 1, 2, sum_refs_ast(&[(1, 1), (1, 3)]))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 3, ref_ast(1, 2))
+        .unwrap();
+    // D: D1 = B1 (dependent of the cycle)
+    graph
+        .set_cell_formula("Sheet1", 1, 4, ref_ast(1, 2))
+        .unwrap();
+
+    let u_id = vertex_id_at(&graph, 1, 1);
+    let b_id = vertex_id_at(&graph, 1, 2);
+    let c_id = vertex_id_at(&graph, 1, 3);
+    let d_id = vertex_id_at(&graph, 1, 4);
+
+    let scheduler = Scheduler::new(&graph);
+    let all = get_vertex_ids_in_order(&graph);
+    let schedule = scheduler.create_schedule(&all).unwrap();
+
+    assert_eq!(schedule.units.len(), 3, "units: {:?}", schedule.units);
+    match &schedule.units[0] {
+        ScheduleUnit::Layer(l) => assert_eq!(l.vertices, vec![u_id]),
+        other => panic!("unit 0 should be Layer{{U}}, got {other:?}"),
+    }
+    match &schedule.units[1] {
+        ScheduleUnit::Cycle(c) => {
+            let set: FxHashSet<VertexId> = c.iter().copied().collect();
+            assert_eq!(set.len(), 2);
+            assert!(set.contains(&b_id) && set.contains(&c_id));
+        }
+        other => panic!("unit 1 should be Cycle{{B,C}}, got {other:?}"),
+    }
+    match &schedule.units[2] {
+        ScheduleUnit::Layer(l) => assert_eq!(l.vertices, vec![d_id]),
+        other => panic!("unit 2 should be Layer{{D}}, got {other:?}"),
+    }
+
+    // Compatibility views are preserved.
+    assert_eq!(schedule.cycles.len(), 1);
+    assert_eq!(schedule.layers.len(), 2);
+    assert_eq!(schedule.layers[0].vertices, vec![u_id]);
+    assert_eq!(schedule.layers[1].vertices, vec![d_id]);
+}
+
+/// SCC1 -> mid vertex -> SCC2: condensation order chains across SCCs.
+#[test]
+fn units_order_multi_scc_chain() {
+    let mut graph = DependencyGraph::new();
+
+    // SCC1: A1 = B1, B1 = A1
+    graph
+        .set_cell_formula("Sheet1", 1, 1, ref_ast(1, 2))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 2, ref_ast(1, 1))
+        .unwrap();
+    // Mid: C1 = A1
+    graph
+        .set_cell_formula("Sheet1", 1, 3, ref_ast(1, 1))
+        .unwrap();
+    // SCC2: D1 = C1 + E1, E1 = D1
+    graph
+        .set_cell_formula("Sheet1", 1, 4, sum_refs_ast(&[(1, 3), (1, 5)]))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 5, ref_ast(1, 4))
+        .unwrap();
+
+    let a_id = vertex_id_at(&graph, 1, 1);
+    let b_id = vertex_id_at(&graph, 1, 2);
+    let c_id = vertex_id_at(&graph, 1, 3);
+    let d_id = vertex_id_at(&graph, 1, 4);
+    let e_id = vertex_id_at(&graph, 1, 5);
+
+    let scheduler = Scheduler::new(&graph);
+    let all = get_vertex_ids_in_order(&graph);
+    let schedule = scheduler.create_schedule(&all).unwrap();
+
+    assert_eq!(schedule.units.len(), 3, "units: {:?}", schedule.units);
+    match &schedule.units[0] {
+        ScheduleUnit::Cycle(c) => {
+            let set: FxHashSet<VertexId> = c.iter().copied().collect();
+            assert!(set.contains(&a_id) && set.contains(&b_id));
+        }
+        other => panic!("unit 0 should be Cycle{{A,B}}, got {other:?}"),
+    }
+    match &schedule.units[1] {
+        ScheduleUnit::Layer(l) => assert_eq!(l.vertices, vec![c_id]),
+        other => panic!("unit 1 should be Layer{{C}}, got {other:?}"),
+    }
+    match &schedule.units[2] {
+        ScheduleUnit::Cycle(c) => {
+            let set: FxHashSet<VertexId> = c.iter().copied().collect();
+            assert!(set.contains(&d_id) && set.contains(&e_id));
+        }
+        other => panic!("unit 2 should be Cycle{{D,E}}, got {other:?}"),
+    }
+    assert_eq!(schedule.cycles.len(), 2);
+    assert_eq!(schedule.layers.len(), 1);
+}
+
+/// Two independent SCCs land in the same Kahn wave; their relative order is
+/// deterministic: ascending by smallest member VertexId.
+#[test]
+fn independent_cycles_same_wave_sorted_by_smallest_member() {
+    let mut graph = DependencyGraph::new();
+
+    // SCC-a: A1 = B1, B1 = A1 (created first => smaller vertex ids)
+    graph
+        .set_cell_formula("Sheet1", 1, 1, ref_ast(1, 2))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 2, ref_ast(1, 1))
+        .unwrap();
+    // SCC-b: C1 = D1, D1 = C1
+    graph
+        .set_cell_formula("Sheet1", 1, 3, ref_ast(1, 4))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 4, ref_ast(1, 3))
+        .unwrap();
+
+    let a_id = vertex_id_at(&graph, 1, 1);
+    let c_id = vertex_id_at(&graph, 1, 3);
+    assert!(a_id < c_id, "test setup expects A1 created before C1");
+
+    let scheduler = Scheduler::new(&graph);
+    let all = get_vertex_ids_in_order(&graph);
+    let schedule = scheduler.create_schedule(&all).unwrap();
+
+    assert_eq!(schedule.units.len(), 2, "units: {:?}", schedule.units);
+    match (&schedule.units[0], &schedule.units[1]) {
+        (ScheduleUnit::Cycle(first), ScheduleUnit::Cycle(second)) => {
+            assert!(first.contains(&a_id), "smaller-id SCC must come first");
+            assert!(second.contains(&c_id));
+        }
+        other => panic!("expected two Cycle units, got {other:?}"),
+    }
+    assert!(schedule.layers.is_empty());
+    assert_eq!(schedule.cycles.len(), 2);
+}
+
+/// Cycle-free schedules must be byte-for-byte the legacy layer construction:
+/// `units` is exactly the old layers wrapped, and `layers` matches
+/// `build_layers` output.
+#[test]
+fn fast_path_units_match_legacy_layers() {
+    let mut graph = DependencyGraph::new();
+
+    // Diamond: A1, A2 values; B1 = A1 + A2; C1 = B1.
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    graph
+        .set_cell_value("Sheet1", 2, 1, LiteralValue::Int(2))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 2, sum_refs_ast(&[(1, 1), (2, 1)]))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 3, ref_ast(1, 2))
+        .unwrap();
+
+    let scheduler = Scheduler::new(&graph);
+    let all = get_vertex_ids_in_order(&graph);
+    let schedule = scheduler.create_schedule(&all).unwrap();
+    assert!(schedule.cycles.is_empty());
+
+    // Reconstruct layers the pre-change way: tarjan -> separate -> build_layers.
+    let sccs = scheduler.tarjan_scc(&all).unwrap();
+    let (cycles, acyclic_sccs) = scheduler.separate_cycles(sccs);
+    assert!(cycles.is_empty());
+    let legacy_layers = scheduler.build_layers(acyclic_sccs).unwrap();
+
+    assert_eq!(schedule.layers.len(), legacy_layers.len());
+    for (got, want) in schedule.layers.iter().zip(legacy_layers.iter()) {
+        assert_eq!(got.vertices, want.vertices);
+    }
+
+    // Units are exactly those layers, wrapped, in order.
+    assert_eq!(schedule.units.len(), legacy_layers.len());
+    for (unit, want) in schedule.units.iter().zip(legacy_layers.iter()) {
+        match unit {
+            ScheduleUnit::Layer(l) => assert_eq!(l.vertices, want.vertices),
+            other => panic!("fast path must emit only Layer units, got {other:?}"),
+        }
+    }
+}
+
+/// Randomized invariant: every Cycle unit appears strictly after all units
+/// containing its external dependencies and strictly before all units
+/// containing its external dependents.
+#[test]
+fn cycle_units_respect_condensation_invariant_random() {
+    for seed in 1u64..=24 {
+        let mut rng = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let mut next = || {
+            // xorshift64*
+            rng ^= rng >> 12;
+            rng ^= rng << 25;
+            rng ^= rng >> 27;
+            rng.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        };
+
+        const N: u32 = 12;
+        let mut graph = DependencyGraph::new();
+
+        // Random forward DAG edges j -> i (i < j), plus a few back edges
+        // i -> j (i < j) to create cycles. Cell (row r, col 1) for r in 1..=N.
+        let mut deps: Vec<Vec<u32>> = vec![Vec::new(); (N + 1) as usize];
+        for j in 2..=N {
+            for i in 1..j {
+                if next() % 100 < 30 {
+                    deps[j as usize].push(i);
+                }
+            }
+        }
+        for _ in 0..3 {
+            let i = 1 + (next() % (N as u64 - 1)) as u32; // 1..N
+            let j = i + 1 + (next() % ((N - i) as u64)) as u32; // i+1..=N
+            deps[i as usize].push(j);
+        }
+
+        for r in 1..=N {
+            let d = &deps[r as usize];
+            if d.is_empty() {
+                graph
+                    .set_cell_value("Sheet1", r, 1, LiteralValue::Int(r as i64))
+                    .unwrap();
+            } else {
+                let refs: Vec<(u32, u32)> = d.iter().map(|&dr| (dr, 1)).collect();
+                graph
+                    .set_cell_formula("Sheet1", r, 1, sum_refs_ast(&refs))
+                    .unwrap();
+            }
+        }
+
+        let scheduler = Scheduler::new(&graph);
+        let all = get_vertex_ids_in_order(&graph);
+        let scheduled: FxHashSet<VertexId> = all.iter().copied().collect();
+        let schedule = scheduler.create_schedule(&all).unwrap();
+
+        let pos = unit_positions(&schedule.units);
+        assert_eq!(
+            pos.len(),
+            all.len(),
+            "seed {seed}: every scheduled vertex must appear in exactly one unit"
+        );
+
+        for (idx, unit) in schedule.units.iter().enumerate() {
+            let ScheduleUnit::Cycle(members) = unit else {
+                continue;
+            };
+            let member_set: FxHashSet<VertexId> = members.iter().copied().collect();
+            for &v in members {
+                for dep in graph.get_dependencies(v) {
+                    if scheduled.contains(&dep) && !member_set.contains(&dep) {
+                        assert!(
+                            pos[&dep] < idx,
+                            "seed {seed}: external dependency {dep:?} of cycle at unit {idx} \
+                             is at unit {} (must be earlier)",
+                            pos[&dep]
+                        );
+                    }
+                }
+                for dependent in graph.get_dependents(v) {
+                    if scheduled.contains(&dependent) && !member_set.contains(&dependent) {
+                        assert!(
+                            pos[&dependent] > idx,
+                            "seed {seed}: external dependent {dependent:?} of cycle at unit {idx} \
+                             is at unit {} (must be later)",
+                            pos[&dependent]
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/formualizer-workbook/tests/cycle_schedule_pinning.rs
+++ b/crates/formualizer-workbook/tests/cycle_schedule_pinning.rs
@@ -1,0 +1,92 @@
+//! Pinning tests for cycle-stamping result-equivalence (Stage 0 of the
+//! cycle-evaluation work; pre-work for RFC #112).
+//!
+//! Stage 0 moves cycle stamping from "all cycles up-front" to "per-SCC at the
+//! cycle's condensation position in the schedule". These tests pin the
+//! observable contract: dependents of a cycle read the #CIRC-derived result
+//! identically, and unrelated work alongside a cycle evaluates normally.
+
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_workbook::Workbook;
+
+fn is_circ(v: &Option<LiteralValue>) -> bool {
+    matches!(v, Some(LiteralValue::Error(e)) if e.kind == ExcelErrorKind::Circ)
+}
+
+/// A1 <-> B1 cycle with downstream dependent C1 = A1 + 1, full recalc path.
+/// C1 must observe the stamped #CIRC and propagate it.
+#[test]
+fn dependent_of_cycle_reads_circ_via_evaluate_all() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    wb.set_formula("S", 1, 1, "=B1").unwrap();
+    wb.set_formula("S", 1, 2, "=A1").unwrap();
+    wb.set_formula("S", 1, 3, "=A1+1").unwrap();
+    wb.evaluate_all().unwrap();
+
+    assert!(
+        is_circ(&wb.get_value("S", 1, 1)),
+        "A1 should be #CIRC, got {:?}",
+        wb.get_value("S", 1, 1)
+    );
+    assert!(
+        is_circ(&wb.get_value("S", 1, 2)),
+        "B1 should be #CIRC, got {:?}",
+        wb.get_value("S", 1, 2)
+    );
+    assert!(
+        is_circ(&wb.get_value("S", 1, 3)),
+        "C1 = A1+1 should propagate #CIRC, got {:?}",
+        wb.get_value("S", 1, 3)
+    );
+}
+
+/// Same shape, but evaluated through the demand-driven path (`evaluate_cell`),
+/// which schedules the minimal subgraph with virtual deps.
+#[test]
+fn dependent_of_cycle_reads_circ_via_evaluate_cell() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    wb.set_formula("S", 1, 1, "=B1").unwrap();
+    wb.set_formula("S", 1, 2, "=A1").unwrap();
+    wb.set_formula("S", 1, 3, "=A1+1").unwrap();
+
+    let c1 = wb.evaluate_cell("S", 1, 3).unwrap();
+    assert!(
+        is_circ(&Some(c1.clone())),
+        "demand-driven C1 = A1+1 should propagate #CIRC, got {c1:?}"
+    );
+    assert!(
+        is_circ(&wb.get_value("S", 1, 1)),
+        "A1 should be #CIRC after demand eval, got {:?}",
+        wb.get_value("S", 1, 1)
+    );
+    assert!(
+        is_circ(&wb.get_value("S", 1, 2)),
+        "B1 should be #CIRC after demand eval, got {:?}",
+        wb.get_value("S", 1, 2)
+    );
+}
+
+/// A cycle alongside an unrelated acyclic chain: the chain must evaluate to
+/// normal values while the cycle members are stamped #CIRC.
+#[test]
+fn cycle_plus_unrelated_parallel_work_evaluates_correctly() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    // Cycle.
+    wb.set_formula("S", 1, 1, "=B1").unwrap();
+    wb.set_formula("S", 1, 2, "=A1").unwrap();
+    // Unrelated chain.
+    wb.set_formula("S", 1, 4, "=1+1").unwrap();
+    wb.set_formula("S", 1, 5, "=D1*2").unwrap();
+    wb.evaluate_all().unwrap();
+
+    assert!(is_circ(&wb.get_value("S", 1, 1)));
+    assert!(is_circ(&wb.get_value("S", 1, 2)));
+    assert_eq!(wb.get_value("S", 1, 4), Some(LiteralValue::Number(2.0)));
+    assert_eq!(wb.get_value("S", 1, 5), Some(LiteralValue::Number(4.0)));
+}


### PR DESCRIPTION
Pre-work for the runtime-cycle-verdicts RFC (#112). Zero behavior change — the existing suite is the contract, and new pinning tests lock in result-equivalence.

## What this does

**Scheduler**: `Schedule` gains `units: Vec<ScheduleUnit>` (`Layer(..) | Cycle(..)`) — a condensation-ordered walk where each cyclic SCC is a super-node positioned after its upstream dependencies and before its dependents. Cycle-free schedules (the overwhelmingly common case) take a fast path that is byte-for-byte the old layer construction, just wrapped — no condensation or hashing work on the hot path. The compatibility views `schedule.layers` and `schedule.cycles` keep their exact pre-change contents. The dynamic-topo (pk) branch conservatively emits Cycle units first (today's stamp-first semantics), noted in a comment.

**Eval**: a single per-SCC application point, `apply_cycle_outcome(cycle, delta, dirty_filter)`, wraps the `stamp_cycle_error` helper from #115, and all eight schedule-consumption sites now walk `schedule.units` in one loop instead of "stamp all cycles, then run all layers". Site-specific behavior is preserved exactly: the recalc-plan path's dirty-only filtering, cancellation checks (now one per unit), delta collection, telemetry accounting, and per-layer flush points.

## Why

Today, correctness depends on cycles being stamped before any layer runs: `build_layers` ignores cycle edges when computing in-degrees, so dependents of cycle members can land in layer 0 and must find `#CIRC` already written. That implicit ordering becomes explicit condensation ordering here — which is exactly the structure #112 needs to *evaluate* SCC units in place (upstream values fresh, dependents downstream) instead of stamping them. This PR lands the structural change with zero semantic change so the RFC work plugs into a stable seam.

## Tests

New scheduler tests (`engine/tests/schedule_units.rs`): upstream → SCC → dependent unit positioning, multi-SCC chains, deterministic ordering of independent SCCs, fast-path equivalence against a literal reconstruction of the old `build_layers` output, and a 24-seed randomized invariant check (every Cycle unit strictly after its external dependencies and before its external dependents). New workbook pinning tests (`cycle_schedule_pinning.rs`) verified green against pre-change code first, then post-change: `#CIRC` propagation to dependents via both `evaluate_all` and the demand path, and cycles alongside unrelated parallel work. No existing tests modified.

Validated locally with the CI commands: fmt clean, clippy `-D warnings` clean, full workspace suite (CI exclusions) → 2402 passed, 0 failed.
