### PR TITLE
feat(eval): live-edge collector + lazy SHORT_CIRCUIT dispatch (Stage 1 for #112)

### DIFF
--- a/crates/formualizer-eval/src/builtins/lookup/choose.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/choose.rs
@@ -73,7 +73,9 @@ impl Function for ChooseFn {
         2
     }
 
-    func_caps!(PURE, LOOKUP);
+    // SHORT_CIRCUIT: only the selected choice is evaluated; untaken choices
+    // must not be materialized (see `Function::dispatch`).
+    func_caps!(PURE, LOOKUP, SHORT_CIRCUIT);
 
     fn arg_schema(&self) -> &'static [ArgSchema] {
         use once_cell::sync::Lazy;
@@ -123,10 +125,12 @@ impl Function for ChooseFn {
             return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
         }
 
+        // NumberStrict index semantics (previously enforced by eager dispatch
+        // validation): only genuine numbers are accepted; numeric text,
+        // booleans, etc. yield #VALUE!.
         let index = match index_val {
             LiteralValue::Number(n) => n as i64,
             LiteralValue::Int(i) => i,
-            LiteralValue::Text(s) => s.parse::<f64>().map(|n| n as i64).unwrap_or(-1),
             _ => {
                 return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
                     ExcelError::new(ExcelErrorKind::Value),

--- a/crates/formualizer-eval/src/engine/live_edges.rs
+++ b/crates/formualizer-eval/src/engine/live_edges.rs
@@ -1,0 +1,445 @@
+//! Live-edge collection for statically-cyclic SCC evaluation (Stage 1 of the
+//! runtime-cycle-verdicts work; pre-work for RFC #112).
+//!
+//! When a statically-cyclic SCC is evaluated member-by-member (Stage 2), we
+//! must record which reads *actually occurred* targeting other SCC members
+//! ("live edges"). Untaken short-circuit branches (`IF`/`IFS`/`CHOOSE`/
+//! `SWITCH`, ...) never execute their reads, so they contribute no live edges
+//! for free. After a pass, Stage 2 classifies the live subgraph: acyclic means
+//! the cycle was phantom (values stand); cyclic means `#CIRC!` or iterative
+//! evaluation.
+//!
+//! Stage 1 ships only the collection machinery:
+//!
+//! * [`LiveEdgeCollector`] — a per-SCC set of member cells plus the live edges
+//!   observed so far.
+//! * [`RecordingContext`] — a delegating [`EvaluationContext`] wrapper around
+//!   `&Engine<R>` that records reads as they resolve and forwards everything
+//!   else verbatim.
+//!
+//! # Inertness (binding constraint)
+//!
+//! Nothing in this module is wired into any production evaluation path. The
+//! acyclic/hot evaluation path never constructs a `RecordingContext`; no
+//! `Engine` field, flag, or branch was added. The wrapper is only exercised by
+//! Stage-2 SCC tasks (future) and by tests, so its cost is strictly zero for
+//! ordinary recalculation.
+//!
+//! # Threading
+//!
+//! SCC members are evaluated **sequentially on a single thread**; the
+//! collector is never contended. Interior mutability is required because the
+//! resolver traits take `&self`, and the `Send + Sync` super-bounds on
+//! [`crate::traits::ReferenceResolver`] et al. rule out `RefCell`, so we use a
+//! `Mutex`. It is uncontended by construction (single-threaded SCC pass), so
+//! the lock is a fast path (uncontested futex acquire) and never blocks.
+//!
+//! # Coordinates
+//!
+//! The collector API uses the engine's internal convention: 0-based row and
+//! column indices, rectangles **inclusive** of both corners (matching
+//! [`RangeView::start_row`]/[`RangeView::end_row`] and `CellRef`'s `Coord`).
+//! Resolver-level call sites (1-based Excel coordinates) convert before
+//! recording.
+
+use std::sync::Mutex;
+
+use formualizer_common::{ExcelError, LiteralValue};
+use formualizer_parse::parser::{ReferenceType, TableReference};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::engine::eval::Engine;
+use crate::engine::range_view::RangeView;
+use crate::reference::{CellRef, SheetId};
+use crate::traits::{
+    EvaluationContext, FunctionProvider, NamedRangeResolver, Range, RangeResolver, ReferenceInfo,
+    ReferenceResolver, Resolver, SourceResolver, Table, TableResolver,
+};
+
+/* ───────────────────────── LiveEdgeCollector ───────────────────────── */
+
+/// One SCC member cell in collector-internal form (0-based coordinates).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MemberCell {
+    sheet_id: SheetId,
+    row: u32,
+    col: u32,
+}
+
+#[derive(Default)]
+struct CollectorState {
+    /// Index (into `members`) of the member currently being evaluated.
+    /// `None` until `set_current` is called; reads observed while `None` are
+    /// not attributable and are dropped.
+    current: Option<u32>,
+    /// Live edges as `(from_member_idx, to_member_idx)`. Self-edges `(i, i)`
+    /// are recorded (e.g. a member whose range argument includes itself).
+    edges: FxHashSet<(u32, u32)>,
+}
+
+/// Records which reads actually occurred targeting SCC members during a
+/// sequential member-by-member evaluation pass.
+///
+/// * Scalar reads are O(1) (hash lookup keyed by `(sheet, row, col)`).
+/// * Rectangle reads are recorded **once per resolved rect** and intersected
+///   with the membership in O(|SCC|) — never per cell of the rect.
+pub struct LiveEdgeCollector {
+    /// Iterable membership for rect intersection.
+    members: Vec<MemberCell>,
+    /// O(1) scalar lookup: (sheet_id, row0, col0) -> member index.
+    index: FxHashMap<(SheetId, u32, u32), u32>,
+    /// See module docs: uncontended Mutex forced by `Send + Sync` bounds on
+    /// the resolver traits; SCC passes are single-threaded.
+    state: Mutex<CollectorState>,
+}
+
+impl LiveEdgeCollector {
+    /// Build a collector for the given SCC membership. Member order defines
+    /// the indices used in recorded edges.
+    pub fn new(members: &[CellRef]) -> Self {
+        let members: Vec<MemberCell> = members
+            .iter()
+            .map(|c| MemberCell {
+                sheet_id: c.sheet_id,
+                row: c.coord.row(),
+                col: c.coord.col(),
+            })
+            .collect();
+        let mut index = FxHashMap::default();
+        index.reserve(members.len());
+        for (i, m) in members.iter().enumerate() {
+            index.insert((m.sheet_id, m.row, m.col), i as u32);
+        }
+        Self {
+            members,
+            index,
+            state: Mutex::new(CollectorState::default()),
+        }
+    }
+
+    pub fn member_count(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Set the member whose formula is about to be evaluated; subsequent
+    /// recorded reads are attributed to it.
+    pub fn set_current(&self, member_idx: u32) {
+        debug_assert!((member_idx as usize) < self.members.len());
+        self.state.lock().unwrap().current = Some(member_idx);
+    }
+
+    /// Record a scalar read of `(sheet_id, row, col)` (0-based).
+    pub fn record_scalar(&self, sheet_id: SheetId, row: u32, col: u32) {
+        let Some(&to) = self.index.get(&(sheet_id, row, col)) else {
+            return;
+        };
+        let mut st = self.state.lock().unwrap();
+        if let Some(from) = st.current {
+            st.edges.insert((from, to));
+        }
+    }
+
+    /// Record a rectangle read (0-based, inclusive corners). Intersection is
+    /// O(|SCC|): each member is tested against the rect once; the rect is
+    /// never enumerated per cell.
+    pub fn record_rect(&self, sheet_id: SheetId, sr: u32, sc: u32, er: u32, ec: u32) {
+        let mut st = self.state.lock().unwrap();
+        let Some(from) = st.current else {
+            return;
+        };
+        for (i, m) in self.members.iter().enumerate() {
+            if m.sheet_id == sheet_id && m.row >= sr && m.row <= er && m.col >= sc && m.col <= ec {
+                st.edges.insert((from, i as u32));
+            }
+        }
+    }
+
+    /// Drain the collected edges, leaving the collector empty (current member
+    /// attribution is preserved).
+    pub fn take_edges(&self) -> FxHashSet<(u32, u32)> {
+        std::mem::take(&mut self.state.lock().unwrap().edges)
+    }
+}
+
+/* ───────────────────────── RecordingContext ───────────────────────── */
+
+/// Delegating [`EvaluationContext`] that wraps `&Engine<R>` and records reads
+/// into a [`LiveEdgeCollector`].
+///
+/// Interception points (everything else is pure delegation):
+///
+/// * `EvaluationContext::resolve_cell_reference_value` — the interpreter's
+///   scalar read path (current-sheet aware).
+/// * `EvaluationContext::resolve_range_view` — the single choke point for
+///   range, named-range, table and dynamic (`INDIRECT`/`OFFSET`) reads. The
+///   engine resolves un/partially-bounded references to concrete used-region
+///   bounds, and the returned view carries the resolved sheet + rect, so we
+///   record exactly that rect once. Views materialised from owned rows (array
+///   literals, named literals/formulas) carry the synthetic `"__tmp"` sheet,
+///   which has no `SheetId`, so they are skipped automatically.
+/// * `ReferenceResolver::resolve_cell_reference` — sheet-qualified scalar
+///   reads (e.g. implicit intersection).
+/// * `RangeResolver::resolve_range_reference` — legacy boxed-range path; the
+///   rect is resolved via the engine's own `resolve_range_view` normalisation
+///   so unbounded references record their used-region bounds.
+///
+/// Not recordable at this layer (Stage 2 follow-ups, noted in tests):
+///
+/// * `NamedRangeResolver::resolve_named_range_reference` — values-only API
+///   with no sheet/region context. The engine-level named-range path flows
+///   through `resolve_range_view` (intercepted); only the external-resolver
+///   fallback is invisible.
+/// * `TableResolver::resolve_table_reference` — returns an opaque `Table`.
+///   Engine-registered tables flow through `resolve_range_view` (intercepted).
+pub struct RecordingContext<'a, R: EvaluationContext> {
+    engine: &'a Engine<R>,
+    collector: &'a LiveEdgeCollector,
+}
+
+impl<'a, R: EvaluationContext> RecordingContext<'a, R> {
+    pub fn new(engine: &'a Engine<R>, collector: &'a LiveEdgeCollector) -> Self {
+        Self { engine, collector }
+    }
+
+    /// Record a scalar read given Excel 1-based coordinates.
+    fn record_cell_1based(&self, sheet_name: &str, row: u32, col: u32) {
+        if row == 0 || col == 0 {
+            return;
+        }
+        if let Some(sid) = self.engine.sheet_id(sheet_name) {
+            self.collector.record_scalar(sid, row - 1, col - 1);
+        }
+    }
+
+    /// Record the resolved rect of a `RangeView`. View bounds are absolute,
+    /// 0-based and inclusive. Owned/temporary views (sheet `"__tmp"`) have no
+    /// registered `SheetId` and are skipped.
+    fn record_view(&self, view: &RangeView<'_>) {
+        if view.is_empty() {
+            return;
+        }
+        if let Some(sid) = self.engine.sheet_id(view.sheet_name()) {
+            self.collector.record_rect(
+                sid,
+                view.start_row() as u32,
+                view.start_col() as u32,
+                view.end_row() as u32,
+                view.end_col() as u32,
+            );
+        }
+    }
+}
+
+impl<'a, R: EvaluationContext> ReferenceResolver for RecordingContext<'a, R> {
+    fn resolve_cell_reference(
+        &self,
+        sheet: Option<&str>,
+        row: u32,
+        col: u32,
+    ) -> Result<LiteralValue, ExcelError> {
+        // Unqualified (`None`) references are rejected by the engine itself
+        // (no current-sheet context at this trait level), so there is nothing
+        // attributable to record in that case.
+        if let Some(sheet_name) = sheet {
+            self.record_cell_1based(sheet_name, row, col);
+        }
+        self.engine.resolve_cell_reference(sheet, row, col)
+    }
+}
+
+impl<'a, R: EvaluationContext> RangeResolver for RecordingContext<'a, R> {
+    fn resolve_range_reference(
+        &self,
+        sheet: Option<&str>,
+        sr: Option<u32>,
+        sc: Option<u32>,
+        er: Option<u32>,
+        ec: Option<u32>,
+    ) -> Result<Box<dyn Range>, ExcelError> {
+        // Resolve the rect through the engine's own bound normalisation
+        // (used-region for unbounded axes) rather than duplicating it here.
+        if let Some(sheet_name) = sheet {
+            let reference = ReferenceType::Range {
+                sheet: Some(sheet_name.to_string()),
+                start_row: sr,
+                start_col: sc,
+                end_row: er,
+                end_col: ec,
+                start_row_abs: true,
+                start_col_abs: true,
+                end_row_abs: true,
+                end_col_abs: true,
+            };
+            if let Ok(view) = self.engine.resolve_range_view(&reference, sheet_name) {
+                self.record_view(&view);
+            }
+        }
+        self.engine.resolve_range_reference(sheet, sr, sc, er, ec)
+    }
+}
+
+impl<'a, R: EvaluationContext> NamedRangeResolver for RecordingContext<'a, R> {
+    fn resolve_named_range_reference(
+        &self,
+        name: &str,
+    ) -> Result<Vec<Vec<LiteralValue>>, ExcelError> {
+        // Values-only API without sheet/region context; the engine-level
+        // named-range path is intercepted in `resolve_range_view` instead.
+        self.engine.resolve_named_range_reference(name)
+    }
+}
+
+impl<'a, R: EvaluationContext> TableResolver for RecordingContext<'a, R> {
+    fn resolve_table_reference(&self, tref: &TableReference) -> Result<Box<dyn Table>, ExcelError> {
+        // Opaque `Table` without region context; engine-registered tables are
+        // intercepted in `resolve_range_view` instead.
+        self.engine.resolve_table_reference(tref)
+    }
+}
+
+impl<'a, R: EvaluationContext> SourceResolver for RecordingContext<'a, R> {
+    fn source_scalar_version(&self, name: &str) -> Option<u64> {
+        self.engine.source_scalar_version(name)
+    }
+    fn resolve_source_scalar(&self, name: &str) -> Result<LiteralValue, ExcelError> {
+        self.engine.resolve_source_scalar(name)
+    }
+    fn source_table_version(&self, name: &str) -> Option<u64> {
+        self.engine.source_table_version(name)
+    }
+    fn resolve_source_table(&self, name: &str) -> Result<Box<dyn Table>, ExcelError> {
+        self.engine.resolve_source_table(name)
+    }
+}
+
+impl<'a, R: EvaluationContext> Resolver for RecordingContext<'a, R> {}
+
+impl<'a, R: EvaluationContext> FunctionProvider for RecordingContext<'a, R> {
+    fn get_function(
+        &self,
+        ns: &str,
+        name: &str,
+    ) -> Option<std::sync::Arc<dyn crate::traits::Function>> {
+        self.engine.get_function(ns, name)
+    }
+}
+
+impl<'a, R: EvaluationContext> EvaluationContext for RecordingContext<'a, R> {
+    /* ── intercept-and-record ── */
+
+    fn resolve_range_view<'c>(
+        &'c self,
+        reference: &ReferenceType,
+        current_sheet: &str,
+    ) -> Result<RangeView<'c>, ExcelError> {
+        let view = self.engine.resolve_range_view(reference, current_sheet)?;
+        self.record_view(&view);
+        Ok(view)
+    }
+
+    fn resolve_cell_reference_value(
+        &self,
+        sheet: Option<&str>,
+        row: u32,
+        col: u32,
+        current_sheet: &str,
+    ) -> Result<LiteralValue, ExcelError> {
+        self.record_cell_1based(sheet.unwrap_or(current_sheet), row, col);
+        self.engine
+            .resolve_cell_reference_value(sheet, row, col, current_sheet)
+    }
+
+    /* ── pure delegation ── */
+
+    fn thread_pool(&self) -> Option<&std::sync::Arc<rayon::ThreadPool>> {
+        self.engine.thread_pool()
+    }
+    fn cancellation_token(&self) -> Option<std::sync::Arc<std::sync::atomic::AtomicBool>> {
+        self.engine.cancellation_token()
+    }
+    fn chunk_hint(&self) -> Option<usize> {
+        self.engine.chunk_hint()
+    }
+    fn locale(&self) -> crate::locale::Locale {
+        self.engine.locale()
+    }
+    fn workbook_sheet_count(&self) -> Option<usize> {
+        self.engine.workbook_sheet_count()
+    }
+    fn sheet_index_by_name(&self, sheet: &str) -> Option<usize> {
+        self.engine.sheet_index_by_name(sheet)
+    }
+    fn current_sheet_index(&self, current_sheet: &str) -> Option<usize> {
+        self.engine.current_sheet_index(current_sheet)
+    }
+    fn inspect_reference(
+        &self,
+        reference: &ReferenceType,
+        current_sheet: &str,
+    ) -> Result<Option<ReferenceInfo>, ExcelError> {
+        self.engine.inspect_reference(reference, current_sheet)
+    }
+    fn formula_text_at_cell(&self, cell: CellRef) -> Result<Option<String>, ExcelError> {
+        self.engine.formula_text_at_cell(cell)
+    }
+    fn clock(&self) -> &dyn crate::timezone::ClockProvider {
+        self.engine.clock()
+    }
+    fn timezone(&self) -> &crate::timezone::TimeZoneSpec {
+        self.engine.timezone()
+    }
+    fn volatile_level(&self) -> crate::traits::VolatileLevel {
+        self.engine.volatile_level()
+    }
+    fn workbook_seed(&self) -> u64 {
+        self.engine.workbook_seed()
+    }
+    fn recalc_epoch(&self) -> u64 {
+        self.engine.recalc_epoch()
+    }
+    fn used_rows_for_columns(
+        &self,
+        sheet: &str,
+        start_col: u32,
+        end_col: u32,
+    ) -> Option<(u32, u32)> {
+        self.engine.used_rows_for_columns(sheet, start_col, end_col)
+    }
+    fn used_cols_for_rows(&self, sheet: &str, start_row: u32, end_row: u32) -> Option<(u32, u32)> {
+        self.engine.used_cols_for_rows(sheet, start_row, end_row)
+    }
+    fn sheet_bounds(&self, sheet: &str) -> Option<(u32, u32)> {
+        self.engine.sheet_bounds(sheet)
+    }
+    fn data_snapshot_id(&self) -> u64 {
+        self.engine.data_snapshot_id()
+    }
+    fn backend_caps(&self) -> crate::traits::BackendCaps {
+        self.engine.backend_caps()
+    }
+    fn date_system(&self) -> crate::engine::DateSystem {
+        self.engine.date_system()
+    }
+    fn build_lookup_index(
+        &self,
+        view: &RangeView<'_>,
+        axis: crate::engine::lookup_index_cache::LookupAxis,
+    ) -> Option<std::sync::Arc<crate::engine::lookup_index_cache::LookupIndex>> {
+        self.engine.build_lookup_index(view, axis)
+    }
+    fn build_criteria_mask(
+        &self,
+        view: &RangeView<'_>,
+        col_in_view: usize,
+        pred: &crate::args::CriteriaPredicate,
+    ) -> Option<std::sync::Arc<arrow_array::BooleanArray>> {
+        self.engine.build_criteria_mask(view, col_in_view, pred)
+    }
+    fn build_row_visibility_mask(
+        &self,
+        view: &RangeView<'_>,
+        mode: crate::engine::row_visibility::VisibilityMaskMode,
+    ) -> Option<std::sync::Arc<arrow_array::BooleanArray>> {
+        self.engine.build_row_visibility_mask(view, mode)
+    }
+}

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -12,6 +12,7 @@ pub mod ingest;
 pub mod ingest_builder;
 pub(crate) mod ingest_pipeline;
 pub mod journal;
