### PR TITLE
fix(graph): record self-loops for whole-axis and stripe-compressed range self-inclusion

### DIFF
--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -33,6 +33,41 @@ impl DependencyGraph {
         &self.stripe_to_dependents
     }
 
+    /// True when a (possibly open-ended) range region on `sheet_id` covers
+    /// the formula vertex's own cell. Used to record a self-loop for
+    /// stripe-compressed / whole-axis self-inclusion (#120): such references
+    /// never produce explicit cell edges, so the ingest self-reference check
+    /// (which scans expanded cell deps) misses them. `None` bounds mean the
+    /// axis is unbounded (whole column/row), which always covers the cell.
+    fn range_region_contains_self(
+        &self,
+        dependent: VertexId,
+        sheet_id: SheetId,
+        s_row: Option<u32>,
+        e_row: Option<u32>,
+        s_col: Option<u32>,
+        e_col: Option<u32>,
+    ) -> bool {
+        if self.store.sheet_id(dependent) != sheet_id {
+            return false;
+        }
+        let coord = self.store.coord(dependent);
+        let r0 = coord.row();
+        let c0 = coord.col();
+        s_row.is_none_or(|s| r0 >= s)
+            && e_row.is_none_or(|e| r0 <= e)
+            && s_col.is_none_or(|s| c0 >= s)
+            && e_col.is_none_or(|e| c0 <= e)
+    }
+
+    /// Record a self-loop edge (vertex → itself). The edge store and Tarjan
+    /// both treat self-loops as cycles (`separate_cycles` via `has_self_loop`).
+    fn record_self_loop(&mut self, vertex: VertexId) {
+        if !self.has_self_loop(vertex) {
+            self.edges.add_edge(vertex, vertex);
+        }
+    }
+
     pub(super) fn add_range_dependent_edges(
         &mut self,
         dependent: VertexId,
@@ -56,6 +91,14 @@ impl DependencyGraph {
             let e_row = range.end_row.map(|b| b.index);
             let s_col = range.start_col.map(|b| b.index);
             let e_col = range.end_col.map(|b| b.index);
+
+            // #120: a compressed range whose region covers this formula's own
+            // cell is a self-reference. Record a self-loop so SCC detection
+            // flags the cycle (the ingest self-ref check only sees expanded
+            // cell edges, which compressed ranges do not produce).
+            if self.range_region_contains_self(dependent, sheet_id, s_row, e_row, s_col, e_col) {
+                self.record_self_loop(dependent);
+            }
 
             let col_stripes = (s_row.is_none() && e_row.is_none())
                 || (s_col.is_some() && e_col.is_some() && (s_row.is_none() || e_row.is_none()));
@@ -268,6 +311,12 @@ impl DependencyGraph {
             let e_row = range.end_row.map(|b| b.index);
             let s_col = range.start_col.map(|b| b.index);
             let e_col = range.end_col.map(|b| b.index);
+
+            // #120: see add_range_dependent_edges — compressed range covering
+            // the formula's own cell records a self-loop for SCC detection.
+            if self.range_region_contains_self(dependent, sheet_id, s_row, e_row, s_col, e_col) {
+                self.record_self_loop(dependent);
+            }
 
             let col_stripes = (s_row.is_none() && e_row.is_none())
                 || (s_col.is_some() && e_col.is_some() && (s_row.is_none() || e_row.is_none()));

--- a/crates/formualizer-eval/src/engine/tests/dynamic_lookup_arrow.rs
+++ b/crates/formualizer-eval/src/engine/tests/dynamic_lookup_arrow.rs
@@ -31,12 +31,14 @@ fn take_whole_column_returns_single_cell_without_materializing() {
     let wb = TestWorkbook::new();
     let mut engine = Engine::new(wb, EvalConfig::default());
 
+    // Placed in column C so the whole-column reference is not self-inclusive
+    // (a `=TAKE(A:A,1)` *in* column A would be circular per #120).
     engine
-        .set_cell_formula("Sheet1", 1, 1, parse("=TAKE(A:A,1)").unwrap())
+        .set_cell_formula("Sheet1", 1, 3, parse("=TAKE(A:A,1)").unwrap())
         .unwrap();
 
     engine.evaluate_all().unwrap();
-    assert_eq!(engine.get_cell_value("Sheet1", 1, 1), None);
+    assert_eq!(engine.get_cell_value("Sheet1", 1, 3), None);
 }
 
 #[test]
@@ -44,11 +46,12 @@ fn drop_whole_column_can_return_last_cell_without_materializing() {
     let wb = TestWorkbook::new();
     let mut engine = Engine::new(wb, EvalConfig::default());
 
-    // DROP(A:A,1048575) returns the last row of A:A.
+    // DROP(A:A,1048575) returns the last row of A:A. Placed in column C so the
+    // whole-column reference is not self-inclusive (#120).
     engine
-        .set_cell_formula("Sheet1", 1, 1, parse("=DROP(A:A,1048575)").unwrap())
+        .set_cell_formula("Sheet1", 1, 3, parse("=DROP(A:A,1048575)").unwrap())
         .unwrap();
 
     engine.evaluate_all().unwrap();
-    assert_eq!(engine.get_cell_value("Sheet1", 1, 1), None);
+    assert_eq!(engine.get_cell_value("Sheet1", 1, 3), None);
 }

--- a/crates/formualizer-eval/src/engine/tests/named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/named_ranges.rs
@@ -356,12 +356,16 @@ fn row_and_columns_named_range_track_anchor_and_width_updates() {
 fn rows_full_column_reference_returns_excel_sheet_height() {
     let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
 
+    // Placed in column E (not column A): a whole-column ref self-included in
+    // its own column is flagged circular (#120, consistent with bounded
+    // self-inclusion which already errors at ingest regardless of the
+    // shape-only function).
     engine
-        .set_cell_formula("Sheet1", 1, 1, parse("=ROWS(A:A)").unwrap())
+        .set_cell_formula("Sheet1", 1, 5, parse("=ROWS(A:A)").unwrap())
         .unwrap();
     engine.evaluate_all().unwrap();
 
-    match engine.get_cell_value("Sheet1", 1, 1) {
+    match engine.get_cell_value("Sheet1", 1, 5) {
         Some(LiteralValue::Int(v)) => assert_eq!(v, 1_048_576),
         Some(LiteralValue::Number(v)) => assert!((v - 1_048_576.0).abs() < 1e-9),
         other => panic!("expected 1048576 rows for full-column reference, got {other:?}"),
@@ -372,12 +376,14 @@ fn rows_full_column_reference_returns_excel_sheet_height() {
 fn columns_full_row_reference_returns_excel_sheet_width() {
     let mut engine = Engine::new(TestWorkbook::new(), canonical_cfg());
 
+    // Placed in row 5 (not row 1): a whole-row ref self-included in its own
+    // row is flagged circular (#120, consistent with bounded self-inclusion).
     engine
-        .set_cell_formula("Sheet1", 1, 1, parse("=COLUMNS(1:1)").unwrap())
+        .set_cell_formula("Sheet1", 5, 1, parse("=COLUMNS(1:1)").unwrap())
         .unwrap();
     engine.evaluate_all().unwrap();
 
-    match engine.get_cell_value("Sheet1", 1, 1) {
+    match engine.get_cell_value("Sheet1", 5, 1) {
         Some(LiteralValue::Int(v)) => assert_eq!(v, 16_384),
         Some(LiteralValue::Number(v)) => assert!((v - 16_384.0).abs() < 1e-9),
         other => panic!("expected 16384 columns for full-row reference, got {other:?}"),

--- a/crates/formualizer-eval/src/engine/tests/scc_runtime_cycles.rs
+++ b/crates/formualizer-eval/src/engine/tests/scc_runtime_cycles.rs
@@ -343,12 +343,16 @@ fn named_range_covering_the_cell_rejected_at_ingest_in_both_modes() {
     }
 }
 
-/// KNOWN GAP (pre-existing, pre-dates #112 — static dependency extraction,
-/// not Runtime evaluation): whole-column self-inclusion `=SUM(B:B)` in B1 is
-/// not detected as a static SCC, so no cycle unit exists for either mode to
-/// handle. Spec §7.8's stripe-path `#CIRC!` is therefore NOT yet delivered;
-/// this test pins that Runtime at least matches Static exactly (no silent
-/// divergence) until the detection gap is fixed.
+/// Spec §7.8 stripe-path self-inclusion (#120): whole-column `=SUM(B:B)` in
+/// B1 references column B, which contains B1 itself. At ingest the stripe
+/// region is detected to cover the formula's own cell, so a SELF-LOOP edge is
+/// recorded; Tarjan then sees a single-vertex SCC with a self-loop and
+/// `separate_cycles` classifies it as a cycle. Both modes resolve to `#CIRC!`
+/// under `CyclePolicy::Error` and Runtime still matches Static exactly.
+///
+/// This pin previously documented the *incorrect* pre-#120 value (silent
+/// `9.0`, 0 cycle errors); it was consciously updated when the detection gap
+/// was closed.
 #[test]
 fn whole_column_self_inclusion_gap_runtime_matches_static() {
     let run = |cfg: EvalConfig| {
@@ -363,10 +367,112 @@ fn whole_column_self_inclusion_gap_runtime_matches_static() {
     let static_out = run(EvalConfig::default());
     let runtime_out = run(runtime_cfg());
     assert_eq!(static_out, runtime_out);
-    // Document today's (incorrect per spec §7.8) value so a future detection
-    // fix must consciously update this pin.
-    assert_eq!(static_out.0, Some(LiteralValue::Number(9.0)));
-    assert_eq!(static_out.1, 0);
+    // Whole-column self-inclusion is now a detected cycle in both modes.
+    assert!(
+        matches!(
+            static_out.0,
+            Some(LiteralValue::Error(ref e)) if e.kind == ExcelErrorKind::Circ
+        ),
+        "expected #CIRC, got {:?}",
+        static_out.0
+    );
+    assert_eq!(static_out.1, 1);
+}
+
+/// #120: whole-column self-inclusion `=SUM(B:B)` placed in column B is a
+/// circular reference (Excel flags it). The stripe region covers the
+/// formula's own cell, so a self-loop is recorded at ingest and the cell
+/// resolves to `#CIRC!` under both detection modes.
+#[test]
+fn whole_column_in_column_self_inclusion_is_circ_both_modes() {
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        for r in 2..=4u32 {
+            set_value(&mut engine, "Sheet1", r, 2, LiteralValue::Number(r as f64));
+        }
+        // B1 = SUM(B:B) ⇒ B1 ∈ column B ⇒ self-loop.
+        set_formula(&mut engine, "Sheet1", 1, 2, "=SUM(B:B)");
+        engine.evaluate_all().unwrap();
+        assert!(
+            is_circ(&engine, "Sheet1", 1, 2),
+            "B1=SUM(B:B) must be #CIRC, got {:?}",
+            engine.get_cell_value("Sheet1", 1, 2)
+        );
+    }
+}
+
+/// #120 symmetric whole-row case: `=SUM(2:2)` placed in row 2 is circular.
+#[test]
+fn whole_row_in_row_self_inclusion_is_circ_both_modes() {
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        for c in 3..=5u32 {
+            set_value(&mut engine, "Sheet1", 2, c, LiteralValue::Number(c as f64));
+        }
+        // B2 = SUM(2:2) ⇒ B2 ∈ row 2 ⇒ self-loop.
+        set_formula(&mut engine, "Sheet1", 2, 2, "=SUM(2:2)");
+        engine.evaluate_all().unwrap();
+        assert!(
+            is_circ(&engine, "Sheet1", 2, 2),
+            "B2=SUM(2:2) must be #CIRC, got {:?}",
+            engine.get_cell_value("Sheet1", 2, 2)
+        );
+    }
+}
+
+/// #120 large bounded range over the expansion limit: `=SUM(B1:B100000)` in
+/// B5 is stripe-compressed (not expanded to explicit cell edges), so the
+/// pre-#120 ingest self-reference check never saw B5. The stripe region now
+/// covers B5 ⇒ self-loop ⇒ `#CIRC!`.
+#[test]
+fn large_bounded_range_self_inclusion_is_circ_both_modes() {
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        for r in 1..=4u32 {
+            set_value(&mut engine, "Sheet1", r, 2, LiteralValue::Number(r as f64));
+        }
+        set_formula(&mut engine, "Sheet1", 5, 2, "=SUM(B1:B100000)");
+        engine.evaluate_all().unwrap();
+        assert!(
+            is_circ(&engine, "Sheet1", 5, 2),
+            "B5=SUM(B1:B100000) must be #CIRC, got {:?}",
+            engine.get_cell_value("Sheet1", 5, 2)
+        );
+    }
+}
+
+/// #120 NEGATIVE control: a whole-column reference consumed from OUTSIDE the
+/// column stays acyclic and computes normally.
+#[test]
+fn whole_column_referenced_from_outside_stays_acyclic() {
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        for r in 1..=3u32 {
+            set_value(&mut engine, "Sheet1", r, 2, LiteralValue::Number(r as f64));
+        }
+        // C1 = SUM(B:B): column C is not referenced ⇒ no self-loop.
+        set_formula(&mut engine, "Sheet1", 1, 3, "=SUM(B:B)");
+        let res = engine.evaluate_all().unwrap();
+        assert_eq!(num(&engine, "Sheet1", 1, 3), 6.0);
+        assert_eq!(res.cycle_errors, 0);
+    }
+}
+
+/// #120 NEGATIVE control: a large bounded range NOT intersecting the
+/// formula's own cell is unchanged (computes, no cycle).
+#[test]
+fn large_bounded_range_non_intersecting_stays_acyclic() {
+    for cfg in [EvalConfig::default(), runtime_cfg()] {
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        for r in 1..=4u32 {
+            set_value(&mut engine, "Sheet1", r, 1, LiteralValue::Number(r as f64));
+        }
+        // B5 = SUM(A1:A100000): own cell B5 is in column B, range is column A.
+        set_formula(&mut engine, "Sheet1", 5, 2, "=SUM(A1:A100000)");
+        let res = engine.evaluate_all().unwrap();
+        assert_eq!(num(&engine, "Sheet1", 5, 2), 10.0);
+        assert_eq!(res.cycle_errors, 0);
+    }
 }
 
 /* ──────────────────── 7.9 spill anchor inside an SCC ─────────────────── */

--- a/crates/formualizer-eval/src/engine/tests/stripe_streaming_integration.rs
+++ b/crates/formualizer-eval/src/engine/tests/stripe_streaming_integration.rs
@@ -329,13 +329,15 @@ fn test_streaming_range_shape_variations() {
 
     let dense_formula = "=SUM(B1:Z100)";
     let dense_ast = parse(dense_formula).unwrap();
-    engine.set_cell_formula("Sheet1", 3, 5, dense_ast).unwrap();
+    // Place outside the B1:Z100 rectangle (col 60) so the formula is not
+    // self-inclusive — E3 sits inside B1:Z100 and would be circular per #120.
+    engine.set_cell_formula("Sheet1", 3, 60, dense_ast).unwrap();
 
     engine.evaluate_all().unwrap();
 
     let tall_result = engine.get_cell_value("Sheet1", 1, 5).unwrap();
     let wide_result = engine.get_cell_value("Sheet1", 2, 5).unwrap();
-    let dense_result = engine.get_cell_value("Sheet1", 3, 5).unwrap();
+    let dense_result = engine.get_cell_value("Sheet1", 3, 60).unwrap();
 
     // BUG IDENTIFIED: When multiple streaming formulas are evaluated together,
     // tall and wide ranges return 1 instead of the correct sum.

--- a/crates/formualizer-eval/src/engine/tests/sumifs_cached_mask_padding.rs
+++ b/crates/formualizer-eval/src/engine/tests/sumifs_cached_mask_padding.rs
@@ -33,13 +33,15 @@ fn sumifs_cached_mask_padding_uses_slice_and_padding_branches() {
     }
 
     // Drive SUMIFS through the engine to ensure it uses cached criteria masks.
+    // Placed in column E so the whole-column refs (A:A/B:B) are not
+    // self-inclusive — a SUMIFS *in* column A/B would be circular per #120.
     let formula = parse("=SUMIFS(A:A, B:B, \"Yes\")").unwrap();
-    engine.set_cell_formula("Sheet1", 1, 1, formula).unwrap();
-    engine.evaluate_cell("Sheet1", 1, 1).unwrap();
+    engine.set_cell_formula("Sheet1", 1, 5, formula).unwrap();
+    engine.evaluate_cell("Sheet1", 1, 5).unwrap();
 
     // Result: sum of rows 1, 51, 100 (1-based) => 1 + 51 + 100 = 152
     assert_eq!(
-        engine.get_cell_value("Sheet1", 1, 1).unwrap(),
+        engine.get_cell_value("Sheet1", 1, 5).unwrap(),
         LiteralValue::Number(152.0)
     );
 

--- a/crates/formualizer-eval/src/engine/tests/whole_column_sumifs.rs
+++ b/crates/formualizer-eval/src/engine/tests/whole_column_sumifs.rs
@@ -108,17 +108,19 @@ fn sumifs_whole_columns_empty_vs_populated() {
     // Column C is empty (but referenced in formula)
     // Column D has criteria for column C
 
-    // SUMIFS with empty column reference should still work
+    // SUMIFS with empty column reference should still work. Placed in column E
+    // so the whole-column references (A:A/B:B/C:C) are not self-inclusive — a
+    // SUMIFS *in* one of those columns would be circular per #120.
     let formula = parse("=SUMIFS(A:A, B:B, \"Yes\", C:C, \"\")").unwrap();
 
-    engine.set_cell_formula("Sheet1", 2, 1, formula).unwrap();
+    engine.set_cell_formula("Sheet1", 2, 5, formula).unwrap();
 
-    let result = engine.evaluate_cell("Sheet1", 2, 1);
+    let result = engine.evaluate_cell("Sheet1", 2, 5);
     assert!(result.is_ok(), "SUMIFS with empty column should not error");
 
     // Result should be 300 (both rows match "Yes" and empty matches empty)
     assert_eq!(
-        engine.get_cell_value("Sheet1", 2, 1).unwrap(),
+        engine.get_cell_value("Sheet1", 2, 5).unwrap(),
         LiteralValue::Number(300.0)
     );
 }


### PR DESCRIPTION
Fixes #120.

Whole-column/row and large bounded references use stripe-compressed dependencies that drive dirty propagation only — they never surface as graph edges for Tarjan. So `=SUM(B:B)` placed in B1 (and, it turns out, `=SUM(B1:B100000)` placed in B5 — anything over the 64-cell expansion limit) formed no SCC and silently evaluated to a stale, self-excluding value. Excel flags both as circular.

Fix: at range-dependency registration (`range_deps.rs`, both the standard and fast-path key routes), if the referenced region contains the formula's own coordinate (same-sheet; unbounded axes always contain), record a self-loop edge. `separate_cycles` already classifies self-loops as cycles, so both detection modes do the right thing for free: `Static` → `#CIRC`; `Runtime` → live self-edge via the range-read rect → policy verdict. Cross-sheet whole-column references stay acyclic (negative control tested).

Tests: whole-column-in-column, whole-row-in-row, and large-bounded-range self-inclusion — each under both Static and Runtime — plus negative controls; the documented-gap pin test consciously updated per its comment. Five existing tests had incidentally placed whole-axis formulas inside their own referenced axis (genuinely circular per Excel) and were relocated with intent preserved and comments added.

Two honest notes: shape-only functions (`ROWS(A:A)` in A1) are now conservatively flagged although Excel permits them — consistent with the engine's existing ingest-time treatment of bounded dense self-inclusion, which also has no function context; and a `FormulaArray` whose *spill region* (not anchor) intersects the referenced stripe is not yet handled — noted in-code as a follow-up.

Full workspace suite (CI exclusions): 2477 passed, 0 failed. fmt/clippy clean.
