### PR TITLE
feat(eval): runtime cycle detection — SCC evaluation via live-edge iteration (Stage 2 for #112)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -3,6 +3,8 @@ use crate::arrow_store::{OverlayFragment, OverlayValue, SheetStore};
 use crate::engine::arena::AstNodeId;
 use crate::engine::eval_delta::{DeltaCollector, DeltaMode, EvalDelta};
 use crate::engine::ingest_pipeline::{DependencyPlanRow, FormulaAstInput};
+use crate::engine::live_edges::{LiveEdgeCollector, RecordingContext};
+use crate::engine::live_graph::analyze_live_graph;
 use crate::engine::lookup_index_cache::{
     BuildOutcome, LookupAxis, LookupIndex, LookupIndexCache, LookupIndexCacheReport,
     LookupIndexKey, estimate_bytes,
@@ -13,9 +15,10 @@ use crate::engine::row_visibility::RowVisibilityState;
 use crate::engine::spill::{RegionLockManager, SpillMeta, SpillShape};
 use crate::engine::virtual_deps::VirtualDepBuilder;
 use crate::engine::{
-    DependencyGraph, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaIngestReport,
-    FormulaParseDiagnostic, FormulaParsePolicy, FormulaPlaneMode, RowVisibilitySource,
-    ScheduleUnit, Scheduler, VertexId, VertexKind, VisibilityMaskMode,
+    CycleDetection, CyclePolicy, DependencyGraph, EvalConfig, FormulaIngestBatch,
+    FormulaIngestRecord, FormulaIngestReport, FormulaParseDiagnostic, FormulaParsePolicy,
+    FormulaPlaneMode, RowVisibilitySource, ScheduleUnit, Scheduler, VertexId, VertexKind,
+    VisibilityMaskMode,
 };
 use crate::formula_plane::placement::{
     CandidateAnalysis, FormulaPlacementCandidate, FormulaPlacementResult, PlacementFallbackReason,
@@ -393,6 +396,9 @@ pub struct Engine<R> {
     // Phase 3b virtual-dependency convergence telemetry
     last_virtual_dep_telemetry: VirtualDepTelemetry,
     virtual_dep_fallback_activations: u64,
+
+    // Runtime-cycle SCC evaluation telemetry (RFC #112, Stage 2)
+    last_cycle_telemetry: CycleTelemetry,
 
     /// FormulaPlane authority `indexes_epoch` observed by the most recent
     /// successful `evaluate_all` pass. Used to schedule whole-span work for
@@ -937,6 +943,36 @@ pub struct VirtualDepTelemetry {
     pub fallback_mode_activations: u64,
 }
 
+/// Per-recalc telemetry for SCC evaluation under `CycleDetection::Runtime`
+/// (spec `formualizer-cycle-semantics-spec.md` §10, Stage-2 subset; the
+/// `Iterate`-specific fields arrive in Stage 3).
+///
+/// Collection is gated by the existing telemetry flag
+/// (`EvalConfig::enable_virtual_dep_telemetry`), mirroring
+/// [`VirtualDepTelemetry`]; the struct is always public. Counters reset at
+/// the start of every evaluation request.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CycleTelemetry {
+    /// SCC tasks executed (static SCCs that reached Runtime evaluation).
+    pub static_sccs: usize,
+    /// SCC tasks whose live subgraph was acyclic — values produced.
+    pub phantom_sccs: usize,
+    /// Distinct live cycles witnessed across all SCC tasks.
+    pub live_cycles_witnessed: usize,
+    /// Cells stamped `#CIRC!` by Runtime SCC tasks.
+    pub circ_cells_stamped: usize,
+    /// Evaluation sweeps over (subsets of) SCC members, totalled across tasks
+    /// (pass 1 included).
+    pub settle_passes_total: usize,
+    /// Largest pass count any single SCC task needed.
+    pub max_passes_single_scc: usize,
+    /// SCC tasks that hit the defensive settle cap (|SCC| + 2). Always 0
+    /// unless a bug exists — the acyclic settle is monotone.
+    pub capped_sccs: usize,
+    /// Total wall-clock time spent inside Runtime SCC tasks.
+    pub elapsed_ms: u128,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ScheduleBuildMeta {
     candidate_vertices: usize,
@@ -1323,6 +1359,7 @@ where
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
             virtual_dep_fallback_activations: 0,
+            last_cycle_telemetry: CycleTelemetry::default(),
             formula_plane_indexes_epoch_seen: 0,
             #[cfg(test)]
             last_formula_plane_span_eval_report: None,
@@ -1391,6 +1428,7 @@ where
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
             virtual_dep_fallback_activations: 0,
+            last_cycle_telemetry: CycleTelemetry::default(),
             formula_plane_indexes_epoch_seen: 0,
             #[cfg(test)]
             last_formula_plane_span_eval_report: None,
@@ -1420,6 +1458,19 @@ where
 
     pub fn last_virtual_dep_telemetry(&self) -> &VirtualDepTelemetry {
         &self.last_virtual_dep_telemetry
+    }
+
+    /// Telemetry from Runtime SCC evaluation during the most recent
+    /// evaluation request (always default-zero under `CycleDetection::Static`
+    /// or when `enable_virtual_dep_telemetry` is off).
+    pub fn last_cycle_telemetry(&self) -> &CycleTelemetry {
+        &self.last_cycle_telemetry
+    }
+
+    /// Reset per-recalc cycle telemetry. Called at the start of every
+    /// evaluation request that walks schedule units.
+    fn reset_cycle_telemetry(&mut self) {
+        self.last_cycle_telemetry = CycleTelemetry::default();
     }
 
     pub fn virtual_dep_fallback_activations(&self) -> u64 {
@@ -7759,6 +7810,7 @@ where
         #[cfg(feature = "tracing")]
         let _span_eval = tracing::info_span!("evaluate_until", targets = targets.len()).entered();
         let start = crate::instant::FzInstant::now();
+        self.reset_cycle_telemetry();
         let _source_cache = self.source_cache_session();
         if self.graph.formula_authority().active_span_count() > 0 {
             return self.evaluate_authoritative_formula_plane_all();
@@ -7822,8 +7874,9 @@ where
         for &unit in &schedule.units {
             match unit {
                 ScheduleUnit::Cycle(i) => {
-                    self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
-                    cycle_errors += 1;
+                    if self.handle_cycle_unit(schedule.unit_cycle(i), None, None, None)? > 0 {
+                        cycle_errors += 1;
+                    }
                 }
                 ScheduleUnit::Layer(i) => {
                     let layer = schedule.unit_layer(i);
@@ -7860,6 +7913,7 @@ where
         let _span_eval =
             tracing::info_span!("evaluate_until_with_delta", targets = targets.len()).entered();
         let start = crate::instant::FzInstant::now();
+        self.reset_cycle_telemetry();
         let _source_cache = self.source_cache_session();
 
         let mut target_addrs = Vec::new();
@@ -7902,8 +7956,10 @@ where
         for &unit in &schedule.units {
             match unit {
                 ScheduleUnit::Cycle(i) => {
-                    self.apply_cycle_outcome(schedule.unit_cycle(i), Some(delta), None);
-                    cycle_errors += 1;
+                    if self.handle_cycle_unit(schedule.unit_cycle(i), Some(delta), None, None)? > 0
+                    {
+                        cycle_errors += 1;
+                    }
                 }
                 ScheduleUnit::Layer(i) => {
                     let layer = schedule.unit_layer(i);
@@ -7953,6 +8009,7 @@ where
 
     /// Evaluate using a previously constructed plan. This avoids rebuilding layer schedules for each run.
     pub fn evaluate_recalc_plan(&mut self, plan: &RecalcPlan) -> Result<EvalResult, ExcelError> {
+        self.reset_cycle_telemetry();
         let _source_cache = self.source_cache_session();
         self.validate_deterministic_mode()?;
         if self.config.defer_graph_building {
@@ -7987,13 +8044,16 @@ where
         for &unit in &plan.schedule.units {
             match unit {
                 ScheduleUnit::Cycle(i) => {
-                    // Recalc-plan quirk: stamp only the DIRTY members of the
-                    // cycle, and count the cycle only when it had any.
-                    let stamped = self.apply_cycle_outcome(
+                    // Recalc-plan quirk (Static): stamp only the DIRTY members
+                    // of the cycle, and count the cycle only when it had any.
+                    // Under Runtime the filter means: skip when no member is
+                    // dirty, evaluate the whole SCC when any is.
+                    let stamped = self.handle_cycle_unit(
                         plan.schedule.unit_cycle(i),
                         None,
                         Some(&dirty_set),
-                    );
+                        None,
+                    )?;
                     if stamped > 0 {
                         cycle_errors += 1;
                     }
@@ -8435,8 +8495,9 @@ where
         for &unit in &schedule.units {
             match unit {
                 ScheduleUnit::Cycle(i) => {
-                    self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
-                    cycle_count += 1;
+                    if self.handle_cycle_unit(schedule.unit_cycle(i), None, None, None)? > 0 {
+                        cycle_count += 1;
+                    }
                 }
                 ScheduleUnit::Layer(i) => {
                     let layer = schedule.unit_layer(i);
@@ -8456,6 +8517,7 @@ where
     /// `AuthoritativeExperimental` mode. This is now an internal primitive; it
     /// must not be invoked directly from public APIs.
     fn evaluate_all_legacy_impl(&mut self) -> Result<EvalResult, ExcelError> {
+        self.reset_cycle_telemetry();
         self.reset_virtual_dep_telemetry_if_disabled();
         #[cfg(feature = "tracing")]
         let _span_eval = tracing::info_span!("evaluate_all").entered();
@@ -8544,6 +8606,7 @@ where
         &mut self,
         delta: &mut DeltaCollector,
     ) -> Result<EvalResult, ExcelError> {
+        self.reset_cycle_telemetry();
         let _source_cache = self.source_cache_session();
         if self.config.defer_graph_building {
             self.build_graph_all()?;
@@ -8585,8 +8648,15 @@ where
             for &unit in &schedule.units {
                 match unit {
                     ScheduleUnit::Cycle(i) => {
-                        self.apply_cycle_outcome(schedule.unit_cycle(i), Some(delta), None);
-                        cycle_errors += 1;
+                        if self.handle_cycle_unit(
+                            schedule.unit_cycle(i),
+                            Some(delta),
+                            None,
+                            None,
+                        )? > 0
+                        {
+                            cycle_errors += 1;
+                        }
                     }
                     ScheduleUnit::Layer(i) => {
                         let layer = schedule.unit_layer(i);
@@ -9208,6 +9278,7 @@ where
         &mut self,
         cancel_flag: &AtomicBool,
     ) -> Result<EvalResult, ExcelError> {
+        self.reset_cycle_telemetry();
         let _source_cache = self.source_cache_session();
         self.validate_deterministic_mode()?;
         if self.config.defer_graph_building {
@@ -9276,8 +9347,15 @@ where
                             ));
                         }
 
-                        self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
-                        cycle_errors += 1;
+                        if self.handle_cycle_unit(
+                            schedule.unit_cycle(i),
+                            None,
+                            None,
+                            Some(cancel_flag),
+                        )? > 0
+                        {
+                            cycle_errors += 1;
+                        }
                     }
                     ScheduleUnit::Layer(i) => {
                         let layer = schedule.unit_layer(i);
@@ -9362,6 +9440,7 @@ where
         cancel_flag: &AtomicBool,
     ) -> Result<EvalResult, ExcelError> {
         let start = crate::instant::FzInstant::now();
+        self.reset_cycle_telemetry();
         if self.graph.formula_authority().active_span_count() > 0 {
             if cancel_flag.load(Ordering::Relaxed) {
                 return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
@@ -9425,8 +9504,15 @@ where
                         ));
                     }
 
-                    self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
-                    cycle_errors += 1;
+                    if self.handle_cycle_unit(
+                        schedule.unit_cycle(i),
+                        None,
+                        None,
+                        Some(cancel_flag),
+                    )? > 0
+                    {
+                        cycle_errors += 1;
+                    }
                 }
                 ScheduleUnit::Layer(i) => {
                     let layer = schedule.unit_layer(i);
@@ -11723,6 +11809,504 @@ where
         self.mirror_vertex_value_to_overlay(vertex_id, circ_error);
     }
 
+    /// Dispatch point for one `ScheduleUnit::Cycle` (RFC #112, Stage 2).
+    ///
+    /// * `CycleDetection::Static` — today's behavior, byte-for-byte: stamp
+    ///   `#CIRC!` on the (optionally dirty-filtered) members.
+    /// * `CycleDetection::Runtime` — evaluate the SCC via
+    ///   [`Self::evaluate_scc_unit`]. The recalc-plan dirty quirk maps to:
+    ///   no dirty member → skip the task entirely (values stand); any dirty
+    ///   member → the whole SCC evaluates (an SCC cannot be partially
+    ///   evaluated).
+    ///
+    /// Returns the number of `#CIRC!`-stamped vertices, so call sites can
+    /// keep their `cycle_errors` accounting (`> 0` ⇒ count the unit).
+    fn handle_cycle_unit(
+        &mut self,
+        cycle: &[VertexId],
+        mut delta: Option<&mut DeltaCollector>,
+        dirty_filter: Option<&FxHashSet<VertexId>>,
+        cancel_flag: Option<&AtomicBool>,
+    ) -> Result<usize, ExcelError> {
+        match self.config.cycle.detection {
+            CycleDetection::Static => {
+                Ok(self.apply_cycle_outcome(cycle, delta.as_deref_mut(), dirty_filter))
+            }
+            CycleDetection::Runtime => {
+                if let Some(filter) = dirty_filter
+                    && !cycle.iter().any(|v| filter.contains(v))
+                {
+                    return Ok(0);
+                }
+                match self.config.cycle.policy {
+                    CyclePolicy::Error => self.evaluate_scc_unit(cycle, delta, cancel_flag),
+                }
+            }
+        }
+    }
+
+    /// Evaluate one statically-cyclic SCC under `CycleDetection::Runtime`
+    /// (design doc `formualizer-stage2-scc-evaluation-design.md` §3; contract
+    /// spec §3, Error-policy subset).
+    ///
+    /// Phantom SCCs (live-acyclic) produce ordinary values; live cycles get
+    /// `#CIRC!` with live-cycle-only blast radius. Runs sequentially on the
+    /// coordinating thread; commits are write-through per member (no
+    /// `ComputedWriteBuffer` — that buffer is scoped to layer evaluation and
+    /// always flushed before a Cycle unit runs, G1), so later members' scalar
+    /// *and* range reads observe earlier members' results through the overlay
+    /// cascade. Deltas are recorded once per member at end of task (G11).
+    ///
+    /// Returns the number of vertices stamped `#CIRC!`.
+    ///
+    /// `pub(crate)` so tests can drive SCC shapes (e.g. name-vertex members)
+    /// that ingest-time cycle rejection makes unreachable via public edits.
+    pub(crate) fn evaluate_scc_unit(
+        &mut self,
+        cycle: &[VertexId],
+        mut delta: Option<&mut DeltaCollector>,
+        cancel_flag: Option<&AtomicBool>,
+    ) -> Result<usize, ExcelError> {
+        struct SccMember {
+            vertex: VertexId,
+            cell: Option<CellRef>,
+        }
+
+        let task_start = crate::instant::FzInstant::now();
+        let collect_telemetry = self.config.enable_virtual_dep_telemetry;
+
+        // ── 0. Member order (spec §7.13): cells ascending (sheet, row, col);
+        // name vertices after, lexicographic by folded canonical name; any
+        // other vertex kind (defensive — `get_evaluation_vertices` only emits
+        // formula/name kinds) last by id, never evaluated.
+        let mut cell_members: Vec<(VertexId, CellRef)> = Vec::new();
+        let mut name_members: Vec<(VertexId, String)> = Vec::new();
+        let mut other_members: Vec<VertexId> = Vec::new();
+        for &v in cycle {
+            match self.graph.get_vertex_kind(v) {
+                VertexKind::FormulaScalar | VertexKind::FormulaArray => {
+                    match self.graph.get_cell_ref(v) {
+                        Some(cell) => cell_members.push((v, cell)),
+                        None => other_members.push(v),
+                    }
+                }
+                VertexKind::NamedScalar | VertexKind::NamedArray => {
+                    match self.graph.name_key_for_vertex(v) {
+                        Some(key) => name_members.push((v, key)),
+                        None => other_members.push(v),
+                    }
+                }
+                _ => other_members.push(v),
+            }
+        }
+        cell_members.sort_unstable_by_key(|(_, c)| (c.sheet_id, c.coord.row(), c.coord.col()));
+        name_members.sort_unstable_by(|(av, ak), (bv, bk)| ak.cmp(bk).then(av.cmp(bv)));
+        other_members.sort_unstable();
+
+        let cell_refs: Vec<CellRef> = cell_members.iter().map(|(_, c)| *c).collect();
+        let name_keys: Vec<String> = name_members.iter().map(|(_, k)| k.clone()).collect();
+        let mut members: Vec<SccMember> = Vec::with_capacity(cycle.len());
+        for (v, c) in &cell_members {
+            members.push(SccMember {
+                vertex: *v,
+                cell: Some(*c),
+            });
+        }
+        for (v, _) in &name_members {
+            members.push(SccMember {
+                vertex: *v,
+                cell: None,
+            });
+        }
+        for v in &other_members {
+            members.push(SccMember {
+                vertex: *v,
+                cell: None,
+            });
+        }
+        let n = members.len();
+        // Indices addressable by the collector (cells + names); `other`
+        // members can be neither edge sources nor targets.
+        let recordable = cell_refs.len() + name_keys.len();
+
+        let circ_error = LiteralValue::Error(
+            ExcelError::new(ExcelErrorKind::Circ)
+                .with_message("Circular dependency detected".to_string()),
+        );
+
+        // ── 1. Pre-task value snapshot (overlay-first for cells — G3; the
+        // graph value map may be evicted in value-cache-disabled mode).
+        let snapshot: Vec<LiteralValue> = members
+            .iter()
+            .map(|m| match m.cell {
+                Some(cell) => {
+                    let sheet_name = self.graph.sheet_name(cell.sheet_id);
+                    self.get_cell_value(sheet_name, cell.coord.row() + 1, cell.coord.col() + 1)
+                        .unwrap_or(LiteralValue::Empty)
+                }
+                None => self
+                    .graph
+                    .get_value(m.vertex)
+                    .unwrap_or(LiteralValue::Empty),
+            })
+            .collect();
+
+        // ── 2. Pre-scan: spill anchors (FormulaArray) are stamped `#CIRC!`
+        // with full spill teardown (spec §7.9, #115) and excluded from
+        // evaluation. They stay recordable edge TARGETS (readers see `#CIRC!`
+        // and propagate). Non-evaluable defensive members are excluded too.
+        let mut excluded = vec![false; n];
+        let mut last_value = snapshot.clone();
+        let mut stamped = 0usize;
+        for (i, m) in members.iter().enumerate() {
+            match self.graph.get_vertex_kind(m.vertex) {
+                VertexKind::FormulaArray => {
+                    // Deltas for the cleared spill-region cells (non-members)
+                    // can only be recorded here; the anchor's own delta is
+                    // covered by the end-of-task snapshot comparison (dedup).
+                    self.stamp_cycle_error(m.vertex, &circ_error, delta.as_deref_mut());
+                    excluded[i] = true;
+                    last_value[i] = circ_error.clone();
+                    stamped += 1;
+                }
+                VertexKind::FormulaScalar | VertexKind::NamedScalar | VertexKind::NamedArray => {}
+                _ => excluded[i] = true,
+            }
+        }
+
+        let collector = LiveEdgeCollector::new_with_names(&cell_refs, &name_keys);
+
+        // Per-member live out-edges, refreshed whenever a member re-runs.
+        let mut out_edges: Vec<Vec<u32>> = vec![Vec::new(); n];
+        // Position of each member in the most recent pass (-1 = did not run).
+        let mut pos: Vec<i64> = vec![-1; n];
+        // Whether each member's committed value changed in the most recent pass.
+        let mut changed = vec![false; n];
+
+        // Evaluate-and-commit one member; returns Ok(true) when the member was
+        // stamped `#CIRC!` (array result — would-be spill anchor, spec §7.9).
+        macro_rules! run_member {
+            ($i:expr) => {{
+                let i: usize = $i;
+                let m = &members[i];
+                if i < recordable {
+                    collector.set_current(i as u32);
+                }
+                let value = {
+                    let ctx = RecordingContext::new(&*self, &collector);
+                    match self.evaluate_vertex_recorded(m.vertex, &ctx, &collector) {
+                        Ok(v) => v,
+                        Err(e) => LiteralValue::Error(e),
+                    }
+                };
+                let is_cell_formula = m.cell.is_some();
+                if is_cell_formula && matches!(value, LiteralValue::Array(_)) {
+                    // A member that *would* spill inside an SCC gets the
+                    // conservative §7.9 verdict. It has never spilled before
+                    // (a prior spill would make it FormulaArray, pre-stamped
+                    // above), so there is no projection to tear down.
+                    self.stamp_cycle_error(m.vertex, &circ_error, None);
+                    excluded[i] = true;
+                    stamped += 1;
+                    changed[i] = last_value[i] != circ_error;
+                    last_value[i] = circ_error.clone();
+                } else {
+                    self.graph.update_vertex_value(m.vertex, value.clone());
+                    self.mirror_vertex_value_to_overlay(m.vertex, &value);
+                    // §7.14 invariant (G2): a formula member must never be
+                    // shadowed by a user/delta overlay entry, or iteration
+                    // reads would silently diverge from committed values.
+                    #[cfg(debug_assertions)]
+                    if let Some(cell) = m.cell {
+                        let sheet_name = self.graph.sheet_name(cell.sheet_id).to_string();
+                        debug_assert!(
+                            self.read_delta_overlay_cell(
+                                &sheet_name,
+                                cell.coord.row() + 1,
+                                cell.coord.col() + 1
+                            )
+                            .is_none(),
+                            "user overlay must never shadow a formula SCC member ({sheet_name}!r{}c{})",
+                            cell.coord.row() + 1,
+                            cell.coord.col() + 1
+                        );
+                    }
+                    changed[i] = last_value[i] != value;
+                    last_value[i] = value;
+                }
+            }};
+        }
+
+        let check_cancel = |flag: Option<&AtomicBool>| -> Result<(), ExcelError> {
+            if let Some(flag) = flag
+                && flag.load(Ordering::Relaxed)
+            {
+                return Err(ExcelError::new(ExcelErrorKind::Cancelled)
+                    .with_message("Evaluation cancelled during SCC evaluation".to_string()));
+            }
+            Ok(())
+        };
+
+        // ── 3. Pass 1: all evaluable members in member order.
+        check_cancel(cancel_flag)?;
+        let mut passes = 1usize;
+        {
+            let mut p = 0i64;
+            for i in 0..n {
+                if excluded[i] {
+                    continue;
+                }
+                run_member!(i);
+                pos[i] = p;
+                p += 1;
+            }
+        }
+
+        // ── 4. Settle loop (design doc §3 step 4). Defensive cap: the
+        // acyclic settle is monotone, so |SCC| + 2 passes can only be
+        // exceeded by a bug; cap hits stamp the remainder and set telemetry.
+        let cap = n + 2;
+        let mut witnessed_cycles = 0usize;
+        let mut capped = false;
+        loop {
+            // Drain this pass's recordings; members that ran replace their
+            // out-edge set, members that didn't keep last-known edges.
+            let drained = collector.take_edges();
+            for i in 0..n {
+                if pos[i] >= 0 {
+                    out_edges[i].clear();
+                }
+            }
+            for (from, to) in drained {
+                debug_assert!(
+                    pos[from as usize] >= 0,
+                    "edge from a member that did not run"
+                );
+                out_edges[from as usize].push(to);
+            }
+            let mut edges: Vec<(u32, u32)> = Vec::new();
+            for (i, outs) in out_edges.iter().enumerate() {
+                if excluded[i] {
+                    continue;
+                }
+                for &t in outs {
+                    edges.push((i as u32, t));
+                }
+            }
+            edges.sort_unstable();
+            edges.dedup();
+
+            let analysis = analyze_live_graph(n, &edges);
+
+            if analysis.cycle_count > 0 {
+                // POLICY (Error): stamp every member of a live cycle, then one
+                // settling pass over the remaining members in live-topological
+                // order so error propagation downstream is consistent
+                // (spec §3.4). Blast radius = live cycles only.
+                witnessed_cycles += analysis.cycle_count;
+                for i in 0..n {
+                    if analysis.in_cycle[i] && !excluded[i] {
+                        self.stamp_cycle_error(members[i].vertex, &circ_error, None);
+                        excluded[i] = true;
+                        last_value[i] = circ_error.clone();
+                        stamped += 1;
+                    }
+                }
+                check_cancel(cancel_flag)?;
+                let order: Vec<usize> = analysis
+                    .topo
+                    .iter()
+                    .map(|&i| i as usize)
+                    .filter(|&i| !excluded[i])
+                    .collect();
+                if !order.is_empty() {
+                    passes += 1;
+                    for i in order {
+                        run_member!(i);
+                    }
+                }
+                break;
+            }
+
+            // Acyclic: find stale readers — members whose live read of `to`
+            // happened before `to`'s value changed in the pass that just ran.
+            let mut stale: Vec<usize> = Vec::new();
+            for i in 0..n {
+                if excluded[i] {
+                    continue;
+                }
+                let is_stale = out_edges[i].iter().any(|&t| {
+                    let t = t as usize;
+                    changed[t] && (pos[i] < 0 || (pos[t] >= 0 && pos[i] < pos[t]))
+                });
+                if is_stale {
+                    stale.push(i);
+                }
+            }
+            if stale.is_empty() {
+                break; // values exact — phantom SCC
+            }
+            if passes >= cap {
+                // Defensive only; hitting this is a bug (loud telemetry).
+                capped = true;
+                for (i, m) in members.iter().enumerate() {
+                    if !excluded[i] {
+                        self.stamp_cycle_error(m.vertex, &circ_error, None);
+                        excluded[i] = true;
+                        last_value[i] = circ_error.clone();
+                        stamped += 1;
+                    }
+                }
+                break;
+            }
+
+            check_cancel(cancel_flag)?;
+            // Re-evaluate stale readers in live-topo order, recording fresh
+            // edges (branches may flip on re-eval — spec §7.3 — which is why
+            // classification repeats).
+            let topo_pos = analysis.topo_positions();
+            stale.sort_unstable_by_key(|&i| topo_pos[i]);
+            for x in pos.iter_mut() {
+                *x = -1;
+            }
+            changed.fill(false);
+            passes += 1;
+            for (p, i) in stale.into_iter().enumerate() {
+                run_member!(i);
+                pos[i] = p as i64;
+            }
+        }
+
+        // ── 5. End of task: one delta per member whose final value differs
+        // from the pre-task snapshot (spec §3 side-effect rule, G11).
+        collector.clear_current();
+        if let Some(d) = delta
+            && d.mode != DeltaMode::Off
+        {
+            for (i, m) in members.iter().enumerate() {
+                if let Some(cell) = m.cell
+                    && last_value[i] != snapshot[i]
+                {
+                    d.record_cell(cell.sheet_id, cell.coord.row(), cell.coord.col());
+                }
+            }
+        }
+
+        if collect_telemetry {
+            let t = &mut self.last_cycle_telemetry;
+            t.static_sccs += 1;
+            if witnessed_cycles == 0 && stamped == 0 && !capped {
+                t.phantom_sccs += 1;
+            }
+            t.live_cycles_witnessed += witnessed_cycles;
+            t.circ_cells_stamped += stamped;
+            t.settle_passes_total += passes;
+            t.max_passes_single_scc = t.max_passes_single_scc.max(passes);
+            if capped {
+                t.capped_sccs += 1;
+            }
+            t.elapsed_ms += task_start.elapsed().as_millis();
+        }
+
+        Ok(stamped)
+    }
+
+    /// Recorded sibling of [`Self::evaluate_vertex_immutable`]: evaluates one
+    /// SCC member's AST via an [`Interpreter`] over a [`RecordingContext`] so
+    /// reads that actually occur are captured as live edges. Value semantics
+    /// must match `evaluate_vertex_immutable` exactly (including the missing-
+    /// AST `Number(0.0)` quirk, G14); named Cell/Range/Literal definitions
+    /// delegate to it after recording the definition region by hand (those
+    /// reads bypass the context).
+    fn evaluate_vertex_recorded(
+        &self,
+        vertex_id: VertexId,
+        ctx: &RecordingContext<'_, R>,
+        collector: &LiveEdgeCollector,
+    ) -> Result<LiteralValue, ExcelError> {
+        if !self.graph.vertex_exists(vertex_id) {
+            return Err(ExcelError::new(formualizer_common::ExcelErrorKind::Ref)
+                .with_message(format!("Vertex not found: {vertex_id:?}")));
+        }
+
+        let kind = self.graph.get_vertex_kind(vertex_id);
+        let sheet_id = self.graph.get_vertex_sheet_id(vertex_id);
+
+        match kind {
+            VertexKind::FormulaScalar | VertexKind::FormulaArray => {
+                let Some(ast_id) = self.graph.get_formula_id(vertex_id) else {
+                    return Ok(LiteralValue::Number(0.0)); // G14 quirk
+                };
+                let sheet_name = self.graph.sheet_name(sheet_id);
+                let cell_ref = self
+                    .graph
+                    .get_cell_ref(vertex_id)
+                    .expect("cell ref for vertex");
+                let interpreter = Interpreter::new_with_cell(ctx, sheet_name, cell_ref);
+                interpreter
+                    .evaluate_arena_ast(ast_id, self.graph.data_store(), self.graph.sheet_reg())
+                    .map(|cv| cv.into_literal())
+            }
+            VertexKind::NamedScalar | VertexKind::NamedArray => {
+                let named_range = self.graph.named_range_by_vertex(vertex_id).ok_or_else(|| {
+                    ExcelError::new(ExcelErrorKind::Name)
+                        .with_message("Named range metadata missing".to_string())
+                })?;
+
+                match &named_range.definition {
+                    NamedDefinition::Formula { ast, .. } => {
+                        let context_sheet = match named_range.scope {
+                            NameScope::Sheet(id) => id,
+                            NameScope::Workbook => sheet_id,
+                        };
+                        let sheet_name = self.graph.sheet_name(context_sheet);
+                        let cell_ref = self
+                            .graph
+                            .get_cell_ref(vertex_id)
+                            .unwrap_or_else(|| self.graph.make_cell_ref(sheet_name, 0, 0));
+                        let interpreter = Interpreter::new_with_cell(ctx, sheet_name, cell_ref);
+                        if kind == VertexKind::NamedScalar {
+                            interpreter.evaluate_ast(ast).map(|cv| cv.into_literal())
+                        } else {
+                            match interpreter.evaluate_ast(ast) {
+                                Ok(cv) => match cv.into_literal() {
+                                    v @ LiteralValue::Array(_) => Ok(v),
+                                    other => Ok(LiteralValue::Array(vec![vec![other]])),
+                                },
+                                Err(err) => Ok(LiteralValue::Error(err)),
+                            }
+                        }
+                    }
+                    NamedDefinition::Cell(cell_ref) => {
+                        // The definition is read via direct grid access in
+                        // `evaluate_vertex_immutable`; record the live edge
+                        // by hand before delegating.
+                        collector.record_scalar(
+                            cell_ref.sheet_id,
+                            cell_ref.coord.row(),
+                            cell_ref.coord.col(),
+                        );
+                        self.evaluate_vertex_immutable(vertex_id)
+                    }
+                    NamedDefinition::Range(range_ref) => {
+                        if range_ref.start.sheet_id == range_ref.end.sheet_id {
+                            collector.record_rect(
+                                range_ref.start.sheet_id,
+                                range_ref.start.coord.row(),
+                                range_ref.start.coord.col(),
+                                range_ref.end.coord.row(),
+                                range_ref.end.coord.col(),
+                            );
+                        }
+                        self.evaluate_vertex_immutable(vertex_id)
+                    }
+                    NamedDefinition::Literal(_) => self.evaluate_vertex_immutable(vertex_id),
+                }
+            }
+            _ => self.evaluate_vertex_immutable(vertex_id),
+        }
+    }
+
     /// Helper: commit spill via shim and mirror resulting cells into Arrow overlay when enabled.
     fn commit_spill_and_mirror(
         &mut self,
@@ -13008,6 +13592,7 @@ where
     /// This is the same flow as `evaluate_all` but threads a ChangeLog through
     /// every effect application so that spill commits/clears are captured.
     pub fn evaluate_all_logged(&mut self, log: &mut ChangeLog) -> Result<EvalResult, ExcelError> {
+        self.reset_cycle_telemetry();
         let _source_cache = self.source_cache_session();
         self.validate_deterministic_mode()?;
         if self.config.defer_graph_building {
@@ -13051,8 +13636,19 @@ where
             for &unit in &schedule.units {
                 match unit {
                     ScheduleUnit::Cycle(i) => {
-                        self.apply_cycle_outcome(schedule.unit_cycle(i), None, None);
-                        cycle_errors += 1;
+                        // Journal integration (design doc §4 last row): the
+                        // ChangeLog in this path only records SpillClear /
+                        // SpillCommit events; WriteCell effects are never
+                        // logged (see `apply_write_cell`). Runtime SCC tasks
+                        // write values directly and never spill (§7.9 stamps
+                        // would-be anchors), and their spill *teardown* is the
+                        // same unlogged `stamp_cycle_error` the Static path
+                        // already uses here — so direct commits coexist with
+                        // the journal cleanly, with identical semantics to
+                        // Static. Pinned by `scc_runtime_cycles` tests.
+                        if self.handle_cycle_unit(schedule.unit_cycle(i), None, None, None)? > 0 {
+                            cycle_errors += 1;
+                        }
                     }
                     ScheduleUnit::Layer(i) => {
                         computed_vertices +=

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -265,6 +265,15 @@ impl DependencyGraph {
             .map(|nr| &nr.definition)
     }
 
+    /// The folded lookup key (see [`Self::name_lookup_key`]) of the name
+    /// represented by `vertex`, if it is a name vertex. Used by SCC tasks for
+    /// deterministic member ordering and live name-read matching (RFC #112).
+    pub(crate) fn name_key_for_vertex(&self, vertex: VertexId) -> Option<String> {
+        self.name_vertex_lookup
+            .get(&vertex)
+            .map(|(_, name)| self.name_lookup_key(name))
+    }
+
     pub fn named_range_by_vertex(&self, vertex: VertexId) -> Option<&NamedRange> {
         self.name_vertex_lookup
             .get(&vertex)

--- a/crates/formualizer-eval/src/engine/live_edges.rs
+++ b/crates/formualizer-eval/src/engine/live_edges.rs
@@ -83,11 +83,22 @@ struct CollectorState {
 /// * Scalar reads are O(1) (hash lookup keyed by `(sheet, row, col)`).
 /// * Rectangle reads are recorded **once per resolved rect** and intersected
 ///   with the membership in O(|SCC|) — never per cell of the rect.
+/// * Name reads (named-formula SCC members, spec §7.13) are O(1) lookups by
+///   the engine-folded name key.
+///
+/// Member indices are split: cell members occupy `0..cell_count`, name
+/// members occupy `cell_count..cell_count + name_count` (matching the spec
+/// §7.13 member ordering used by SCC tasks: cells first, then names).
 pub struct LiveEdgeCollector {
     /// Iterable membership for rect intersection.
     members: Vec<MemberCell>,
     /// O(1) scalar lookup: (sheet_id, row0, col0) -> member index.
     index: FxHashMap<(SheetId, u32, u32), u32>,
+    /// O(1) name lookup: engine-folded name key -> member index (indices
+    /// start after the cell members).
+    name_index: FxHashMap<String, u32>,
+    /// Total member count (cells + names); valid `set_current` range.
+    total_members: usize,
     /// See module docs: uncontended Mutex forced by `Send + Sync` bounds on
     /// the resolver traits; SCC passes are single-threaded.
     state: Mutex<CollectorState>,
@@ -97,7 +108,15 @@ impl LiveEdgeCollector {
     /// Build a collector for the given SCC membership. Member order defines
     /// the indices used in recorded edges.
     pub fn new(members: &[CellRef]) -> Self {
-        let members: Vec<MemberCell> = members
+        Self::new_with_names(members, &[])
+    }
+
+    /// Build a collector over cell members plus name-vertex members. Cell
+    /// members get indices `0..cells.len()`; name member `j` gets index
+    /// `cells.len() + j`. `names` must already be folded with the engine's
+    /// name-folding rule (see [`Engine::fold_name_key`]).
+    pub fn new_with_names(cells: &[CellRef], names: &[String]) -> Self {
+        let members: Vec<MemberCell> = cells
             .iter()
             .map(|c| MemberCell {
                 sheet_id: c.sheet_id,
@@ -110,22 +129,36 @@ impl LiveEdgeCollector {
         for (i, m) in members.iter().enumerate() {
             index.insert((m.sheet_id, m.row, m.col), i as u32);
         }
+        let mut name_index = FxHashMap::default();
+        name_index.reserve(names.len());
+        for (j, name) in names.iter().enumerate() {
+            name_index.insert(name.clone(), (members.len() + j) as u32);
+        }
+        let total_members = members.len() + names.len();
         Self {
             members,
             index,
+            name_index,
+            total_members,
             state: Mutex::new(CollectorState::default()),
         }
     }
 
     pub fn member_count(&self) -> usize {
-        self.members.len()
+        self.total_members
     }
 
     /// Set the member whose formula is about to be evaluated; subsequent
     /// recorded reads are attributed to it.
     pub fn set_current(&self, member_idx: u32) {
-        debug_assert!((member_idx as usize) < self.members.len());
+        debug_assert!((member_idx as usize) < self.total_members);
         self.state.lock().unwrap().current = Some(member_idx);
+    }
+
+    /// Stop attributing reads to any member (used between passes so that
+    /// out-of-band reads — snapshots, deltas — never record edges).
+    pub fn clear_current(&self) {
+        self.state.lock().unwrap().current = None;
     }
 
     /// Record a scalar read of `(sheet_id, row, col)` (0-based).
@@ -151,6 +184,18 @@ impl LiveEdgeCollector {
             if m.sheet_id == sheet_id && m.row >= sr && m.row <= er && m.col >= sc && m.col <= ec {
                 st.edges.insert((from, i as u32));
             }
+        }
+    }
+
+    /// Record a read of a named entity by folded name key (e.g. a formula
+    /// referencing a named-formula SCC member).
+    pub fn record_name(&self, folded_name: &str) {
+        let Some(&to) = self.name_index.get(folded_name) else {
+            return;
+        };
+        let mut st = self.state.lock().unwrap();
+        if let Some(from) = st.current {
+            st.edges.insert((from, to));
         }
     }
 
@@ -199,6 +244,13 @@ pub struct RecordingContext<'a, R: EvaluationContext> {
 impl<'a, R: EvaluationContext> RecordingContext<'a, R> {
     pub fn new(engine: &'a Engine<R>, collector: &'a LiveEdgeCollector) -> Self {
         Self { engine, collector }
+    }
+
+    /// Record a read of a named entity, folding the raw reference text with
+    /// the engine's name-folding rule so it matches collector name keys.
+    fn record_name(&self, raw_name: &str) {
+        let key = self.engine.graph.name_lookup_key(raw_name);
+        self.collector.record_name(&key);
     }
 
     /// Record a scalar read given Excel 1-based coordinates.
@@ -283,8 +335,10 @@ impl<'a, R: EvaluationContext> NamedRangeResolver for RecordingContext<'a, R> {
         &self,
         name: &str,
     ) -> Result<Vec<Vec<LiteralValue>>, ExcelError> {
-        // Values-only API without sheet/region context; the engine-level
-        // named-range path is intercepted in `resolve_range_view` instead.
+        // Values-only API without sheet/region context; record the *name*
+        // member edge (if the name itself is an SCC member) — region-level
+        // reads flow through `resolve_range_view` instead.
+        self.record_name(name);
         self.engine.resolve_named_range_reference(name)
     }
 }
@@ -332,6 +386,13 @@ impl<'a, R: EvaluationContext> EvaluationContext for RecordingContext<'a, R> {
         reference: &ReferenceType,
         current_sheet: &str,
     ) -> Result<RangeView<'c>, ExcelError> {
+        // Named reads can target a name *vertex* that is itself an SCC member
+        // (a named formula, spec §7.13). Those resolve to owned-row views with
+        // no sheet rect, so they must be recorded by name here in addition to
+        // the rect recording below (which covers Cell/Range definitions).
+        if let ReferenceType::NamedRange(name) = reference {
+            self.record_name(name);
+        }
         let view = self.engine.resolve_range_view(reference, current_sheet)?;
         self.record_view(&view);
         Ok(view)

--- a/crates/formualizer-eval/src/engine/live_graph.rs
+++ b/crates/formualizer-eval/src/engine/live_graph.rs
@@ -1,0 +1,245 @@
+//! Local SCC analysis over a recorded live-edge list (Stage 2 of the
+//! runtime-cycle-verdicts work, RFC #112).
+//!
+//! `evaluate_scc_unit` records live edges as `(from_idx, to_idx)` pairs over
+//! the member index space of one statically-cyclic SCC (`from` *reads* `to`,
+//! i.e. `from` depends on `to`). This module classifies that small index
+//! graph:
+//!
+//! * which members sit on a **live cycle** (SCC of size > 1, or a self-loop),
+//! * a deterministic **live-topological order** (dependencies before
+//!   dependents) used for stale-reader settling and the post-stamp
+//!   consistency pass.
+//!
+//! The scheduler's Tarjan reads dependency-graph adjacency, not edge lists,
+//! so this is a separate ~80-line iterative implementation. It is
+//! deterministic given a deterministic edge list: callers must pass sorted
+//! edges (the collector hands out a hash set; sort before calling).
+
+/// Classification of the live index graph of one SCC task.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiveGraphAnalysis {
+    /// `in_cycle[i]` — member `i` lies on a live cycle (its live SCC has
+    /// size > 1, or it has a live self-edge).
+    pub in_cycle: Vec<bool>,
+    /// Number of distinct live cycles (cyclic live SCCs).
+    pub cycle_count: usize,
+    /// All member indices in live-topological order: every member appears
+    /// after all members it has a live edge *to* (its live dependencies).
+    /// Members of one cyclic SCC appear contiguously (their internal order is
+    /// deterministic but otherwise meaningless).
+    pub topo: Vec<u32>,
+}
+
+impl LiveGraphAnalysis {
+    /// `pos[i]` = position of member `i` in `topo` (for ordering subsets).
+    pub fn topo_positions(&self) -> Vec<u32> {
+        let mut pos = vec![0u32; self.topo.len()];
+        for (p, &i) in self.topo.iter().enumerate() {
+            pos[i as usize] = p as u32;
+        }
+        pos
+    }
+}
+
+/// Iterative Tarjan over `n` nodes and directed `edges` (`from` depends on
+/// `to`). `edges` must be sorted and deduplicated for deterministic output.
+pub(crate) fn analyze_live_graph(n: usize, edges: &[(u32, u32)]) -> LiveGraphAnalysis {
+    debug_assert!(
+        edges.is_sorted(),
+        "live edges must be sorted for determinism"
+    );
+
+    // CSR adjacency.
+    let mut adj_start = vec![0usize; n + 1];
+    for &(from, _) in edges {
+        adj_start[from as usize + 1] += 1;
+    }
+    for i in 0..n {
+        adj_start[i + 1] += adj_start[i];
+    }
+    // `edges` is sorted by `from`, so the slice for node i is contiguous.
+    let adj = |i: usize| -> &[(u32, u32)] { &edges[adj_start[i]..adj_start[i + 1]] };
+
+    const UNVISITED: u32 = u32::MAX;
+    let mut index = vec![UNVISITED; n];
+    let mut lowlink = vec![0u32; n];
+    let mut on_stack = vec![false; n];
+    let mut stack: Vec<u32> = Vec::new();
+    let mut next_index = 0u32;
+
+    let mut in_cycle = vec![false; n];
+    let mut cycle_count = 0usize;
+    // Tarjan emits an SCC only after all SCCs it depends on were emitted, so
+    // emission order == live-topological order (dependencies first).
+    let mut topo: Vec<u32> = Vec::with_capacity(n);
+
+    // Explicit DFS frames: (node, next-edge-offset within its adjacency).
+    let mut frames: Vec<(u32, usize)> = Vec::new();
+    for root in 0..n as u32 {
+        if index[root as usize] != UNVISITED {
+            continue;
+        }
+        frames.push((root, 0));
+        index[root as usize] = next_index;
+        lowlink[root as usize] = next_index;
+        next_index += 1;
+        stack.push(root);
+        on_stack[root as usize] = true;
+
+        while let Some(&(v, next_edge)) = frames.last() {
+            let vu = v as usize;
+            if let Some(&(_, w)) = adj(vu).get(next_edge) {
+                frames.last_mut().expect("frame exists").1 += 1;
+                let wu = w as usize;
+                if index[wu] == UNVISITED {
+                    index[wu] = next_index;
+                    lowlink[wu] = next_index;
+                    next_index += 1;
+                    stack.push(w);
+                    on_stack[wu] = true;
+                    frames.push((w, 0));
+                } else if on_stack[wu] {
+                    lowlink[vu] = lowlink[vu].min(index[wu]);
+                }
+            } else {
+                // v is exhausted: maybe emit an SCC, then propagate lowlink.
+                if lowlink[vu] == index[vu] {
+                    let scc_start = topo.len();
+                    loop {
+                        let w = stack.pop().expect("tarjan stack underflow");
+                        on_stack[w as usize] = false;
+                        topo.push(w);
+                        if w == v {
+                            break;
+                        }
+                    }
+                    let members = &mut topo[scc_start..];
+                    // Deterministic intra-SCC order (pop order depends on DFS).
+                    members.sort_unstable();
+                    let cyclic = members.len() > 1 || adj(vu).iter().any(|&(_, w)| w == v); // self-loop
+                    if cyclic {
+                        cycle_count += 1;
+                        for &m in topo[scc_start..].iter() {
+                            in_cycle[m as usize] = true;
+                        }
+                    }
+                }
+                frames.pop();
+                if let Some(&(parent, _)) = frames.last() {
+                    let pu = parent as usize;
+                    lowlink[pu] = lowlink[pu].min(lowlink[vu]);
+                }
+            }
+        }
+    }
+
+    LiveGraphAnalysis {
+        in_cycle,
+        cycle_count,
+        topo,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn analyze(n: usize, mut edges: Vec<(u32, u32)>) -> LiveGraphAnalysis {
+        edges.sort_unstable();
+        edges.dedup();
+        analyze_live_graph(n, &edges)
+    }
+
+    fn assert_topo_consistent(a: &LiveGraphAnalysis, n: usize, edges: &[(u32, u32)]) {
+        assert_eq!(a.topo.len(), n);
+        let pos = a.topo_positions();
+        for &(from, to) in edges {
+            if from == to {
+                continue;
+            }
+            // Within a cyclic SCC ordering constraints don't apply.
+            if a.in_cycle[from as usize] && a.in_cycle[to as usize] {
+                continue;
+            }
+            assert!(
+                pos[to as usize] < pos[from as usize],
+                "dependency {to} must precede reader {from} in topo {:?}",
+                a.topo
+            );
+        }
+    }
+
+    #[test]
+    fn empty_graph_is_acyclic() {
+        let a = analyze(3, vec![]);
+        assert_eq!(a.cycle_count, 0);
+        assert_eq!(a.in_cycle, vec![false; 3]);
+        assert_eq!(a.topo.len(), 3);
+    }
+
+    #[test]
+    fn self_loop_is_a_cycle() {
+        let a = analyze(2, vec![(0, 0)]);
+        assert_eq!(a.cycle_count, 1);
+        assert_eq!(a.in_cycle, vec![true, false]);
+    }
+
+    #[test]
+    fn two_cycle_detected() {
+        let edges = vec![(0, 1), (1, 0)];
+        let a = analyze(2, edges.clone());
+        assert_eq!(a.cycle_count, 1);
+        assert_eq!(a.in_cycle, vec![true, true]);
+        assert_topo_consistent(&a, 2, &edges);
+    }
+
+    #[test]
+    fn chain_is_acyclic_with_deps_first_topo() {
+        // 0 reads 1, 1 reads 2: topo must be [2, 1, 0].
+        let edges = vec![(0, 1), (1, 2)];
+        let a = analyze(3, edges.clone());
+        assert_eq!(a.cycle_count, 0);
+        assert_eq!(a.in_cycle, vec![false; 3]);
+        assert_eq!(a.topo, vec![2, 1, 0]);
+        assert_topo_consistent(&a, 3, &edges);
+    }
+
+    #[test]
+    fn disjoint_components_cycle_and_chain() {
+        // Component A: 0 <-> 1 (cycle). Component B: 2 reads 3 (chain).
+        // Node 4 isolated.
+        let edges = vec![(0, 1), (1, 0), (2, 3)];
+        let a = analyze(5, edges.clone());
+        assert_eq!(a.cycle_count, 1);
+        assert_eq!(a.in_cycle, vec![true, true, false, false, false]);
+        assert_topo_consistent(&a, 5, &edges);
+    }
+
+    #[test]
+    fn cycle_with_downstream_reader() {
+        // 2 reads the cycle {0,1}; 3 reads 2.
+        let edges = vec![(0, 1), (1, 0), (2, 0), (3, 2)];
+        let a = analyze(4, edges.clone());
+        assert_eq!(a.cycle_count, 1);
+        assert_eq!(a.in_cycle, vec![true, true, false, false]);
+        let pos = a.topo_positions();
+        assert!(pos[0] < pos[2] && pos[1] < pos[2] && pos[2] < pos[3]);
+    }
+
+    #[test]
+    fn two_distinct_cycles_counted() {
+        let edges = vec![(0, 1), (1, 0), (2, 2)];
+        let a = analyze(3, edges);
+        assert_eq!(a.cycle_count, 2);
+        assert_eq!(a.in_cycle, vec![true, true, true]);
+    }
+
+    #[test]
+    fn deterministic_for_same_input() {
+        let edges = vec![(0, 2), (1, 2), (2, 3), (4, 0), (4, 1)];
+        let a1 = analyze(5, edges.clone());
+        let a2 = analyze(5, edges);
+        assert_eq!(a1, a2);
+    }
+}

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -606,6 +606,11 @@ pub struct EvalConfig {
     /// Spill behavior configuration (conflicts, bounds, buffering)
     pub spill: SpillConfig,
 
+    /// Cycle handling configuration (detection mode + policy). Defaults to
+    /// `CycleDetection::Static` (today's stamp-every-static-SCC behavior);
+    /// `CycleDetection::Runtime` is opt-in (RFC #112).
+    pub cycle: CycleConfig,
+
     /// Use dynamic topological ordering (Pearce-Kelly algorithm)
     pub use_dynamic_topo: bool,
     /// Maximum nodes to visit before falling back to full rebuild
@@ -696,6 +701,7 @@ impl Default for EvalConfig {
             stripe_width: 256,
             enable_block_stripes: false,
             spill: SpillConfig::default(),
+            cycle: CycleConfig::default(),
 
             // Dynamic topology configuration
             use_dynamic_topo: false, // Disabled by default for compatibility
@@ -791,6 +797,46 @@ impl EvalConfig {
         self.formula_plane_mode = mode;
         self
     }
+
+    #[inline]
+    pub fn with_cycle(mut self, cycle: CycleConfig) -> Self {
+        self.cycle = cycle;
+        self
+    }
+}
+
+/// Cycle handling configuration (spec: `formualizer-cycle-semantics-spec.md` §2).
+///
+/// Nested under [`EvalConfig`] like [`SpillConfig`]; flows through
+/// `WorkbookConfig.eval` automatically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CycleConfig {
+    pub detection: CycleDetection,
+    pub policy: CyclePolicy,
+}
+
+/// How statically-cyclic SCCs are treated at evaluation time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CycleDetection {
+    /// Today's behavior: every static SCC is stamped `#CIRC!`. Compat escape
+    /// hatch; no live-edge machinery runs.
+    #[default]
+    Static,
+    /// Static SCCs are candidates; members are evaluated with live-edge
+    /// recording and only *live* cycles get the policy verdict. Phantom
+    /// (live-acyclic) SCCs produce ordinary values (discussion #99).
+    Runtime,
+}
+
+/// What happens to witnessed (live) cycles under `CycleDetection::Runtime`.
+///
+/// `Iterate` (Excel-style iterative calculation) is Stage 3 and intentionally
+/// absent from this enum until then (no dead config).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CyclePolicy {
+    /// Live cycles produce `#CIRC!`.
+    #[default]
+    Error,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -13,6 +13,7 @@ pub mod ingest_builder;
 pub(crate) mod ingest_pipeline;
 pub mod journal;
 pub mod live_edges;
+pub mod live_graph;
 pub mod lookup_index_cache;
 pub mod plan;
 pub mod range_view;

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -45,7 +45,8 @@ mod tests;
 
 pub use arena::AstNodeId;
 pub use eval::{
-    Engine, EngineAction, EngineBaselineStats, EvalResult, RecalcPlan, VirtualDepTelemetry,
+    CycleTelemetry, Engine, EngineAction, EngineBaselineStats, EvalResult, RecalcPlan,
+    VirtualDepTelemetry,
 };
 pub use eval_delta::{DeltaMode, EvalDelta};
 pub use formula_ingest::{FormulaIngestBatch, FormulaIngestRecord, FormulaIngestReport};

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -137,5 +137,6 @@ mod visibility_mask_cache;
 
 mod demand_subgraph_named_range;
 mod dn_range_xlsx_subgraph;
-mod short_circuit_dispatch;
 mod live_edges;
+mod scc_runtime_cycles;
+mod short_circuit_dispatch;

--- a/crates/formualizer-eval/src/engine/tests/scc_runtime_cycles.rs
+++ b/crates/formualizer-eval/src/engine/tests/scc_runtime_cycles.rs
@@ -1,0 +1,1007 @@
+//! Stage 2 — SCC evaluation under `CycleDetection::Runtime` (RFC #112).
+//!
+//! Test inventory from `formualizer-stage2-scc-evaluation-design.md` §5 and
+//! the spec's §7 Error-policy subset: phantom (guarded) cycles produce
+//! values, live cycles produce `#CIRC!` with live-cycle-only blast radius,
+//! and `CycleDetection::Static` (the default) stays byte-for-byte today's
+//! behavior.
+
+use crate::engine::graph::editor::undo_engine::UndoEngine;
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig};
+use crate::reference::{CellRef, Coord, RangeRef};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue, PackedSheetCell};
+use formualizer_parse::parser::parse;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+fn runtime_cycle() -> CycleConfig {
+    CycleConfig {
+        detection: CycleDetection::Runtime,
+        policy: CyclePolicy::Error,
+    }
+}
+
+fn runtime_cfg() -> EvalConfig {
+    EvalConfig::default()
+        .with_cycle(runtime_cycle())
+        .with_virtual_dep_telemetry(true)
+}
+
+fn runtime_engine() -> Engine<TestWorkbook> {
+    Engine::new(TestWorkbook::new(), runtime_cfg())
+}
+
+fn static_engine() -> Engine<TestWorkbook> {
+    Engine::new(TestWorkbook::new(), EvalConfig::default())
+}
+
+fn set_formula(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, f: &str) {
+    engine
+        .set_cell_formula(sheet, row, col, parse(f).expect("parse"))
+        .expect("set formula");
+}
+
+fn set_value(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, v: LiteralValue) {
+    engine
+        .set_cell_value(sheet, row, col, v)
+        .expect("set value");
+}
+
+fn num(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> f64 {
+    match engine.get_cell_value(sheet, row, col) {
+        Some(LiteralValue::Number(n)) => n,
+        Some(LiteralValue::Int(i)) => i as f64,
+        other => panic!("expected number at {sheet} r{row}c{col}, got {other:?}"),
+    }
+}
+
+fn is_circ(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> bool {
+    matches!(
+        engine.get_cell_value(sheet, row, col),
+        Some(LiteralValue::Error(e)) if e.kind == ExcelErrorKind::Circ
+    )
+}
+
+/// Build the discussion-#99 guarded pair: A1 guard, A2/A3 the static SCC.
+fn build_99_pair(engine: &mut Engine<TestWorkbook>, guard: bool) {
+    set_value(engine, "Sheet1", 1, 1, LiteralValue::Boolean(guard));
+    set_formula(engine, "Sheet1", 2, 1, "=IF(A1,555,A3)");
+    set_formula(engine, "Sheet1", 3, 1, "=IF(A1,A2,999)");
+}
+
+/* ───────────────────────── 7.1 self-reference ───────────────────────── */
+
+/// Engine rule that PRE-EMPTS spec §7.1's eval-time `#CIRC!`: a direct
+/// self-reference (`=A1+1` in A1, or an expanded range containing the cell)
+/// is rejected when the formula is SET ("Self-reference detected"). Runtime
+/// mode must not change that edit-time rule. Eval-time self-loop handling is
+/// still exercised through dynamic refs (see the INDIRECT tests) and the
+/// `live_graph` unit tests.
+#[test]
+fn direct_self_reference_rejected_at_ingest_in_both_modes() {
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        let err = engine
+            .set_cell_formula("Sheet1", 1, 1, parse("=A1+1").unwrap())
+            .unwrap_err();
+        assert_eq!(err.kind, ExcelErrorKind::Circ);
+        // Dense range covering the cell expands to direct deps → same rule.
+        let err = engine
+            .set_cell_formula("Sheet1", 5, 1, parse("=SUM(A1:A10)").unwrap())
+            .unwrap_err();
+        assert_eq!(err.kind, ExcelErrorKind::Circ);
+    }
+}
+
+#[test]
+fn live_two_cycle_is_circ_via_evaluate_all_and_evaluate_cell() {
+    let mut engine = runtime_engine();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=B1+1");
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1+1");
+    let res = engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 1, 1));
+    assert!(is_circ(&engine, "Sheet1", 1, 2));
+    assert_eq!(res.cycle_errors, 1);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.static_sccs, 1);
+    assert_eq!(t.phantom_sccs, 0);
+    assert_eq!(t.live_cycles_witnessed, 1);
+    assert_eq!(t.circ_cells_stamped, 2);
+
+    let mut engine = runtime_engine();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=B1+1");
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1+1");
+    let v = engine.evaluate_cell("Sheet1", 1, 1).unwrap();
+    assert!(
+        matches!(v, Some(LiteralValue::Error(ref e)) if e.kind == ExcelErrorKind::Circ),
+        "got {v:?}"
+    );
+}
+
+/* ──────────────── 7.2 #99 guarded pair — both polarities ─────────────── */
+
+#[test]
+fn guarded_pair_99_evaluates_to_values_under_runtime() {
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    let res = engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+    assert_eq!(res.cycle_errors, 0, "phantom SCC must not count as a cycle");
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.static_sccs, 1);
+    assert_eq!(t.phantom_sccs, 1);
+    assert_eq!(t.live_cycles_witnessed, 0);
+    assert_eq!(t.circ_cells_stamped, 0);
+    // A2 is ordered first and A3 reads it fresh: exactly one pass.
+    assert_eq!(t.settle_passes_total, 1);
+}
+
+#[test]
+fn guarded_pair_99_opposite_polarity_settles_to_values() {
+    // Same pair but the live edge points at the *later*-ordered member:
+    // A2 = IF(A1, A3, 999), A3 = IF(A1, 555, A2). With A1=TRUE the live
+    // edge is A2→A3 and A2 runs first, so one settle re-eval is needed.
+    let mut engine = runtime_engine();
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Boolean(true));
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(A1,A3,999)");
+    set_formula(&mut engine, "Sheet1", 3, 1, "=IF(A1,555,A2)");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.phantom_sccs, 1);
+    assert_eq!(t.settle_passes_total, 2, "polarity flip costs one settle");
+}
+
+#[test]
+fn guarded_pair_99_guard_flip_between_recalcs_reverses_values() {
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+
+    // Flip the guard: live edges reverse, values follow.
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Boolean(false));
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 999.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 999.0);
+    assert_eq!(engine.last_cycle_telemetry().phantom_sccs, 1);
+
+    // And back.
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Boolean(true));
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+}
+
+#[test]
+fn guarded_pair_99_via_evaluate_cell_both_polarities() {
+    // Demand path (evaluate_until under the hood): the demand closure pulls
+    // the whole SCC via static deps and evaluates it as one task.
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    let v = engine.evaluate_cell("Sheet1", 2, 1).unwrap();
+    assert_eq!(v, Some(LiteralValue::Number(555.0)));
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, false);
+    let v = engine.evaluate_cell("Sheet1", 3, 1).unwrap();
+    assert_eq!(v, Some(LiteralValue::Number(999.0)));
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 999.0);
+}
+
+#[test]
+fn guarded_chains_three_and_five_cells_mixed_polarity() {
+    // 3-cell guarded ring: every static edge exists, live edges form a chain.
+    let mut engine = runtime_engine();
+    set_value(&mut engine, "Sheet1", 1, 7, LiteralValue::Boolean(true)); // G1
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(G1,100,A2)");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(G1,A1,A3)");
+    set_formula(&mut engine, "Sheet1", 3, 1, "=IF(G1,A2,100)");
+    engine.evaluate_all().unwrap();
+    for r in 1..=3 {
+        assert_eq!(num(&engine, "Sheet1", r, 1), 100.0, "row {r}");
+    }
+    assert_eq!(engine.last_cycle_telemetry().phantom_sccs, 1);
+
+    // Flip: live edges reverse direction (reads now go down the column,
+    // against member order → settling required).
+    set_value(&mut engine, "Sheet1", 1, 7, LiteralValue::Boolean(false));
+    engine.evaluate_all().unwrap();
+    for r in 1..=3 {
+        assert_eq!(num(&engine, "Sheet1", r, 1), 100.0, "row {r} after flip");
+    }
+
+    // 5-cell ring with mixed polarity guards.
+    let mut engine = runtime_engine();
+    set_value(&mut engine, "Sheet1", 1, 7, LiteralValue::Boolean(true));
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(G1,42,B5)");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(G1,A1,B1)"); // reads up (fresh)
+    set_formula(&mut engine, "Sheet1", 3, 1, "=IF(NOT(G1),B1,A2)"); // reads up (fresh)
+    set_formula(&mut engine, "Sheet1", 4, 1, "=IF(G1,A5,A3)"); // reads DOWN (stale)
+    set_formula(&mut engine, "Sheet1", 5, 1, "=IF(G1,A3,A4)"); // reads up
+    // Static ring closure: B5 referenced by A1's untaken branch.
+    set_formula(&mut engine, "Sheet1", 5, 2, "=A1");
+    engine.evaluate_all().unwrap();
+    for r in 1..=5 {
+        assert_eq!(num(&engine, "Sheet1", r, 1), 42.0, "row {r}");
+    }
+}
+
+/* ─────────────── 7.3 guard inside the cycle (always live) ────────────── */
+
+#[test]
+fn guard_reading_cycle_member_is_a_live_cycle() {
+    // Spec §7.3's literal example (`=IF(A1, A2+1, 5)` in A2) contains a
+    // direct self-reference and is rejected at ingest; the same semantics —
+    // a guard read that is itself a live edge into the cycle — is built with
+    // two cells: A1's GUARD always reads A2, and A2 always reads A1, so the
+    // live subgraph is cyclic in every guard state.
+    for guard_seed in [0.0, 9.0] {
+        let mut engine = runtime_engine();
+        set_value(
+            &mut engine,
+            "Sheet1",
+            1,
+            2,
+            LiteralValue::Number(guard_seed),
+        );
+        set_formula(&mut engine, "Sheet1", 1, 1, "=IF(A2>0,A2+1,5)");
+        set_formula(&mut engine, "Sheet1", 2, 1, "=A1+B1");
+        engine.evaluate_all().unwrap();
+        assert!(is_circ(&engine, "Sheet1", 1, 1), "seed {guard_seed}");
+        assert!(is_circ(&engine, "Sheet1", 2, 1), "seed {guard_seed}");
+        assert_eq!(engine.last_cycle_telemetry().live_cycles_witnessed, 1);
+    }
+}
+
+/* ─────────────── 7.4 arithmetic routing — always live ────────────────── */
+
+#[test]
+fn arithmetic_routing_stays_circ() {
+    // Both operands of `+`/`*` always evaluate: the reads genuinely occur,
+    // so the cycle is live regardless of the mixing weight g (A1).
+    let mut engine = runtime_engine();
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(0.0)); // g
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1*99+(1-A1)*C1"); // B1
+    set_formula(&mut engine, "Sheet1", 1, 3, "=A1*B1+(1-A1)*7"); // C1
+    engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 1, 2));
+    assert!(is_circ(&engine, "Sheet1", 1, 3));
+}
+
+/* ─────────────────────── 7.8 range self-inclusion ────────────────────── */
+
+#[test]
+fn range_mediated_live_cycle_is_circ() {
+    // A5 ranges over B1:B10 which contains B5 = A5: the rect read records a
+    // live edge into B5 and the cycle is witnessed. (Direct self-inclusion —
+    // `=SUM(A1:A10)` in A5 — is rejected at ingest; see the §7.1 test.)
+    let mut engine = runtime_engine();
+    for r in 1..=10u32 {
+        if r != 5 {
+            set_value(&mut engine, "Sheet1", r, 2, LiteralValue::Number(r as f64));
+        }
+    }
+    set_formula(&mut engine, "Sheet1", 5, 1, "=SUM(B1:B10)");
+    set_formula(&mut engine, "Sheet1", 5, 2, "=A5");
+    engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 5, 1));
+    assert!(is_circ(&engine, "Sheet1", 5, 2));
+    assert_eq!(engine.last_cycle_telemetry().live_cycles_witnessed, 1);
+}
+
+#[test]
+fn range_mediated_guarded_cycle_is_phantom_until_guard_flips() {
+    // Same shape but the range read sits in a guarded branch: phantom while
+    // the guard holds (Static would stamp #CIRC — documented diff), live
+    // cycle when it flips.
+    let mut engine = runtime_engine();
+    set_value(&mut engine, "Sheet1", 1, 7, LiteralValue::Boolean(true)); // G1
+    for r in 1..=10u32 {
+        if r != 5 {
+            set_value(&mut engine, "Sheet1", r, 2, LiteralValue::Number(1.0));
+        }
+    }
+    set_formula(&mut engine, "Sheet1", 5, 1, "=IF(G1,5,SUM(B1:B10))");
+    set_formula(&mut engine, "Sheet1", 5, 2, "=A5");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 5, 1), 5.0);
+    assert_eq!(num(&engine, "Sheet1", 5, 2), 5.0);
+    assert_eq!(engine.last_cycle_telemetry().phantom_sccs, 1);
+
+    set_value(&mut engine, "Sheet1", 1, 7, LiteralValue::Boolean(false));
+    engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 5, 1));
+    assert!(is_circ(&engine, "Sheet1", 5, 2));
+}
+
+#[test]
+fn named_range_covering_the_cell_rejected_at_ingest_in_both_modes() {
+    // A name whose region covers the formula's own cell is rejected when the
+    // formula is set ("Circular reference through named range") — existing
+    // engine rule, identical under Runtime.
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        let sheet_id = engine.sheet_id("Sheet1").unwrap();
+        let nr = RangeRef::new(
+            CellRef::new(sheet_id, Coord::from_excel(1, 1, true, true)),
+            CellRef::new(sheet_id, Coord::from_excel(10, 1, true, true)),
+        );
+        engine
+            .define_name("COVER", NamedDefinition::Range(nr), NameScope::Workbook)
+            .unwrap();
+        let err = engine
+            .set_cell_formula("Sheet1", 5, 1, parse("=SUM(COVER)").unwrap())
+            .unwrap_err();
+        assert_eq!(err.kind, ExcelErrorKind::Circ);
+    }
+}
+
+/// KNOWN GAP (pre-existing, pre-dates #112 — static dependency extraction,
+/// not Runtime evaluation): whole-column self-inclusion `=SUM(B:B)` in B1 is
+/// not detected as a static SCC, so no cycle unit exists for either mode to
+/// handle. Spec §7.8's stripe-path `#CIRC!` is therefore NOT yet delivered;
+/// this test pins that Runtime at least matches Static exactly (no silent
+/// divergence) until the detection gap is fixed.
+#[test]
+fn whole_column_self_inclusion_gap_runtime_matches_static() {
+    let run = |cfg: EvalConfig| {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        for r in 2..=4u32 {
+            set_value(&mut engine, "Sheet1", r, 2, LiteralValue::Number(r as f64));
+        }
+        set_formula(&mut engine, "Sheet1", 1, 2, "=SUM(B:B)");
+        let res = engine.evaluate_all().unwrap();
+        (engine.get_cell_value("Sheet1", 1, 2), res.cycle_errors)
+    };
+    let static_out = run(EvalConfig::default());
+    let runtime_out = run(runtime_cfg());
+    assert_eq!(static_out, runtime_out);
+    // Document today's (incorrect per spec §7.8) value so a future detection
+    // fix must consciously update this pin.
+    assert_eq!(static_out.0, Some(LiteralValue::Number(9.0)));
+    assert_eq!(static_out.1, 0);
+}
+
+/* ──────────────────── 7.9 spill anchor inside an SCC ─────────────────── */
+
+#[test]
+fn spill_anchor_in_scc_is_circ_and_region_freed() {
+    let mut engine = runtime_engine();
+    // Prime: B1 spills SEQUENCE(C1) with C1 = 3 → B1:B3.
+    set_value(&mut engine, "Sheet1", 1, 3, LiteralValue::Number(3.0));
+    set_formula(&mut engine, "Sheet1", 1, 2, "=SEQUENCE(C1)");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 2), 2.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 2), 3.0);
+
+    // Introduce the cycle: C1 = B1 + 1 ⇒ static SCC {B1, C1}.
+    set_formula(&mut engine, "Sheet1", 1, 3, "=B1+1");
+    engine.evaluate_all().unwrap();
+
+    // Anchor pre-stamped #CIRC with spill teardown (spec §7.9, #115).
+    assert!(is_circ(&engine, "Sheet1", 1, 2));
+    for r in 2..=3 {
+        assert!(
+            matches!(
+                engine.get_cell_value("Sheet1", r, 2),
+                None | Some(LiteralValue::Empty)
+            ),
+            "spilled B{r} must be cleared, got {:?}",
+            engine.get_cell_value("Sheet1", r, 2)
+        );
+    }
+    // C1 reads the stamped anchor: #CIRC propagates through arithmetic.
+    assert!(is_circ(&engine, "Sheet1", 1, 3));
+
+    // Region freed: a new spill into the former region succeeds.
+    set_formula(&mut engine, "Sheet1", 2, 2, "=SEQUENCE(2)");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 2), 1.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 2), 2.0);
+}
+
+#[test]
+fn array_result_first_produced_inside_scc_is_stamped() {
+    // A member that would *become* a spill anchor during the SCC task gets
+    // the conservative §7.9 verdict instead of spilling.
+    let mut engine = runtime_engine();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=SEQUENCE(2)+0*A2");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=A1");
+    engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 1, 1));
+    assert!(
+        is_circ(&engine, "Sheet1", 2, 1),
+        "readers see propagated #CIRC"
+    );
+}
+
+/* ───────────── 7.13 cross-sheet and named-formula members ────────────── */
+
+#[test]
+fn cross_sheet_phantom_scc_produces_values() {
+    let mut engine = runtime_engine();
+    engine.add_sheet("Sheet2").unwrap();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(TRUE,5,Sheet2!A1)");
+    set_formula(&mut engine, "Sheet2", 1, 1, "=Sheet1!A1+1");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 5.0);
+    assert_eq!(num(&engine, "Sheet2", 1, 1), 6.0);
+    assert_eq!(engine.last_cycle_telemetry().phantom_sccs, 1);
+}
+
+/// Entering a cell formula that reads a name already depending on that cell
+/// is rejected at ingest in both modes (existing rule).
+#[test]
+fn named_formula_cycle_rejected_at_ingest_in_both_modes() {
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        engine
+            .define_name(
+                "N",
+                NamedDefinition::Formula {
+                    ast: parse("=A1+1").unwrap(),
+                    dependencies: Vec::new(),
+                    range_deps: Vec::new(),
+                },
+                NameScope::Workbook,
+            )
+            .unwrap();
+        let err = engine
+            .set_cell_formula("Sheet1", 1, 1, parse("=N").unwrap())
+            .unwrap_err();
+        assert_eq!(err.kind, ExcelErrorKind::Circ);
+    }
+}
+
+/// Direct SCC-task test for name-vertex members (spec §7.13): the scheduler
+/// cannot currently produce a {cell, name} SCC (no static name-cycle edges),
+/// so drive `evaluate_scc_unit` with the membership directly. Pass 1 records
+/// the cell's read OF the name (by folded key) and the name's read of the
+/// cell — a witnessed live cycle stamping both.
+#[test]
+fn named_formula_member_live_cycle_is_circ_in_scc_task() {
+    let mut engine = runtime_engine();
+    engine
+        .define_name(
+            "N",
+            NamedDefinition::Literal(LiteralValue::Number(1.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=N");
+    engine.evaluate_all().unwrap();
+    // Re-point the name at a formula reading A1 (allowed via update path).
+    engine
+        .graph
+        .update_name(
+            "N",
+            NamedDefinition::Formula {
+                ast: parse("=A1+1").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let a1 = *engine
+        .graph
+        .get_vertex_id_for_address(&CellRef::new(sheet_id, Coord::from_excel(1, 1, true, true)))
+        .unwrap();
+    let n = engine
+        .graph
+        .resolve_name_entry("N", sheet_id)
+        .expect("name entry")
+        .vertex;
+
+    let stamped = engine.evaluate_scc_unit(&[a1, n], None, None).unwrap();
+    assert_eq!(stamped, 2, "both the cell and the name member are stamped");
+    assert!(is_circ(&engine, "Sheet1", 1, 1));
+    assert!(matches!(
+        engine.graph.get_value(n),
+        Some(LiteralValue::Error(ref e)) if e.kind == ExcelErrorKind::Circ
+    ));
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.live_cycles_witnessed, 1);
+    assert_eq!(t.circ_cells_stamped, 2);
+}
+
+/// Phantom counterpart: the cell's guarded branch never reads the name, so
+/// the SCC task produces values for both members.
+#[test]
+fn named_formula_member_phantom_produces_values_in_scc_task() {
+    let mut engine = runtime_engine();
+    engine
+        .define_name(
+            "N",
+            NamedDefinition::Literal(LiteralValue::Number(1.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(TRUE,2,N)");
+    engine.evaluate_all().unwrap();
+    engine
+        .graph
+        .update_name(
+            "N",
+            NamedDefinition::Formula {
+                ast: parse("=A1+1").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let a1 = *engine
+        .graph
+        .get_vertex_id_for_address(&CellRef::new(sheet_id, Coord::from_excel(1, 1, true, true)))
+        .unwrap();
+    let n = engine
+        .graph
+        .resolve_name_entry("N", sheet_id)
+        .expect("name entry")
+        .vertex;
+
+    let stamped = engine.evaluate_scc_unit(&[a1, n], None, None).unwrap();
+    assert_eq!(stamped, 0);
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 2.0);
+    assert_eq!(engine.graph.get_value(n), Some(LiteralValue::Number(3.0)));
+    assert_eq!(engine.last_cycle_telemetry().phantom_sccs, 1);
+}
+
+/* ───────────── 7.14 user value over a formula member ─────────────────── */
+
+#[test]
+fn user_value_over_formula_removes_it_from_the_scc() {
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 1);
+
+    // Overwrite A3 with a literal: its formula is removed (engine rule), so
+    // no static SCC remains.
+    set_value(&mut engine, "Sheet1", 3, 1, LiteralValue::Number(777.0));
+    let res = engine.evaluate_all().unwrap();
+    assert_eq!(res.cycle_errors, 0);
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 0);
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 777.0);
+}
+
+/* ─────────────────────────── blast radius ────────────────────────────── */
+
+#[test]
+fn blast_radius_only_live_cycle_members_are_stamped() {
+    // 10-member static ring C1..C10 (each row r references row r+1 in an
+    // untaken branch; C10 closes the ring to C1). Only C5↔C6 is live.
+    let mut engine = runtime_engine();
+    for r in 1..=10u32 {
+        let f = match r {
+            5 => "=IF(TRUE,C6,C6)".to_string(), // live edge C5→C6 (both arms)
+            6 => "=IF(TRUE,C5,C7)".to_string(), // live edge C6→C5
+            10 => "=IF(TRUE,100,C1)".to_string(),
+            _ => format!("=IF(TRUE,{},C{})", r * 10, r + 1),
+        };
+        set_formula(&mut engine, "Sheet1", r, 3, &f);
+    }
+    let res = engine.evaluate_all().unwrap();
+
+    assert!(is_circ(&engine, "Sheet1", 5, 3), "C5 on the live cycle");
+    assert!(is_circ(&engine, "Sheet1", 6, 3), "C6 on the live cycle");
+    for r in [1u32, 2, 3, 4, 7, 8, 9] {
+        assert_eq!(num(&engine, "Sheet1", r, 3), (r * 10) as f64, "C{r}");
+    }
+    assert_eq!(num(&engine, "Sheet1", 10, 3), 100.0);
+
+    assert_eq!(res.cycle_errors, 1);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.static_sccs, 1);
+    assert_eq!(t.live_cycles_witnessed, 1);
+    assert_eq!(t.circ_cells_stamped, 2, "exactly the live-cycle members");
+    assert_eq!(t.phantom_sccs, 0);
+}
+
+/* ─────────────────────────── settle mechanics ────────────────────────── */
+
+#[test]
+fn engineered_stale_reader_settles_to_exact_values() {
+    // A1 (ordered first) live-reads A2 (ordered later): pass 1 sees A2's
+    // pre-task value, the settle pass fixes it.
+    let mut engine = runtime_engine();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(TRUE,A2,0)");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(TRUE,7,A1)");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 7.0);
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 7.0);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.phantom_sccs, 1);
+    assert_eq!(t.settle_passes_total, 2);
+    assert_eq!(t.max_passes_single_scc, 2);
+}
+
+#[test]
+fn branch_flip_during_settle_creating_live_cycle_is_circ() {
+    // Pass 1 is acyclic; C1's settle re-eval flips its branch onto C3,
+    // closing a live cycle C1↔C3 that only classification-after-settle sees.
+    let mut engine = runtime_engine();
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(A2=999,A3,7)");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(TRUE,999,A1)");
+    set_formula(&mut engine, "Sheet1", 3, 1, "=IF(TRUE,A1,8)");
+    engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 1, 1), "A1 joins the live cycle");
+    assert!(is_circ(&engine, "Sheet1", 3, 1), "A3 joins the live cycle");
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 999.0, "A2 keeps its value");
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.live_cycles_witnessed, 1);
+    assert_eq!(t.circ_cells_stamped, 2);
+    assert_eq!(t.capped_sccs, 0);
+}
+
+/* ───────────────────────────── side effects ──────────────────────────── */
+
+#[test]
+fn one_delta_per_member_per_recalc() {
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    let (_res, delta) = engine.evaluate_all_with_delta().unwrap();
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let mut expected = vec![
+        PackedSheetCell::try_new(sheet_id, 1, 0).unwrap(), // A2 (0-based r1c0)
+        PackedSheetCell::try_new(sheet_id, 2, 0).unwrap(), // A3
+    ];
+    expected.sort_unstable();
+    assert_eq!(delta.changed_cells, expected);
+
+    // No changes → no deltas (values persist, the SCC isn't re-stamped).
+    let (_res, delta) = engine.evaluate_all_with_delta().unwrap();
+    assert!(
+        delta.changed_cells.is_empty(),
+        "got {:?}",
+        delta.changed_cells
+    );
+
+    // Guard flip: exactly one delta per member again.
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Boolean(false));
+    let (_res, delta) = engine.evaluate_all_with_delta().unwrap();
+    assert_eq!(delta.changed_cells, expected);
+}
+
+#[test]
+fn evaluation_writes_do_not_hit_the_changelog() {
+    // G11 confirm: `evaluate_all_logged` records only spill events for
+    // computed results; Runtime SCC commits must not add anything either.
+    use crate::engine::ChangeLog;
+    use crate::engine::graph::editor::change_log::ChangeEvent;
+
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    let mut log = ChangeLog::new();
+    engine.evaluate_all_logged(&mut log).unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    for ev in log.events() {
+        assert!(
+            matches!(
+                ev,
+                ChangeEvent::CompoundStart { .. } | ChangeEvent::CompoundEnd { .. }
+            ),
+            "unexpected changelog event from SCC evaluation: {ev:?}"
+        );
+    }
+}
+
+#[test]
+fn undo_of_the_triggering_edit_restores_pre_recalc_values() {
+    let mut engine = runtime_engine();
+    let mut undo = UndoEngine::new();
+
+    let (_v, journal) = engine
+        .action_atomic_journal("seed".to_string(), |tx| {
+            tx.set_cell_value("Sheet1", 1, 1, LiteralValue::Boolean(true))?;
+            tx.set_cell_formula("Sheet1", 2, 1, parse("=IF(A1,555,A3)").unwrap())?;
+            tx.set_cell_formula("Sheet1", 3, 1, parse("=IF(A1,A2,999)").unwrap())?;
+            Ok(())
+        })
+        .unwrap();
+    undo.push_action(journal);
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+
+    let (_v, journal) = engine
+        .action_atomic_journal("flip".to_string(), |tx| {
+            tx.set_cell_value("Sheet1", 1, 1, LiteralValue::Boolean(false))?;
+            Ok(())
+        })
+        .unwrap();
+    undo.push_action(journal);
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 999.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 999.0);
+
+    // Undo the flip and recalc: pre-flip values come back.
+    engine.undo_action(&mut undo).unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+}
+
+#[test]
+fn cancellation_is_honored_at_settle_pass_boundaries() {
+    use crate::args::ArgSchema;
+    use crate::function::{FnCaps, Function};
+    use crate::traits::{ArgumentHandle, FunctionContext};
+
+    // TRIP() sets the cancel flag as a side effect of pass 1; the SCC task's
+    // per-settle-pass check must observe it before re-evaluating.
+    #[derive(Debug)]
+    struct TripFn(Arc<AtomicBool>);
+    impl Function for TripFn {
+        fn caps(&self) -> FnCaps {
+            FnCaps::empty()
+        }
+        fn name(&self) -> &'static str {
+            "TRIPCANCEL"
+        }
+        fn arg_schema(&self) -> &'static [ArgSchema] {
+            &[]
+        }
+        fn eval<'a, 'b, 'c>(
+            &self,
+            _args: &'c [ArgumentHandle<'a, 'b>],
+            _ctx: &dyn FunctionContext<'b>,
+        ) -> Result<crate::traits::CalcValue<'b>, formualizer_common::ExcelError> {
+            self.0.store(true, Ordering::Relaxed);
+            Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(0)))
+        }
+    }
+
+    let flag = Arc::new(AtomicBool::new(false));
+    let wb = TestWorkbook::new().with_function(Arc::new(TripFn(flag.clone())));
+    let mut engine = Engine::new(wb, runtime_cfg());
+    // Stale-reader shape: A1 needs a settle pass, A2's pass-1 evaluation
+    // trips the flag.
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(TRUE,A2,0)");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(TRUE,7+TRIPCANCEL(),A1)");
+    let err = engine.evaluate_all_cancellable(flag).unwrap_err();
+    assert_eq!(err.kind, ExcelErrorKind::Cancelled);
+    assert!(
+        err.message.as_deref().unwrap_or("").contains("SCC"),
+        "cancellation must come from the SCC pass boundary, got {err:?}"
+    );
+}
+
+/* ───────────────────── G12: INDIRECT inside an SCC ───────────────────── */
+
+#[test]
+fn indirect_cycle_through_replan_then_target_change_breaks_it() {
+    // A1 = INDIRECT(D1)+1 with D1 → "B1" and B1 = A1+1: the virtual edge
+    // closes a 2-vertex SCC (tarjan_scc_with_virtual); both members are
+    // live (arithmetic) → #CIRC. (A single-vertex virtual SELF-edge does not
+    // form a cycle unit today — pre-existing scheduler behavior, identical
+    // under Static — so the pair shape is the canonical G12 case.)
+    let mut engine = runtime_engine();
+    set_value(
+        &mut engine,
+        "Sheet1",
+        1,
+        4,
+        LiteralValue::Text("B1".to_string()),
+    );
+    set_formula(&mut engine, "Sheet1", 1, 1, "=INDIRECT(D1)+1");
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1+1");
+    engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 1, 1));
+    assert!(is_circ(&engine, "Sheet1", 1, 2));
+
+    // Re-point the dynamic ref: the outer replan loop drops the virtual
+    // edge and both cells evaluate normally.
+    set_value(&mut engine, "Sheet1", 3, 1, LiteralValue::Number(10.0)); // A3
+    set_value(
+        &mut engine,
+        "Sheet1",
+        1,
+        4,
+        LiteralValue::Text("A3".to_string()),
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 11.0);
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 12.0);
+}
+
+#[test]
+fn indirect_in_untaken_branch_is_phantom() {
+    // The virtual-dep builder registers INDIRECT targets statically, so the
+    // self-edge exists in the schedule; at runtime the branch never executes
+    // and the SCC is phantom.
+    let mut engine = runtime_engine();
+    set_value(
+        &mut engine,
+        "Sheet1",
+        1,
+        4,
+        LiteralValue::Text("A1".to_string()),
+    );
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(TRUE,1,INDIRECT(D1))");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 1.0);
+}
+
+/* ───────────────── recalc-plan dirty quirk under Runtime ─────────────── */
+
+#[test]
+fn recalc_plan_skips_clean_cycles_and_evaluates_dirty_ones_whole() {
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    set_formula(&mut engine, "Sheet1", 1, 5, "=1+1"); // unrelated formula E1
+
+    let plan = engine.build_recalc_plan().unwrap();
+    engine.evaluate_recalc_plan(&plan).unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 1);
+
+    // Dirty only the unrelated formula: the clean SCC must be skipped
+    // entirely (values stand, no task runs).
+    set_formula(&mut engine, "Sheet1", 1, 5, "=2+2");
+    engine.evaluate_recalc_plan(&plan).unwrap();
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 0);
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+
+    // Dirty a cycle member (via its guard): the whole SCC evaluates.
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Boolean(false));
+    engine.evaluate_recalc_plan(&plan).unwrap();
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 1);
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 999.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 999.0);
+}
+
+/* ──────────────────────── compat & determinism ───────────────────────── */
+
+#[test]
+fn static_default_keeps_stamping_the_99_pair() {
+    // Golden dual-mode pin: the only documented diff (spec §8) is values vs
+    // #CIRC for the guarded phantom pair.
+    let mut engine = static_engine();
+    build_99_pair(&mut engine, true);
+    let res = engine.evaluate_all().unwrap();
+    assert!(is_circ(&engine, "Sheet1", 2, 1));
+    assert!(is_circ(&engine, "Sheet1", 3, 1));
+    assert_eq!(res.cycle_errors, 1);
+    // Telemetry stays default-zero in Static mode.
+    assert_eq!(
+        engine.last_cycle_telemetry(),
+        &crate::engine::CycleTelemetry::default()
+    );
+}
+
+#[test]
+fn dual_mode_corpus_documented_diffs_only() {
+    // For each scenario: build identically under both modes; live cycles
+    // must be #CIRC in both, phantoms differ exactly as documented.
+    type Builder = fn(&mut Engine<TestWorkbook>);
+    type Scenario = (Builder, &'static [(u32, u32)], &'static [(u32, u32, f64)]);
+    let scenarios: Vec<Scenario> = vec![
+        // (build, circ-in-both, runtime-values)
+        (
+            |e| {
+                set_value(e, "Sheet1", 1, 7, LiteralValue::Boolean(true));
+                set_value(e, "Sheet1", 1, 2, LiteralValue::Number(1.0));
+                set_formula(e, "Sheet1", 5, 1, "=IF(G1,5,SUM(B1:B10))");
+                set_formula(e, "Sheet1", 5, 2, "=A5");
+            },
+            &[][..],
+            &[(5, 1, 5.0), (5, 2, 5.0)][..],
+        ),
+        (
+            |e| build_99_pair(e, true),
+            &[][..],
+            &[(2, 1, 555.0), (3, 1, 555.0)][..],
+        ),
+        (
+            |e| {
+                set_formula(e, "Sheet1", 1, 1, "=B1+1");
+                set_formula(e, "Sheet1", 1, 2, "=A1+1");
+            },
+            &[(1, 1), (1, 2)][..],
+            &[][..],
+        ),
+    ];
+
+    for (build, circ_both, runtime_values) in scenarios {
+        let mut st = static_engine();
+        build(&mut st);
+        st.evaluate_all().unwrap();
+        let mut rt = runtime_engine();
+        build(&mut rt);
+        rt.evaluate_all().unwrap();
+
+        for &(r, c) in circ_both {
+            assert!(is_circ(&st, "Sheet1", r, c), "static r{r}c{c}");
+            assert!(is_circ(&rt, "Sheet1", r, c), "runtime r{r}c{c}");
+        }
+        for &(r, c, v) in runtime_values {
+            assert!(
+                is_circ(&st, "Sheet1", r, c),
+                "static stamps phantoms r{r}c{c}"
+            );
+            assert_eq!(num(&rt, "Sheet1", r, c), v, "runtime value r{r}c{c}");
+        }
+    }
+}
+
+#[test]
+fn deterministic_across_thread_counts_and_repeats() {
+    fn build_and_run(threads: usize) -> (Vec<Option<LiteralValue>>, crate::engine::CycleTelemetry) {
+        let cfg = EvalConfig {
+            max_threads: Some(threads),
+            enable_parallel: threads > 1,
+            ..runtime_cfg()
+        };
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        // Mixed workbook: phantom pair + live pair + blast-radius ring +
+        // downstream readers.
+        build_99_pair(&mut engine, true);
+        set_formula(&mut engine, "Sheet1", 1, 2, "=B2+1");
+        set_formula(&mut engine, "Sheet1", 2, 2, "=B1+1");
+        for r in 1..=10u32 {
+            let f = match r {
+                5 => "=IF(TRUE,C6,C6)".to_string(),
+                6 => "=IF(TRUE,C5,C7)".to_string(),
+                10 => "=IF(TRUE,100,C1)".to_string(),
+                _ => format!("=IF(TRUE,{},C{})", r * 10, r + 1),
+            };
+            set_formula(&mut engine, "Sheet1", r, 3, &f);
+        }
+        set_formula(&mut engine, "Sheet1", 1, 4, "=A2+C1"); // downstream
+        engine.evaluate_all().unwrap();
+
+        let mut values = Vec::new();
+        for r in 1..=10u32 {
+            for c in 1..=4u32 {
+                values.push(engine.get_cell_value("Sheet1", r, c));
+            }
+        }
+        let mut telemetry = engine.last_cycle_telemetry().clone();
+        telemetry.elapsed_ms = 0; // wall clock is the only nondeterministic field
+        (values, telemetry)
+    }
+
+    let baseline = build_and_run(1);
+    for threads in [1usize, 2, 8] {
+        for run in 0..2 {
+            let out = build_and_run(threads);
+            assert_eq!(out, baseline, "threads={threads} run={run}");
+        }
+    }
+}
+
+/* ──────────────── journaled-effects site under Runtime ───────────────── */
+
+#[test]
+fn evaluate_all_logged_handles_runtime_cycles_directly() {
+    use crate::engine::ChangeLog;
+
+    // Phantom and live cycles through the ChangeLog-threaded path produce
+    // identical results to plain evaluate_all (the journal only ever records
+    // spill events, which SCC tasks never produce).
+    let mut engine = runtime_engine();
+    build_99_pair(&mut engine, true);
+    set_formula(&mut engine, "Sheet1", 1, 2, "=B2+1");
+    set_formula(&mut engine, "Sheet1", 2, 2, "=B1+1");
+    let mut log = ChangeLog::new();
+    let res = engine.evaluate_all_logged(&mut log).unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 555.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 555.0);
+    assert!(is_circ(&engine, "Sheet1", 1, 2));
+    assert!(is_circ(&engine, "Sheet1", 2, 2));
+    assert_eq!(res.cycle_errors, 1);
+}


