### PR TITLE
fix(workbook): per-cell changelog deltas — interactive set_formula goes quadratic→linear

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -57,6 +57,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 type StagedFormulaEntry = (u32, u32, String);
+// NOTE(#126): the per-sheet `Vec` makes `stage_formula_text`/`clear_staged_formula_text`/
+// `get_staged_formula_text` O(staged-on-sheet) per call. The changelog O(N^2) regression
+// (full before/after snapshots per edit) is fixed via per-cell `StagedFormulaCellChanged`
+// deltas. Converting this Vec to a `(row,col)`-keyed map would make the residual lookups
+// O(1), but it threads through `build_graph_all`/`build_graph_for_sheets`/ingest records,
+// so it is intentionally left as a separate, contained follow-up.
 type StagedFormulaMap = std::collections::HashMap<String, Vec<StagedFormulaEntry>>;
 
 fn producer_dirty_to_span_dirty(
@@ -2775,29 +2781,6 @@ where
         self.staged_formulas.values().map(Vec::len).sum()
     }
 
-    pub fn staged_formula_state_snapshot(&self) -> Vec<(String, u32, u32, String)> {
-        let mut snapshot = Vec::new();
-        for (sheet, entries) in &self.staged_formulas {
-            for (row, col, text) in entries {
-                snapshot.push((sheet.clone(), *row, *col, text.clone()));
-            }
-        }
-        snapshot.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then(a.1.cmp(&b.1))
-                .then(a.2.cmp(&b.2))
-                .then(a.3.cmp(&b.3))
-        });
-        snapshot
-    }
-
-    pub fn restore_staged_formula_state(&mut self, snapshot: &[(String, u32, u32, String)]) {
-        self.staged_formulas.clear();
-        for (sheet, row, col, text) in snapshot {
-            self.stage_formula_text(sheet, *row, *col, text.clone());
-        }
-    }
-
     /// Stage a formula text instead of inserting into the graph (used when deferring is enabled).
     pub fn stage_formula_text(&mut self, sheet: &str, row: u32, col: u32, text: String) {
         let entries = self.staged_formulas.entry(sheet.to_string()).or_default();
@@ -3813,14 +3796,39 @@ where
     }
 
     fn apply_inverse_staged_formula_event(&mut self, event: &crate::engine::ChangeEvent) {
-        if let crate::engine::ChangeEvent::StagedFormulaStateChanged { before, .. } = event {
-            self.restore_staged_formula_state(before);
+        if let crate::engine::ChangeEvent::StagedFormulaCellChanged {
+            sheet,
+            row,
+            col,
+            old,
+            ..
+        } = event
+        {
+            self.apply_staged_formula_cell(sheet, *row, *col, old.as_deref());
         }
     }
 
     fn apply_forward_staged_formula_event(&mut self, event: &crate::engine::ChangeEvent) {
-        if let crate::engine::ChangeEvent::StagedFormulaStateChanged { after, .. } = event {
-            self.restore_staged_formula_state(after);
+        if let crate::engine::ChangeEvent::StagedFormulaCellChanged {
+            sheet,
+            row,
+            col,
+            new,
+            ..
+        } = event
+        {
+            self.apply_staged_formula_cell(sheet, *row, *col, new.as_deref());
+        }
+    }
+
+    /// Set a single cell's staged formula text to `target` (clearing it when
+    /// `None`). Used by undo/redo replay of per-cell staged-formula deltas.
+    fn apply_staged_formula_cell(&mut self, sheet: &str, row: u32, col: u32, target: Option<&str>) {
+        match target {
+            Some(text) => self.stage_formula_text(sheet, row, col, text.to_string()),
+            None => {
+                self.clear_staged_formula_text(sheet, row, col);
+            }
         }
     }
 
@@ -6890,7 +6898,7 @@ where
             | ChangeEvent::EdgeRemoved { .. }
             | ChangeEvent::CompoundStart { .. }
             | ChangeEvent::CompoundEnd { .. }
-            | ChangeEvent::StagedFormulaStateChanged { .. } => {}
+            | ChangeEvent::StagedFormulaCellChanged { .. } => {}
         }
     }
 

