### PR TITLE
feat(formula-plane): demote cycle-member spans to legacy evaluation (CycleMember fallback)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -30,9 +30,11 @@ use crate::formula_plane::producer::{
 };
 use crate::formula_plane::region_index::{DirtyDomain, Region};
 use crate::formula_plane::runtime::{
-    FormulaPlane, FormulaSpanRef, PlacementCoord, PlacementDomain, ResultRegion,
+    FormulaPlane, FormulaSpanId, FormulaSpanRef, PlacementCoord, PlacementDomain, ResultRegion,
 };
-use crate::formula_plane::scheduler::{MixedSchedule, build_mixed_schedule};
+use crate::formula_plane::scheduler::{
+    MixedSchedule, MixedScheduleFallbackReason, build_mixed_schedule,
+};
 #[cfg(test)]
 use crate::formula_plane::span_eval::SpanEvalReport;
 use crate::formula_plane::span_eval::{SpanComputedWriteSink, SpanEvalTask, SpanEvaluator};
@@ -384,6 +386,16 @@ pub struct Engine<R> {
     last_formula_ingest_report: Option<FormulaIngestReport>,
     /// Aggregate centralized formula ingest report for this engine.
     formula_ingest_report_total: FormulaIngestReport,
+    /// Count of FormulaPlane spans demoted to legacy because one or more of
+    /// their member cells participate in a statically-cyclic SCC. A span member
+    /// must never be span-evaluated (gotcha G8 of the cycle-architecture track,
+    /// refs #112): under `CycleDetection::Static` the cycle stamping would race
+    /// span writes, and under `Runtime` SCC members must be evaluated by the
+    /// legacy `evaluate_scc_unit` path. Cyclic spans are demoted at
+    /// schedule-build time (the earliest point cross-cell cycles through span
+    /// producers become visible) so the cycle members land on the legacy graph
+    /// path. Observational only.
+    formula_plane_cycle_member_span_demotions: u64,
     /// Transient cancellation flag used during evaluation
     active_cancel_flag: Option<Arc<AtomicBool>>,
 
@@ -924,6 +936,9 @@ pub struct EngineBaselineStats {
     pub formula_plane_active_span_count: usize,
     pub formula_plane_producer_result_entries: usize,
     pub formula_plane_consumer_read_entries: usize,
+    /// Number of spans demoted to legacy because a member participated in a
+    /// statically-cyclic SCC (gotcha G8, refs #112).
+    pub formula_plane_cycle_member_span_demotions: u64,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1355,6 +1370,7 @@ where
             formula_parse_diagnostics: Vec::new(),
             last_formula_ingest_report: None,
             formula_ingest_report_total: FormulaIngestReport::default(),
+            formula_plane_cycle_member_span_demotions: 0,
             active_cancel_flag: None,
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
@@ -1424,6 +1440,7 @@ where
             formula_parse_diagnostics: Vec::new(),
             last_formula_ingest_report: None,
             formula_ingest_report_total: FormulaIngestReport::default(),
+            formula_plane_cycle_member_span_demotions: 0,
             active_cancel_flag: None,
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
@@ -2116,6 +2133,8 @@ where
             formula_plane_active_span_count: formula_authority.active_span_count(),
             formula_plane_producer_result_entries: formula_authority.producer_results.len(),
             formula_plane_consumer_read_entries: formula_authority.consumer_reads.len(),
+            formula_plane_cycle_member_span_demotions: self
+                .formula_plane_cycle_member_span_demotions,
         }
     }
 
@@ -4827,6 +4846,113 @@ where
         }
         self.formula_plane_indexes_epoch_seen = 0;
         Ok(())