+pub mod live_edges;
 pub mod lookup_index_cache;
 pub mod plan;
 pub mod range_view;

--- a/crates/formualizer-eval/src/engine/tests/live_edges.rs
+++ b/crates/formualizer-eval/src/engine/tests/live_edges.rs
@@ -1,0 +1,434 @@
+//! Tests for the Stage-1 live-edge collector (pre-work for RFC #112).
+//!
+//! These drive a real `Engine` wrapped in `RecordingContext`, evaluating
+//! formula ASTs via `Interpreter` directly — exactly how Stage-2 SCC tasks
+//! will evaluate statically-cyclic members. Nothing here touches production
+//! evaluation paths: `RecordingContext` is constructed only by this test
+//! module, and no public `Engine` API exposes or stores a collector.
+
+use crate::engine::live_edges::{LiveEdgeCollector, RecordingContext};
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{Engine, EvalConfig};
+use crate::interpreter::Interpreter;
+use crate::reference::{CellRef, Coord, RangeRef};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use rustc_hash::FxHashSet;
+
+fn parse(formula: &str) -> formualizer_parse::parser::ASTNode {
+    formualizer_parse::parser::parse(formula).expect("valid formula")
+}
+
+fn new_engine() -> Engine<TestWorkbook> {
+    Engine::new(TestWorkbook::new(), EvalConfig::default())
+}
+
+fn cell(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> CellRef {
+    CellRef::new(
+        engine.sheet_id(sheet).expect("sheet exists"),
+        Coord::from_excel(row, col, true, true),
+    )
+}
+
+/// Evaluate `formula` as if it were the body of `member` (an SCC member at
+/// `member_idx`), recording live edges into `collector`.
+fn eval_as_member(
+    engine: &Engine<TestWorkbook>,
+    collector: &LiveEdgeCollector,
+    member_idx: u32,
+    sheet: &str,
+    member: CellRef,
+    formula: &str,
+) -> LiteralValue {
+    collector.set_current(member_idx);
+    let ctx = RecordingContext::new(engine, collector);
+    let interp = Interpreter::new_with_cell(&ctx, sheet, member);
+    interp
+        .evaluate_ast(&parse(formula))
+        .map(|cv| cv.into_literal())
+        .unwrap_or_else(LiteralValue::Error)
+}
+
+fn edges(collector: &LiveEdgeCollector) -> FxHashSet<(u32, u32)> {
+    collector.take_edges()
+}
+
+fn set_num(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, v: f64) {
+    engine
+        .set_cell_value(sheet, row, col, LiteralValue::Number(v))
+        .unwrap();
+}
+
+/* ─────────────────────────── 1. scalar reads ─────────────────────────── */
+
+#[test]
+fn scalar_read_of_member_records_edge() {
+    let mut engine = new_engine();
+    set_num(&mut engine, "Sheet1", 1, 1, 5.0); // A1 (member)
+    set_num(&mut engine, "Sheet1", 1, 2, 7.0); // B1 (non-member)
+    engine.evaluate_all().unwrap();
+
+    // Members: [C1 (the evaluating member), A1].
+    let c1 = cell(&engine, "Sheet1", 1, 3);
+    let a1 = cell(&engine, "Sheet1", 1, 1);
+    let collector = LiveEdgeCollector::new(&[c1, a1]);
+
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", c1, "=A1");
+    assert_eq!(v, LiteralValue::Number(5.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+
+    // Reading a non-member records nothing.
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", c1, "=B1");
+    assert_eq!(v, LiteralValue::Number(7.0));
+    assert!(edges(&collector).is_empty());
+}
+
+/* ──────────────────────── 2. short-circuiting ────────────────────────── */
+
+/// For each (formula_no_edge, formula_edge) pair: the member read sits in a
+/// branch that is untaken in the first formula and taken in the second.
+fn assert_short_circuit_polarity(no_edge: &str, edge_expected: &str) {
+    let mut engine = new_engine();
+    set_num(&mut engine, "Sheet1", 1, 1, 5.0); // A1 (member)
+    engine.evaluate_all().unwrap();
+
+    let c1 = cell(&engine, "Sheet1", 1, 3);
+    let a1 = cell(&engine, "Sheet1", 1, 1);
+    let collector = LiveEdgeCollector::new(&[c1, a1]);
+
+    eval_as_member(&engine, &collector, 0, "Sheet1", c1, no_edge);
+    assert!(
+        edges(&collector).is_empty(),
+        "{no_edge}: untaken branch must record no live edge"
+    );
+
+    eval_as_member(&engine, &collector, 0, "Sheet1", c1, edge_expected);
+    assert_eq!(
+        edges(&collector),
+        FxHashSet::from_iter([(0, 1)]),
+        "{edge_expected}: taken branch must record the live edge"
+    );
+}
+
+#[test]
+fn if_short_circuit_polarity() {
+    assert_short_circuit_polarity("=IF(TRUE, 1, A1)", "=IF(FALSE, 1, A1)");
+}
+
+#[test]
+fn ifs_short_circuit_polarity() {
+    assert_short_circuit_polarity("=IFS(TRUE, 1, TRUE, A1)", "=IFS(FALSE, 1, TRUE, A1)");
+}
+
+#[test]
+fn choose_short_circuit_polarity() {
+    assert_short_circuit_polarity("=CHOOSE(1, 9, A1)", "=CHOOSE(2, 9, A1)");
+}
+
+#[test]
+fn switch_short_circuit_polarity() {
+    // First: case 1 matches, default (A1) untaken. Second: default taken.
+    assert_short_circuit_polarity("=SWITCH(1, 1, 9, A1)", "=SWITCH(2, 1, 9, A1)");
+}
+
+/* ─────────────────────────── 3. range reads ──────────────────────────── */
+
+#[test]
+fn range_read_intersects_members_exactly() {
+    let mut engine = new_engine();
+    for r in 1..=10 {
+        set_num(&mut engine, "Sheet1", r, 2, r as f64); // B1:B10
+        set_num(&mut engine, "Sheet1", r, 3, r as f64); // C1:C10
+    }
+    engine.evaluate_all().unwrap();
+
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let b3 = cell(&engine, "Sheet1", 3, 2);
+    let b7 = cell(&engine, "Sheet1", 7, 2);
+    let collector = LiveEdgeCollector::new(&[d1, b3, b7]);
+
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(B1:B10)");
+    assert_eq!(v, LiteralValue::Number(55.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1), (0, 2)]));
+
+    // A rect not containing any member records nothing.
+    eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(C1:C10)");
+    assert!(edges(&collector).is_empty());
+
+    // Rect adjacent to a member (B4:B6 vs members B3/B7) records nothing.
+    eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(B4:B6)");
+    assert!(edges(&collector).is_empty());
+}
+
+#[test]
+fn range_read_boundary_inclusion_at_rect_corners() {
+    let mut engine = new_engine();
+    for r in 1..=10 {
+        set_num(&mut engine, "Sheet1", r, 2, 1.0); // B1:B10
+    }
+    engine.evaluate_all().unwrap();
+
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let b1 = cell(&engine, "Sheet1", 1, 2); // top corner of B1:B10
+    let b10 = cell(&engine, "Sheet1", 10, 2); // bottom corner of B1:B10
+    let collector = LiveEdgeCollector::new(&[d1, b1, b10]);
+
+    eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(B1:B10)");
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1), (0, 2)]));
+
+    // One row inside: B2:B9 excludes both corner members.
+    eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(B2:B9)");
+    assert!(edges(&collector).is_empty());
+}
+
+/* ─────────────────── 4. whole-column (unbounded) reads ───────────────── */
+
+#[test]
+fn whole_column_read_resolves_used_bounds_and_records_member() {
+    let mut engine = new_engine();
+    for r in 1..=10 {
+        set_num(&mut engine, "Sheet1", r, 2, r as f64); // B1:B10
+    }
+    engine.evaluate_all().unwrap();
+
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let b5 = cell(&engine, "Sheet1", 5, 2);
+    let a5 = cell(&engine, "Sheet1", 5, 1); // not in column B
+    let collector = LiveEdgeCollector::new(&[d1, b5, a5]);
+
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(B:B)");
+    assert_eq!(v, LiteralValue::Number(55.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+}
+
+/* ───────────────────────── 5. named ranges ───────────────────────────── */
+
+#[test]
+fn named_range_region_containing_member_records_edge() {
+    let mut engine = new_engine();
+    for r in 1..=5 {
+        set_num(&mut engine, "Sheet1", r, 2, r as f64); // B1:B5
+    }
+    engine.evaluate_all().unwrap();
+
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let nr_range = RangeRef::new(
+        CellRef::new(sheet_id, Coord::from_excel(2, 2, true, true)), // B2
+        CellRef::new(sheet_id, Coord::from_excel(4, 2, true, true)), // B4
+    );
+    engine
+        .define_name("NR", NamedDefinition::Range(nr_range), NameScope::Workbook)
+        .unwrap();
+
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let b3 = cell(&engine, "Sheet1", 3, 2); // inside NR
+    let b5 = cell(&engine, "Sheet1", 5, 2); // outside NR
+    let collector = LiveEdgeCollector::new(&[d1, b3, b5]);
+
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(NR)");
+    assert_eq!(v, LiteralValue::Number(9.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+}
+
+#[test]
+fn table_column_region_containing_member_records_edge() {
+    let mut engine = new_engine();
+    // Table T over A1:B3: header row + 2 data rows.
+    set_num(&mut engine, "Sheet1", 2, 1, 5.0);
+    set_num(&mut engine, "Sheet1", 2, 2, 10.0);
+    set_num(&mut engine, "Sheet1", 3, 1, 7.0);
+    set_num(&mut engine, "Sheet1", 3, 2, 20.0);
+    engine.evaluate_all().unwrap();
+
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let range = RangeRef::new(
+        CellRef::new(sheet_id, Coord::from_excel(1, 1, true, true)),
+        CellRef::new(sheet_id, Coord::from_excel(3, 2, true, true)),
+    );
+    engine
+        .define_table(
+            "Sales",
+            range,
+            true,
+            vec!["Region".into(), "Amount".into()],
+            false,
+        )
+        .unwrap();
+
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let b2 = cell(&engine, "Sheet1", 2, 2); // inside Sales[Amount]
+    let a2 = cell(&engine, "Sheet1", 2, 1); // in Sales[Region], not [Amount]
+    let collector = LiveEdgeCollector::new(&[d1, b2, a2]);
+
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=SUM(Sales[Amount])");
+    assert_eq!(v, LiteralValue::Number(30.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+}
+
+/* ──────────────────── 6. dynamic reads (INDIRECT) ─────────────────────── */
+
+#[test]
+fn indirect_scalar_read_flows_through_wrapper() {
+    let mut engine = new_engine();
+    set_num(&mut engine, "Sheet1", 3, 2, 42.0); // B3 (member)
+    engine.evaluate_all().unwrap();
+
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let b3 = cell(&engine, "Sheet1", 3, 2);
+    let collector = LiveEdgeCollector::new(&[d1, b3]);
+
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=INDIRECT(\"B3\")");
+    assert_eq!(v, LiteralValue::Number(42.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+
+    // Dynamic *range* read: the rect is recorded at resolution time.
+    let v = eval_as_member(
+        &engine,
+        &collector,
+        0,
+        "Sheet1",
+        d1,
+        "=SUM(INDIRECT(\"B1:B5\"))",
+    );
+    assert_eq!(v, LiteralValue::Number(42.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+
+    // Dynamic read of a non-member records nothing.
+    eval_as_member(&engine, &collector, 0, "Sheet1", d1, "=INDIRECT(\"C3\")");
+    assert!(edges(&collector).is_empty());
+}
+
+/* ─────────────────────────── 8. attribution ──────────────────────────── */
+
+#[test]
+fn edges_attribute_to_current_member() {
+    let mut engine = new_engine();
+    set_num(&mut engine, "Sheet1", 1, 1, 1.0); // A1
+    set_num(&mut engine, "Sheet1", 2, 1, 2.0); // A2
+    engine.evaluate_all().unwrap();
+
+    let a1 = cell(&engine, "Sheet1", 1, 1);
+    let a2 = cell(&engine, "Sheet1", 2, 1);
+    let collector = LiveEdgeCollector::new(&[a1, a2]);
+
+    // A1's formula reads A2; A2's formula reads A1 (a 2-cycle).
+    eval_as_member(&engine, &collector, 0, "Sheet1", a1, "=A2");
+    eval_as_member(&engine, &collector, 1, "Sheet1", a2, "=A1");
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1), (1, 0)]));
+}
+
+/* ─────────────────────────── 9. self-edges ───────────────────────────── */
+
+#[test]
+fn member_ranging_over_itself_records_self_edge() {
+    let mut engine = new_engine();
+    for r in 1..=3 {
+        set_num(&mut engine, "Sheet1", r, 2, r as f64); // B1:B3
+    }
+    engine.evaluate_all().unwrap();
+
+    let b2 = cell(&engine, "Sheet1", 2, 2);
+    let collector = LiveEdgeCollector::new(&[b2]);
+
+    // B2's formula ranges over B1:B3, which includes B2 itself.
+    eval_as_member(&engine, &collector, 0, "Sheet1", b2, "=SUM(B1:B3)");
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 0)]));
+}
+
+/* ─────────────────────────── 10. multi-sheet ─────────────────────────── */
+
+#[test]
+fn cross_sheet_qualified_reads_record_member_on_other_sheet() {
+    let mut engine = new_engine();
+    engine.add_sheet("Sheet2").unwrap();
+    set_num(&mut engine, "Sheet1", 1, 1, 1.0); // Sheet1!A1
+    set_num(&mut engine, "Sheet2", 1, 1, 9.0); // Sheet2!A1 (member)
+    set_num(&mut engine, "Sheet2", 2, 1, 8.0); // Sheet2!A2
+    engine.evaluate_all().unwrap();
+
+    let s1_c1 = cell(&engine, "Sheet1", 1, 3);
+    let s2_a1 = cell(&engine, "Sheet2", 1, 1);
+    let collector = LiveEdgeCollector::new(&[s1_c1, s2_a1]);
+
+    // Scalar qualified read from Sheet1.
+    let v = eval_as_member(&engine, &collector, 0, "Sheet1", s1_c1, "=Sheet2!A1");
+    assert_eq!(v, LiteralValue::Number(9.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+
+    // Same coordinates on the *current* sheet must NOT match the member.
+    eval_as_member(&engine, &collector, 0, "Sheet1", s1_c1, "=A1");
+    assert!(edges(&collector).is_empty());
+
+    // Qualified range read.
+    let v = eval_as_member(
+        &engine,
+        &collector,
+        0,
+        "Sheet1",
+        s1_c1,
+        "=SUM(Sheet2!A1:A2)",
+    );
+    assert_eq!(v, LiteralValue::Number(17.0));
+    assert_eq!(edges(&collector), FxHashSet::from_iter([(0, 1)]));
+}
+
+/* ──────────────────────────── 11. inertness ──────────────────────────── */
+
+/// Structural inertness: the acyclic/hot path never constructs a
+/// `RecordingContext` — no `Engine` API creates, stores, or exposes one (the
+/// only constructor takes an externally-owned collector), so production
+/// evaluation is untouched by this module. This test pins the cheap proxies
+/// for that argument: the wrapper is two borrowed pointers (no owned state to
+/// allocate), and wrapped evaluation is value-identical to bare evaluation.
+#[test]
+fn wrapper_is_inert_and_value_transparent() {
+    assert_eq!(
+        std::mem::size_of::<RecordingContext<'_, TestWorkbook>>(),
+        2 * std::mem::size_of::<usize>(),
+        "RecordingContext must stay two borrowed pointers"
+    );
+
+    let mut engine = new_engine();
+    for r in 1..=10 {
+        set_num(&mut engine, "Sheet1", r, 2, r as f64); // B1:B10
+    }
+    set_num(&mut engine, "Sheet1", 1, 1, 100.0); // A1
+    engine.evaluate_all().unwrap();
+
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let formula = "=SUM(B1:B10)+A1*2";
+
+    // Bare engine context (production shape).
+    let bare = {
+        let interp = Interpreter::new_with_cell(&engine, "Sheet1", d1);
+        interp.evaluate_ast(&parse(formula)).unwrap().into_literal()
+    };
+
+    // Wrapped with an empty membership: identical value, zero edges.
+    let collector = LiveEdgeCollector::new(&[]);
+    let ctx = RecordingContext::new(&engine, &collector);
+    let wrapped = {
+        let interp = Interpreter::new_with_cell(&ctx, "Sheet1", d1);
+        interp.evaluate_ast(&parse(formula)).unwrap().into_literal()
+    };
+
+    assert_eq!(bare, wrapped);
+    assert!(collector.take_edges().is_empty());
+}
+
+/// Reads observed before `set_current` is called are not attributable to any
+/// member and must be dropped rather than mis-attributed.
+#[test]
+fn reads_without_current_member_are_dropped() {
+    let mut engine = new_engine();
+    set_num(&mut engine, "Sheet1", 1, 1, 5.0); // A1 (member)
+    engine.evaluate_all().unwrap();
+
+    let a1 = cell(&engine, "Sheet1", 1, 1);
+    let collector = LiveEdgeCollector::new(&[a1]);
+    let ctx = RecordingContext::new(&engine, &collector);
+    let d1 = cell(&engine, "Sheet1", 1, 4);
+    let interp = Interpreter::new_with_cell(&ctx, "Sheet1", d1);
+    let _ = interp.evaluate_ast(&parse("=A1"));
+    assert!(collector.take_edges().is_empty());
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -138,3 +138,4 @@ mod visibility_mask_cache;
 mod demand_subgraph_named_range;
 mod dn_range_xlsx_subgraph;
 mod short_circuit_dispatch;
+mod live_edges;

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -137,3 +137,4 @@ mod visibility_mask_cache;
 
 mod demand_subgraph_named_range;
 mod dn_range_xlsx_subgraph;
+mod short_circuit_dispatch;

--- a/crates/formualizer-eval/src/engine/tests/short_circuit_dispatch.rs
+++ b/crates/formualizer-eval/src/engine/tests/short_circuit_dispatch.rs
@@ -1,0 +1,87 @@
+//! Regression tests for lazy dispatch of `FnCaps::SHORT_CIRCUIT` functions.
+//!
+//! `Function::dispatch` must not eagerly materialize arguments of
+//! short-circuit functions: doing so executes reads (and arbitrary
+//! subexpressions) in untaken branches, defeating the documented
+//! short-circuit semantics and double-evaluating taken branches. This is
+//! load-bearing for live-edge collection (RFC #112 Stage 1): untaken branches
+//! must produce no observable reads.
+
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug)]
+struct CountFn(Arc<AtomicUsize>);
+impl crate::function::Function for CountFn {
+    fn caps(&self) -> crate::function::FnCaps {
+        crate::function::FnCaps::PURE
+    }
+    fn name(&self) -> &'static str {
+        "COUNTING"
+    }
+    fn min_args(&self) -> usize {
+        0
+    }
+    fn eval<'a, 'b, 'c>(
+        &self,
+        _args: &'c [crate::traits::ArgumentHandle<'a, 'b>],
+        _ctx: &dyn crate::traits::FunctionContext<'b>,
+    ) -> Result<crate::traits::CalcValue<'b>, formualizer_common::ExcelError> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(7)))
+    }
+}
+
+fn harness() -> (TestWorkbook, Arc<AtomicUsize>) {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let wb = TestWorkbook::new()
+        .with_function(Arc::new(crate::builtins::logical::IfFn))
+        .with_function(Arc::new(CountFn(counter.clone())));
+    (wb, counter)
+}
+
+fn eval(wb: &TestWorkbook, formula: &str) -> LiteralValue {
+    let interp = wb.interpreter();
+    let ast = formualizer_parse::parser::parse(formula).unwrap();
+    interp.evaluate_ast(&ast).unwrap().into_literal()
+}
+
+#[test]
+fn if_untaken_branch_is_not_evaluated_through_dispatch() {
+    let (wb, counter) = harness();
+
+    let v = eval(&wb, "=IF(TRUE,1,COUNTING())");
+    assert_eq!(v, LiteralValue::Number(1.0));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "untaken IF branch must not be evaluated"
+    );
+
+    let v = eval(&wb, "=IF(FALSE,1,COUNTING())");
+    assert_eq!(v, LiteralValue::Int(7));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "taken IF branch must be evaluated exactly once"
+    );
+}
+
+#[test]
+fn if_arity_error_is_preserved_with_lazy_dispatch() {
+    let (wb, counter) = harness();
+    let v = eval(&wb, "=IF(COUNTING())");
+    match v {
+        LiteralValue::Error(e) => {
+            assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Value);
+        }
+        other => panic!("expected #VALUE! arity error, got {other:?}"),
+    }
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "arity failure must not evaluate arguments"
+    );
+}