--- a/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
@@ -145,10 +145,25 @@ pub enum ChangeEvent {
         anchor: VertexId,
         old: SpillSnapshot,
     },
-    /// Workbook-level staged formula snapshot used to keep deferred edits undoable.
-    StagedFormulaStateChanged {
-        before: Vec<(String, u32, u32, String)>,
-        after: Vec<(String, u32, u32, String)>,
+    /// Workbook-level per-cell staged formula delta used to keep deferred edits
+    /// undoable.
+    ///
+    /// Replaces the former `StagedFormulaStateChanged` full before/after snapshot
+    /// pair (which made interactive `set_formula` O(N) per edit and O(N^2) in
+    /// changelog memory — see #126). Each edit records only the affected cell's
+    /// staged text transition, so a sequence of N edits costs O(N) total.
+    ///
+    /// - `old`: the staged formula text for the cell before the edit, if any.
+    /// - `new`: the staged formula text for the cell after the edit, if any.
+    ///
+    /// Undo restores `old` (re-stage if `Some`, clear if `None`); redo applies
+    /// `new` (re-stage if `Some`, clear if `None`).
+    StagedFormulaCellChanged {
+        sheet: String,
+        row: u32,
+        col: u32,
+        old: Option<String>,
+        new: Option<String>,
     },
 }
 

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -528,7 +528,7 @@ impl<'g> VertexEditor<'g> {
                     )
                     .map_err(EditorError::Excel)?;
             }
-            ChangeEvent::StagedFormulaStateChanged { .. } => {
+            ChangeEvent::StagedFormulaCellChanged { .. } => {
                 // Workbook-level deferred state is replayed by Engine undo/redo wrappers.
             }
             // Granular events for compound operations

--- a/crates/formualizer-eval/src/engine/journal.rs
+++ b/crates/formualizer-eval/src/engine/journal.rs
@@ -291,7 +291,7 @@ fn apply_forward_change_event(
         }
         ChangeEvent::CompoundStart { .. }
         | ChangeEvent::CompoundEnd { .. }
-        | ChangeEvent::StagedFormulaStateChanged { .. } => {}
+        | ChangeEvent::StagedFormulaCellChanged { .. } => {}
     }
     Ok(())
 }

--- a/crates/formualizer-eval/src/engine/tests/changelog_replay.rs
+++ b/crates/formualizer-eval/src/engine/tests/changelog_replay.rs
@@ -170,7 +170,7 @@ fn replay_events(graph: &mut DependencyGraph, events: &[ChangeEvent]) {
             // mutate the graph snapshot under test.
             ChangeEvent::EdgeAdded { .. }
             | ChangeEvent::EdgeRemoved { .. }
-            | ChangeEvent::StagedFormulaStateChanged { .. } => {}
+            | ChangeEvent::StagedFormulaCellChanged { .. } => {}
         }
     }
 }

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -882,8 +882,6 @@ pub struct Workbook {
     undo: formualizer_eval::engine::graph::editor::undo_engine::UndoEngine,
 }
 