+    }
+
+    /// Collect the [`FormulaSpanRef`]s for span producers the mixed scheduler
+    /// reported as cycle members (gotcha G8, refs #112). These spans must be
+    /// demoted to legacy so the cycle members are resolved on the legacy SCC
+    /// path; see [`Self::demote_cyclic_spans`].
+    fn collect_cyclic_span_refs(
+        &self,
+        schedule: &MixedSchedule,
+        span_refs_by_id: &BTreeMap<FormulaSpanId, FormulaSpanRef>,
+    ) -> Vec<FormulaSpanRef> {
+        let mut refs = Vec::new();
+        for fallback in &schedule.fallbacks {
+            if fallback.reason != MixedScheduleFallbackReason::CycleDetected {
+                continue;
+            }
+            if let FormulaProducerId::Span(span_id) = fallback.producer
+                && let Some(span_ref) = span_refs_by_id.get(&span_id)
+                && !refs.contains(span_ref)
+            {
+                refs.push(*span_ref);
+            }
+        }
+        refs
+    }
+
+    /// Demote the given cyclic spans to legacy graph vertices so their member
+    /// cells participate in the legacy Tarjan SCC pass (gotcha G8, refs #112).
+    ///
+    /// Reuses the non-structural demotion seam, which materializes each span's
+    /// cells back onto the legacy graph and re-promotes any acyclic remainder
+    /// that still forms a promotable run. We pass a `Region` that covers exactly
+    /// the demote-target span domains so disjoint spans are left untouched.
+    fn demote_cyclic_spans(&mut self, span_refs: &[FormulaSpanRef]) -> Result<(), ExcelError> {
+        let mut regions: Vec<Region> = Vec::new();
+        {
+            let authority = self.graph.formula_authority();
+            for span_ref in span_refs {
+                if let Some(span) = authority.plane.spans.get(*span_ref) {
+                    regions.push(Region::from_domain(&span.domain));
+                }
+            }
+        }
+        for region in regions {
+            self.demote_spans_preserving_computed_overlays(region.sheet_id(), region)
+                .map_err(|err| {
+                    ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
+                        "FormulaPlane cycle-member span demotion failed: {err:?}"
+                    ))
+                })?;
+        }
+        self.formula_plane_cycle_member_span_demotions = self
+            .formula_plane_cycle_member_span_demotions
+            .saturating_add(span_refs.len() as u64);
+        // Mirror the demotion into the cumulative ingest report's fallback
+        // histogram so cycle exclusions are visible like every other placement
+        // fallback reason.
+        Self::record_shadow_fallback_reason(
+            &mut self.formula_ingest_report_total,
+            PlacementFallbackReason::CycleMember,
+            span_refs.len() as u64,
+        );
+        Ok(())
+    }
+
+    /// Evaluate residual *legacy-only* cyclic SCCs before the FormulaPlane
+    /// mixed schedule runs (gotcha G8, refs #112).
+    ///
+    /// After cyclic spans are demoted to legacy ([`Self::demote_cyclic_spans`]),
+    /// every cycle member is a graph vertex, so the cycle is now visible to the
+    /// legacy Tarjan pass and lives entirely among legacy producers. The mixed
+    /// schedule treats any cycle as not authoritative-safe; rather than abandon
+    /// the surviving spans by falling through to a pure-legacy `evaluate_all`,
+    /// stamp/evaluate just the cyclic SCC units here (`handle_cycle_unit` honors
+    /// `CycleDetection::Static` vs `Runtime`), clear their dirty flags, and let
+    /// the mixed schedule proceed cycle-free over the surviving spans plus the
+    /// acyclic legacy work.
+    ///
+    /// Returns the number of cyclic SCC units that stamped at least one cell.
+    fn evaluate_legacy_cycle_prepass(&mut self) -> Result<usize, ExcelError> {
+        let dirty = self.graph.get_evaluation_vertices();
+        if dirty.is_empty() {
+            return Ok(0);
+        }
+        let (schedule, _vdeps, _meta) = self.create_evaluation_schedule(&dirty)?;
+        let dirty_set: FxHashSet<VertexId> = dirty.iter().copied().collect();
+        let mut cycle_errors = 0usize;
+        let mut stamped_vertices: Vec<VertexId> = Vec::new();
+        for &unit in &schedule.units {
+            let ScheduleUnit::Cycle(i) = unit else {
+                continue;
+            };
+            let members = schedule.unit_cycle(i);
+            let stamped = self.handle_cycle_unit(members, None, Some(&dirty_set), None)?;
+            if stamped > 0 {
+                cycle_errors += 1;
+            }
+            stamped_vertices.extend(members.iter().copied());
+        }
+        // Clear dirty only on the cyclic members so the subsequent mixed
+        // schedule no longer sees them as dirty legacy producers (which is what
+        // surfaced the cycle). Acyclic legacy work stays dirty and is scheduled
+        // normally alongside the surviving spans.
+        if !stamped_vertices.is_empty() {
+            self.graph.clear_dirty_flags(&stamped_vertices);
+        }
+        Ok(cycle_errors)
     }
 
     /// Insert rows (1-based) and mirror into Arrow store when enabled
