### PR TITLE
fix(eval): populate CycleTelemetry on the workbook/arrow evaluate path

### DIFF
--- a/crates/formualizer-bench-core/src/bin/probe-scc-phantom-pairs.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-scc-phantom-pairs.rs
@@ -107,11 +107,9 @@ struct SccPhantomProbeReport {
     recalc_ms_p95: f64,
     recalc_ms_max: f64,
     recalc_us_per_pair_p50: f64,
-    /// Best-effort SCC telemetry. NOTE: under the arrow-canonical workbook path
-    /// the runtime SCC evaluation produces correct values but does NOT populate
-    /// `last_cycle_telemetry` (the legacy/`TestWorkbook` path does); these
-    /// fields read 0 here even though every pair resolved as a phantom SCC. The
-    /// authoritative correctness signal is the value self-check (`sample_*`).
+    /// SCC telemetry from `last_cycle_telemetry` (populated on the workbook
+    /// path too — the telemetry gap this probe originally surfaced is fixed).
+    /// Runtime mode self-checks `initial_phantom_sccs == pairs`.
     initial_phantom_sccs: usize,
     initial_settle_passes_total: usize,
     /// `#CIRC!` cells observed on the initial eval, counted by reading cells.
@@ -212,9 +210,8 @@ fn run_probe(cli: &Cli) -> Result<SccPhantomProbeReport> {
     let initial_eval_ms = initial_start.elapsed().as_secs_f64() * 1000.0;
 
     let telemetry = workbook.engine().last_cycle_telemetry().clone();
-    // `#CIRC!` count is the authoritative cycle-handling signal here (read from
-    // cells, not telemetry, since the arrow-canonical path leaves telemetry at
-    // 0). Runtime: every pair is phantom → 0 circ. Static: 2 per pair.
+    // `#CIRC!` count is cross-checked from cells AND telemetry. Runtime: every
+    // pair is phantom → 0 circ, `phantom_sccs == pairs`. Static: 2 per pair.
     let initial_circ_cells = count_circ_cells(&workbook, cli.pairs)?;
     match cli.mode {
         Mode::Runtime => {
@@ -227,6 +224,13 @@ fn run_probe(cli: &Cli) -> Result<SccPhantomProbeReport> {
                 bail!(
                     "runtime mode: phantom pairs must not produce cycle errors, got {}",
                     initial_result.cycle_errors
+                );
+            }
+            if telemetry.phantom_sccs != cli.pairs {
+                bail!(
+                    "runtime mode: telemetry must report every pair as a phantom SCC, got {} of {}",
+                    telemetry.phantom_sccs,
+                    cli.pairs
                 );
             }
         }

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -962,10 +962,11 @@ pub struct VirtualDepTelemetry {
 /// (spec `formualizer-cycle-semantics-spec.md` §10, Stage-2 subset; the
 /// `Iterate`-specific fields arrive in Stage 3).
 ///
-/// Collection is gated by the existing telemetry flag
-/// (`EvalConfig::enable_virtual_dep_telemetry`), mirroring
-/// [`VirtualDepTelemetry`]; the struct is always public. Counters reset at
-/// the start of every evaluation request.
+/// Collection is unconditional: SCC tasks are rare relative to ordinary
+/// vertex evaluation and the counters are a handful of integer adds per
+/// task, so no config flag gates them (unlike [`VirtualDepTelemetry`],
+/// which pays per-schedule costs). Counters reset at the start of every
+/// evaluation request.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CycleTelemetry {
     /// SCC tasks executed (static SCCs that reached Runtime evaluation).
@@ -8216,6 +8217,13 @@ where
         })
     }
     fn evaluate_authoritative_formula_plane_all(&mut self) -> Result<EvalResult, ExcelError> {
+        // Fresh per-request cycle counters. Some callers (`evaluate_vertex`,
+        // `evaluate_cells*`) reach this coordinator without an entry-point
+        // reset; callers that did reset have accumulated nothing in between,
+        // so the duplicate reset is harmless. The composed legacy primitive
+        // below intentionally does not reset, so `evaluate_legacy_cycle_prepass`
+        // counts survive into the final telemetry.
+        self.reset_cycle_telemetry();
         // The FormulaPlane coordinator is now selected by mode for evaluate_all.
         // SingletonUnique formulas intentionally remain legacy graph vertices;
         // when no spans are active, execute through the private legacy primitive
@@ -8651,6 +8659,7 @@ where
     /// coordinator; the coordinator itself composes with private legacy
     /// primitives for legacy-only work.
     fn evaluate_all_coordinator(&mut self) -> Result<EvalResult, ExcelError> {
+        self.reset_cycle_telemetry();
         if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental {
             return self.evaluate_authoritative_formula_plane_all();
         }
@@ -8692,8 +8701,12 @@ where
     /// when no active spans exist or FormulaPlane authority is not in
     /// `AuthoritativeExperimental` mode. This is now an internal primitive; it
     /// must not be invoked directly from public APIs.
+    ///
+    /// Does NOT reset `last_cycle_telemetry`: the FormulaPlane coordinator
+    /// composes this primitive *after* `evaluate_legacy_cycle_prepass` may
+    /// have accumulated counts (G8 demotion path); resets happen at the
+    /// public entry points / coordinators instead.
     fn evaluate_all_legacy_impl(&mut self) -> Result<EvalResult, ExcelError> {
-        self.reset_cycle_telemetry();
         self.reset_virtual_dep_telemetry_if_disabled();
         #[cfg(feature = "tracing")]
         let _span_eval = tracing::info_span!("evaluate_all").entered();
@@ -12049,7 +12062,6 @@ where
         }
 
         let task_start = crate::instant::FzInstant::now();
-        let collect_telemetry = self.config.enable_virtual_dep_telemetry;
 
         // ── 0. Member order (spec §7.13): cells ascending (sheet, row, col);
         // name vertices after, lexicographic by folded canonical name; any
@@ -12368,7 +12380,7 @@ where
             }
         }
 
-        if collect_telemetry {
+        {
             let t = &mut self.last_cycle_telemetry;
             t.static_sccs += 1;
             if witnessed_cycles == 0 && stamped == 0 && !capped {

--- a/crates/formualizer-workbook/tests/cycle_runtime_telemetry.rs
+++ b/crates/formualizer-workbook/tests/cycle_runtime_telemetry.rs
@@ -1,0 +1,116 @@
+//! `CycleTelemetry` must populate on the workbook/arrow-canonical evaluate
+//! path (refs #112; found by the phantom-pairs probe, #123).
+//!
+//! The engine-direct tests (`engine/tests/scc_runtime_cycles.rs`) exercise
+//! telemetry with `with_virtual_dep_telemetry(true)`; the workbook path uses
+//! the default config, where Runtime SCC evaluation produced correct values
+//! but left `last_cycle_telemetry()` at zero. These tests pin the workbook
+//! contract: a #99 phantom pair resolves to values AND reports
+//! `phantom_sccs == 1` through the engine accessor, for both the incremental
+//! (`Workbook::new_with_config` + `set_formula`) and bulk-ingest
+//! (`Workbook::from_reader`, EagerAll) constructions.
+
+use formualizer_eval::engine::{CycleConfig, CycleDetection, CyclePolicy};
+use formualizer_workbook::{LiteralValue, Workbook, WorkbookConfig};
+
+fn runtime_cycle() -> CycleConfig {
+    CycleConfig {
+        detection: CycleDetection::Runtime,
+        policy: CyclePolicy::Error,
+    }
+}
+
+fn runtime_config() -> WorkbookConfig {
+    let mut config = WorkbookConfig::ephemeral();
+    config.eval = config.eval.with_cycle(runtime_cycle());
+    config
+}
+
+fn num(wb: &Workbook, sheet: &str, row: u32, col: u32) -> f64 {
+    match wb.get_value(sheet, row, col) {
+        Some(LiteralValue::Number(n)) => n,
+        Some(LiteralValue::Int(i)) => i as f64,
+        other => panic!("expected number at {sheet} r{row}c{col}, got {other:?}"),
+    }
+}
+
+fn assert_phantom_pair_telemetry(wb: &mut Workbook, sheet: &str) {
+    let res = wb.evaluate_all().expect("evaluate_all");
+    assert_eq!(res.cycle_errors, 0, "phantom pair must not stamp #CIRC");
+
+    // Guard TRUE → A keeps 100, B reads A → both 100; consumer 200.
+    assert_eq!(num(wb, sheet, 1, 2), 100.0);
+    assert_eq!(num(wb, sheet, 1, 3), 100.0);
+    assert_eq!(num(wb, sheet, 1, 4), 200.0);
+
+    let t = wb.engine().last_cycle_telemetry();
+    assert_eq!(t.static_sccs, 1, "one SCC task must run: {t:?}");
+    assert_eq!(t.phantom_sccs, 1, "pair must resolve as phantom: {t:?}");
+    assert_eq!(t.live_cycles_witnessed, 0, "{t:?}");
+    assert_eq!(t.circ_cells_stamped, 0, "{t:?}");
+    assert!(t.settle_passes_total >= 1, "{t:?}");
+}
+
+/// Discussion-#99 guarded pair through the plain workbook construction:
+/// `set_formula` ingest, default (telemetry-flag-off) config.
+#[test]
+fn phantom_pair_populates_cycle_telemetry_via_set_formula() {
+    let mut wb = Workbook::new_with_config(runtime_config());
+    wb.add_sheet("S").unwrap();
+    wb.set_value("S", 1, 1, LiteralValue::Boolean(true))
+        .unwrap();
+    wb.set_formula("S", 1, 2, "=IF(A1,100,C1)").unwrap();
+    wb.set_formula("S", 1, 3, "=IF(A1,B1,999)").unwrap();
+    wb.set_formula("S", 1, 4, "=B1+C1").unwrap();
+
+    assert_phantom_pair_telemetry(&mut wb, "S");
+}
+
+/// Same pair through the bulk-ingest path the phantom-pairs probe (#123)
+/// uses: `Workbook::from_reader` with `LoadStrategy::EagerAll`, so the graph
+/// (and the SCC) is built in one batched arrow-canonical ingest pass.
+#[cfg(feature = "json")]
+#[test]
+fn phantom_pair_populates_cycle_telemetry_via_bulk_load() {
+    use formualizer_workbook::{JsonAdapter, LoadStrategy, SpreadsheetReader};
+
+    let bytes = br#"{
+        "version": 1,
+        "sheets": {
+            "S": {
+                "cells": [
+                    { "row": 1, "col": 1, "value": { "type": "Boolean", "value": true } },
+                    { "row": 1, "col": 2, "formula": "=IF(A1,100,C1)" },
+                    { "row": 1, "col": 3, "formula": "=IF(A1,B1,999)" },
+                    { "row": 1, "col": 4, "formula": "=B1+C1" }
+                ]
+            }
+        }
+    }"#
+    .to_vec();
+
+    let adapter = JsonAdapter::open_bytes(bytes).unwrap();
+    let mut wb = Workbook::from_reader(adapter, LoadStrategy::EagerAll, runtime_config()).unwrap();
+
+    assert_phantom_pair_telemetry(&mut wb, "S");
+}
+
+/// A second `evaluate_all` with no dirty work must reset the counters: the
+/// telemetry is per-recalc, not cumulative across requests.
+#[test]
+fn cycle_telemetry_resets_per_evaluation_request() {
+    let mut wb = Workbook::new_with_config(runtime_config());
+    wb.add_sheet("S").unwrap();
+    wb.set_value("S", 1, 1, LiteralValue::Boolean(true))
+        .unwrap();
+    wb.set_formula("S", 1, 2, "=IF(A1,100,C1)").unwrap();
+    wb.set_formula("S", 1, 3, "=IF(A1,B1,999)").unwrap();
+
+    wb.evaluate_all().unwrap();
+    assert_eq!(wb.engine().last_cycle_telemetry().phantom_sccs, 1);
+
+    // Nothing dirty: the SCC task does not re-run, counters return to zero.
+    wb.evaluate_all().unwrap();
+    assert_eq!(wb.engine().last_cycle_telemetry().static_sccs, 0);
+    assert_eq!(wb.engine().last_cycle_telemetry().phantom_sccs, 0);
+}


### PR DESCRIPTION
Found by the phantom-pairs probe (#123): under the workbook/arrow-canonical path, runtime SCC evaluation produced correct values but `last_cycle_telemetry()` read all zeros. Refs #112.

Root cause was not a missed entry-point reset: `evaluate_scc_unit` gated its telemetry accumulation on `enable_virtual_dep_telemetry`, which engine-direct tests enable but the workbook default config leaves off. The gating was a deliberate Stage-2a choice that turned out wrong for the workbook contract.

Fix: collection is now ungated (a handful of integer adds per SCC task; the timer was already taken unconditionally). While verifying the #121 prepass requirement, reset placement was also corrected: `evaluate_all_legacy_impl` no longer resets (it is a composed primitive that the FormulaPlane coordinator calls *after* the cycle-demotion prepass may have accumulated counts), and resets were added at the tops of `evaluate_all_coordinator` and the FP-authoritative path — covering entries that previously stale-accumulated.

Tests (failing-first): three new workbook-level tests — telemetry populated via `set_formula` construction, via bulk load (`from_reader` + EagerAll, mirroring the probe), and per-request reset. The probe's stale "telemetry reads 0" caveat is removed and runtime mode now hard-asserts `phantom_sccs == pairs` (verified live: 50 pairs → `phantom_sccs: 50, settle_passes: 75`).

Full workspace suite (CI exclusions): 2472 passed, 0 failed (baseline 2469 + 3). fmt/clippy clean.