-type StagedFormulaState = Vec<(String, u32, u32, String)>;
-
 trait WorkbookActionOps {
     fn set_value(
         &mut self,
@@ -1503,6 +1501,12 @@ impl Workbook {
     pub fn engine_mut(&mut self) -> &mut formualizer_eval::engine::Engine<WBResolver> {
         &mut self.engine
     }
+    /// Read-only access to the workbook changelog (audit trail of graph/staged mutations).
+    ///
+    /// Primarily for tests and tooling that need to introspect recorded events.
+    pub fn changelog(&self) -> &formualizer_eval::engine::ChangeLog {
+        &self.log
+    }
     pub fn eval_config(&self) -> &formualizer_eval::engine::EvalConfig {
         &self.engine.config
     }
@@ -1553,22 +1557,41 @@ impl Workbook {
         self.log.set_reason(reason);
     }
 
-    fn staged_formula_state_snapshot(&self) -> StagedFormulaState {
-        self.engine.staged_formula_state_snapshot()
+    /// Read the staged formula text for a single cell (cloned), if any.
+    ///
+    /// Cheap O(per-sheet) lookup used to snapshot the *old* staged state of a
+    /// cell before mutating it, so a per-cell delta can be recorded for undo.
+    fn staged_formula_cell(&self, sheet: &str, row: u32, col: u32) -> Option<String> {
+        self.engine.get_staged_formula_text(sheet, row, col)
     }
 
-    fn record_staged_formula_state_change(&mut self, before: StagedFormulaState) {
+    /// Record a per-cell staged-formula delta for undo/redo.
+    ///
+    /// `before` is the staged text prior to the edit; `after` is the staged text
+    /// after the edit. No-op when the value is unchanged or the changelog is off.
+    /// This replaces the former full before/after snapshot pair (see #126), so a
+    /// sequence of N staged-formula edits costs O(N) changelog memory, not O(N^2).
+    fn record_staged_formula_cell_change(
+        &mut self,
+        sheet: &str,
+        row: u32,
+        col: u32,
+        before: Option<String>,
+        after: Option<String>,
+    ) {
         if !self.enable_changelog {
             return;
         }
-        let after = self.staged_formula_state_snapshot();
         if before == after {
             return;
         }
         self.log.record(
-            formualizer_eval::engine::graph::editor::change_log::ChangeEvent::StagedFormulaStateChanged {
-                before,
-                after,
+            formualizer_eval::engine::graph::editor::change_log::ChangeEvent::StagedFormulaCellChanged {
+                sheet: sheet.to_string(),
+                row,
+                col,
+                old: before,
+                new: after,
             },
         );
     }
@@ -2065,7 +2088,7 @@ impl Workbook {
         self.ensure_arrow_sheet_capacity(sheet, row as usize, col as usize);
         let staged_before = self
             .enable_changelog
-            .then(|| self.staged_formula_state_snapshot());
+            .then(|| self.staged_formula_cell(sheet, row, col));
         if self.enable_changelog {
             // Use VertexEditor with logging for graph, then mirror overlay and mark edited
             let sheet_id = self
@@ -2094,7 +2117,7 @@ impl Workbook {
             self.mirror_value_to_overlay(sheet, row, col, &value);
             self.engine.clear_staged_formula_text(sheet, row, col);
             if let Some(before) = staged_before {
-                self.record_staged_formula_state_change(before);
+                self.record_staged_formula_cell_change(sheet, row, col, before, None);
             }
             self.engine.mark_data_edited();
             Ok(())
@@ -2117,7 +2140,7 @@ impl Workbook {
         self.ensure_arrow_sheet_capacity(sheet, row as usize, col as usize);
         let staged_before = self
             .enable_changelog
-            .then(|| self.staged_formula_state_snapshot());
+            .then(|| self.staged_formula_cell(sheet, row, col));
         if self.engine.config.defer_graph_building {
             if self.engine.get_cell(sheet, row, col).is_some() {
                 let with_eq = if formula.starts_with('=') {
@@ -2148,7 +2171,7 @@ impl Workbook {
                         .patch_last_cell_event_old_state(cell, old_value, old_formula);
                     self.engine.clear_staged_formula_text(sheet, row, col);
                     if let Some(before) = staged_before {
-                        self.record_staged_formula_state_change(before);
+                        self.record_staged_formula_cell_change(sheet, row, col, before, None);
                     }
                     self.engine.mark_data_edited();
                     Ok(())
@@ -2163,7 +2186,8 @@ impl Workbook {
                 self.engine
                     .stage_formula_text(sheet, row, col, formula.to_string());
                 if let Some(before) = staged_before {
-                    self.record_staged_formula_state_change(before);
+                    let after = self.staged_formula_cell(sheet, row, col);
+                    self.record_staged_formula_cell_change(sheet, row, col, before, after);
                 }
                 Ok(())
             }
@@ -2189,7 +2213,7 @@ impl Workbook {
                 });
                 self.engine.clear_staged_formula_text(sheet, row, col);
                 if let Some(before) = staged_before {
-                    self.record_staged_formula_state_change(before);
+                    self.record_staged_formula_cell_change(sheet, row, col, before, None);
                 }
                 self.engine.mark_data_edited();
                 Ok(())
@@ -2287,9 +2311,6 @@ impl Workbook {
         _start: (u32, u32),
         cells: BTreeMap<(u32, u32), crate::traits::CellData>,
     ) -> Result<(), IoError> {
-        let staged_before = self
-            .enable_changelog
-            .then(|| self.staged_formula_state_snapshot());
         if self.enable_changelog {
             let sheet_id = self
                 .engine
@@ -2299,6 +2320,8 @@ impl Workbook {
 
             // Capture per-cell old state from Arrow truth BEFORE applying the bulk edit.
             // In canonical mode the graph value cache is empty, so ChangeLog old_value must be patched.
+            // `staged_before` is the cell's staged formula text prior to the edit, used to
+            // record a per-cell staged-formula delta for undo/redo (see #126).
             #[allow(clippy::type_complexity)]
             let mut items: Vec<(
                 u32,
@@ -2307,6 +2330,7 @@ impl Workbook {
                 formualizer_eval::reference::CellRef,
                 Option<LiteralValue>,
                 Option<formualizer_parse::ASTNode>,
+                Option<String>,
             )> = Vec::with_capacity(cells.len());
             for ((r, c), d) in cells.into_iter() {
                 let cell = formualizer_eval::reference::CellRef::new(
@@ -2315,7 +2339,8 @@ impl Workbook {
                 );
                 let old_value = self.engine.get_cell_value(sheet, r, c);
                 let old_formula = self.engine.get_cell(sheet, r, c).and_then(|(ast, _)| ast);
-                items.push((r, c, d, cell, old_value, old_formula));
+                let staged_before = self.staged_formula_cell(sheet, r, c);
+                items.push((r, c, d, cell, old_value, old_formula, staged_before));
             }
 
             let mut overlay_ops: Vec<(u32, u32, LiteralValue)> = Vec::new();
@@ -2323,7 +2348,7 @@ impl Workbook {
 
             self.engine
                 .edit_with_logger(&mut self.log, |editor| -> Result<(), IoError> {
-                    for (r, c, d, cell, _old_value, _old_formula) in items.iter() {
+                    for (r, c, d, cell, _old_value, _old_formula, _staged_before) in items.iter() {
                         if let Some(v) = d.value.clone() {
                             editor.set_cell_value(*cell, v.clone());
                             // If a formula is also being set for this cell, do not mirror the
@@ -2352,7 +2377,7 @@ impl Workbook {
                 })?;
 
             // Patch old_value/old_formula for each cell's last SetValue/SetFormula event.
-            for (_r, _c, _d, cell, old_value, old_formula) in items.iter().rev() {
+            for (_r, _c, _d, cell, old_value, old_formula, _staged_before) in items.iter().rev() {
                 self.log.patch_last_cell_event_old_state(
                     *cell,
                     old_value.clone(),
@@ -2363,7 +2388,7 @@ impl Workbook {
             for (r, c, v) in overlay_ops {
                 self.mirror_value_to_overlay(sheet, r, c, &v);
             }
-            for (r, c, d, _cell, _old_value, _old_formula) in &items {
+            for (r, c, d, _cell, _old_value, _old_formula, _staged_before) in &items {
                 if d.formula.is_none() && d.value.is_some() {
                     self.engine.clear_staged_formula_text(sheet, *r, *c);
                 }
@@ -2374,8 +2399,19 @@ impl Workbook {
             for (r, c, f) in staged_forms {
                 self.engine.stage_formula_text(sheet, r, c, f);
             }
-            if let Some(before) = staged_before {
-                self.record_staged_formula_state_change(before);
+            // Record a per-cell staged-formula delta for every touched cell whose
+            // staged state changed (see #126: avoids O(N^2) full snapshots).
+            for (r, c, _d, _cell, _old_value, _old_formula, staged_before) in &items {
+                let after = self.staged_formula_cell(sheet, *r, *c);
+                if *staged_before != after {
+                    self.record_staged_formula_cell_change(
+                        sheet,
+                        *r,
+                        *c,
+                        staged_before.clone(),
+                        after,
+                    );
+                }
             }
             self.engine.mark_data_edited();
             Ok(())
@@ -2418,9 +2454,6 @@ impl Workbook {
         start_col: u32,
         rows: &[Vec<LiteralValue>],
     ) -> Result<(), IoError> {
-        let staged_before = self
-            .enable_changelog
-            .then(|| self.staged_formula_state_snapshot());
         if self.enable_changelog {
             let sheet_id = self
                 .engine
@@ -2428,6 +2461,8 @@ impl Workbook {
                 .unwrap_or_else(|| self.engine.add_sheet(sheet).expect("add sheet"));
 
             // Capture old state from Arrow truth BEFORE applying the batch.
+            // `staged_before` is the cell's staged formula text prior to the edit,
+            // used to record a per-cell staged-formula delta for undo/redo (see #126).
             #[allow(clippy::type_complexity)]
             let mut items: Vec<(
                 u32,
@@ -2436,6 +2471,7 @@ impl Workbook {
                 formualizer_eval::reference::CellRef,
                 Option<LiteralValue>,
                 Option<formualizer_parse::ASTNode>,
+                Option<String>,
             )> = Vec::new();
             for (ri, rvals) in rows.iter().enumerate() {
                 let r = start_row + ri as u32;
@@ -2447,17 +2483,18 @@ impl Workbook {
                     );
                     let old_value = self.engine.get_cell_value(sheet, r, c);
                     let old_formula = self.engine.get_cell(sheet, r, c).and_then(|(ast, _)| ast);
-                    items.push((r, c, v.clone(), cell, old_value, old_formula));
+                    let staged_before = self.staged_formula_cell(sheet, r, c);
+                    items.push((r, c, v.clone(), cell, old_value, old_formula, staged_before));
                 }
             }
 
             self.engine.edit_with_logger(&mut self.log, |editor| {
-                for (_r, _c, v, cell, _old_value, _old_formula) in items.iter() {
+                for (_r, _c, v, cell, _old_value, _old_formula, _staged_before) in items.iter() {
                     editor.set_cell_value(*cell, v.clone());
                 }
             });
 
-            for (_r, _c, _v, cell, old_value, old_formula) in items.iter().rev() {
+            for (_r, _c, _v, cell, old_value, old_formula, _staged_before) in items.iter().rev() {
                 self.log.patch_last_cell_event_old_state(
                     *cell,
                     old_value.clone(),
@@ -2465,12 +2502,13 @@ impl Workbook {
                 );
             }
 
-            for (r, c, v, _cell, _old_value, _old_formula) in items {
+            for (r, c, v, _cell, _old_value, _old_formula, staged_before) in items {
                 self.mirror_value_to_overlay(sheet, r, c, &v);
                 self.engine.clear_staged_formula_text(sheet, r, c);
-            }
-            if let Some(before) = staged_before {
-                self.record_staged_formula_state_change(before);
+                // Setting a literal value clears any staged formula for this cell.
+                if staged_before.is_some() {
+                    self.record_staged_formula_cell_change(sheet, r, c, staged_before, None);
+                }
             }
             self.engine.mark_data_edited();
             Ok(())
@@ -2505,20 +2543,24 @@ impl Workbook {
         let end_row = start_row.saturating_add((height - 1) as u32);
         let end_col = start_col.saturating_add((width - 1) as u32);
         self.ensure_arrow_sheet_capacity(sheet, end_row as usize, end_col as usize);
-        let staged_before = self
-            .enable_changelog
-            .then(|| self.staged_formula_state_snapshot());
 
         if self.engine.config.defer_graph_building {
+            // Per-cell staged-formula deltas (see #126). Capture each cell's prior
+            // staged text before overwriting so undo/redo can replay precisely.
             for (ri, rforms) in rows.iter().enumerate() {
                 let r = start_row + ri as u32;
                 for (ci, f) in rforms.iter().enumerate() {
                     let c = start_col + ci as u32;
+                    let staged_before = self
+                        .enable_changelog
+                        .then(|| self.staged_formula_cell(sheet, r, c))
+                        .flatten();
                     self.engine.stage_formula_text(sheet, r, c, f.clone());
+                    if self.enable_changelog {
+                        let after = self.staged_formula_cell(sheet, r, c);
+                        self.record_staged_formula_cell_change(sheet, r, c, staged_before, after);
+                    }
                 }
-            }
-            if let Some(before) = staged_before {
-                self.record_staged_formula_state_change(before);
             }
             Ok(())
         } else if self.enable_changelog {
@@ -2526,6 +2568,16 @@ impl Workbook {
                 .engine
                 .sheet_id(sheet)
                 .unwrap_or_else(|| self.engine.add_sheet(sheet).expect("add sheet"));
+
+            // Capture each cell's prior staged text before the batch edit clears it.
+            let mut staged_before: Vec<(u32, u32, Option<String>)> = Vec::new();
+            for (ri, rforms) in rows.iter().enumerate() {
+                let r = start_row + ri as u32;
+                for (ci, _f) in rforms.iter().enumerate() {
+                    let c = start_col + ci as u32;
+                    staged_before.push((r, c, self.staged_formula_cell(sheet, r, c)));
+                }
+            }
 
             self.engine
                 .edit_with_logger(&mut self.log, |editor| -> Result<(), IoError> {
@@ -2557,8 +2609,11 @@ impl Workbook {
                     self.engine.clear_staged_formula_text(sheet, r, c);
                 }
             }
-            if let Some(before) = staged_before {
-                self.record_staged_formula_state_change(before);
+            // Setting a graph formula clears any staged text; record per-cell deltas.
+            for (r, c, before) in staged_before {
+                if before.is_some() {
+                    self.record_staged_formula_cell_change(sheet, r, c, before, None);
+                }
             }
             self.engine.mark_data_edited();
             Ok(())

--- a/crates/formualizer-workbook/tests/staged_formula_changelog.rs
+++ b/crates/formualizer-workbook/tests/staged_formula_changelog.rs
@@ -1,0 +1,199 @@
+//! Regression tests for issue #126: changelog staged-state recording must be
+//! O(N), not O(N^2), and undo/redo semantics over staged formulas must be
+//! preserved exactly.
+//!
+//! These tests are written against the contract (undo/redo restores state) and
+//! against a payload-size budget (linear in the number of edits). They are
+//! intended to pass both before and after the fix for the undo/redo contract,
+//! and to *fail* on `main` for the scaling budget (documenting the regression).
+
+use formualizer_common::LiteralValue;
+use formualizer_eval::engine::ChangeEvent;
+use formualizer_workbook::Workbook;
+
+fn assert_numeric_eq(v: Option<LiteralValue>, expected: f64) {
+    match v {
+        Some(LiteralValue::Number(n)) => assert!((n - expected).abs() < 1e-9),
+        Some(LiteralValue::Int(i)) => assert!(((i as f64) - expected).abs() < 1e-9),
+        other => panic!("expected numeric {expected}, got {other:?}"),
+    }
+}
+
+/// Total number of staged-formula text strings retained across every recorded
+/// staged-formula changelog event. With the old snapshot-pair design this is
+/// O(N^2) in the number of `set_formula` calls; with per-cell deltas it is O(N).
+fn staged_formula_changelog_payload(wb: &Workbook) -> usize {
+    let mut total = 0usize;
+    for ev in wb.changelog().events() {
+        total += staged_formula_event_payload(ev);
+    }
+    total
+}
+
+fn staged_formula_event_payload(ev: &ChangeEvent) -> usize {
+    match ev {
+        // Per-cell delta (counts the staged texts present in this event). The old
+        // snapshot-pair design (`StagedFormulaStateChanged { before, after }`) recorded
+        // O(N) texts per edit and is intentionally removed by the #126 fix.
+        ChangeEvent::StagedFormulaCellChanged { old, new, .. } => {
+            old.is_some() as usize + new.is_some() as usize
+        }
+        _ => 0,
+    }
+}
+
+#[test]
+fn undo_redo_mixed_sequence_restores_state() {
+    // Mixed sequence: several set_formula (some overwriting each other), with
+    // interleaved set_value, each wrapped in its own action. Undo all -> original
+    // (empty) state. Redo all -> final state.
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    // Action 1: stage formula at A1
+    wb.begin_action("a1=1+1");
+    wb.set_formula("S", 1, 1, "1+1").unwrap();
+    wb.end_action();
+
+    // Action 2: stage formula at B1
+    wb.begin_action("b1=2+2");
+    wb.set_formula("S", 1, 2, "2+2").unwrap();
+    wb.end_action();
+
+    // Action 3: overwrite A1 staged formula with a new staged formula
+    wb.begin_action("a1=3+3");
+    wb.set_formula("S", 1, 1, "3+3").unwrap();
+    wb.end_action();
+
+    // Action 4: overwrite B1 staged formula with a literal value (clears staged)
+    wb.begin_action("b1=9");
+    wb.set_value("S", 1, 2, LiteralValue::Int(9)).unwrap();
+    wb.end_action();
+
+    // Action 5: stage formula at C1
+    wb.begin_action("c1=5+5");
+    wb.set_formula("S", 1, 3, "5+5").unwrap();
+    wb.end_action();
+
+    // Final state.
+    assert_eq!(wb.get_formula("S", 1, 1), Some("3+3".to_string()));
+    assert_eq!(wb.get_formula("S", 1, 2), None);
+    assert_numeric_eq(wb.get_value("S", 1, 2), 9.0);
+    assert_eq!(wb.get_formula("S", 1, 3), Some("5+5".to_string()));
+
+    // Undo all five actions -> original empty state.
+    for _ in 0..5 {
+        wb.undo().unwrap();
+    }
+    assert_eq!(wb.get_formula("S", 1, 1), None);
+    assert_eq!(wb.get_formula("S", 1, 2), None);
+    assert_emptyish(wb.get_value("S", 1, 2));
+    assert_eq!(wb.get_formula("S", 1, 3), None);
+
+    // Redo all five actions -> final state.
+    for _ in 0..5 {
+        wb.redo().unwrap();
+    }
+    assert_eq!(wb.get_formula("S", 1, 1), Some("3+3".to_string()));
+    assert_eq!(wb.get_formula("S", 1, 2), None);
+    assert_numeric_eq(wb.get_value("S", 1, 2), 9.0);
+    assert_eq!(wb.get_formula("S", 1, 3), Some("5+5".to_string()));
+    assert_eq!(
+        wb.evaluate_cell("S", 1, 1).unwrap(),
+        LiteralValue::Number(6.0)
+    );
+    assert_eq!(
+        wb.evaluate_cell("S", 1, 3).unwrap(),
+        LiteralValue::Number(10.0)
+    );
+}
+
+#[test]
+fn undo_redo_overwrite_same_cell_chain() {
+    // Repeatedly overwrite the same staged cell, then unwind step by step.
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    let chain = ["1+1", "2+2", "3+3", "4+4"];
+    for f in chain {
+        wb.begin_action("set");
+        wb.set_formula("S", 1, 1, f).unwrap();
+        wb.end_action();
+    }
+    assert_eq!(wb.get_formula("S", 1, 1), Some("4+4".to_string()));
+
+    // Undo step by step; each step reveals the prior staged formula.
+    wb.undo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("3+3".to_string()));
+    wb.undo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("2+2".to_string()));
+    wb.undo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("1+1".to_string()));
+    wb.undo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), None);
+
+    // Redo all the way back up.
+    for f in chain {
+        wb.redo().unwrap();
+        assert_eq!(wb.get_formula("S", 1, 1), Some(f.to_string()));
+    }
+}
+
+#[test]
+fn staged_formula_changelog_payload_is_linear() {
+    // After N distinct set_formula calls (each staging a new cell), the total
+    // staged-formula changelog payload must be O(N), not O(N^2).
+    //
+    // Old snapshot-pair design records `before` + `after` full vectors per edit:
+    //   edit i records ~ (i-1) + i texts  => sum ~ N^2.
+    // Per-cell delta design records at most a constant (here 1) per edit => N.
+    let n: u32 = 400;
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+
+    for i in 0..n {
+        wb.set_formula("S", i + 1, 1, "1+1").unwrap();
+    }
+
+    let payload = staged_formula_changelog_payload(&wb);
+    let n = n as usize;
+
+    // Linear budget: at most a small constant factor of N. The per-cell delta
+    // design records exactly 1 staged text per new staged cell (old=None,
+    // new=Some), i.e. exactly N. We allow generous slack (4*N) while still
+    // catching the quadratic regression, which for N=400 would be ~160_000.
+    assert!(
+        payload <= 4 * n,
+        "staged-formula changelog payload {payload} exceeds linear budget {} for N={n} \
+         (quadratic regression would be ~{})",
+        4 * n,
+        n * n
+    );
+}
+
+fn assert_emptyish(v: Option<LiteralValue>) {
+    assert!(matches!(v, None | Some(LiteralValue::Empty)));
+}
+
+/// Manual measurement loop for #126: interactive default (changelog on,
+/// defer_graph_building on), per-cell `set_formula` on fresh cells at 2k/4k/8k.
+/// Run with: `cargo test -p formualizer-workbook --test staged_formula_changelog \
+///   --release -- --ignored --nocapture measure_set_formula_scaling`
+#[test]
+#[ignore]
+fn measure_set_formula_scaling() {
+    for n in [2000u32, 4000, 8000] {
+        let mut wb = Workbook::new(); // interactive default: changelog on, defer on
+        wb.add_sheet("S").unwrap();
+        let start = std::time::Instant::now();
+        for i in 0..n {
+            wb.set_formula("S", i + 1, 1, "1+1").unwrap();
+        }
+        let elapsed = start.elapsed();
+        let payload = staged_formula_changelog_payload(&wb);
+        println!(
+            "N={n:>5}  set_formula loop = {:>8.2} ms  changelog_staged_payload = {payload}",
+            elapsed.as_secs_f64() * 1000.0
+        );
+    }
+}


### PR DESCRIPTION
Fixes #126.

With the changelog enabled (the `Workbook::new()` default), every `set_formula` took a full staged-state snapshot before AND after the edit — a clone+sort of all staged formulas including their Strings — and recorded both vectors in a `StagedFormulaStateChanged` event: O(N) per edit, O(N²) changelog memory.

Consumer mapping first: exactly two replay handlers read the payload (undo restores `before`, redo applies `after`); four other match arms were no-ops; `ChangeEvent` is never serialized. The event is replaced by a per-cell delta — `StagedFormulaCellChanged { sheet, row, col, old, new }` — recorded by all five producers (`set_value`, `set_formula`, `write_range`, `set_values`, `set_formulas`); undo re-applies `old` in reverse order, redo applies `new` forward. The batch path converts to per-cell deltas too, keeping a single uniform replay path with O(batch) payload. The O(N) snapshot helpers are deleted.

**Measured** (release, interactive default, per-cell `set_formula` loop): 2k/4k/8k = 480/2037/8151 ms before → **5.7/13.8/44.7 ms** after (~182× at 8k). Changelog staged payload is now exactly N (a failing-on-main test pinned the old N² payload at 160,000 for 400 edits).

Tests: undo/redo across a mixed overwrite-and-interleave sequence and a same-cell overwrite chain — both written against current main first to pin the contract, green before and after; payload-linearity assertion (fails on main); an `#[ignore]`d measurement loop. Full workspace suite (CI exclusions): 2475 passed, 0 failed (baseline 2472 + 3). fmt/clippy clean.

Honest residual: per-edit time still grows mildly super-linearly from the per-sheet staged-formula Vec scan (`stage_formula_text`) — ~180× smaller than the eliminated term at 8k, noted in-code with a `NOTE(#126)`, relevant only around 100k+ staged formulas.