@@ -8120,15 +8246,65 @@ where
             .take_pending_changed_regions();
 
         let start = crate::instant::FzInstant::now();
-        let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) =
-            self.build_formula_plane_mixed_schedule(span_seed_mode, &pending_changed_regions)?;
+        let mut span_seed_mode = span_seed_mode;
+        let mut pending_changed_regions = pending_changed_regions;
+        // #CIRC stamps produced by demoting cyclic spans and resolving the
+        // residual legacy-only cycle ahead of the mixed schedule (gotcha G8).
+        let mut prepass_cycle_errors = 0usize;
+        const MAX_CYCLE_DEMOTE_ITERS: usize = 64;
+        let mut cycle_demote_iters = 0usize;
+        let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) = loop {
+            let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) =
+                self.build_formula_plane_mixed_schedule(span_seed_mode, &pending_changed_regions)?;
 
-        if !schedule.is_authoritative_safe() {
-            return Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
-                "FormulaPlane mixed schedule is not authoritative-safe: {:?}",
-                schedule.fallbacks
-            )));
-        }
+            if schedule.is_authoritative_safe() {
+                break (schedule, span_refs_by_id, plane_epoch, legacy_vertices);
+            }
+
+            // Gotcha G8 (refs #112): a span whose member cell participates in a
+            // statically-cyclic SCC must never be span-evaluated. Cross-cell
+            // cycles that route through a span producer are invisible to the
+            // legacy Tarjan pass (the span member has no graph vertex) and only
+            // surface here, as `CycleDetected` fallbacks in the producer-bounded
+            // mixed schedule. Demote the cyclic spans to legacy graph vertices
+            // so the cycle members move onto the legacy SCC path, then resolve
+            // the now legacy-only cycle ahead of the schedule and rebuild.
+            // Spans that do not touch the cycle are left untouched.
+            let cyclic_spans = self.collect_cyclic_span_refs(&schedule, &span_refs_by_id);
+            if !cyclic_spans.is_empty() {
+                self.demote_cyclic_spans(&cyclic_spans)?;
+            }
+
+            if self.graph.formula_authority().active_span_count() == 0 {
+                // All spans demoted; nothing left for the FP coordinator. The
+                // legacy evaluator resolves the (now fully legacy) cycle.
+                return self.evaluate_all_legacy_impl();
+            }
+
+            // Resolve the residual legacy-only cycle (`handle_cycle_unit`
+            // honors Static vs Runtime) before rebuilding so the mixed schedule
+            // is cycle-free and the surviving spans still get evaluated.
+            prepass_cycle_errors =
+                prepass_cycle_errors.saturating_add(self.evaluate_legacy_cycle_prepass()?);
+
+            // Re-seed every surviving span whole after the geometry/dirty
+            // changes; the demotion already reset
+            // `formula_plane_indexes_epoch_seen` to 0.
+            span_seed_mode = SpanSeedMode::WholeAll;
+            pending_changed_regions = self
+                .graph
+                .formula_authority_mut()
+                .take_pending_changed_regions();
+
+            cycle_demote_iters += 1;
+            if cycle_demote_iters >= MAX_CYCLE_DEMOTE_ITERS {
+                // Defensive bound: every iteration either demotes ≥1 span or
+                // stamps the legacy cycle, both strictly reducing residual work.
+                // If we somehow fail to converge, fall back to pure legacy to
+                // stay correct rather than spin.
+                return self.evaluate_all_legacy_impl();
+            }
+        };
 
         let mut computed_vertices = 0usize;
         #[cfg(test)]
