### PR TITLE
perf(scheduler): store schedule units as indices, not layer clones

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -7819,13 +7819,14 @@ where
         // evaluate_all).
         let mut cycle_errors = 0;
         let mut computed_vertices = 0;
-        for unit in &schedule.units {
+        for &unit in &schedule.units {
             match unit {
-                ScheduleUnit::Cycle(cycle) => {
-                    self.apply_cycle_outcome(cycle, None, None);
+                ScheduleUnit::Cycle(i) => {
+                    self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
                     cycle_errors += 1;
                 }
-                ScheduleUnit::Layer(layer) => {
+                ScheduleUnit::Layer(i) => {
+                    let layer = schedule.unit_layer(i);
                     if self.thread_pool.is_some() && layer.vertices.len() > 1 {
                         computed_vertices += self.evaluate_layer_parallel(layer)?;
                     } else {
@@ -7898,13 +7899,14 @@ where
 
         let mut cycle_errors = 0;
         let mut computed_vertices = 0;
-        for unit in &schedule.units {
+        for &unit in &schedule.units {
             match unit {
-                ScheduleUnit::Cycle(cycle) => {
-                    self.apply_cycle_outcome(cycle, Some(delta), None);
+                ScheduleUnit::Cycle(i) => {
+                    self.apply_cycle_outcome(schedule.unit_cycle(i), Some(delta), None);
                     cycle_errors += 1;
                 }
-                ScheduleUnit::Layer(layer) => {
+                ScheduleUnit::Layer(i) => {
+                    let layer = schedule.unit_layer(i);
                     if self.thread_pool.is_some() && layer.vertices.len() > 1 {
                         computed_vertices +=
                             self.evaluate_layer_parallel_with_delta(layer, delta)?;
@@ -7982,18 +7984,24 @@ where
         let mut computed_vertices = 0;
         let mut cycle_errors = 0;
 
-        for unit in &plan.schedule.units {
+        for &unit in &plan.schedule.units {
             match unit {
-                ScheduleUnit::Cycle(cycle) => {
+                ScheduleUnit::Cycle(i) => {
                     // Recalc-plan quirk: stamp only the DIRTY members of the
                     // cycle, and count the cycle only when it had any.
-                    let stamped = self.apply_cycle_outcome(cycle, None, Some(&dirty_set));
+                    let stamped = self.apply_cycle_outcome(
+                        plan.schedule.unit_cycle(i),
+                        None,
+                        Some(&dirty_set),
+                    );
                     if stamped > 0 {
                         cycle_errors += 1;
                     }
                 }
-                ScheduleUnit::Layer(layer) => {
-                    let work: Vec<VertexId> = layer
+                ScheduleUnit::Layer(i) => {
+                    let work: Vec<VertexId> = plan
+                        .schedule
+                        .unit_layer(i)
                         .vertices
                         .iter()
                         .copied()
@@ -8424,13 +8432,14 @@ where
     ) -> Result<(usize, usize), ExcelError> {
         let mut computed_vertices = 0;
         let mut cycle_count = 0;
-        for unit in &schedule.units {
+        for &unit in &schedule.units {
             match unit {
-                ScheduleUnit::Cycle(cycle) => {
-                    self.apply_cycle_outcome(cycle, None, None);
+                ScheduleUnit::Cycle(i) => {
+                    self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
                     cycle_count += 1;
                 }
-                ScheduleUnit::Layer(layer) => {
+                ScheduleUnit::Layer(i) => {
+                    let layer = schedule.unit_layer(i);
                     if self.thread_pool.is_some() && layer.vertices.len() > 1 {
                         computed_vertices += self.evaluate_layer_parallel(layer)?;
                     } else {
@@ -8573,13 +8582,14 @@ where
                 Self::accumulate_schedule_meta(t, &meta);
             }
 
-            for unit in &schedule.units {
+            for &unit in &schedule.units {
                 match unit {
-                    ScheduleUnit::Cycle(cycle) => {
-                        self.apply_cycle_outcome(cycle, Some(delta), None);
+                    ScheduleUnit::Cycle(i) => {
+                        self.apply_cycle_outcome(schedule.unit_cycle(i), Some(delta), None);
                         cycle_errors += 1;
                     }
-                    ScheduleUnit::Layer(layer) => {
+                    ScheduleUnit::Layer(i) => {
+                        let layer = schedule.unit_layer(i);
                         if self.thread_pool.is_some() && layer.vertices.len() > 1 {
                             computed_vertices +=
                                 self.evaluate_layer_parallel_with_delta(layer, delta)?;
@@ -9251,9 +9261,9 @@ where
 
             // Walk units in condensation order, checking cancellation between
             // units (formerly between cycles and between layers).
-            for unit in &schedule.units {
+            for &unit in &schedule.units {
                 match unit {
-                    ScheduleUnit::Cycle(cycle) => {
+                    ScheduleUnit::Cycle(i) => {
                         // Check cancellation between cycles
                         if cancel_flag.load(Ordering::Relaxed) {
                             if let Some(mut t) = telemetry {
@@ -9266,10 +9276,11 @@ where
                             ));
                         }
 
-                        self.apply_cycle_outcome(cycle, None, None);
+                        self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
                         cycle_errors += 1;
                     }
-                    ScheduleUnit::Layer(layer) => {
+                    ScheduleUnit::Layer(i) => {
+                        let layer = schedule.unit_layer(i);
                         // Check cancellation between layers
                         if cancel_flag.load(Ordering::Relaxed) {
                             if let Some(mut t) = telemetry {
@@ -9404,9 +9415,9 @@ where
         // units (formerly between cycles and between layers).
         let mut cycle_errors = 0;
         let mut computed_vertices = 0;
-        for unit in &schedule.units {
+        for &unit in &schedule.units {
             match unit {
-                ScheduleUnit::Cycle(cycle) => {
+                ScheduleUnit::Cycle(i) => {
                     // Check cancellation between cycles
                     if cancel_flag.load(Ordering::Relaxed) {
                         return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
@@ -9414,10 +9425,11 @@ where
                         ));
                     }
 
-                    self.apply_cycle_outcome(cycle, None, None);
+                    self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
                     cycle_errors += 1;
                 }
-                ScheduleUnit::Layer(layer) => {
+                ScheduleUnit::Layer(i) => {
+                    let layer = schedule.unit_layer(i);
                     // Check cancellation between layers
                     if cancel_flag.load(Ordering::Relaxed) {
                         return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
@@ -13036,14 +13048,15 @@ where
 
             // Walk units in condensation order: stamp cycles at their
             // position, evaluate layers with ChangeLog recording.
-            for unit in &schedule.units {
+            for &unit in &schedule.units {
                 match unit {
-                    ScheduleUnit::Cycle(cycle) => {
-                        self.apply_cycle_outcome(cycle, None, None);
+                    ScheduleUnit::Cycle(i) => {
+                        self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
                         cycle_errors += 1;
                     }
-                    ScheduleUnit::Layer(layer) => {
-                        computed_vertices += self.evaluate_layer_logged(layer, log)?;
+                    ScheduleUnit::Layer(i) => {
+                        computed_vertices +=
+                            self.evaluate_layer_logged(schedule.unit_layer(i), log)?;
                     }
                 }
             }

--- a/crates/formualizer-eval/src/engine/scheduler.rs
+++ b/crates/formualizer-eval/src/engine/scheduler.rs
@@ -13,11 +13,14 @@ pub struct Layer {
 }
 
 /// One step of the canonical schedule walk: either an acyclic Kahn wave
-/// (`Layer`) or a cyclic SCC treated as a single super-node (`Cycle`).
-#[derive(Debug, Clone)]
+/// (`Layer`, an index into `Schedule::layers`) or a cyclic SCC treated as a
+/// single super-node (`Cycle`, an index into `Schedule::cycles`). Storing
+/// indices keeps `Schedule::layers`/`Schedule::cycles` the single owners of
+/// the vertex Vecs, so building or cloning a schedule never duplicates them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScheduleUnit {
-    Layer(Layer),
-    Cycle(Vec<VertexId>),
+    Layer(u32),
+    Cycle(u32),
 }
 
 #[derive(Debug, Clone)]
@@ -39,15 +42,22 @@ impl Schedule {
             cycles.is_empty(),
             "Schedule::from_parts is the cycle-free fast path"
         );
-        let units = layers
-            .iter()
-            .map(|l| ScheduleUnit::Layer(l.clone()))
-            .collect();
+        let units = (0..layers.len() as u32).map(ScheduleUnit::Layer).collect();
         Schedule {
             units,
             cycles,
             layers,
         }
+    }
+
+    /// Resolve a `ScheduleUnit::Layer` index.
+    pub fn unit_layer(&self, i: u32) -> &Layer {
+        &self.layers[i as usize]
+    }
+
+    /// Resolve a `ScheduleUnit::Cycle` index.
+    pub fn unit_cycle(&self, i: u32) -> &[VertexId] {
+        &self.cycles[i as usize]
     }
 }
 
@@ -88,9 +98,9 @@ impl<'a> Scheduler<'a> {
             let mut cycle_order: Vec<usize> = (0..cycles.len()).collect();
             cycle_order.sort_by_key(|&i| cycles[i].iter().copied().min());
             for i in cycle_order {
-                units.push(ScheduleUnit::Cycle(cycles[i].clone()));
+                units.push(ScheduleUnit::Cycle(i as u32));
             }
-            units.extend(layers.iter().map(|l| ScheduleUnit::Layer(l.clone())));
+            units.extend((0..layers.len() as u32).map(ScheduleUnit::Layer));
             return Ok(Schedule {
                 units,
                 cycles,
@@ -633,7 +643,7 @@ impl<'a> Scheduler<'a> {
                 .collect();
             wave_cycles.sort_by_key(|&n| cycles[n].iter().copied().min());
             for n in wave_cycles {
-                units.push(ScheduleUnit::Cycle(cycles[n].clone()));
+                units.push(ScheduleUnit::Cycle(n as u32));
             }
 
             let mut wave_vertices: Vec<VertexId> = current
@@ -645,11 +655,10 @@ impl<'a> Scheduler<'a> {
             if !wave_vertices.is_empty() {
                 // Sort for deterministic output, as in build_layers.
                 wave_vertices.sort();
-                let layer = Layer {
+                units.push(ScheduleUnit::Layer(layers.len() as u32));
+                layers.push(Layer {
                     vertices: wave_vertices,
-                };
-                layers.push(layer.clone());
-                units.push(ScheduleUnit::Layer(layer));
+                });
             }
 
             processed_count += current.len();

--- a/crates/formualizer-eval/src/engine/tests/schedule_units.rs
+++ b/crates/formualizer-eval/src/engine/tests/schedule_units.rs
@@ -8,7 +8,7 @@
 //! exactly as before.
 
 use super::common::get_vertex_ids_in_order;
-use crate::engine::scheduler::ScheduleUnit;
+use crate::engine::scheduler::{Schedule, ScheduleUnit};
 use crate::engine::{DependencyGraph, Scheduler, VertexId};
 use formualizer_common::LiteralValue;
 use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
@@ -54,12 +54,12 @@ fn vertex_id_at(graph: &DependencyGraph, row: u32, col: u32) -> VertexId {
 }
 
 /// Map each scheduled vertex to the index of the unit that contains it.
-fn unit_positions(units: &[ScheduleUnit]) -> rustc_hash::FxHashMap<VertexId, usize> {
+fn unit_positions(schedule: &Schedule) -> rustc_hash::FxHashMap<VertexId, usize> {
     let mut pos = rustc_hash::FxHashMap::default();
-    for (i, unit) in units.iter().enumerate() {
+    for (i, &unit) in schedule.units.iter().enumerate() {
         let members: &[VertexId] = match unit {
-            ScheduleUnit::Layer(layer) => &layer.vertices,
-            ScheduleUnit::Cycle(cycle) => cycle,
+            ScheduleUnit::Layer(l) => &schedule.unit_layer(l).vertices,
+            ScheduleUnit::Cycle(c) => schedule.unit_cycle(c),
         };
         for &v in members {
             let prev = pos.insert(v, i);
@@ -101,20 +101,20 @@ fn units_position_cycle_between_upstream_and_dependent() {
     let schedule = scheduler.create_schedule(&all).unwrap();
 
     assert_eq!(schedule.units.len(), 3, "units: {:?}", schedule.units);
-    match &schedule.units[0] {
-        ScheduleUnit::Layer(l) => assert_eq!(l.vertices, vec![u_id]),
+    match schedule.units[0] {
+        ScheduleUnit::Layer(l) => assert_eq!(schedule.unit_layer(l).vertices, vec![u_id]),
         other => panic!("unit 0 should be Layer{{U}}, got {other:?}"),
     }
-    match &schedule.units[1] {
+    match schedule.units[1] {
         ScheduleUnit::Cycle(c) => {
-            let set: FxHashSet<VertexId> = c.iter().copied().collect();
+            let set: FxHashSet<VertexId> = schedule.unit_cycle(c).iter().copied().collect();
             assert_eq!(set.len(), 2);
             assert!(set.contains(&b_id) && set.contains(&c_id));
         }
         other => panic!("unit 1 should be Cycle{{B,C}}, got {other:?}"),
     }
-    match &schedule.units[2] {
-        ScheduleUnit::Layer(l) => assert_eq!(l.vertices, vec![d_id]),
+    match schedule.units[2] {
+        ScheduleUnit::Layer(l) => assert_eq!(schedule.unit_layer(l).vertices, vec![d_id]),
         other => panic!("unit 2 should be Layer{{D}}, got {other:?}"),
     }
 
@@ -160,20 +160,20 @@ fn units_order_multi_scc_chain() {
     let schedule = scheduler.create_schedule(&all).unwrap();
 
     assert_eq!(schedule.units.len(), 3, "units: {:?}", schedule.units);
-    match &schedule.units[0] {
+    match schedule.units[0] {
         ScheduleUnit::Cycle(c) => {
-            let set: FxHashSet<VertexId> = c.iter().copied().collect();
+            let set: FxHashSet<VertexId> = schedule.unit_cycle(c).iter().copied().collect();
             assert!(set.contains(&a_id) && set.contains(&b_id));
         }
         other => panic!("unit 0 should be Cycle{{A,B}}, got {other:?}"),
     }
-    match &schedule.units[1] {
-        ScheduleUnit::Layer(l) => assert_eq!(l.vertices, vec![c_id]),
+    match schedule.units[1] {
+        ScheduleUnit::Layer(l) => assert_eq!(schedule.unit_layer(l).vertices, vec![c_id]),
         other => panic!("unit 1 should be Layer{{C}}, got {other:?}"),
     }
-    match &schedule.units[2] {
+    match schedule.units[2] {
         ScheduleUnit::Cycle(c) => {
-            let set: FxHashSet<VertexId> = c.iter().copied().collect();
+            let set: FxHashSet<VertexId> = schedule.unit_cycle(c).iter().copied().collect();
             assert!(set.contains(&d_id) && set.contains(&e_id));
         }
         other => panic!("unit 2 should be Cycle{{D,E}}, got {other:?}"),
@@ -212,10 +212,13 @@ fn independent_cycles_same_wave_sorted_by_smallest_member() {
     let schedule = scheduler.create_schedule(&all).unwrap();
 
     assert_eq!(schedule.units.len(), 2, "units: {:?}", schedule.units);
-    match (&schedule.units[0], &schedule.units[1]) {
+    match (schedule.units[0], schedule.units[1]) {
         (ScheduleUnit::Cycle(first), ScheduleUnit::Cycle(second)) => {
-            assert!(first.contains(&a_id), "smaller-id SCC must come first");
-            assert!(second.contains(&c_id));
+            assert!(
+                schedule.unit_cycle(first).contains(&a_id),
+                "smaller-id SCC must come first"
+            );
+            assert!(schedule.unit_cycle(second).contains(&c_id));
         }
         other => panic!("expected two Cycle units, got {other:?}"),
     }
@@ -260,11 +263,11 @@ fn fast_path_units_match_legacy_layers() {
         assert_eq!(got.vertices, want.vertices);
     }
 
-    // Units are exactly those layers, wrapped, in order.
+    // Units are exactly those layers, referenced in order.
     assert_eq!(schedule.units.len(), legacy_layers.len());
-    for (unit, want) in schedule.units.iter().zip(legacy_layers.iter()) {
+    for (&unit, want) in schedule.units.iter().zip(legacy_layers.iter()) {
         match unit {
-            ScheduleUnit::Layer(l) => assert_eq!(l.vertices, want.vertices),
+            ScheduleUnit::Layer(l) => assert_eq!(schedule.unit_layer(l).vertices, want.vertices),
             other => panic!("fast path must emit only Layer units, got {other:?}"),
         }
     }
@@ -323,17 +326,18 @@ fn cycle_units_respect_condensation_invariant_random() {
         let scheduled: FxHashSet<VertexId> = all.iter().copied().collect();
         let schedule = scheduler.create_schedule(&all).unwrap();
 
-        let pos = unit_positions(&schedule.units);
+        let pos = unit_positions(&schedule);
         assert_eq!(
             pos.len(),
             all.len(),
             "seed {seed}: every scheduled vertex must appear in exactly one unit"
         );
 
-        for (idx, unit) in schedule.units.iter().enumerate() {
-            let ScheduleUnit::Cycle(members) = unit else {
+        for (idx, &unit) in schedule.units.iter().enumerate() {
+            let ScheduleUnit::Cycle(c) = unit else {
                 continue;
             };
+            let members = schedule.unit_cycle(c);
             let member_set: FxHashSet<VertexId> = members.iter().copied().collect();
             for &v in members {
                 for dep in graph.get_dependencies(v) {


### PR DESCRIPTION
Follow-up to #116, found by post-merge performance red-teaming. Refs #112.

## The regression

#116's `Schedule.units` stored owned clones of every `Layer`, so each schedule build duplicated all layer vectors, and the static schedule cache's fill/hit path (`cached.schedule.clone()`) cloned the doubled structure again. On deep-chain shapes this roughly doubles per-schedule tiny-Vec allocations. Measured with interleaved A/B rounds of `probe-load-envelope --scenario linear-rollup --rows 200000 --logical-cols 8` (~200k single-vertex layers): evaluate regressed +2.6–5.1% vs pre-#116. Wide-layer shapes (`probe-finance-recalc`, 50k rows) showed no regression — the cost scales with layer *count*, not vertex count.

## The fix

`ScheduleUnit` becomes `Copy` tagged indices — `Layer(u32) | Cycle(u32)` — into `Schedule.layers`/`Schedule.cycles`, which are now the sole owners. All three build paths (fast path, condensation, dynamic-topo conservative path) push indices with zero cloning; ordering semantics are byte-identical. The eight eval consumption sites resolve via `unit_layer`/`unit_cycle` accessors. Representation change only.

## Validation

- Interleaved A/B vs pre-#116 baseline, linear-rollup 200k: evaluate 609/629/651 ms (this PR) vs 753/656/628 ms (baseline) — regression eliminated, at-or-below baseline within noise.
- `probe-finance-recalc` sanity: p50 5.3 ms, checksums identical.
- fmt clean, clippy `-D warnings` clean, full workspace suite (CI exclusions): 2402 passed, 0 failed. Scheduler unit tests updated to resolve indices; assertion semantics unchanged.