### PR DESCRIPTION
Stage 2 of #112: statically-cyclic SCCs can now be *evaluated* instead of stamped. Guarded phantom cycles — the discussion #99 pattern — produce real values; genuinely live cycles get `#CIRC` confined to the actual cycle members. **Opt-in**: `CycleConfig { detection: Runtime, policy: Error }`; the default remains `Static` (today's behavior, byte-for-byte), with the default flip tracked for after iterative calculation lands.

## What it does

Under `Runtime` detection, the `ScheduleUnit::Cycle` arm routes to `evaluate_scc_unit`: members evaluate sequentially in spec'd order (cells by `(sheet, row, col)`, then names lexicographically) through the Stage 1 `RecordingContext`, committing write-through so later members' scalar and range reads see fresh values. Live edges — reads that actually happened, targeting members — feed a settle loop: a local SCC analysis classifies the live subgraph; acyclic means phantom (stale readers re-settle in live-topological order until exact — branches can flip mid-settle, so classification repeats, with a defensive |SCC|+2 cap and loud telemetry); a live cycle means `#CIRC` on exactly the live-cycle members plus one consistency pass for the rest. Spill-anchor members are conservatively pre-stamped (`#CIRC` + the #115 teardown); arrays first produced mid-task get the same conservative verdict. Deltas are recorded once per member per recalc against a pre-task snapshot — never per pass. Cancellation is honored at pass boundaries. `CycleTelemetry` (phantom/witnessed/stamped/passes/capped) sits beside `VirtualDepTelemetry` under the same gating.

For the #99 example under `Runtime`: `A2=IF(A1,555,A3)`, `A3=IF(A1,A2,999)` evaluates to 555/555 with `A1=TRUE`, flips correctly on recalc when `A1` changes, and `B1=B2+1 / B2=B1+1` stays `#CIRC`.

## Notable findings from implementation

- **Journaled-effects path integrates cleanly** (no fallback): evaluation `WriteCell` effects never log to the ChangeLog — only spill effects do — so Runtime's direct commits introduce no new unlogged mutation kinds vs Static. Pinned by test.
- **Pre-existing gap, now pinned**: whole-column self-inclusion (`=SUM(B:B)` in B1) never forms an SCC under either mode — the static dependency extraction misses the self-edge and the formula silently evaluates. Pre-dates this work; pinned with a Runtime==Static parity test that documents the wrong value so a future fix must consciously update it. Issue to follow.
- Ingest-time rejection (self-references, covering names) pre-empts some cycle shapes before evaluation; parity under both modes is pinned.

## Tests

42 new: the #99 pair in both polarities via both `evaluate_all` and `evaluate_cell`, guard flips between recalcs, 3/5-cell guarded chains, guard-read cycles in both states, arithmetic routing (stays `#CIRC` — both reads are live), range-mediated live and phantom cycles, spill-anchor stamping with region-freed proof, cross-sheet phantoms, named-member SCC tasks, blast radius (exactly 2 of 10 stamped), engineered stale-reader settle, branch-flip-during-settle creating a live cycle, exact per-recalc delta sets, changelog isolation, undo, cancellation mid-task, INDIRECT-in-SCC across the replan loop, recalc-plan dirty quirk (clean SCC skipped; any-dirty evaluates whole SCC), dual-mode corpus parity, and determinism across `max_threads` {1,2,8} (values + telemetry identical). Plus 8 unit tests on the live-graph SCC analysis.

Full workspace suite (CI exclusions): **2462 passed, 0 failed** (2420 baseline intact + 42). fmt and clippy `-D warnings` clean.

## Bench gate (standing rule; interleaved A/B vs main @ 2a760b11)

`linear-rollup 200k` evaluate: 814/910/864 ms vs main 862/897/972 ms; `probe-finance-recalc` p50 7.6/7.1/7.3 vs 6.6/7.9/8.1 ms — no consistent direction on either, within noise (Runtime is off by default and the acyclic path is structurally unchanged). Checksums identical.

Follow-ups tracked for the next PR (2b): FormulaPlane `CycleMember` exclusion, the property-test oracle vs a reference lazy interpreter, and the `scc_phantom_pairs_10k` bench scenario.
