### PR TITLE
fix(graph): amortize CSR rebuilds — cell-by-cell formula edits go quadratic→linear

### DIFF
--- a/crates/formualizer-bench-core/src/bin/probe-scc-phantom-pairs.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-scc-phantom-pairs.rs
@@ -192,8 +192,10 @@ fn run_probe(cli: &Cli) -> Result<SccPhantomProbeReport> {
     };
 
     // Bulk-load via EagerAll: the graph (and its SCCs) is built in one batched
-    // ingest pass, which scales linearly — unlike incremental per-formula edits
-    // under an active cycle config, which re-run detection per edit.
+    // ingest pass, which scales linearly. (Incremental per-formula edits used
+    // to scale quadratically here — not because of per-edit cycle detection,
+    // but because each edit forced a full CSR rebuild (#125) plus redundant
+    // per-edit dependency work (#126).)
     let mut config = WorkbookConfig::ephemeral();
     config.eval = config.eval.with_cycle(cycle);
     let load_start = Instant::now();

--- a/crates/formualizer-eval/src/engine/delta_edges.rs
+++ b/crates/formualizer-eval/src/engine/delta_edges.rs
@@ -311,6 +311,102 @@ mod tests {
     }
 
     #[test]
+    fn test_merged_in_view_add_and_remove() {
+        let csr = CsrEdges::from_adjacency(
+            vec![(0u32, vec![2u32]), (1u32, vec![2u32])],
+            &[
+                AbsCoord::new(0, 0),
+                AbsCoord::new(0, 1),
+                AbsCoord::new(0, 2),
+                AbsCoord::new(0, 3),
+            ],
+        );
+        let mut delta = DeltaEdgeSlab::new();
+
+        // New incoming edge 3 -> 2, removed incoming edge 0 -> 2.
+        delta.add_edge(VertexId(3), VertexId(2));
+        delta.remove_edge(VertexId(0), VertexId(2));
+
+        let merged = delta.merged_in_view(&csr, VertexId(2));
+        assert_eq!(merged, vec![VertexId(1), VertexId(3)]);
+    }
+
+    #[test]
+    fn test_merged_in_view_last_op_wins() {
+        let csr = CsrEdges::from_adjacency(
+            vec![(0u32, vec![1u32])],
+            &[AbsCoord::new(0, 0), AbsCoord::new(0, 1)],
+        );
+        let mut delta = DeltaEdgeSlab::new();
+
+        delta.remove_edge(VertexId(0), VertexId(1));
+        delta.add_edge(VertexId(0), VertexId(1));
+        assert_eq!(delta.merged_in_view(&csr, VertexId(1)), vec![VertexId(0)]);
+
+        delta.add_edge(VertexId(2), VertexId(1));
+        delta.remove_edge(VertexId(2), VertexId(1));
+        assert_eq!(delta.merged_in_view(&csr, VertexId(1)), vec![VertexId(0)]);
+    }
+
+    #[test]
+    fn test_end_batch_below_threshold_defers_rebuild() {
+        let mut edges = CsrMutableEdges::with_coords(vec![
+            AbsCoord::new(0, 0),
+            AbsCoord::new(0, 1),
+            AbsCoord::new(0, 2),
+        ]);
+        let before = edges.rebuild_count();
+
+        edges.begin_batch();
+        edges.add_edge(VertexId(0), VertexId(1));
+        edges.add_edge(VertexId(0), VertexId(2));
+        edges.end_batch();
+
+        // Small edit bursts must not trigger a full rebuild (#125)...
+        assert_eq!(edges.rebuild_count(), before);
+        // ...while reads stay correct through the merged views.
+        assert_eq!(edges.out_edges(VertexId(0)), vec![VertexId(1), VertexId(2)]);
+        assert_eq!(edges.in_edges_merged(VertexId(1)), vec![VertexId(0)]);
+        assert_eq!(edges.in_edges_merged(VertexId(2)), vec![VertexId(0)]);
+    }
+
+    #[test]
+    fn test_end_batch_rebuilds_at_threshold() {
+        let coords: Vec<AbsCoord> = (0..1200u32).map(|i| AbsCoord::new(i, 0)).collect();
+        let mut edges = CsrMutableEdges::with_coords(coords);
+        let before = edges.rebuild_count();
+
+        edges.begin_batch();
+        for i in 0..1100u32 {
+            edges.add_edge(VertexId(i), VertexId(i + 1));
+        }
+        edges.end_batch();
+
+        assert_eq!(edges.rebuild_count(), before + 1);
+        assert_eq!(edges.delta_size(), 0);
+        assert_eq!(edges.out_edges(VertexId(0)), vec![VertexId(1)]);
+        assert_eq!(edges.in_edges(VertexId(1)), &[VertexId(0)]);
+    }
+
+    #[test]
+    fn test_add_vertex_defers_rebuild() {
+        let mut edges = CsrMutableEdges::new();
+        edges.add_vertex(AbsCoord::new(0, 0), 1024);
+        edges.add_vertex(AbsCoord::new(0, 1), 1025);
+        assert_eq!(edges.rebuild_count(), 0);
+
+        edges.add_edge(VertexId(1024), VertexId(1025));
+        // Reads see the new vertex/edge before any rebuild.
+        assert_eq!(edges.out_edges(VertexId(1024)), vec![VertexId(1025)]);
+        assert_eq!(edges.in_edges_merged(VertexId(1025)), vec![VertexId(1024)]);
+
+        // And the next rebuild folds the vertex into the CSR base.
+        edges.rebuild();
+        assert_eq!(edges.out_edges(VertexId(1024)), vec![VertexId(1025)]);
+        assert_eq!(edges.in_edges(VertexId(1025)), &[VertexId(1024)]);
+    }
+
+    #[test]
     fn test_end_batch_rebuilds_on_coord_change_only() {
         let mut edges =
             CsrMutableEdges::with_coords(vec![AbsCoord::new(0, 0), AbsCoord::new(0, 1)]);
@@ -335,6 +431,13 @@ pub struct DeltaEdgeSlab {
     /// Edges to remove, stored as sets for O(1) lookup
     removals: FxHashMap<VertexId, FxHashSet<VertexId>>,
 
+    /// Reverse index of `additions`: target -> sources. Keeps incoming-edge
+    /// reads delta-aware in O(degree) instead of O(V) scans (#125).
+    additions_in: FxHashMap<VertexId, FxHashSet<VertexId>>,
+
+    /// Reverse index of `removals`: target -> sources.
+    removals_in: FxHashMap<VertexId, FxHashSet<VertexId>>,
+
     /// Total operation count for rebuild threshold
     op_count: usize,
 
@@ -348,6 +451,8 @@ impl DeltaEdgeSlab {
         Self {
             additions: FxHashMap::default(),
             removals: FxHashMap::default(),
+            additions_in: FxHashMap::default(),
+            removals_in: FxHashMap::default(),
             op_count: 0,
             coord_changed: false,
         }
@@ -359,8 +464,12 @@ impl DeltaEdgeSlab {
         if let Some(rem) = self.removals.get_mut(&from) {
             rem.remove(&to);
         }
-        // Insert into additions set
+        if let Some(rem) = self.removals_in.get_mut(&to) {
+            rem.remove(&from);
+        }
+        // Insert into additions set (forward and reverse)
         self.additions.entry(from).or_default().insert(to);
+        self.additions_in.entry(to).or_default().insert(from);
         self.op_count += 1;
     }
 
@@ -370,8 +479,12 @@ impl DeltaEdgeSlab {
         if let Some(adds) = self.additions.get_mut(&from) {
             adds.remove(&to);
         }
-        // Record removal
+        if let Some(adds) = self.additions_in.get_mut(&to) {
+            adds.remove(&from);
+        }
+        // Record removal (forward and reverse)
         self.removals.entry(from).or_default().insert(to);
+        self.removals_in.entry(to).or_default().insert(from);
         self.op_count += 1;
     }
 
@@ -388,6 +501,22 @@ impl DeltaEdgeSlab {
             result.extend(adds.iter().copied());
         }
         // Dedup deterministically and sort by VertexId for stable order
+        let mut seen: FxHashSet<VertexId> = FxHashSet::default();
+        result.retain(|e| seen.insert(*e));
+        result.sort_by_key(|e| e.0);
+        result
+    }
+
+    /// Get a merged view of *incoming* edges for a vertex, combining the CSR
+    /// reverse edges with the delta's reverse index. O(in-degree), not O(V).
+    pub fn merged_in_view(&self, csr: &CsrEdges, v: VertexId) -> Vec<VertexId> {
+        let mut result: Vec<_> = csr.in_edges(v).to_vec();
+        if let Some(removes) = self.removals_in.get(&v) {
+            result.retain(|e| !removes.contains(e));
+        }
+        if let Some(adds) = self.additions_in.get(&v) {
+            result.extend(adds.iter().copied());
+        }
         let mut seen: FxHashSet<VertexId> = FxHashSet::default();
         result.retain(|e| seen.insert(*e));
         result.sort_by_key(|e| e.0);
@@ -413,6 +542,8 @@ impl DeltaEdgeSlab {
     pub fn clear(&mut self) {
         self.additions.clear();
         self.removals.clear();
+        self.additions_in.clear();
+        self.removals_in.clear();
         self.op_count = 0;
         self.coord_changed = false;
     }
@@ -485,6 +616,9 @@ pub struct CsrMutableEdges {
 
     /// Nested batch depth; non-zero defers automatic rebuilds.
     batch_depth: usize,
+
+    /// Number of full CSR rebuilds performed (observability / regression tests).
+    rebuild_count: u64,
 }
 
 impl CsrMutableEdges {
@@ -497,6 +631,7 @@ impl CsrMutableEdges {
             vertex_ids: Vec::new(),
             vertex_pos: FxHashMap::default(),
             batch_depth: 0,
+            rebuild_count: 0,
         }
     }
 
@@ -518,6 +653,7 @@ impl CsrMutableEdges {
             vertex_ids,
             vertex_pos,
             batch_depth: 0,
+            rebuild_count: 0,
         }
     }
 
@@ -558,6 +694,17 @@ impl CsrMutableEdges {
     /// After rebuild, this will include all changes
     pub fn in_edges(&self, v: VertexId) -> &[VertexId] {
         self.base.in_edges(v)
+    }
+
+    /// Get incoming edges for a vertex with pending delta mutations applied.
+    ///
+    /// O(in-degree + pending delta entries for `v`); never scans all vertices.
+    pub fn in_edges_merged(&self, v: VertexId) -> Vec<VertexId> {
+        if self.delta.op_count() == 0 {
+            self.base.in_edges(v).to_vec()
+        } else {
+            self.delta.merged_in_view(&self.base, v)
+        }
     }
 
     /// Borrow incoming edges when no delta mutations are pending.
@@ -601,7 +748,16 @@ impl CsrMutableEdges {
                 .delta
                 .apply_to_csr(&self.base, &self.coords, &self.vertex_ids);
             self.delta.clear();
+            self.rebuild_count += 1;
         }
+    }
+
+    /// Number of full CSR rebuilds performed so far.
+    ///
+    /// Per-edit dependency updates must amortize rebuilds (#125); regression
+    /// tests assert on this counter instead of wall-clock time.
+    pub fn rebuild_count(&self) -> u64 {
+        self.rebuild_count
     }
 
     /// Check and perform rebuild if threshold reached
@@ -616,25 +772,31 @@ impl CsrMutableEdges {
         self.batch_depth = self.batch_depth.saturating_add(1);
     }
 
-    /// Exit batch mode and rebuild if needed.
+    /// Exit batch mode and rebuild only when the amortization threshold (or a
+    /// coordinate change) demands it.
+    ///
+    /// Rebuilding unconditionally here made every single-formula edit O(V)
+    /// and cell-by-cell edit loops O(N^2) (#125). Pending delta mutations are
+    /// visible to readers through the merged out/in views, so deferring the
+    /// rebuild is safe.
     pub fn end_batch(&mut self) {
         self.batch_depth = self.batch_depth.saturating_sub(1);
-        if self.batch_depth == 0 && (self.delta.op_count() > 0 || self.delta.needs_rebuild()) {
+        if self.batch_depth == 0 && self.delta.needs_rebuild() {
             self.rebuild();
         }
     }
 
     /// Add a new vertex with its coordinate and ID
+    ///
+    /// Does NOT rebuild the CSR base: reads of a vertex that is not in the
+    /// base yet gracefully resolve to "no edges" plus any pending delta
+    /// mutations, and the next rebuild picks the vertex up from
+    /// `coords`/`vertex_ids` (#125).
     pub fn add_vertex(&mut self, coord: AbsCoord, vertex_id: u32) -> usize {
         let idx = self.coords.len();
         self.coords.push(coord);
         self.vertex_ids.push(vertex_id);
         self.vertex_pos.insert(vertex_id, idx);
-
-        // Rebuild base to include new vertex
-        // This is necessary to maintain CSR structure consistency
-        self.rebuild();
-
         idx
     }
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -7938,6 +7938,9 @@ where
         let _span_eval = tracing::info_span!("evaluate_until", targets = targets.len()).entered();
         let start = crate::instant::FzInstant::now();
         self.reset_cycle_telemetry();
+        // Fold any pending edge deltas once so scheduling/eval reads use the
+        // zero-allocation CSR slices (#125 write-cheap / read-flush split).
+        self.graph.flush_pending_edge_deltas();
         let _source_cache = self.source_cache_session();
         if self.graph.formula_authority().active_span_count() > 0 {
             return self.evaluate_authoritative_formula_plane_all();
@@ -8041,6 +8044,7 @@ where
             tracing::info_span!("evaluate_until_with_delta", targets = targets.len()).entered();
         let start = crate::instant::FzInstant::now();
         self.reset_cycle_telemetry();
+        self.graph.flush_pending_edge_deltas();
         let _source_cache = self.source_cache_session();
 
         let mut target_addrs = Vec::new();
@@ -9204,6 +9208,9 @@ where
         &mut self,
         to_evaluate: &[VertexId],
     ) -> Result<ScheduleBuildOutput, ExcelError> {
+        // Fold pending edge deltas once per schedule build so traversal uses
+        // the zero-allocation CSR slices (#125).
+        self.graph.flush_pending_edge_deltas();
         if self.can_use_static_schedule_cache(to_evaluate) {
             if let Some(cached) = self.cached_static_schedule.as_ref()
                 && cached.topology_epoch == self.topology_epoch
@@ -9630,6 +9637,7 @@ where
     ) -> Result<EvalResult, ExcelError> {
         let start = crate::instant::FzInstant::now();
         self.reset_cycle_telemetry();
+        self.graph.flush_pending_edge_deltas();
         if self.graph.formula_authority().active_span_count() > 0 {
             if cancel_flag.load(Ordering::Relaxed) {
                 return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -661,8 +661,7 @@ impl<'g> VertexEditor<'g> {
             });
         }
 
-        // Get dependents before removing edges
-        // Note: get_dependents may require CSR rebuild if delta has changes
+        // Get dependents before removing edges (delta-aware; no rebuild needed)
         let dependents = self.graph.get_dependents(id);
 
         // Capture old state (dependencies & dependents) BEFORE edge removal
@@ -841,13 +840,8 @@ impl<'g> VertexEditor<'g> {
             self.graph.update_vertex_value(id, value);
             summary.value_changed = true;
 
-            // Force edge rebuild if needed to get accurate dependents
-            // get_dependents may require rebuild when delta has changes
-            if self.graph.edges_delta_size() > 0 {
-                self.graph.rebuild_edges();
-            }
-
-            // Mark dependents as dirty
+            // Mark dependents as dirty. get_dependents is delta-aware, so no
+            // CSR rebuild is required even when edits are pending (#125).
             let dependents = self.graph.get_dependents(id);
             for dep in &dependents {
                 self.graph.set_dirty(*dep, true);

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -2978,7 +2978,10 @@ impl DependencyGraph {
             return Vec::new();
         }
 
-        // Ensure reverse edges are usable (delta.in_edges is intentionally not delta-aware).
+        // Fold pending deltas once so the propagation loop below can use the
+        // zero-allocation base `in_edges` slices. This is a deliberate
+        // rebuild-on-read seam: one rebuild per bulk propagation, amortized
+        // (the per-vertex alternative would allocate a merged Vec per visit).
         if self.edges.delta_size() > 0 {
             self.edges.rebuild();
         }
@@ -3303,47 +3306,12 @@ impl DependencyGraph {
     }
 
     /// Get dependents of a vertex (vertices that depend on this vertex)
-    /// Uses reverse edges for O(1) lookup when available
+    ///
+    /// Delta-aware: pending edge mutations that have not been folded into the
+    /// CSR base yet are merged in via the delta slab's reverse index, so this
+    /// is O(in-degree) even mid-edit (no O(V) scan, no forced rebuild; #125).
     pub(crate) fn get_dependents(&self, vertex_id: VertexId) -> Vec<VertexId> {
-        // If there are pending changes in delta, we need to scan
-        // Otherwise we can use the fast reverse edges
-        if self.edges.delta_size() > 0 {
-            #[cfg(test)]
-            {
-                // This scan is intentionally tracked for perf regression tests.
-                // It is expected to be rare in normal operation.
-                if let Ok(mut g) = self.instr.lock() {
-                    g.dependents_scan_fallback_calls += 1;
-                    g.dependents_scan_vertices_scanned += self.cell_to_vertex.len() as u64;
-                }
-            }
-            // Fall back to scanning when delta has changes
-            let mut dependents = Vec::new();
-            for (&_addr, &vid) in &self.cell_to_vertex {
-                let out_edges = self.edges.out_edges(vid);
-                if out_edges.contains(&vertex_id) {
-                    dependents.push(vid);
-                }
-            }
-            for named in self.named_ranges.values() {
-                let vid = named.vertex;
-                let out_edges = self.edges.out_edges(vid);
-                if out_edges.contains(&vertex_id) {
-                    dependents.push(vid);
-                }
-            }
-            for named in self.sheet_named_ranges.values() {
-                let vid = named.vertex;
-                let out_edges = self.edges.out_edges(vid);
-                if out_edges.contains(&vertex_id) {
-                    dependents.push(vid);
-                }
-            }
-            dependents
-        } else {
-            // Fast path: use reverse edges from CSR
-            self.edges.in_edges(vertex_id).to_vec()
-        }
+        self.edges.in_edges_merged(vertex_id)
     }
 
     // Internal helper methods for Milestone 0.4
@@ -3383,11 +3351,8 @@ impl DependencyGraph {
         // Remove outgoing edges (this vertex's dependencies)
         self.remove_dependent_edges(id);
 
-        // Force rebuild to get accurate dependents list
-        // This is necessary because get_dependents uses CSR reverse edges
-        self.edges.rebuild();
-
-        // Remove incoming edges (vertices that depend on this vertex)
+        // Remove incoming edges (vertices that depend on this vertex).
+        // get_dependents is delta-aware, so no rebuild is needed here (#125).
         let dependents = self.get_dependents(id);
         if self.pk_order.is_some()
             && let Some(mut pk) = self.pk_order.take()
@@ -3536,10 +3501,26 @@ impl DependencyGraph {
         self.edges.rebuild();
     }
 
+    /// Fold pending edge deltas into the CSR base ahead of a read-heavy phase
+    /// (scheduling/evaluation), restoring the zero-allocation slice fast
+    /// paths. No-op when no deltas are pending. This is the read-side half of
+    /// the #125 amortization: writes defer rebuilds, read bursts pay for at
+    /// most one.
+    pub fn flush_pending_edge_deltas(&mut self) {
+        self.edges.rebuild();
+    }
+
     /// Get delta size (internal use)
     #[doc(hidden)]
     pub fn edges_delta_size(&self) -> usize {
         self.edges.delta_size()
+    }
+
+    /// Number of full CSR rebuilds performed so far (observability; used by
+    /// the #125 rebuild-amortization regression tests).
+    #[doc(hidden)]
+    pub fn edges_rebuild_count(&self) -> u64 {
+        self.edges.rebuild_count()
     }
 
     /// Get vertex ID for specific cell address

--- a/crates/formualizer-eval/src/engine/tests/csr_rebuild_amortization.rs
+++ b/crates/formualizer-eval/src/engine/tests/csr_rebuild_amortization.rs
@@ -1,0 +1,221 @@
+//! Regression tests for issue #125: per-edit full CSR rebuilds made
+//! cell-by-cell formula edits O(N^2).
+//!
+//! The fix amortizes CSR rebuilds (threshold-based instead of per
+//! `end_batch`/`add_vertex`) and makes dependent (reverse-edge) reads
+//! delta-aware so correctness never depends on an eager rebuild.
+//!
+//! These tests use a rebuild counter rather than wall-clock time so they are
+//! stable in CI.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::reference::{CellRef, Coord};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn make_engine() -> Engine<TestWorkbook> {
+    Engine::new(TestWorkbook::new(), EvalConfig::default())
+}
+
+/// Run `n` per-cell formula edits (each referencing the cell to its left) and
+/// return the number of CSR rebuilds the burst triggered.
+fn rebuilds_for_edit_burst(n: u32) -> u64 {
+    let mut engine = make_engine();
+    // Seed input column with values.
+    for row in 1..=n {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Int(row as i64))
+            .unwrap();
+    }
+    let before = engine.graph.edges_rebuild_count();
+    for row in 1..=n {
+        let ast = parse(format!("=A{row}+1")).unwrap();
+        engine.set_cell_formula("Sheet1", row, 2, ast).unwrap();
+    }
+    engine.graph.edges_rebuild_count() - before
+}
+
+/// Per-cell formula edits must not trigger a CSR rebuild per edit. With the
+/// 1000-op delta threshold, a burst of N single-dependency edits should
+/// rebuild roughly N/1000 times (each edit contributes a small constant
+/// number of delta ops), not N times.
+#[test]
+fn per_cell_formula_edits_amortize_csr_rebuilds() {
+    let n = 2000u32;
+    let rebuilds = rebuilds_for_edit_burst(n);
+    // Each edit contributes ~2 delta ops (placeholder churn + 1 dependency
+    // edge), so allow a generous multiple of total_ops/threshold. The point
+    // is to reject anything close to one rebuild per edit.
+    assert!(
+        rebuilds <= 20,
+        "expected amortized rebuilds (~total_ops/1000) for {n} per-cell edits, got {rebuilds}"
+    );
+}
+
+/// Rebuild count must scale linearly with edit count (counter-based stand-in
+/// for the wall-clock scaling assertion, which is too noisy for CI).
+#[test]
+fn csr_rebuild_count_scales_linearly_with_edits() {
+    let small = rebuilds_for_edit_burst(2000);
+    let large = rebuilds_for_edit_burst(8000);
+    // 4x the edits should mean ~4x the rebuilds (plus slack for off-by-one
+    // threshold crossings) — not 16x as the old per-edit rebuild produced.
+    assert!(
+        large <= 4 * small + 8,
+        "rebuild count grew superlinearly: {small} rebuilds at 2k edits vs {large} at 8k"
+    );
+}
+
+/// Dependent (reverse-edge) reads must observe edits that have not yet been
+/// folded into the CSR base, without falling back to an O(V) scan or
+/// requiring an explicit rebuild.
+#[test]
+fn unrebuilt_edits_are_visible_to_dependent_reads() {
+    let mut engine = make_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 3, LiteralValue::Int(3))
+        .unwrap();
+
+    // B1 = A1 (single edit: stays in the delta slab, below rebuild threshold)
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=A1").unwrap())
+        .unwrap();
+
+    let sheet_id = engine.graph.sheet_id("Sheet1").unwrap();
+    let a1 = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet_id, Coord::from_excel(1, 1, true, true)))
+        .unwrap();
+    let b1 = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet_id, Coord::from_excel(1, 2, true, true)))
+        .unwrap();
+    let c1 = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet_id, Coord::from_excel(1, 3, true, true)))
+        .unwrap();
+
+    assert!(
+        engine.graph.get_dependents(a1).contains(&b1),
+        "freshly added edge A1<-B1 must be visible to dependent reads"
+    );
+
+    // Re-point B1 at C1: A1 loses the dependent, C1 gains it — again without
+    // any rebuild in between.
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=C1").unwrap())
+        .unwrap();
+    assert!(
+        !engine.graph.get_dependents(a1).contains(&b1),
+        "removed edge A1<-B1 must disappear from dependent reads"
+    );
+    assert!(
+        engine.graph.get_dependents(c1).contains(&b1),
+        "new edge C1<-B1 must be visible to dependent reads"
+    );
+}
+
+/// Editing a value with un-rebuilt formula edges pending must still dirty the
+/// dependent formulas (mark_dirty consumes reverse edges).
+#[test]
+fn dirty_propagation_sees_unrebuilt_edges() {
+    let mut engine = make_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=A1*10").unwrap())
+        .unwrap();
+
+    let sheet_id = engine.graph.sheet_id("Sheet1").unwrap();
+    let b1 = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet_id, Coord::from_excel(1, 2, true, true)))
+        .unwrap();
+
+    // Value edit while the B1->A1 edge is still in the delta slab.
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(5))
+        .unwrap();
+    assert!(
+        engine.graph.get_evaluation_vertices().contains(&b1),
+        "dirty propagation must reach B1 through the un-rebuilt edge"
+    );
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(50.0))
+    );
+}
+
+/// End-to-end: edit -> evaluate -> re-edit dependencies -> evaluate. The
+/// scheduler must respect fresh dependency edges after every edit burst.
+#[test]
+fn edit_then_evaluate_respects_fresh_dependencies() {
+    let mut engine = make_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(2))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 3, LiteralValue::Int(7))
+        .unwrap();
+
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=A1+1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(3.0))
+    );
+
+    // Re-point at C1; the old A1 edge must be gone and the new C1 edge live.
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=C1+1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(8.0))
+    );
+
+    // Editing A1 must no longer dirty B1; editing C1 must.
+    engine
+        .set_cell_value("Sheet1", 1, 3, LiteralValue::Int(40))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(41.0))
+    );
+}
+
+/// Long per-cell edit bursts followed by evaluation produce correct results
+/// (the scheduling seam flushes pending deltas exactly once).
+#[test]
+fn edit_burst_then_evaluate_is_correct() {
+    let n = 256u32;
+    let mut engine = make_engine();
+    for row in 1..=n {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Int(row as i64))
+            .unwrap();
+    }
+    for row in 1..=n {
+        let ast = parse(format!("=A{row}*2")).unwrap();
+        engine.set_cell_formula("Sheet1", row, 2, ast).unwrap();
+    }
+    engine.evaluate_all().unwrap();
+    for row in 1..=n {
+        assert_eq!(
+            engine.get_cell_value("Sheet1", row, 2),
+            Some(LiteralValue::Number(row as f64 * 2.0)),
+            "row {row}"
+        );
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -136,6 +136,7 @@ mod row_visibility_transactions;
 mod subtotal_visibility;
 mod visibility_mask_cache;
 
+mod csr_rebuild_amortization;
 mod demand_subgraph_named_range;
 mod dn_range_xlsx_subgraph;
 mod live_edges;


### PR DESCRIPTION
Fixes #125.

Per-cell `set_formula` was O(N²): `add_dependent_edges` wrapped each formula's edges in `begin_batch`/`end_batch`, and `end_batch` rebuilt the full CSR unconditionally (re-merging adjacency for every vertex), defeating the existing 1000-op amortization threshold; `add_vertex` forced rebuilds too.

The blocker for simply deferring rebuilds was the read contract: out-edges were already delta-aware, but **in-edges were not** — `get_dependents` fell back to an O(V) full-graph scan when the delta slab was non-empty, and several sites force-rebuilt before reading dependents. So the fix is a write-cheap/read-flush split: the delta slab gains a reverse index making `get_dependents` O(in-degree) delta-aware (force-rebuilds removed), `end_batch` honors the amortization threshold, `add_vertex` no longer rebuilds, and `flush_pending_edge_deltas()` runs once at the evaluation seams (`evaluate_until*`, `create_evaluation_schedule`) so eval keeps its zero-allocation slice fast paths. `&self` preview paths stay correct via merged reads.

Also corrects the wrong attribution comment in `probe-scc-phantom-pairs.rs` (the O(N²) was never cycle detection — it was this + #126).

**Measured** (release, ephemeral, per-cell `set_formula` loop): 2k/4k/8k = 517/1880/7525 ms before → **19/32/93 ms** after (quadratic → linear, ~81× at 8k). Single edits in large workbooks now pay O(deps), not O(V).

Tests: 11 new, counter-based rather than wall-clock (rebuild-count bound for a 2k burst, linear rebuild scaling 2k→8k, un-rebuilt edges visible to dependent reads and dirty propagation, edit→evaluate→re-edit freshness) plus 5 delta-slab unit tests. Full workspace suite (CI exclusions): 2483 passed, 0 failed (baseline 2472 + 11). fmt/clippy clean.

Bench gate (interleaved A/B vs main, 6 rounds): linear-rollup 200k and finance-recalc both within noise, mixed direction. Edit-path scaling numbers above are the headline.

Follow-up noted: exposing engine `begin_batch`/`end_batch` through the Workbook API (routes through changelog/transaction machinery; per-edit cost is now amortized anyway).