--- a/crates/formualizer-eval/src/function.rs
+++ b/crates/formualizer-eval/src/function.rs
@@ -163,6 +163,29 @@ pub trait Function: Send + Sync + 'static {
         args: &'c [crate::traits::ArgumentHandle<'a, 'b>],
         ctx: &dyn crate::traits::FunctionContext<'b>,
     ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+        // Short-circuit functions (IF/IFS/CHOOSE/SWITCH/AND/OR, ...) evaluate
+        // their arguments lazily inside `eval`; eagerly materializing every
+        // argument here would execute reads in untaken branches (defeating the
+        // documented short-circuit semantics) and double-evaluate taken ones.
+        // Their schemas are Any-kind with no per-arg coercion, so per-argument
+        // validation cannot fail; only the min-arity check is meaningful.
+        // (LET/LAMBDA already bypass validation via `dispatch` overrides for
+        // the same reason.)
+        if self.caps().contains(FnCaps::SHORT_CIRCUIT) {
+            if args.len() < self.min_args() {
+                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                    ExcelError::new(formualizer_common::ExcelErrorKind::Value).with_message(
+                        format!(
+                            "Too few arguments: expected at least {}, got {}",
+                            self.min_args(),
+                            args.len()
+                        ),
+                    ),
+                )));
+            }
+            return self.eval(args, ctx);
+        }
+
         // Central argument validation (includes min-arity check)
         {
             use crate::args::{ValidationOptions, validate_and_prepare};


### PR DESCRIPTION
Stage 1 pre-work for the runtime-cycle-verdicts RFC (#112): the machinery that records which reads *actually occur* during evaluation ("live edges"), restricted to a set of watched cells. Nothing in production evaluation uses it yet — it is exercised only by tests; wiring into SCC evaluation is Stage 2.

## Significant finding fixed along the way: SHORT_CIRCUIT was defeated by dispatch

Test-first development of the branch-polarity tests exposed that `FnCaps::SHORT_CIRCUIT` did not actually prevent untaken-branch evaluation: the default `Function::dispatch` eagerly materialized every scalar argument during validation and discarded the results. So `=IF(TRUE, 1, A1)` still read A1, untaken branches of IF/IFS/CHOOSE/SWITCH/AND/OR all executed, and taken branches were evaluated twice (once in validation, once in eval). LET/LAMBDA already bypassed validation via `dispatch` overrides for exactly this reason.

The fix gates per-argument validation on the `SHORT_CIRCUIT` cap, preserving the byte-identical min-arity error. All affected builtins use Any-kind/no-coercion schemas whose per-arg validation could never fail, so the only behavioral delta is the documented one: untaken branches no longer execute. CHOOSE gains the cap (its eval was already lazy) and now enforces the NumberStrict index semantics that eager validation previously provided (numeric-text index stays `#VALUE!`, pinned by the existing test). Regression-pinned in `engine/tests/short_circuit_dispatch.rs` with a counting-function proof.

This fix is load-bearing for #112 — live-edge collection requires untaken branches to produce no reads — and is independently a perf win (no more double-evaluating taken branches).

## The collector

- `LiveEdgeCollector` (`engine/live_edges.rs`): watched members with O(1) scalar lookup and O(|members|) rect intersection — rects are recorded once at range-resolution time, never per cell. Self-edges recorded. State behind an uncontended Mutex (collection happens only in sequential contexts; `Send + Sync` trait bounds rule out `RefCell`).
- `RecordingContext<'a, R>` wraps `&Engine<R>` and implements the full interpreter-facing trait surface (`ReferenceResolver`, `RangeResolver`, `NamedRangeResolver`, `TableResolver`, `Resolver`, `SourceResolver`, `FunctionProvider`, `EvaluationContext`), recording on the read paths (`resolve_cell_reference_value`, `resolve_cell_reference`, `resolve_range_view` — the choke point that also captures engine-registered names, tables, whole-column used-bounds resolution, and INDIRECT/OFFSET dynamic reads) and purely delegating everything else. Same shape as the existing `DynamicRefCollector` precedent.
- **Hot-path cost: structurally zero.** No Engine field, no flag, no branch — the wrapper only exists when explicitly constructed. `eval.rs` and `traits.rs` are untouched.

## Tests

18 new (16 live-edge + 2 dispatch): scalar member/non-member, branch-polarity pairs for IF/IFS/CHOOSE/SWITCH, range intersection with boundary cases, whole-column used-bounds, named-range and table-column regions, INDIRECT scalar/range/negative, cross-member attribution, self-edge, multi-sheet, wrapper inertness/parity. Full workspace suite (CI exclusions): 2420 passed, 0 failed (baseline 2402 + 18). fmt and clippy `-D warnings` clean.

## Bench gate (interleaved A/B vs main @ 2d3b7210, per-track standing rule)

- `linear-rollup 200k` evaluate: 719/642/608 ms vs main 610/650/671 ms — no consistent direction, within noise.
- `probe-finance-recalc`: p50 5.7/5.2/5.0 ms vs main 5.9/5.6/8.6 ms; totals trend lower — consistent with removing taken-branch double-evaluation. Checksums identical.

Known gaps, deliberately deferred to Stage 2 (noted in code): spill operator `#` (no interpreter unary handler yet), values-only fallback resolver paths for unregistered names/tables, 3D references (NImpl engine-wide).