@@ -8243,7 +8419,7 @@ where
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
         Ok(EvalResult {
             computed_vertices,
-            cycle_errors: 0,
+            cycle_errors: prepass_cycle_errors,
             elapsed: start.elapsed(),
         })
     }

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
@@ -1,0 +1,239 @@
+//! Gotcha G8 of the cycle-architecture track (refs PSU3D0/formualizer#112,
+//! follows merged #119): a FormulaPlane span member that participates in a
+//! statically-cyclic SCC must never be span-evaluated.
+//!
+//! Cross-cell cycles that route through a span producer are invisible to the
+//! legacy Tarjan pass (the span member has no graph vertex of its own) and only
+//! surface as `CycleDetected` fallbacks in the producer-bounded mixed schedule.
+//! The FP coordinator demotes the offending span(s) to legacy graph vertices at
+//! schedule-build time so the cycle members are resolved on the legacy SCC path
+//! (`handle_cycle_unit` under `CycleDetection::Static`, `evaluate_scc_unit`
+//! under `Runtime`), while spans that do not touch the cycle keep span
+//! treatment.
+
+use std::sync::Arc;
+
+use crate::engine::{
+    CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig, FormulaIngestBatch,
+    FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+fn authoritative_engine(detection: CycleDetection) -> Engine<TestWorkbook> {
+    let cfg = EvalConfig::default()
+        .with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental)
+        .with_cycle(CycleConfig {
+            detection,
+            policy: CyclePolicy::Error,
+        });
+    Engine::new(TestWorkbook::default(), cfg)
+}
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    let ast = parse(formula).unwrap();
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn num(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> f64 {
+    match engine.get_cell_value(sheet, row, col) {
+        Some(LiteralValue::Number(n)) => n,
+        Some(LiteralValue::Int(i)) => i as f64,
+        other => panic!("expected number at {sheet} r{row}c{col}, got {other:?}"),
+    }
+}
+
+fn is_circ(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> bool {
+    matches!(
+        engine.get_cell_value(sheet, row, col),
+        Some(LiteralValue::Error(e)) if e.kind == ExcelErrorKind::Circ
+    )
+}
+
+/// Build a workbook with:
+/// * Column B rows 1..=120: span family `=A{r}+C{r}` (reads col A values and col
+///   C, which is empty except for the cycle-closing cell) — 120 cells, well over
+///   the promotion threshold, promoting to a single span.
+/// * Column E rows 1..=120: an *independent* span family `=A{r}*2`, untouched by
+///   the cycle.
+/// * `C5 = B5`: closes a static cycle `B5 -> C5 -> B5` through the span member B5.
+fn build_workbook(detection: CycleDetection) -> Engine<TestWorkbook> {
+    let mut engine = authoritative_engine(detection);
+    let mut col_b = Vec::new();
+    let mut col_e = Vec::new();
+    for row in 1..=120 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        col_b.push(record(&mut engine, row, 2, &format!("=A{row}+C{row}")));
+        col_e.push(record(&mut engine, row, 5, &format!("=A{row}*2")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(
+            "Sheet1",
+            col_b.into_iter().chain(col_e).collect(),
+        )])
+        .unwrap();
+    // Both families promote to spans before the cycle is introduced.
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+
+    // Close the cycle through span member B5 by setting C5 = B5.
+    engine
+        .set_cell_formula("Sheet1", 5, 3, parse("=B5").unwrap())
+        .unwrap();
+    // Setting an out-of-span cell does not eagerly demote: the cycle is only
+    // observable once the mixed producer schedule exists at eval time.
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    engine
+}
+
+/// (a) cycle members are not span-evaluated — the cyclic span is demoted and the
+/// `CycleMember` placement-fallback reason is recorded; (b) results are correct
+/// under `CycleDetection::Static`: `#CIRC` for the cycle members, real span
+/// results for the rest; (c) the independent span family is untouched.
+#[test]
+fn span_member_in_static_cycle_is_demoted_and_circ() {
+    let mut engine = build_workbook(CycleDetection::Static);
+
+    let result = engine.evaluate_all().expect("eval must not bail out");
+    assert_eq!(result.cycle_errors, 1, "exactly one live SCC stamped");
+
+    // (a) the cyclic span family was demoted to legacy.
+    let stats = engine.baseline_stats();
+    assert_eq!(
+        stats.formula_plane_cycle_member_span_demotions, 1,
+        "the column-B span must be demoted for cycle membership"
+    );
+    // The CycleMember fallback reason is recorded in the cumulative ingest
+    // report like every other placement fallback reason.
+    assert_eq!(
+        engine
+            .formula_ingest_report_total()
+            .fallback_reasons
+            .get("CycleMember")
+            .copied(),
+        Some(1),
+        "CycleMember fallback must be recorded in diagnostics"
+    );
+
+    // (b) static cycle members are #CIRC; the rest of the demoted family still
+    // computes correct values on the legacy path.
+    assert!(
+        is_circ(&engine, "Sheet1", 5, 2),
+        "B5 (cycle member) is #CIRC"
+    );
+    assert!(
+        is_circ(&engine, "Sheet1", 5, 3),
+        "C5 (cycle member) is #CIRC"
+    );
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 1.0, "B1 = A1 + C1 = 1");
+    assert_eq!(num(&engine, "Sheet1", 10, 2), 10.0, "B10 = A10 + C10 = 10");
+    assert_eq!(num(&engine, "Sheet1", 120, 2), 120.0, "B120 = A120 + C120");
+
+    // (c) the independent column-E span family is unaffected: still a span and
+    // still correct.
+    assert_eq!(
+        stats.formula_plane_active_span_count, 1,
+        "the independent column-E span survives"
+    );
+    assert_eq!(num(&engine, "Sheet1", 1, 5), 2.0, "E1 = A1 * 2");
+    assert_eq!(num(&engine, "Sheet1", 120, 5), 240.0, "E120 = A120 * 2");
+}
+
+/// (b) under `CycleDetection::Runtime`: the cyclic span is still demoted and the
+/// live cycle (C5 = B5 unconditionally) yields `#CIRC` per the live-edge policy,
+/// while phantom-free non-cycle members get ordinary values and the independent
+/// span survives.
+#[test]
+fn span_member_in_runtime_cycle_is_demoted_and_circ() {
+    let mut engine = build_workbook(CycleDetection::Runtime);
+
+    let result = engine.evaluate_all().expect("eval must not bail out");
+    assert_eq!(result.cycle_errors, 1, "one live cycle witnessed");
+
+    let stats = engine.baseline_stats();
+    assert_eq!(stats.formula_plane_cycle_member_span_demotions, 1);
+    assert_eq!(
+        engine
+            .formula_ingest_report_total()
+            .fallback_reasons
+            .get("CycleMember")
+            .copied(),
+        Some(1)
+    );
+
+    // Live cycle members are #CIRC under Runtime/Error policy.
+    assert!(is_circ(&engine, "Sheet1", 5, 2));
+    assert!(is_circ(&engine, "Sheet1", 5, 3));
+    // Non-cycle members compute ordinary values (no phantom stamping).
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 1.0);
+    assert_eq!(num(&engine, "Sheet1", 10, 2), 10.0);
+    assert_eq!(num(&engine, "Sheet1", 120, 2), 120.0);
+
+    // Independent span family survives and is correct.
+    assert_eq!(stats.formula_plane_active_span_count, 1);
+    assert_eq!(num(&engine, "Sheet1", 1, 5), 2.0);
+    assert_eq!(num(&engine, "Sheet1", 120, 5), 240.0);
+}
+
+/// A phantom (guarded, live-acyclic) cycle through a span member must not stamp
+/// `#CIRC` under `CycleDetection::Runtime`: the span is still demoted (its
+/// member is a *static* SCC candidate), but live-edge evaluation resolves the
+/// guarded reference to an ordinary value (discussion #99).
+#[test]
+fn phantom_cycle_through_span_member_yields_value_under_runtime() {
+    let mut engine = authoritative_engine(CycleDetection::Runtime);
+    // F1 guard = false. Column A values 1..=120. Column B span `=A{r}+D{r}`
+    // reads col A (values) and col D (mostly empty).
+    engine
+        .set_cell_value("Sheet1", 1, 6, LiteralValue::Boolean(false))
+        .unwrap();
+    let mut col_b = Vec::new();
+    for row in 1..=120 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        col_b.push(record(&mut engine, row, 2, &format!("=A{row}+D{row}")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", col_b)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+
+    // Guarded back-edge: D5 = IF(F1, B5, 7). With F1=false the live edge does
+    // not reach B5, so the static SCC {B5, D5} is phantom.
+    engine
+        .set_cell_formula("Sheet1", 5, 4, parse("=IF(F1,B5,7)").unwrap())
+        .unwrap();
+
+    let result = engine.evaluate_all().expect("eval must not bail out");
+    assert_eq!(result.cycle_errors, 0, "phantom cycle stamps no #CIRC");
+
+    // The span was still demoted for static cycle membership.
+    assert_eq!(
+        engine
+            .baseline_stats()
+            .formula_plane_cycle_member_span_demotions,
+        1
+    );
+    // Phantom members resolve to ordinary values, not #CIRC.
+    assert!(!is_circ(&engine, "Sheet1", 5, 2));
+    assert_eq!(
+        num(&engine, "Sheet1", 5, 4),
+        7.0,
+        "D5 = IF(false,...,7) = 7"
+    );
+    assert_eq!(num(&engine, "Sheet1", 5, 2), 5.0 + 7.0, "B5 = A5 + D5 = 12");
+    assert_eq!(
+        num(&engine, "Sheet1", 10, 2),
+        10.0,
+        "B10 = A10 + D10 = 10 + 0"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -100,6 +100,7 @@ mod eval_flush_recalc_probe;
 mod formula_edit_propagation;
 mod formula_error_propagation;
 mod formula_overlay_writeback;
+mod formula_plane_cycle_member_exclusion;
 mod formula_plane_demotion_correctness;
 mod formula_plane_dirty_domain_preservation;
 mod formula_plane_index_promotion;

--- a/crates/formualizer-eval/src/formula_plane/placement.rs
+++ b/crates/formualizer-eval/src/formula_plane/placement.rs
@@ -111,6 +111,17 @@ pub(crate) enum PlacementFallbackReason {
     InternalDependency,
     SmallDomain,
     BindingMemoryCapExceeded,
+    /// At least one member of the family participates in a statically-cyclic
+    /// SCC. A cycle member must never be span-evaluated (gotcha G8 of the
+    /// cycle-architecture track, refs #112): under `CycleDetection::Static` the
+    /// cycle stamping would race/overwrite span writes, and under
+    /// `CycleDetection::Runtime` SCC members are evaluated by the legacy
+    /// `evaluate_scc_unit` path and must stay on the graph. Cross-cell cycles
+    /// that pass through a span producer are only observable once the producer
+    /// graph exists, so this reason is recorded when the FP mixed scheduler
+    /// demotes a cyclic span at schedule-build time rather than at initial
+    /// placement.
+    CycleMember,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
Stage 2b follow-up to #119 (refs #112): FormulaPlane had no cycle awareness — a span family containing a cycle member previously made the whole authoritative evaluation bail with `NImpl`, leaving even unrelated spans uncomputable.

Cross-cell cycles through span producers are invisible to the legacy Tarjan pass (span members live in the FP runtime, not the graph), so the only correct hook is schedule-build time in the authoritative path. The fix: detect cycle-touching spans in the mixed schedule, demote exactly those spans via the existing non-structural demotion seam (recording a new `PlacementFallbackReason::CycleMember` in diagnostics), resolve the now legacy-only cycle through `handle_cycle_unit` (honoring `Static` vs `Runtime` detection), then rebuild a cycle-free schedule so surviving spans still get span treatment. The demote-and-retry loop is bounded and strictly reduces residual work. A `formula_plane_cycle_member_span_demotions` counter is surfaced on the baseline stats.

Tests (test-first, 3 new): 120-cell span family with a member cycle under Static (`#CIRC` on cycle members, correct span/legacy values elsewhere, independent span survives), the same under Runtime, and a guarded *phantom* cycle through a span member under Runtime (no `#CIRC`, ordinary values, span demoted). Full workspace suite (CI exclusions): 2465 passed, 0 failed (baseline 2462 + 3). fmt/clippy clean.

Known v1 granularity: the specific family containing the cycle member is demoted wholesale (its non-cyclic siblings compute correctly as legacy cells); re-promoting the acyclic remainder of that family would need mid-eval span splitting and is deferred as a separately-scoped optimization. Independent families are unaffected — verified.
