### PR TITLE
feat(eval): CyclePolicy::Iterate — Excel-style iterative calculation (Stage 3 for #113)

### DIFF
--- a/crates/formualizer-eval/src/engine/convergence.rs
+++ b/crates/formualizer-eval/src/engine/convergence.rs
@@ -1,0 +1,384 @@
+//! Per-member convergence test for `CyclePolicy::Iterate` (RFC #113,
+//! spec `formualizer-cycle-semantics-spec.md` §6).
+//!
+//! Compares one SCC member's pass-*N* value against its pass-*N−1* value.
+//! The rules are engine invariants, deliberately NOT configurable (spec §2
+//! configurability rationale):
+//!
+//! | value pair | converged iff |
+//! |---|---|
+//! | numeric-class × numeric-class (Number/Int/Date/DateTime/Time/Duration) | `\|Δ\| < max_change` on f64 serials (absolute, strict) |
+//! | Boolean × Boolean | equal |
+//! | Text × Text | exactly equal (case-sensitive, no trim) |
+//! | Error × Error | same `ExcelErrorKind` |
+//! | Empty × Empty | converged |
+//! | Array × Array | element-wise scalar rules; shape change ⇒ not converged |
+//! | any type transition | not converged |
+//!
+//! NaN: identical-bit-pattern NaN vs NaN is **converged** (avoids permanent
+//! caps from NaN leakage — the engine has no central NaN→`#NUM!` coercion)
+//! and flags telemetry; NaN vs anything else is not converged.
+
+use crate::builtins::datetime::{date_to_serial_for, datetime_to_serial_for, time_to_fraction};
+use formualizer_common::{DateSystem, LiteralValue};
+
+/// Outcome of one member comparison.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ConvergenceOutcome {
+    pub converged: bool,
+    /// `|Δ|` for numeric-class comparisons (feeds telemetry
+    /// `max_abs_delta_at_stop`); `None` for non-numeric pairs and for
+    /// NaN-involved comparisons (no meaningful delta).
+    pub abs_delta: Option<f64>,
+    /// An identical-bit NaN vs NaN pair converged (telemetry flag, spec §6).
+    pub nan_converged: bool,
+}
+
+impl ConvergenceOutcome {
+    fn converged() -> Self {
+        Self {
+            converged: true,
+            abs_delta: None,
+            nan_converged: false,
+        }
+    }
+    fn not_converged() -> Self {
+        Self {
+            converged: false,
+            abs_delta: None,
+            nan_converged: false,
+        }
+    }
+}
+
+/// f64 serial for a numeric-class value; `None` for every other type.
+/// Boolean is NOT numeric-class (spec §6: Boolean compares by equality, and
+/// Boolean↔Number is a type transition).
+fn numeric_serial(v: &LiteralValue, date_system: DateSystem) -> Option<f64> {
+    match v {
+        LiteralValue::Number(n) => Some(*n),
+        LiteralValue::Int(i) => Some(*i as f64),
+        LiteralValue::Date(d) => Some(date_to_serial_for(date_system, d)),
+        LiteralValue::DateTime(dt) => Some(datetime_to_serial_for(date_system, dt)),
+        LiteralValue::Time(t) => Some(time_to_fraction(t)),
+        LiteralValue::Duration(d) => Some(d.num_seconds() as f64 / 86_400.0),
+        _ => None,
+    }
+}
+
+/// Spec-§6 convergence test for one member: `prev` is the pass-*N−1* value,
+/// `cur` the pass-*N* value.
+pub(crate) fn values_converged(
+    prev: &LiteralValue,
+    cur: &LiteralValue,
+    max_change: f64,
+    date_system: DateSystem,
+) -> ConvergenceOutcome {
+    // Numeric-class pairs first: Int↔Number↔DateTime etc. cross-coerce on
+    // f64 serials and are NOT type transitions.
+    if let (Some(a), Some(b)) = (
+        numeric_serial(prev, date_system),
+        numeric_serial(cur, date_system),
+    ) {
+        if a.is_nan() || b.is_nan() {
+            // Identical-bit NaN vs NaN converges (telemetry-flagged);
+            // anything else involving NaN does not.
+            if a.to_bits() == b.to_bits() {
+                return ConvergenceOutcome {
+                    converged: true,
+                    abs_delta: None,
+                    nan_converged: true,
+                };
+            }
+            return ConvergenceOutcome::not_converged();
+        }
+        let delta = (b - a).abs();
+        return ConvergenceOutcome {
+            // Strict `<`, absolute (Excel semantics). A non-finite delta
+            // (Inf-Inf etc.) is NaN or Inf and correctly fails this test.
+            converged: delta < max_change,
+            abs_delta: Some(delta),
+            nan_converged: false,
+        };
+    }
+
+    match (prev, cur) {
+        (LiteralValue::Boolean(a), LiteralValue::Boolean(b)) => {
+            if a == b {
+                ConvergenceOutcome::converged()
+            } else {
+                ConvergenceOutcome::not_converged()
+            }
+        }
+        (LiteralValue::Text(a), LiteralValue::Text(b)) => {
+            // Exactly equal: case-sensitive, no trim.
+            if a == b {
+                ConvergenceOutcome::converged()
+            } else {
+                ConvergenceOutcome::not_converged()
+            }
+        }
+        (LiteralValue::Error(a), LiteralValue::Error(b)) => {
+            if a.kind == b.kind {
+                ConvergenceOutcome::converged()
+            } else {
+                ConvergenceOutcome::not_converged()
+            }
+        }
+        (LiteralValue::Empty, LiteralValue::Empty) => ConvergenceOutcome::converged(),
+        (LiteralValue::Array(a), LiteralValue::Array(b)) => {
+            // Element-wise with the scalar rules; shape change ⇒ not
+            // converged (fixed rule — spill anchors are pre-stamped in SCCs,
+            // so this only sees non-spilling array results).
+            if a.len() != b.len() || a.iter().zip(b.iter()).any(|(ra, rb)| ra.len() != rb.len()) {
+                return ConvergenceOutcome::not_converged();
+            }
+            let mut out = ConvergenceOutcome::converged();
+            for (ra, rb) in a.iter().zip(b.iter()) {
+                for (ea, eb) in ra.iter().zip(rb.iter()) {
+                    let e = values_converged(ea, eb, max_change, date_system);
+                    if !e.converged {
+                        return ConvergenceOutcome::not_converged();
+                    }
+                    out.nan_converged |= e.nan_converged;
+                    out.abs_delta = match (out.abs_delta, e.abs_delta) {
+                        (Some(x), Some(y)) => Some(x.max(y)),
+                        (x, y) => x.or(y),
+                    };
+                }
+            }
+            out
+        }
+        // Any type transition (incl. Empty↔anything, Error↔value,
+        // Number↔Text, Boolean↔Number) — and the defensive `Pending`
+        // variant, which must never be committed as an SCC value.
+        _ => ConvergenceOutcome::not_converged(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, NaiveDate, NaiveTime};
+    use formualizer_common::{ExcelError, ExcelErrorKind};
+
+    const DS: DateSystem = DateSystem::Excel1900;
+
+    fn conv(prev: &LiteralValue, cur: &LiteralValue) -> ConvergenceOutcome {
+        values_converged(prev, cur, 0.001, DS)
+    }
+
+    /* ── §6 row 1: numeric-class, |Δ| < max_change, strict + absolute ── */
+
+    #[test]
+    fn numbers_within_max_change_converge_strictly() {
+        let a = LiteralValue::Number(1.0);
+        assert!(conv(&a, &LiteralValue::Number(1.0009)).converged);
+        assert!(!conv(&a, &LiteralValue::Number(1.1)).converged);
+        // |Δ| == max_change is NOT converged (strict `<`) — exercised on an
+        // exactly-representable boundary (0.5) to avoid float-rounding
+        // artifacts in the test itself.
+        assert!(
+            !values_converged(
+                &LiteralValue::Number(1.0),
+                &LiteralValue::Number(1.5),
+                0.5,
+                DS
+            )
+            .converged
+        );
+        assert!(
+            values_converged(
+                &LiteralValue::Number(1.0),
+                &LiteralValue::Number(1.25),
+                0.5,
+                DS
+            )
+            .converged
+        );
+        // Absolute, not relative: same |Δ| rule at large magnitudes.
+        assert!(
+            !values_converged(
+                &LiteralValue::Number(1.0e9),
+                &LiteralValue::Number(1.0e9 + 0.002),
+                0.001,
+                DS
+            )
+            .converged
+        );
+        assert_eq!(
+            conv(&a, &LiteralValue::Number(1.0009)).abs_delta,
+            Some(1.0009 - 1.0)
+        );
+    }
+
+    #[test]
+    fn int_number_cross_coercion_is_numeric_class_not_a_transition() {
+        assert!(conv(&LiteralValue::Int(5), &LiteralValue::Number(5.0005)).converged);
+        assert!(conv(&LiteralValue::Number(5.0005), &LiteralValue::Int(5)).converged);
+        assert!(!conv(&LiteralValue::Int(5), &LiteralValue::Number(5.5)).converged);
+        assert!(conv(&LiteralValue::Int(7), &LiteralValue::Int(7)).converged);
+        assert!(!conv(&LiteralValue::Int(7), &LiteralValue::Int(8)).converged);
+    }
+
+    #[test]
+    fn datetime_and_duration_compare_on_f64_serials() {
+        let d1 = LiteralValue::Date(NaiveDate::from_ymd_opt(2026, 6, 9).unwrap());
+        let d2 = LiteralValue::Date(NaiveDate::from_ymd_opt(2026, 6, 10).unwrap());
+        assert!(conv(&d1, &d1.clone()).converged);
+        assert!(!conv(&d1, &d2).converged); // Δ = 1 day = 1.0
+        // Date vs its own serial Number: numeric-class cross-coercion.
+        let serial = date_to_serial_for(DS, &NaiveDate::from_ymd_opt(2026, 6, 9).unwrap());
+        assert!(conv(&d1, &LiteralValue::Number(serial)).converged);
+        // Durations: 43 seconds = ~0.0005 days < 0.001.
+        let s43 = LiteralValue::Duration(Duration::seconds(43));
+        assert!(conv(&LiteralValue::Duration(Duration::zero()), &s43).converged);
+        let s130 = LiteralValue::Duration(Duration::seconds(130));
+        assert!(!conv(&LiteralValue::Duration(Duration::zero()), &s130).converged);
+        // Time-of-day fractions.
+        let t1 = LiteralValue::Time(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+        let t2 = LiteralValue::Time(NaiveTime::from_hms_opt(0, 0, 43).unwrap());
+        assert!(conv(&t1, &t2).converged);
+    }
+
+    /* ── §6 rows 2–5: Boolean / Text / Error / Empty ── */
+
+    #[test]
+    fn booleans_converge_on_equality_only() {
+        let t = LiteralValue::Boolean(true);
+        let f = LiteralValue::Boolean(false);
+        assert!(conv(&t, &t.clone()).converged);
+        assert!(!conv(&t, &f).converged);
+    }
+
+    #[test]
+    fn text_is_exact_case_sensitive_no_trim() {
+        let a = LiteralValue::Text("abc".into());
+        assert!(conv(&a, &LiteralValue::Text("abc".into())).converged);
+        assert!(!conv(&a, &LiteralValue::Text("ABC".into())).converged);
+        assert!(!conv(&a, &LiteralValue::Text("abc ".into())).converged);
+    }
+
+    #[test]
+    fn errors_converge_on_same_kind_only() {
+        let div = LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div));
+        let div2 =
+            LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div).with_message("other msg"));
+        let na = LiteralValue::Error(ExcelError::new(ExcelErrorKind::Na));
+        assert!(conv(&div, &div2).converged, "same kind, message ignored");
+        assert!(!conv(&div, &na).converged);
+    }
+
+    #[test]
+    fn empty_vs_empty_converges() {
+        assert!(conv(&LiteralValue::Empty, &LiteralValue::Empty).converged);
+    }
+
+    /* ── §6 row 6: any type transition ── */
+
+    #[test]
+    fn type_transitions_never_converge() {
+        let n = LiteralValue::Number(0.0);
+        let cases: Vec<(LiteralValue, LiteralValue)> = vec![
+            (n.clone(), LiteralValue::Text("0".into())),
+            (LiteralValue::Text("0".into()), n.clone()),
+            (LiteralValue::Empty, n.clone()),
+            (n.clone(), LiteralValue::Empty),
+            (
+                LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div)),
+                n.clone(),
+            ),
+            (
+                n.clone(),
+                LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div)),
+            ),
+            (LiteralValue::Boolean(true), LiteralValue::Int(1)),
+            (LiteralValue::Empty, LiteralValue::Text(String::new())),
+            (n.clone(), LiteralValue::Array(vec![vec![n.clone()]])),
+        ];
+        for (prev, cur) in cases {
+            assert!(
+                !values_converged(&prev, &cur, f64::MAX, DS).converged,
+                "{prev:?} → {cur:?} must not converge even with a huge max_change"
+            );
+        }
+    }
+
+    /* ── §6 NaN rule ── */
+
+    #[test]
+    fn identical_bit_nan_converges_and_sets_flag() {
+        let nan = LiteralValue::Number(f64::NAN);
+        let out = conv(&nan, &LiteralValue::Number(f64::NAN));
+        assert!(out.converged);
+        assert!(out.nan_converged);
+        assert_eq!(out.abs_delta, None);
+    }
+
+    #[test]
+    fn different_bit_nan_and_nan_vs_value_do_not_converge() {
+        let nan = f64::NAN;
+        let other_nan = f64::from_bits(nan.to_bits() ^ 1);
+        assert!(other_nan.is_nan());
+        let out = conv(&LiteralValue::Number(nan), &LiteralValue::Number(other_nan));
+        assert!(!out.converged);
+        assert!(!out.nan_converged);
+        assert!(!conv(&LiteralValue::Number(nan), &LiteralValue::Number(1.0)).converged);
+        assert!(!conv(&LiteralValue::Number(1.0), &LiteralValue::Number(nan)).converged);
+    }
+
+    /* ── §6 row 7: arrays ── */
+
+    #[test]
+    fn arrays_compare_element_wise_with_scalar_rules() {
+        let a = LiteralValue::Array(vec![vec![
+            LiteralValue::Number(1.0),
+            LiteralValue::Text("x".into()),
+        ]]);
+        let close = LiteralValue::Array(vec![vec![
+            LiteralValue::Number(1.0005),
+            LiteralValue::Text("x".into()),
+        ]]);
+        let far = LiteralValue::Array(vec![vec![
+            LiteralValue::Number(2.0),
+            LiteralValue::Text("x".into()),
+        ]]);
+        let out = conv(&a, &close);
+        assert!(out.converged);
+        assert_eq!(out.abs_delta, Some(1.0005 - 1.0));
+        assert!(!conv(&a, &far).converged);
+    }
+
+    #[test]
+    fn array_shape_change_does_not_converge() {
+        let one = LiteralValue::Array(vec![vec![LiteralValue::Number(1.0)]]);
+        let two = LiteralValue::Array(vec![vec![
+            LiteralValue::Number(1.0),
+            LiteralValue::Number(1.0),
+        ]]);
+        let tall = LiteralValue::Array(vec![
+            vec![LiteralValue::Number(1.0)],
+            vec![LiteralValue::Number(1.0)],
+        ]);
+        assert!(!conv(&one, &two).converged);
+        assert!(!conv(&one, &tall).converged);
+    }
+
+    #[test]
+    fn max_change_zero_means_only_exact_numeric_repeats_converge() {
+        // Valid config (>= 0): strict `<` means only |Δ| < 0 would pass,
+        // i.e. numeric values never converge; exact equality of Δ = 0 fails.
+        let a = LiteralValue::Number(1.0);
+        assert!(!values_converged(&a, &a.clone(), 0.0, DS).converged);
+        // Non-numeric rules are unaffected by max_change.
+        assert!(
+            values_converged(
+                &LiteralValue::Text("x".into()),
+                &LiteralValue::Text("x".into()),
+                0.0,
+                DS
+            )
+            .converged
+        );
+    }
+}

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -418,6 +418,21 @@ pub struct Engine<R> {
     // Runtime-cycle SCC evaluation telemetry (RFC #112, Stage 2)
     last_cycle_telemetry: CycleTelemetry,
 
+    /// SCC members that entered iterative calculation (`CyclePolicy::Iterate`
+    /// with a witnessed live cycle) during the current evaluation request.
+    ///
+    /// Excel re-evaluates circular cells on EVERY recalc (the accumulator
+    /// contract, spec §4/§7.6), but this engine's dirty model marks SCC
+    /// members clean after a recalc and would otherwise skip them forever.
+    /// Resolution: members of iterating SCCs are redirtied volatile-like at
+    /// the end of the same recalc that iterated them
+    /// ([`Self::redirty_for_next_recalc`], called wherever
+    /// `redirty_volatiles` runs). The set is per-recalc, never persisted:
+    /// if an edit breaks the cycle, the next recalc's SCC task either does
+    /// not exist or settles as phantom, nothing re-registers, and the
+    /// redirty chain stops by itself.
+    pending_iterative_redirty: Vec<VertexId>,
+
     /// FormulaPlane authority `indexes_epoch` observed by the most recent
     /// successful `evaluate_all` pass. Used to schedule whole-span work for
     /// any active span the engine has not yet evaluated under the current
@@ -965,15 +980,14 @@ pub struct VirtualDepTelemetry {
 }
 
 /// Per-recalc telemetry for SCC evaluation under `CycleDetection::Runtime`
-/// (spec `formualizer-cycle-semantics-spec.md` §10, Stage-2 subset; the
-/// `Iterate`-specific fields arrive in Stage 3).
+/// (spec `formualizer-cycle-semantics-spec.md` §10).
 ///
 /// Collection is unconditional: SCC tasks are rare relative to ordinary
 /// vertex evaluation and the counters are a handful of integer adds per
 /// task, so no config flag gates them (unlike [`VirtualDepTelemetry`],
 /// which pays per-schedule costs). Counters reset at the start of every
 /// evaluation request.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CycleTelemetry {
     /// SCC tasks executed (static SCCs that reached Runtime evaluation).
     pub static_sccs: usize,
@@ -988,9 +1002,25 @@ pub struct CycleTelemetry {
     pub settle_passes_total: usize,
     /// Largest pass count any single SCC task needed.
     pub max_passes_single_scc: usize,
-    /// SCC tasks that hit the defensive settle cap (|SCC| + 2). Always 0
-    /// unless a bug exists — the acyclic settle is monotone.
+    /// SCC tasks that entered iterative calculation (`CyclePolicy::Iterate`
+    /// with a witnessed live cycle). RFC #113, Stage 3.
+    pub iterated_sccs: usize,
+    /// Iterating SCC tasks that stopped because every member passed the
+    /// spec-§6 convergence test.
+    pub converged_sccs: usize,
+    /// SCC tasks that stopped at a pass cap. Under `CyclePolicy::Iterate`
+    /// this is the Excel `max_iterations` cap (NOT an error — last values
+    /// are kept; includes the no-convergence-test `max_iterations: 1`
+    /// contract). Under `CyclePolicy::Error` it is the defensive acyclic
+    /// settle cap (|SCC| + 2), which only a bug can hit.
     pub capped_sccs: usize,
+    /// Largest `|Δ|` observed in any member's final-pass convergence
+    /// comparison across iterating SCC tasks (numeric-class members only).
+    /// `0.0` when no comparison ran (e.g. `max_iterations: 1`).
+    pub max_abs_delta_at_stop: f64,
+    /// Identical-bit NaN vs NaN member comparisons that were treated as
+    /// converged (spec §6 NaN rule).
+    pub nan_converged: usize,
     /// Total wall-clock time spent inside Runtime SCC tasks.
     pub elapsed_ms: u128,
 }
@@ -1311,7 +1341,16 @@ impl<R> Engine<R>
 where
     R: EvaluationContext,
 {
+    /// # Panics
+    /// Panics when `config.cycle` is invalid ([`CycleConfig::validate`],
+    /// spec §2): `Iterate` with `detection: Static`, `max_iterations == 0`,
+    /// or a negative/non-finite `max_change`. `EvalConfig::with_cycle`
+    /// rejects these at build; this re-validates configs assembled via
+    /// struct literals.
     pub fn new(resolver: R, config: EvalConfig) -> Self {
+        if let Err(msg) = config.cycle.validate() {
+            panic!("invalid CycleConfig: {msg}");
+        }
         crate::builtins::load_builtins();
 
         let clock = config.deterministic_mode.build_clock().unwrap_or_else(|_| {
@@ -1383,6 +1422,7 @@ where
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
             virtual_dep_fallback_activations: 0,
             last_cycle_telemetry: CycleTelemetry::default(),
+            pending_iterative_redirty: Vec::new(),
             formula_plane_indexes_epoch_seen: 0,
             #[cfg(test)]
             last_formula_plane_span_eval_report: None,
@@ -1397,11 +1437,17 @@ where
     }
 
     /// Create an Engine with a custom thread pool (for shared thread pool scenarios)
+    ///
+    /// # Panics
+    /// Panics when `config.cycle` is invalid, exactly like [`Engine::new`].
     pub fn with_thread_pool(
         resolver: R,
         config: EvalConfig,
         thread_pool: Arc<rayon::ThreadPool>,
     ) -> Self {
+        if let Err(msg) = config.cycle.validate() {
+            panic!("invalid CycleConfig: {msg}");
+        }
         crate::builtins::load_builtins();
         let clock = config.deterministic_mode.build_clock().unwrap_or_else(|_| {
             #[cfg(feature = "system-clock")]
@@ -1453,6 +1499,7 @@ where
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
             virtual_dep_fallback_activations: 0,
             last_cycle_telemetry: CycleTelemetry::default(),
+            pending_iterative_redirty: Vec::new(),
             formula_plane_indexes_epoch_seen: 0,
             #[cfg(test)]
             last_formula_plane_span_eval_report: None,
@@ -1495,6 +1542,23 @@ where
     /// evaluation request that walks schedule units.
     fn reset_cycle_telemetry(&mut self) {
         self.last_cycle_telemetry = CycleTelemetry::default();
+        // Defensive: consumed at the end of the previous request; a request
+        // that errored out mid-walk must not leak its members into this one.
+        self.pending_iterative_redirty.clear();
+    }
+
+    /// End-of-recalc redirty: volatile vertices (as always) plus members of
+    /// SCCs that iterated this recalc (`CyclePolicy::Iterate`), so circular
+    /// cells re-evaluate on every recalc exactly like Excel's iterative
+    /// calculation (spec §4 persistence / §7.6 accumulator / §7.11 volatile
+    /// redirty). Replaces the bare `graph.redirty_volatiles()` call at every
+    /// evaluation-flow exit; must run AFTER the flow's `clear_dirty_flags`.
+    fn redirty_for_next_recalc(&mut self) {
+        self.graph.redirty_volatiles();
+        let pending = std::mem::take(&mut self.pending_iterative_redirty);
+        if !pending.is_empty() {
+            self.graph.redirty_iterative_members(&pending);
+        }
     }
 
     pub fn virtual_dep_fallback_activations(&self) -> u64 {
@@ -8033,7 +8097,7 @@ where
         self.graph.clear_dirty_flags(&precedents_to_eval);
 
         // Re-dirty volatile vertices
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
 
         Ok(EvalResult {
             computed_vertices,
@@ -8114,7 +8178,7 @@ where
         }
 
         self.graph.clear_dirty_flags(&precedents_to_eval);
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
 
         Ok(EvalResult {
             computed_vertices,
@@ -8220,7 +8284,7 @@ where
         }
 
         self.graph.clear_dirty_flags(&dirty_vertices);
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
 
         Ok(EvalResult {
             computed_vertices,
@@ -8432,7 +8496,7 @@ where
         // Drop dirty flags on any newly-scheduled FP runtime cells whose graph
         // vertices weren't in the dirty subset (e.g. recently-introduced span
         // result cells); legacy clear_dirty_flags is safe over the full set.
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
         // Mark this indexes-epoch as fully evaluated so subsequent passes can
         // use bounded span dirty closures rather than whole-span work.
         self.formula_plane_indexes_epoch_seen = self.graph.formula_authority().indexes_epoch();
@@ -8785,7 +8849,7 @@ where
         }
 
         // Re-dirty volatile vertices for the next evaluation cycle
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
 
         // Advance recalc epoch after a full evaluation pass finishes
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
@@ -8901,7 +8965,7 @@ where
             self.last_virtual_dep_telemetry = t;
         }
 
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
 
         Ok(EvalResult {
@@ -9616,7 +9680,7 @@ where
         }
 
         // Re-dirty volatile vertices for the next evaluation cycle
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
 
         Ok(EvalResult {
@@ -9747,7 +9811,7 @@ where
         self.graph.clear_dirty_flags(&precedents_to_eval);
 
         // Re-dirty volatile vertices
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
 
         Ok(EvalResult {
             computed_vertices,
@@ -12043,19 +12107,23 @@ where
                 {
                     return Ok(0);
                 }
-                match self.config.cycle.policy {
-                    CyclePolicy::Error => self.evaluate_scc_unit(cycle, delta, cancel_flag),
-                }
+                // Both policies share `evaluate_scc_unit`; they differ only
+                // in the settle loop's live-cycle arm (Error stamps,
+                // Iterate keeps passing — RFC #113).
+                self.evaluate_scc_unit(cycle, delta, cancel_flag)
             }
         }
     }
 
     /// Evaluate one statically-cyclic SCC under `CycleDetection::Runtime`
     /// (design doc `formualizer-stage2-scc-evaluation-design.md` §3; contract
-    /// spec §3, Error-policy subset).
+    /// spec §3; Iterate policy arm per RFC #113).
     ///
-    /// Phantom SCCs (live-acyclic) produce ordinary values; live cycles get
-    /// `#CIRC!` with live-cycle-only blast radius. Runs sequentially on the
+    /// Phantom SCCs (live-acyclic) produce ordinary values under both
+    /// policies; live cycles get `#CIRC!` with live-cycle-only blast radius
+    /// under `CyclePolicy::Error`, or Excel-style iterative calculation
+    /// (converge per spec §6 or cap at `max_iterations` passes) under
+    /// `CyclePolicy::Iterate`. Runs sequentially on the
     /// coordinating thread; commits are write-through per member (no
     /// `ComputedWriteBuffer` — that buffer is scoped to layer evaluation and
     /// always flushed before a Cycle unit runs, G1), so later members' scalar
@@ -12266,12 +12334,40 @@ where
             }
         }
 
-        // ── 4. Settle loop (design doc §3 step 4). Defensive cap: the
-        // acyclic settle is monotone, so |SCC| + 2 passes can only be
-        // exceeded by a bug; cap hits stamp the remainder and set telemetry.
+        // ── 4. Settle loop (design doc §3 step 4; RFC #113 policy arm).
+        //
+        // Acyclic classifications settle stale readers exactly (identical
+        // under both policies — phantom SCCs never iterate). A witnessed
+        // live cycle dispatches on policy: `Error` stamps `#CIRC!` and
+        // stops; `Iterate` keeps running full passes over all members in
+        // member order until converged (spec §6) or capped at
+        // `max_iterations` total passes. A live cycle that only appears
+        // mid-settle takes the same arm, and a cycle that dissolves
+        // mid-iteration falls back to exact acyclic settling.
+        //
+        // Defensive acyclic budget: the acyclic settle is monotone, so more
+        // than |SCC| + 2 settle passes can only be a bug; cap hits stamp the
+        // remainder and set telemetry. Tracked via `settle_passes` so
+        // iteration passes (legitimately many) don't consume the budget.
+        let policy = self.config.cycle.policy;
         let cap = n + 2;
         let mut witnessed_cycles = 0usize;
         let mut capped = false;
+        // ── Iterate-policy state ──
+        let mut iterating = false;
+        let mut converged = false;
+        // Values committed by the last *full* pass; `None` until the first
+        // iteration pass runs (pass 1 has no predecessor to compare against)
+        // and reset when a settle pass runs (no cross-kind comparisons).
+        let mut prev_pass: Option<Vec<LiteralValue>> = None;
+        // Final-round convergence stats (overwritten per round so the values
+        // reported are the ones observed at stop).
+        let mut iter_max_delta = 0f64;
+        let mut iter_nan_converged = 0usize;
+        // Acyclic stale-reader re-eval passes (defensive budget; under pure
+        // Error flow `1 + settle_passes == passes`, preserving Stage-2
+        // behavior exactly).
+        let mut settle_passes = 0usize;
         loop {
             // Drain this pass's recordings; members that ran replace their
             // out-edge set, members that didn't keep last-known edges.
@@ -12303,33 +12399,131 @@ where
             let analysis = analyze_live_graph(n, &edges);
 
             if analysis.cycle_count > 0 {
-                // POLICY (Error): stamp every member of a live cycle, then one
-                // settling pass over the remaining members in live-topological
-                // order so error propagation downstream is consistent
-                // (spec §3.4). Blast radius = live cycles only.
-                witnessed_cycles += analysis.cycle_count;
-                for i in 0..n {
-                    if analysis.in_cycle[i] && !excluded[i] {
-                        self.stamp_cycle_error(members[i].vertex, &circ_error, None);
-                        excluded[i] = true;
-                        last_value[i] = circ_error.clone();
-                        stamped += 1;
+                // Classification repeats every iteration pass under
+                // `Iterate`; record the widest single witness instead of
+                // accumulating so the count stays "distinct live cycles".
+                witnessed_cycles = witnessed_cycles.max(analysis.cycle_count);
+                match policy {
+                    CyclePolicy::Error => {
+                        // POLICY (Error): stamp every member of a live cycle,
+                        // then one settling pass over the remaining members in
+                        // live-topological order so error propagation
+                        // downstream is consistent (spec §3.4). Blast radius =
+                        // live cycles only.
+                        for i in 0..n {
+                            if analysis.in_cycle[i] && !excluded[i] {
+                                self.stamp_cycle_error(members[i].vertex, &circ_error, None);
+                                excluded[i] = true;
+                                last_value[i] = circ_error.clone();
+                                stamped += 1;
+                            }
+                        }
+                        check_cancel(cancel_flag)?;
+                        let order: Vec<usize> = analysis
+                            .topo
+                            .iter()
+                            .map(|&i| i as usize)
+                            .filter(|&i| !excluded[i])
+                            .collect();
+                        if !order.is_empty() {
+                            passes += 1;
+                            for i in order {
+                                run_member!(i);
+                            }
+                        }
+                        break;
+                    }
+                    CyclePolicy::Iterate {
+                        max_iterations,
+                        max_change,
+                    } => {
+                        // POLICY (Iterate), spec §3.5/§6.
+                        iterating = true;
+
+                        // Convergence test: the full pass that just completed
+                        // vs the previous full pass, per the spec-§6 rules.
+                        // `prev_pass` is `None` until an iteration pass has
+                        // run — pass 1 has no predecessor, so no convergence
+                        // test occurs before the second pass (spec §6).
+                        if let Some(prev) = &prev_pass {
+                            let mut round_max_delta = 0f64;
+                            let mut round_nan = 0usize;
+                            let mut all_converged = true;
+                            for i in 0..n {
+                                if excluded[i] {
+                                    // Stamped mid-iteration (array result,
+                                    // §7.9): the value is pinned and cannot
+                                    // change again — trivially settled.
+                                    continue;
+                                }
+                                let out = crate::engine::convergence::values_converged(
+                                    &prev[i],
+                                    &last_value[i],
+                                    max_change,
+                                    self.config.date_system,
+                                );
+                                if out.nan_converged {
+                                    round_nan += 1;
+                                }
+                                if let Some(d) = out.abs_delta {
+                                    round_max_delta = round_max_delta.max(d);
+                                }
+                                if !out.converged {
+                                    all_converged = false;
+                                }
+                            }
+                            // Overwrite (not max): telemetry reports the
+                            // round observed at stop.
+                            iter_max_delta = round_max_delta;
+                            iter_nan_converged = round_nan;
+                            if all_converged {
+                                converged = true;
+                                break;
+                            }
+                        }
+
+                        // ── Pass-counting reconciliation (spec §6/§7.6):
+                        // `max_iterations` counts TOTAL passes, pass 1
+                        // included, and pass 1 has already run by the time a
+                        // live cycle is first witnessed here. The budget is
+                        // therefore checked BEFORE evaluating anything more:
+                        // with `max_iterations: 1` we stop right here — each
+                        // member was evaluated exactly once this recalc (the
+                        // Excel accumulator contract) and no convergence test
+                        // ran (`prev_pass` is still `None`). Capping keeps
+                        // the last committed values and is NOT an error
+                        // (Excel parity); telemetry records it.
+                        if passes >= max_iterations as usize {
+                            capped = true;
+                            break;
+                        }
+
+                        check_cancel(cancel_flag)?;
+                        // One more full pass over every evaluable member in
+                        // member order (Gauss–Seidel: each commit is visible
+                        // to later members within the pass). Live edges
+                        // re-record — guards can flip near convergence
+                        // (§7.3) — so classification repeats next time
+                        // around, and a cycle that dissolves drops back to
+                        // the exact acyclic settle below.
+                        prev_pass = Some(last_value.clone());
+                        for x in pos.iter_mut() {
+                            *x = -1;
+                        }
+                        changed.fill(false);
+                        passes += 1;
+                        let mut p = 0i64;
+                        for i in 0..n {
+                            if excluded[i] {
+                                continue;
+                            }
+                            run_member!(i);
+                            pos[i] = p;
+                            p += 1;
+                        }
+                        continue;
                     }
                 }
-                check_cancel(cancel_flag)?;
-                let order: Vec<usize> = analysis
-                    .topo
-                    .iter()
-                    .map(|&i| i as usize)
-                    .filter(|&i| !excluded[i])
-                    .collect();
-                if !order.is_empty() {
-                    passes += 1;
-                    for i in order {
-                        run_member!(i);
-                    }
-                }
-                break;
             }
 
             // Acyclic: find stale readers — members whose live read of `to`
@@ -12348,9 +12542,9 @@ where
                 }
             }
             if stale.is_empty() {
-                break; // values exact — phantom SCC
+                break; // values exact — phantom SCC (or dissolved live cycle)
             }
-            if passes >= cap {
+            if 1 + settle_passes >= cap {
                 // Defensive only; hitting this is a bug (loud telemetry).
                 capped = true;
                 for (i, m) in members.iter().enumerate() {
@@ -12368,6 +12562,10 @@ where
             // Re-evaluate stale readers in live-topo order, recording fresh
             // edges (branches may flip on re-eval — spec §7.3 — which is why
             // classification repeats).
+            // A settle pass is a partial sweep: drop the full-pass baseline
+            // so a live cycle (re)appearing afterwards never compares values
+            // across mixed pass kinds.
+            prev_pass = None;
             let topo_pos = analysis.topo_positions();
             stale.sort_unstable_by_key(|&i| topo_pos[i]);
             for x in pos.iter_mut() {
@@ -12375,10 +12573,19 @@ where
             }
             changed.fill(false);
             passes += 1;
+            settle_passes += 1;
             for (p, i) in stale.into_iter().enumerate() {
                 run_member!(i);
                 pos[i] = p as i64;
             }
+        }
+
+        // Iteration that ended because the live cycle dissolved and the
+        // acyclic settle reached exactness counts as converged (values are
+        // exact, strictly better than threshold-converged). The defensive
+        // settle cap (`capped` + stamping) is not.
+        if iterating && !converged && !capped {
+            converged = true;
         }
 
         // ── 5. End of task: one delta per member whose final value differs
@@ -12396,6 +12603,17 @@ where
             }
         }
 
+        // Members of an SCC that iterated re-evaluate on EVERY recalc, like
+        // Excel's circular cells: register them for the end-of-recalc
+        // volatile-like redirty (see `pending_iterative_redirty`). Marking
+        // any one member propagates around the (strongly connected) SCC and
+        // to downstream dependents, but all members are registered so the
+        // contract survives partial structural edits between recalcs.
+        if iterating {
+            self.pending_iterative_redirty
+                .extend(members.iter().map(|m| m.vertex));
+        }
+
         {
             let t = &mut self.last_cycle_telemetry;
             t.static_sccs += 1;
@@ -12406,6 +12624,14 @@ where
             t.circ_cells_stamped += stamped;
             t.settle_passes_total += passes;
             t.max_passes_single_scc = t.max_passes_single_scc.max(passes);
+            if iterating {
+                t.iterated_sccs += 1;
+                if converged {
+                    t.converged_sccs += 1;
+                }
+                t.max_abs_delta_at_stop = t.max_abs_delta_at_stop.max(iter_max_delta);
+                t.nan_converged += iter_nan_converged;
+            }
             if capped {
                 t.capped_sccs += 1;
             }
@@ -13892,7 +14118,7 @@ where
 
         log.end_compound();
 
-        self.graph.redirty_volatiles();
+        self.redirty_for_next_recalc();
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
 
         Ok(EvalResult {

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1712,7 +1712,13 @@ impl DependencyGraph {
         // Editing a formula clears any prior structural #REF! marking for this vertex.
         self.ref_error_vertices.remove(&addr_vertex_id);
 
-        if new_dependencies.contains(&addr_vertex_id) {
+        // Under `CyclePolicy::Iterate` (Runtime detection) self-dependencies
+        // are accepted, mirroring Excel with iterative calculation enabled:
+        // the self-edge forms a single-vertex SCC that the scheduler emits as
+        // a Cycle unit and `evaluate_scc_unit` iterates (RFC #113, spec §7.1/
+        // §7.6/§7.8). Everywhere else the edit-time rejection stands.
+        if new_dependencies.contains(&addr_vertex_id) && !self.config.cycle.allows_self_dependency()
+        {
             return Err(ExcelError::new(ExcelErrorKind::Circ)
                 .with_message("Self-reference detected".to_string()));
         }
@@ -2183,6 +2189,19 @@ impl DependencyGraph {
         let volatile_ids: Vec<VertexId> = self.volatile_vertices.iter().copied().collect();
         for id in volatile_ids {
             self.mark_dirty(id);
+        }
+    }
+
+    /// Re-marks members of iterating SCCs (and, via propagation, their
+    /// dependents) dirty for the next evaluation cycle — the volatile-like
+    /// redirty that keeps `CyclePolicy::Iterate` cells re-evaluating every
+    /// recalc (RFC #113; spec §4/§7.6). Vertices deleted since the recalc
+    /// are skipped.
+    pub(crate) fn redirty_iterative_members(&mut self, members: &[VertexId]) {
+        for &id in members {
+            if self.vertex_exists(id) {
+                let _ = self.mark_dirty(id);
+            }
         }
     }
 
@@ -3681,8 +3700,9 @@ impl DependencyGraph {
             }
         };
 
-        // Self-reference / name-cycle safety parity with set_cell_formula.
-        if new_dependencies.contains(&vertex_id) {
+        // Self-reference / name-cycle safety parity with set_cell_formula
+        // (including the `CyclePolicy::Iterate` self-dependency relaxation).
+        if new_dependencies.contains(&vertex_id) && !self.config.cycle.allows_self_dependency() {
             self.mark_as_ref_error(vertex_id);
             return;
         }

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -3,6 +3,7 @@
 //! Provides incremental formula evaluation with dependency tracking.
 
 pub mod arrow_ingest;
+pub(crate) mod convergence;
 pub mod effects;
 pub mod eval;
 pub mod eval_delta;
@@ -800,8 +801,19 @@ impl EvalConfig {
         self
     }
 
+    /// Set the cycle configuration.
+    ///
+    /// # Panics
+    /// Panics when `cycle` is invalid (see [`CycleConfig::validate`]):
+    /// `Iterate` with `detection: Static`, `max_iterations == 0`, or a
+    /// negative/non-finite `max_change` are config errors rejected at build
+    /// (spec §2). [`Engine::new`] re-validates for configs assembled via
+    /// struct literals.
     #[inline]
     pub fn with_cycle(mut self, cycle: CycleConfig) -> Self {
+        if let Err(msg) = cycle.validate() {
+            panic!("invalid CycleConfig: {msg}");
+        }
         self.cycle = cycle;
         self
     }
@@ -811,10 +823,68 @@ impl EvalConfig {
 ///
 /// Nested under [`EvalConfig`] like [`SpillConfig`]; flows through
 /// `WorkbookConfig.eval` automatically.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct CycleConfig {
     pub detection: CycleDetection,
     pub policy: CyclePolicy,
+}
+
+impl CycleConfig {
+    /// Runtime detection + Excel-default iterative calculation
+    /// (`max_iterations: 100`, `max_change: 0.001`).
+    pub fn iterate_excel_defaults() -> Self {
+        Self {
+            detection: CycleDetection::Runtime,
+            policy: CyclePolicy::iterate_excel_defaults(),
+        }
+    }
+
+    /// Runtime detection + iterative calculation with explicit knobs.
+    pub fn iterate(max_iterations: u32, max_change: f64) -> Self {
+        Self {
+            detection: CycleDetection::Runtime,
+            policy: CyclePolicy::Iterate {
+                max_iterations,
+                max_change,
+            },
+        }
+    }
+
+    /// Validate the configuration (spec §2). Invalid combinations are
+    /// rejected at build: [`EvalConfig::with_cycle`] and engine construction
+    /// both panic on `Err`.
+    pub fn validate(&self) -> Result<(), String> {
+        if let CyclePolicy::Iterate {
+            max_iterations,
+            max_change,
+        } = self.policy
+        {
+            if self.detection == CycleDetection::Static {
+                return Err(
+                    "CyclePolicy::Iterate requires CycleDetection::Runtime (spec §2)".to_string(),
+                );
+            }
+            if max_iterations == 0 {
+                return Err("CyclePolicy::Iterate max_iterations must be >= 1".to_string());
+            }
+            if !max_change.is_finite() || max_change < 0.0 {
+                return Err(format!(
+                    "CyclePolicy::Iterate max_change must be finite and >= 0 (got {max_change})"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether ingest may accept formulas whose dependencies include the
+    /// formula's own cell (`=B1+A1` in B1). Excel accepts these only with
+    /// iterative calculation enabled; everywhere else the edit-time
+    /// "Self-reference detected" rejection stands.
+    #[inline]
+    pub(crate) fn allows_self_dependency(&self) -> bool {
+        self.detection == CycleDetection::Runtime
+            && matches!(self.policy, CyclePolicy::Iterate { .. })
+    }
 }
 
 /// How statically-cyclic SCCs are treated at evaluation time.
@@ -831,14 +901,43 @@ pub enum CycleDetection {
 }
 
 /// What happens to witnessed (live) cycles under `CycleDetection::Runtime`.
-///
-/// `Iterate` (Excel-style iterative calculation) is Stage 3 and intentionally
-/// absent from this enum until then (no dead config).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum CyclePolicy {
     /// Live cycles produce `#CIRC!`.
     #[default]
     Error,
+    /// Excel-style iterative calculation (RFC #113, spec §3.5/§6):
+    /// live cycles keep running full passes over all SCC members in member
+    /// order (Gauss–Seidel: each result is committed before the next member
+    /// runs) until every member converges per the spec-§6 rules or
+    /// `max_iterations` total passes (pass 1 included) have run. Hitting the
+    /// cap keeps the last values and is NOT an error (Excel parity);
+    /// telemetry records `capped_sccs`.
+    Iterate {
+        /// Total passes per SCC per recalc, pass 1 included. `1` means each
+        /// member evaluates exactly once per recalc (the Excel accumulator
+        /// contract, spec §7.6); `0` is a config error.
+        max_iterations: u32,
+        /// Absolute per-member convergence threshold on f64 serial values
+        /// (`|Δ| < max_change`, strict — Excel semantics). Negative or
+        /// non-finite values are config errors.
+        max_change: f64,
+    },
+}
+
+impl CyclePolicy {
+    /// Excel's default iterative-calculation knobs.
+    pub const EXCEL_DEFAULT_MAX_ITERATIONS: u32 = 100;
+    /// Excel's default maximum-change threshold.
+    pub const EXCEL_DEFAULT_MAX_CHANGE: f64 = 0.001;
+
+    /// `Iterate` with Excel's defaults (100 iterations, 0.001 max change).
+    pub fn iterate_excel_defaults() -> Self {
+        CyclePolicy::Iterate {
+            max_iterations: Self::EXCEL_DEFAULT_MAX_ITERATIONS,
+            max_change: Self::EXCEL_DEFAULT_MAX_CHANGE,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -140,6 +140,7 @@ mod csr_rebuild_amortization;
 mod demand_subgraph_named_range;
 mod dn_range_xlsx_subgraph;
 mod live_edges;
+mod scc_iterate;
 mod scc_runtime_cycles;
 mod scc_runtime_property;
 mod short_circuit_dispatch;

--- a/crates/formualizer-eval/src/engine/tests/scc_iterate.rs
+++ b/crates/formualizer-eval/src/engine/tests/scc_iterate.rs
@@ -1,0 +1,1005 @@
+//! Stage 3 — `CyclePolicy::Iterate`, Excel-style iterative calculation
+//! (RFC #113; contract spec `formualizer-cycle-semantics-spec.md` §2 config,
+//! §3.5 procedure, §4 seeding/persistence, §6 convergence, §7 cases).
+//!
+//! The §6 convergence matrix itself is unit-tested in
+//! `engine::convergence`; this file covers the workbook-level behaviors:
+//! pass counting, capping, persistence + the volatile-like redirty that
+//! re-fires iterating SCCs every recalc, telemetry, replan interaction,
+//! cancellation, and determinism.
+
+use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+fn iterate_cfg(max_iterations: u32, max_change: f64) -> EvalConfig {
+    EvalConfig::default().with_cycle(CycleConfig::iterate(max_iterations, max_change))
+}
+
+fn iterate_engine(max_iterations: u32, max_change: f64) -> Engine<TestWorkbook> {
+    Engine::new(TestWorkbook::new(), iterate_cfg(max_iterations, max_change))
+}
+
+fn set_formula(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, f: &str) {
+    engine
+        .set_cell_formula(sheet, row, col, parse(f).expect("parse"))
+        .expect("set formula");
+}
+
+fn set_value(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, v: LiteralValue) {
+    engine
+        .set_cell_value(sheet, row, col, v)
+        .expect("set value");
+}
+
+fn num(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> f64 {
+    match engine.get_cell_value(sheet, row, col) {
+        Some(LiteralValue::Number(n)) => n,
+        Some(LiteralValue::Int(i)) => i as f64,
+        other => panic!("expected number at {sheet} r{row}c{col}, got {other:?}"),
+    }
+}
+
+fn err_kind(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> ExcelErrorKind {
+    match engine.get_cell_value(sheet, row, col) {
+        Some(LiteralValue::Error(e)) => e.kind,
+        other => panic!("expected error at {sheet} r{row}c{col}, got {other:?}"),
+    }
+}
+
+/* ───────────────────────── §2 config validation ──────────────────────── */
+
+#[test]
+fn cycle_config_validation_rules() {
+    // Valid combos.
+    assert!(CycleConfig::iterate(1, 0.0).validate().is_ok());
+    assert!(CycleConfig::iterate_excel_defaults().validate().is_ok());
+    assert_eq!(
+        CyclePolicy::iterate_excel_defaults(),
+        CyclePolicy::Iterate {
+            max_iterations: 100,
+            max_change: 0.001
+        }
+    );
+    // Error policy is unconstrained.
+    assert!(
+        CycleConfig {
+            detection: CycleDetection::Static,
+            policy: CyclePolicy::Error,
+        }
+        .validate()
+        .is_ok()
+    );
+
+    // max_iterations == 0.
+    assert!(CycleConfig::iterate(0, 0.001).validate().is_err());
+    // max_change negative / non-finite.
+    assert!(CycleConfig::iterate(100, -0.001).validate().is_err());
+    assert!(CycleConfig::iterate(100, f64::NAN).validate().is_err());
+    assert!(CycleConfig::iterate(100, f64::INFINITY).validate().is_err());
+    assert!(
+        CycleConfig::iterate(100, f64::NEG_INFINITY)
+            .validate()
+            .is_err()
+    );
+    // Iterate with Static detection.
+    assert!(
+        CycleConfig {
+            detection: CycleDetection::Static,
+            policy: CyclePolicy::iterate_excel_defaults(),
+        }
+        .validate()
+        .is_err()
+    );
+}
+
+#[test]
+#[should_panic(expected = "invalid CycleConfig")]
+fn with_cycle_rejects_zero_iterations_at_build() {
+    let _ = EvalConfig::default().with_cycle(CycleConfig::iterate(0, 0.001));
+}
+
+#[test]
+#[should_panic(expected = "invalid CycleConfig")]
+fn with_cycle_rejects_negative_max_change_at_build() {
+    let _ = EvalConfig::default().with_cycle(CycleConfig::iterate(100, -1.0));
+}
+
+#[test]
+#[should_panic(expected = "invalid CycleConfig")]
+fn with_cycle_rejects_iterate_under_static_detection() {
+    let _ = EvalConfig::default().with_cycle(CycleConfig {
+        detection: CycleDetection::Static,
+        policy: CyclePolicy::iterate_excel_defaults(),
+    });
+}
+
+#[test]
+#[should_panic(expected = "invalid CycleConfig")]
+fn engine_new_revalidates_struct_literal_configs() {
+    // Bypasses `with_cycle`; `Engine::new` must still reject it.
+    let cfg = EvalConfig {
+        cycle: CycleConfig::iterate(0, 0.001),
+        ..EvalConfig::default()
+    };
+    let _ = Engine::new(TestWorkbook::new(), cfg);
+}
+
+/* ────────────── ingest: self-dependencies are Iterate-only ───────────── */
+
+#[test]
+fn self_reference_ingest_is_accepted_only_under_iterate() {
+    // Iterate: `=A1+1` in A1 and a dense range covering its own cell are
+    // accepted (Excel parity with iterative calculation on).
+    let mut engine = iterate_engine(100, 0.001);
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=A1+1").unwrap())
+        .expect("self-reference accepted under Iterate");
+    engine
+        .set_cell_formula("Sheet1", 5, 1, parse("=SUM(A2:A10)").unwrap())
+        .expect("dense self-covering range accepted under Iterate");
+
+    // Runtime + Error policy: edit-time rejection stands.
+    let cfg = EvalConfig::default().with_cycle(CycleConfig {
+        detection: CycleDetection::Runtime,
+        policy: CyclePolicy::Error,
+    });
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    let err = engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=A1+1").unwrap())
+        .unwrap_err();
+    assert_eq!(err.kind, ExcelErrorKind::Circ);
+}
+
+/* ───────────────────────── §7.1 self-reference ───────────────────────── */
+
+#[test]
+fn self_reference_caps_at_max_iterations_with_exact_value() {
+    // `=A1+1` increments once per pass from the Empty→0 seed; the SCC never
+    // converges and stops at the cap: value after one recalc == cap.
+    let mut engine = iterate_engine(7, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 1, "=A1+1");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 7.0);
+
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.static_sccs, 1);
+    assert_eq!(t.phantom_sccs, 0);
+    assert_eq!(t.live_cycles_witnessed, 1);
+    assert_eq!(t.circ_cells_stamped, 0);
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 0);
+    assert_eq!(t.capped_sccs, 1);
+    assert_eq!(t.settle_passes_total, 7);
+    assert_eq!(t.max_passes_single_scc, 7);
+    // Final-round residual: each pass adds exactly 1.
+    assert_eq!(t.max_abs_delta_at_stop, 1.0);
+    assert_eq!(t.nan_converged, 0);
+
+    // §4 persistence + per-recalc re-fire: the next recalc (no edits at
+    // all) seeds from 7 and adds the cap again.
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 14.0);
+    assert_eq!(engine.last_cycle_telemetry().capped_sccs, 1);
+}
+
+#[test]
+fn self_reference_small_caps_verified_exactly() {
+    for cap in [1u32, 2, 3, 5] {
+        let mut engine = iterate_engine(cap, 0.001);
+        set_formula(&mut engine, "Sheet1", 1, 1, "=A1+1");
+        engine.evaluate_all().unwrap();
+        assert_eq!(num(&engine, "Sheet1", 1, 1), cap as f64, "cap {cap}");
+        assert_eq!(
+            engine.last_cycle_telemetry().settle_passes_total,
+            cap as usize
+        );
+    }
+}
+
+/* ───────────── §7.4 arithmetic routing: converging pair ──────────────── */
+
+#[test]
+fn arithmetic_routing_converges_to_the_closed_form_fixed_point() {
+    // B1 = g·X + (1−g)·C1, C1 = g·B1 + (1−g)·Y with g = 0.5, X = 10, Y = 20.
+    // Fixed point: b = 5 + 0.5c, c = 0.5b + 10 ⟹ b = 40/3, c = 50/3.
+    // Gauss–Seidel contraction L = g(1−g) = 0.25; at stop the per-pass
+    // delta is < max_change, so |value − fixed point| ≤ L/(1−L)·max_change
+    // < max_change.
+    let max_change = 0.001;
+    let mut engine = iterate_engine(100, max_change);
+    set_formula(&mut engine, "Sheet1", 1, 2, "=0.5*10+0.5*C1"); // B1
+    set_formula(&mut engine, "Sheet1", 1, 3, "=0.5*B1+0.5*20"); // C1
+    engine.evaluate_all().unwrap();
+
+    let b = num(&engine, "Sheet1", 1, 2);
+    let c = num(&engine, "Sheet1", 1, 3);
+    assert!((b - 40.0 / 3.0).abs() < max_change, "B1 = {b}");
+    assert!((c - 50.0 / 3.0).abs() < max_change, "C1 = {c}");
+
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.static_sccs, 1);
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(t.capped_sccs, 0);
+    assert_eq!(t.live_cycles_witnessed, 1);
+    assert!(
+        t.max_abs_delta_at_stop < max_change && t.max_abs_delta_at_stop > 0.0,
+        "converged residual must be the sub-threshold final round, got {}",
+        t.max_abs_delta_at_stop
+    );
+    assert!(
+        t.settle_passes_total > 2 && t.settle_passes_total < 100,
+        "got {} passes",
+        t.settle_passes_total
+    );
+}
+
+/* ───────────────────── §7.5 genuinely divergent pair ─────────────────── */
+
+#[test]
+fn divergent_pair_caps_with_deterministic_values() {
+    // A1 = A2+1, A2 = A1+1 in member order (A1 first): pass k commits
+    // A1 = 2k−1, A2 = 2k. Never converges; capped; NOT an error.
+    let mut engine = iterate_engine(10, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 1, "=A2+1");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=A1+1");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 19.0);
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 20.0);
+
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 0);
+    assert_eq!(t.capped_sccs, 1);
+    assert_eq!(t.circ_cells_stamped, 0, "capping is not an error");
+    assert_eq!(t.settle_passes_total, 10);
+    // Final round: both members moved by 2.
+    assert_eq!(t.max_abs_delta_at_stop, 2.0);
+}
+
+/* ──────────── §7.6 accumulator (`max_iterations: 1`, §4 seed) ─────────── */
+
+#[test]
+fn accumulator_adds_input_exactly_once_per_recalc() {
+    // B1 = B1 + A1 with A1 = 5: three recalcs from a fresh workbook → 15.
+    // No convergence test runs (`max_iterations: 1` ⇒ exactly one pass).
+    let mut engine = iterate_engine(1, 0.001);
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(5.0)); // A1
+    set_formula(&mut engine, "Sheet1", 1, 2, "=B1+A1"); // B1
+
+    for (recalc, expected) in [(1u32, 5.0), (2, 10.0), (3, 15.0)] {
+        engine.evaluate_all().unwrap();
+        assert_eq!(
+            num(&engine, "Sheet1", 1, 2),
+            expected,
+            "after recalc {recalc}"
+        );
+        let t = engine.last_cycle_telemetry();
+        assert_eq!(t.static_sccs, 1, "recalc {recalc} must re-fire the SCC");
+        assert_eq!(t.iterated_sccs, 1);
+        assert_eq!(t.converged_sccs, 0);
+        assert_eq!(t.capped_sccs, 1, "stopping at the pass budget is a cap");
+        assert_eq!(t.settle_passes_total, 1, "exactly one pass per recalc");
+        assert_eq!(
+            t.max_abs_delta_at_stop, 0.0,
+            "no convergence comparison ever ran"
+        );
+    }
+}
+
+#[test]
+fn accumulator_member_evaluates_exactly_max_iterations_times_per_recalc() {
+    use crate::args::ArgSchema;
+    use crate::function::{FnCaps, Function};
+    use crate::traits::{ArgumentHandle, FunctionContext};
+
+    /// Returns 0 and counts invocations — a direct probe of the
+    /// pass-counting contract.
+    #[derive(Debug)]
+    struct CountFn(Arc<AtomicUsize>);
+    impl Function for CountFn {
+        fn caps(&self) -> FnCaps {
+            FnCaps::empty()
+        }
+        fn name(&self) -> &'static str {
+            "COUNTEVALS"
+        }
+        fn arg_schema(&self) -> &'static [ArgSchema] {
+            &[]
+        }
+        fn eval<'a, 'b, 'c>(
+            &self,
+            _args: &'c [ArgumentHandle<'a, 'b>],
+            _ctx: &dyn FunctionContext<'b>,
+        ) -> Result<crate::traits::CalcValue<'b>, formualizer_common::ExcelError> {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(0)))
+        }
+    }
+
+    for cap in [1usize, 3] {
+        let count = Arc::new(AtomicUsize::new(0));
+        let wb = TestWorkbook::new().with_function(Arc::new(CountFn(count.clone())));
+        let mut engine = Engine::new(wb, iterate_cfg(cap as u32, 0.001));
+        set_formula(&mut engine, "Sheet1", 1, 1, "=A1+1+COUNTEVALS()");
+        engine.evaluate_all().unwrap();
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            cap,
+            "cap {cap}: one evaluation per pass"
+        );
+        engine.evaluate_all().unwrap();
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            2 * cap,
+            "cap {cap}: same again on the next recalc"
+        );
+    }
+}
+
+#[test]
+fn accumulator_works_through_the_demand_path_too() {
+    // evaluate_cell shares the unit walk + end-of-recalc redirty.
+    let mut engine = iterate_engine(1, 0.001);
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(5.0));
+    set_formula(&mut engine, "Sheet1", 1, 2, "=B1+A1");
+    for expected in [5.0, 10.0, 15.0] {
+        engine.evaluate_cell("Sheet1", 1, 2).unwrap();
+        assert_eq!(num(&engine, "Sheet1", 1, 2), expected);
+    }
+}
+
+#[test]
+fn iterating_scc_changes_propagate_downstream_each_recalc() {
+    // D1 reads the accumulator from outside the SCC: the volatile-like
+    // redirty must propagate to dependents so downstream stays fresh.
+    let mut engine = iterate_engine(1, 0.001);
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(5.0));
+    set_formula(&mut engine, "Sheet1", 1, 2, "=B1+A1");
+    set_formula(&mut engine, "Sheet1", 1, 4, "=B1*2");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 4), 10.0);
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 4), 20.0);
+}
+
+#[test]
+fn breaking_the_cycle_stops_the_per_recalc_redirty() {
+    // Overwrite the accumulator with a literal: the SCC dissolves, values
+    // freeze, and no work is scheduled on later recalcs (the redirty chain
+    // is per-recalc and self-healing).
+    let mut engine = iterate_engine(1, 0.001);
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(5.0));
+    set_formula(&mut engine, "Sheet1", 1, 2, "=B1+A1");
+    engine.evaluate_all().unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 10.0);
+
+    set_value(&mut engine, "Sheet1", 1, 2, LiteralValue::Number(42.0));
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 42.0);
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 0);
+
+    // And the recalc after that schedules nothing cycle-related at all.
+    let res = engine.evaluate_all().unwrap();
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 0);
+    assert_eq!(res.computed_vertices, 0, "no perpetual redirty leak");
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 42.0);
+}
+
+/* ───────────── §7.7 self-referential timestamp + §7.11 volatiles ──────── */
+
+fn deterministic_iterate_cfg(max_iterations: u32, max_change: f64) -> EvalConfig {
+    use crate::engine::DeterministicMode;
+    use crate::timezone::TimeZoneSpec;
+    let mut cfg = iterate_cfg(max_iterations, max_change);
+    cfg.deterministic_mode = DeterministicMode::Enabled {
+        timestamp_utc: chrono::DateTime::parse_from_rfc3339("2026-06-09T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        timezone: TimeZoneSpec::Utc,
+    };
+    cfg
+}
+
+#[test]
+fn timestamp_pattern_stamps_once_and_is_preserved() {
+    // B1 = IF(A1="", "", IF(B1="", NOW(), B1)) with a fixed clock.
+    let mut engine = Engine::new(TestWorkbook::new(), deterministic_iterate_cfg(100, 0.001));
+    set_formula(
+        &mut engine,
+        "Sheet1",
+        1,
+        2,
+        "=IF(A1=\"\",\"\",IF(B1=\"\",NOW(),B1))",
+    );
+    engine.evaluate_all().unwrap();
+    // A1 empty: the guarded branch returns "" without reading B1 — phantom.
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Text(String::new()))
+    );
+    assert_eq!(engine.last_cycle_telemetry().iterated_sccs, 0);
+
+    // A1 becomes non-empty: NOW() stamps once; the second pass re-reads the
+    // stamp through the taken branch and converges (Δ = 0 — the volatile
+    // sample is per-recalc stable, §7.11).
+    set_value(
+        &mut engine,
+        "Sheet1",
+        1,
+        1,
+        LiteralValue::Text("x".to_string()),
+    );
+    engine.evaluate_all().unwrap();
+    let stamped = num(&engine, "Sheet1", 1, 2);
+    assert!(stamped > 40000.0, "expected a date serial, got {stamped}");
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(t.capped_sccs, 0);
+
+    // Later recalcs preserve the stamp (B1 reads its own previous value).
+    for _ in 0..2 {
+        engine.evaluate_all().unwrap();
+        assert_eq!(num(&engine, "Sheet1", 1, 2), stamped);
+        assert_eq!(engine.last_cycle_telemetry().converged_sccs, 1);
+    }
+}
+
+#[test]
+fn volatile_inside_cycle_is_pass_stable_and_redirties_next_recalc() {
+    // B1 = NOW() + 0·C1, C1 = B1: NOW() must read identically in every pass
+    // of one recalc (fixed clock ⇒ converges with Δ = 0 on pass 2), and the
+    // volatile member re-fires the SCC on the next recalc.
+    let mut engine = Engine::new(TestWorkbook::new(), deterministic_iterate_cfg(100, 0.001));
+    set_formula(&mut engine, "Sheet1", 1, 2, "=NOW()+0*C1");
+    set_formula(&mut engine, "Sheet1", 1, 3, "=B1");
+    engine.evaluate_all().unwrap();
+    let stamped = num(&engine, "Sheet1", 1, 2);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(
+        t.settle_passes_total, 2,
+        "pass 2 must observe the same NOW() sample and converge immediately"
+    );
+    assert_eq!(t.max_abs_delta_at_stop, 0.0);
+
+    // Volatile redirty: the SCC re-evaluates on the next recalc (and the
+    // fixed clock keeps the value identical).
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.last_cycle_telemetry().iterated_sccs, 1);
+    assert_eq!(num(&engine, "Sheet1", 1, 2), stamped);
+    assert_eq!(num(&engine, "Sheet1", 1, 3), stamped);
+}
+
+/* ─────────────────────── §7.8 range self-inclusion ───────────────────── */
+
+#[test]
+fn range_self_inclusion_grows_per_pass_and_caps() {
+    // B2 = SUM(B1:B3) with B1 = 1, B3 = 2: each pass re-adds the previous
+    // total, so the value grows by 3 per pass and never converges.
+    let mut engine = iterate_engine(5, 0.001);
+    set_value(&mut engine, "Sheet1", 1, 2, LiteralValue::Number(1.0));
+    set_value(&mut engine, "Sheet1", 3, 2, LiteralValue::Number(2.0));
+    set_formula(&mut engine, "Sheet1", 2, 2, "=SUM(B1:B3)");
+    engine.evaluate_all().unwrap();
+    // p1: 3, p2: 6, p3: 9, p4: 12, p5: 15.
+    assert_eq!(num(&engine, "Sheet1", 2, 2), 15.0);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.capped_sccs, 1);
+    assert_eq!(t.settle_passes_total, 5);
+    assert_eq!(t.max_abs_delta_at_stop, 3.0);
+
+    // Persistence: the next recalc keeps growing from 15.
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 2, 2), 30.0);
+}
+
+#[test]
+fn whole_column_self_inclusion_iterates_via_the_stripe_path() {
+    // `=SUM(B:B)` in B1 (single-vertex SCC from whole-axis self-inclusion,
+    // #129): grows by the column total each pass, caps.
+    let mut engine = iterate_engine(4, 0.001);
+    set_value(&mut engine, "Sheet1", 4, 2, LiteralValue::Number(2.0));
+    set_value(&mut engine, "Sheet1", 5, 2, LiteralValue::Number(3.0));
+    set_formula(&mut engine, "Sheet1", 1, 2, "=SUM(B:B)");
+    engine.evaluate_all().unwrap();
+    // p1: 5, p2: 10, p3: 15, p4: 20.
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 20.0);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.capped_sccs, 1);
+    assert_eq!(t.settle_passes_total, 4);
+}
+
+/* ─────────────────────── §7.10 errors inside cycles ──────────────────── */
+
+#[test]
+fn error_in_cycle_propagates_and_converges_on_same_kind() {
+    // B1 = 1/C1, C1 = B1 with C1 seeded Empty→0: pass 1 yields #DIV/0!,
+    // pass 2 reproduces it, same-kind errors converge (§6). No #CIRC is
+    // synthesized.
+    let mut engine = iterate_engine(100, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 2, "=1/C1");
+    set_formula(&mut engine, "Sheet1", 1, 3, "=B1");
+    engine.evaluate_all().unwrap();
+    assert_eq!(err_kind(&engine, "Sheet1", 1, 2), ExcelErrorKind::Div);
+    assert_eq!(err_kind(&engine, "Sheet1", 1, 3), ExcelErrorKind::Div);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(t.capped_sccs, 0);
+    assert_eq!(t.circ_cells_stamped, 0);
+    assert_eq!(t.settle_passes_total, 2);
+}
+
+#[test]
+fn cycle_escapes_the_error_when_the_outside_input_changes() {
+    // B1 = IFERROR(0*C1, 0) + 1/D1, C1 = B1. D1 = 0 errors the cycle;
+    // setting D1 = 4 lets iteration escape to a clean fixed point.
+    let mut engine = iterate_engine(100, 0.001);
+    set_value(&mut engine, "Sheet1", 1, 4, LiteralValue::Number(0.0)); // D1
+    set_formula(&mut engine, "Sheet1", 1, 2, "=IFERROR(0*C1,0)+1/D1");
+    set_formula(&mut engine, "Sheet1", 1, 3, "=B1");
+    engine.evaluate_all().unwrap();
+    assert_eq!(err_kind(&engine, "Sheet1", 1, 2), ExcelErrorKind::Div);
+    assert_eq!(err_kind(&engine, "Sheet1", 1, 3), ExcelErrorKind::Div);
+    assert_eq!(engine.last_cycle_telemetry().converged_sccs, 1);
+
+    set_value(&mut engine, "Sheet1", 1, 4, LiteralValue::Number(4.0));
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 0.25);
+    assert_eq!(num(&engine, "Sheet1", 1, 3), 0.25);
+    assert_eq!(engine.last_cycle_telemetry().converged_sccs, 1);
+}
+
+/* ──────────────── §6 type transitions at workbook level ──────────────── */
+
+#[test]
+fn type_oscillation_never_converges_and_caps() {
+    // A1 flips Number↔Text depending on B1's type; B1 = A1. Every pass is a
+    // type transition for one of them, so the SCC caps (even a huge
+    // max_change can't make transitions converge).
+    let mut engine = iterate_engine(9, 1.0e12);
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(ISNUMBER(B1),\"t\",1)");
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1");
+    engine.evaluate_all().unwrap();
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 0);
+    assert_eq!(t.capped_sccs, 1);
+    assert_eq!(t.settle_passes_total, 9);
+}
+
+#[test]
+fn text_cycle_converges_on_exact_equality() {
+    // B1 = IF(C1="", "x", C1), C1 = B1: stabilizes on the text "x".
+    let mut engine = iterate_engine(100, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 2, "=IF(C1=\"\",\"x\",C1)");
+    set_formula(&mut engine, "Sheet1", 1, 3, "=B1");
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Text("x".to_string()))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Text("x".to_string()))
+    );
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(t.capped_sccs, 0);
+}
+
+/* ─────────────── §7.3 guard flips / phantom parity ───────────────────── */
+
+#[test]
+fn guard_flip_inside_iteration_converges_after_the_branch_change() {
+    // A1 = IF(B1>2, 7, B1+1), B1 = A1: the else-branch climbs 1, 2, 3, the
+    // guard flips on pass 4 (7), pass 5 confirms — converged, never capped.
+    let mut engine = iterate_engine(100, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(B1>2,7,B1+1)");
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 7.0);
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 7.0);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(t.capped_sccs, 0);
+    assert_eq!(t.settle_passes_total, 5);
+}
+
+#[test]
+fn live_cycle_appearing_mid_settle_switches_into_iteration() {
+    // Stage-2's branch-flip shape: pass 1 is acyclic; A1's settle re-eval
+    // flips onto A3, closing a live cycle A1↔A3 that only classification-
+    // after-settle sees. Under Iterate it must iterate (and here it
+    // stabilizes immediately) instead of stamping #CIRC.
+    let mut engine = iterate_engine(100, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(A2=999,A3,7)");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(TRUE,999,A1)");
+    set_formula(&mut engine, "Sheet1", 3, 1, "=IF(TRUE,A1,8)");
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 7.0);
+    assert_eq!(num(&engine, "Sheet1", 2, 1), 999.0);
+    assert_eq!(num(&engine, "Sheet1", 3, 1), 7.0);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.circ_cells_stamped, 0);
+    assert_eq!(t.live_cycles_witnessed, 1);
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(t.capped_sccs, 0);
+}
+
+#[test]
+fn phantom_sccs_behave_identically_under_both_policies() {
+    // The #99 guarded pair: phantom under Error AND under Iterate — no
+    // iteration, identical values and settle telemetry.
+    fn run(policy: CyclePolicy) -> (f64, f64, crate::engine::CycleTelemetry) {
+        let cfg = EvalConfig::default().with_cycle(CycleConfig {
+            detection: CycleDetection::Runtime,
+            policy,
+        });
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Boolean(true));
+        set_formula(&mut engine, "Sheet1", 2, 1, "=IF(A1,555,A3)");
+        set_formula(&mut engine, "Sheet1", 3, 1, "=IF(A1,A2,999)");
+        engine.evaluate_all().unwrap();
+        let mut t = engine.last_cycle_telemetry().clone();
+        t.elapsed_ms = 0;
+        (
+            num(&engine, "Sheet1", 2, 1),
+            num(&engine, "Sheet1", 3, 1),
+            t,
+        )
+    }
+    let error = run(CyclePolicy::Error);
+    let iterate = run(CyclePolicy::iterate_excel_defaults());
+    assert_eq!(error, iterate);
+    assert_eq!(iterate.0, 555.0);
+    assert_eq!(iterate.2.phantom_sccs, 1);
+    assert_eq!(iterate.2.iterated_sccs, 0);
+
+    // And a phantom SCC under Iterate never registers the per-recalc
+    // redirty: a second recalc with no edits schedules no SCC task.
+    let cfg = EvalConfig::default().with_cycle(CycleConfig::iterate_excel_defaults());
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Boolean(true));
+    set_formula(&mut engine, "Sheet1", 2, 1, "=IF(A1,555,A3)");
+    set_formula(&mut engine, "Sheet1", 3, 1, "=IF(A1,A2,999)");
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.last_cycle_telemetry().phantom_sccs, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.last_cycle_telemetry().static_sccs, 0);
+}
+
+/* ─────────────── §7.12 / G12: INDIRECT inside an iterating SCC ────────── */
+
+#[test]
+fn indirect_in_iterating_scc_completes_within_bounded_replan() {
+    // A1 = INDIRECT(D1)+1 with D1 → "B1", B1 = A1+1: the virtual edge closes
+    // the SCC; under Iterate the divergent ladder caps inside ONE replan
+    // iteration (total work ≤ MAX_REPLAN × max_iterations passes).
+    let cfg = iterate_cfg(5, 0.001).with_virtual_dep_telemetry(true);
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+    set_value(
+        &mut engine,
+        "Sheet1",
+        1,
+        4,
+        LiteralValue::Text("B1".to_string()),
+    );
+    set_formula(&mut engine, "Sheet1", 1, 1, "=INDIRECT(D1)+1");
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1+1");
+    engine.evaluate_all().unwrap();
+
+    // Member order (A1, B1); pass k commits A1 = 2k−1, B1 = 2k; cap 5.
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 9.0);
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 10.0);
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(t.iterated_sccs, 1);
+    assert_eq!(t.capped_sccs, 1);
+    let vt = engine.last_virtual_dep_telemetry().clone();
+    const MAX_REPLAN: usize = 5;
+    assert!(vt.replan_iterations <= MAX_REPLAN);
+    assert!(
+        t.settle_passes_total <= (1 + MAX_REPLAN) * 5,
+        "combined replan × iteration bound, got {} passes",
+        t.settle_passes_total
+    );
+
+    // Re-point the dynamic ref: the cycle dissolves; plain values.
+    set_value(&mut engine, "Sheet1", 3, 1, LiteralValue::Number(10.0)); // A3
+    set_value(
+        &mut engine,
+        "Sheet1",
+        1,
+        4,
+        LiteralValue::Text("A3".to_string()),
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 11.0);
+    assert_eq!(num(&engine, "Sheet1", 1, 2), 12.0);
+    // …and the per-recalc redirty stops once nothing iterates.
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.last_cycle_telemetry().iterated_sccs, 0);
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 11.0);
+}
+
+/* ────────────── property test: random linear fixed points ─────────────── */
+
+/// Tiny deterministic PRNG (xorshift64*) — no external entropy.
+struct XorShift64(u64);
+impl XorShift64 {
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    /// Integer in [lo, hi] inclusive.
+    fn int_in(&mut self, lo: i64, hi: i64) -> i64 {
+        let span = (hi - lo + 1) as u64;
+        lo + (self.next_u64() % span) as i64
+    }
+}
+
+/// Solve `M x = b` by Gaussian elimination with partial pivoting.
+fn solve_linear(mut m: Vec<Vec<f64>>, mut b: Vec<f64>) -> Vec<f64> {
+    let n = b.len();
+    for col in 0..n {
+        let pivot = (col..n)
+            .max_by(|&a, &b2| m[a][col].abs().partial_cmp(&m[b2][col].abs()).unwrap())
+            .unwrap();
+        m.swap(col, pivot);
+        b.swap(col, pivot);
+        assert!(m[col][col].abs() > 1e-12, "singular test matrix");
+        for row in (col + 1)..n {
+            let f = m[row][col] / m[col][col];
+            let pivot_row = m[col].clone();
+            for (k, pv) in pivot_row.iter().enumerate().skip(col) {
+                m[row][k] -= f * pv;
+            }
+            b[row] -= f * b[col];
+        }
+    }
+    let mut x = vec![0.0; n];
+    for row in (0..n).rev() {
+        let mut acc = b[row];
+        for k in (row + 1)..n {
+            acc -= m[row][k] * x[k];
+        }
+        x[row] = acc / m[row][row];
+    }
+    x
+}
+
+const COLS: [&str; 6] = ["A", "B", "C", "D", "E", "F"];
+
+#[test]
+fn random_contractive_linear_systems_converge_to_the_solution() {
+    // x = A·x + b with ‖A‖∞ ≤ 0.75 by construction (coefficients are
+    // dyadic multiples of 1/64 so the formula text round-trips exactly).
+    for seed in [1u64, 7, 42, 1234, 987_654_321] {
+        let mut rng = XorShift64(seed);
+        let n = rng.int_in(3, 6) as usize;
+        let mut a = vec![vec![0.0f64; n]; n];
+        let mut b = vec![0.0f64; n];
+        for (row, bi) in a.iter_mut().zip(b.iter_mut()) {
+            for aij in row.iter_mut() {
+                *aij = rng.int_in(-8, 8) as f64 * 0.015625; // |aij| ≤ 0.125
+            }
+            *bi = rng.int_in(-40, 40) as f64 * 0.25;
+        }
+
+        let max_change = 1e-9;
+        let mut engine = iterate_engine(1000, max_change);
+        for i in 0..n {
+            let mut f = format!("={}", b[i]);
+            for j in 0..n {
+                f.push_str(&format!("+({})*{}1", a[i][j], COLS[j]));
+            }
+            set_formula(&mut engine, "Sheet1", 1, (i + 1) as u32, &f);
+        }
+        engine.evaluate_all().unwrap();
+
+        // Closed form: (I − A) x = b.
+        let mut m = vec![vec![0.0f64; n]; n];
+        for i in 0..n {
+            for j in 0..n {
+                m[i][j] = if i == j { 1.0 - a[i][j] } else { -a[i][j] };
+            }
+        }
+        let expected = solve_linear(m, b);
+        for (i, want) in expected.iter().enumerate() {
+            let got = num(&engine, "Sheet1", 1, (i + 1) as u32);
+            assert!(
+                (got - want).abs() < 1e-6,
+                "seed {seed} x{i}: got {got}, want {want}"
+            );
+        }
+        let t = engine.last_cycle_telemetry();
+        assert_eq!(t.iterated_sccs, 1, "seed {seed}");
+        assert_eq!(t.converged_sccs, 1, "seed {seed}");
+        assert_eq!(t.capped_sccs, 0, "seed {seed}");
+        assert!(t.max_abs_delta_at_stop < max_change, "seed {seed}");
+    }
+}
+
+#[test]
+fn random_expansive_linear_systems_cap_without_error() {
+    // Ring systems with |coefficient| = 1.5 ⇒ spectral radius 1.5 > 1:
+    // never converges, caps cleanly, values stay finite numbers.
+    for seed in [3u64, 99, 2026] {
+        let mut rng = XorShift64(seed);
+        let n = rng.int_in(3, 6) as usize;
+        let cap = 40u32;
+        let mut engine = iterate_engine(cap, 0.001);
+        for i in 0..n {
+            let j = (i + 1) % n;
+            let sign = if rng.int_in(0, 1) == 0 { "" } else { "-" };
+            let f = format!("=1+({sign}1.5)*{}1", COLS[j]);
+            set_formula(&mut engine, "Sheet1", 1, (i + 1) as u32, &f);
+        }
+        engine.evaluate_all().unwrap();
+        let t = engine.last_cycle_telemetry();
+        assert_eq!(t.iterated_sccs, 1, "seed {seed}");
+        assert_eq!(t.converged_sccs, 0, "seed {seed}");
+        assert_eq!(t.capped_sccs, 1, "seed {seed}");
+        assert_eq!(t.circ_cells_stamped, 0, "seed {seed}: capping ≠ error");
+        assert_eq!(t.settle_passes_total, cap as usize, "seed {seed}");
+        for i in 0..n {
+            let v = num(&engine, "Sheet1", 1, (i + 1) as u32);
+            assert!(v.is_finite(), "seed {seed} x{i} = {v}");
+        }
+    }
+}
+
+/* ───────────────────────── side effects & deltas ──────────────────────── */
+
+#[test]
+fn one_delta_per_member_per_recalc_under_iteration() {
+    use formualizer_common::PackedSheetCell;
+
+    // Divergent pair: both members change every recalc → one delta each,
+    // with the FINAL value only (never per pass).
+    let mut engine = iterate_engine(10, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 1, "=A2+1");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=A1+1");
+    let (_res, delta) = engine.evaluate_all_with_delta().unwrap();
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let mut expected = vec![
+        PackedSheetCell::try_new(sheet_id, 0, 0).unwrap(), // A1 (0-based)
+        PackedSheetCell::try_new(sheet_id, 1, 0).unwrap(), // A2
+    ];
+    expected.sort_unstable();
+    assert_eq!(delta.changed_cells, expected);
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 19.0);
+
+    // Next recalc: values move again → deltas again.
+    let (_res, delta) = engine.evaluate_all_with_delta().unwrap();
+    assert_eq!(delta.changed_cells, expected);
+    assert_eq!(num(&engine, "Sheet1", 1, 1), 39.0);
+
+    // A converged-and-stable SCC re-runs each recalc but produces NO deltas
+    // when the final values don't move.
+    let mut engine = iterate_engine(100, 0.001);
+    set_formula(&mut engine, "Sheet1", 1, 1, "=IF(B1>2,7,B1+1)");
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1");
+    let (_res, delta) = engine.evaluate_all_with_delta().unwrap();
+    assert_eq!(delta.changed_cells.len(), 2);
+    let (_res, delta) = engine.evaluate_all_with_delta().unwrap();
+    assert_eq!(engine.last_cycle_telemetry().iterated_sccs, 1);
+    assert!(
+        delta.changed_cells.is_empty(),
+        "stable values must not re-delta: {:?}",
+        delta.changed_cells
+    );
+}
+
+/* ───────────────────────── cancellation mid-iteration ─────────────────── */
+
+#[test]
+fn cancellation_is_honored_between_iteration_passes() {
+    use crate::args::ArgSchema;
+    use crate::function::{FnCaps, Function};
+    use crate::traits::{ArgumentHandle, FunctionContext};
+
+    // TRIPCANCEL() sets the cancel flag during pass 1 of a divergent pair;
+    // the per-pass check must stop iteration before pass 2.
+    #[derive(Debug)]
+    struct TripFn(Arc<AtomicBool>);
+    impl Function for TripFn {
+        fn caps(&self) -> FnCaps {
+            FnCaps::empty()
+        }
+        fn name(&self) -> &'static str {
+            "TRIPCANCEL"
+        }
+        fn arg_schema(&self) -> &'static [ArgSchema] {
+            &[]
+        }
+        fn eval<'a, 'b, 'c>(
+            &self,
+            _args: &'c [ArgumentHandle<'a, 'b>],
+            _ctx: &dyn FunctionContext<'b>,
+        ) -> Result<crate::traits::CalcValue<'b>, formualizer_common::ExcelError> {
+            self.0.store(true, Ordering::Relaxed);
+            Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(0)))
+        }
+    }
+
+    let flag = Arc::new(AtomicBool::new(false));
+    let wb = TestWorkbook::new().with_function(Arc::new(TripFn(flag.clone())));
+    let mut engine = Engine::new(wb, iterate_cfg(1000, 0.001));
+    set_formula(&mut engine, "Sheet1", 1, 1, "=A2+1+TRIPCANCEL()");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=A1+1");
+    let err = engine.evaluate_all_cancellable(flag).unwrap_err();
+    assert_eq!(err.kind, ExcelErrorKind::Cancelled);
+    assert!(
+        err.message.as_deref().unwrap_or("").contains("SCC"),
+        "cancellation must come from the SCC pass boundary, got {err:?}"
+    );
+}
+
+/* ─────────────────────────── determinism ──────────────────────────────── */
+
+#[test]
+fn iterate_is_deterministic_across_thread_counts_and_repeats() {
+    fn build_and_run(
+        threads: usize,
+    ) -> Vec<(Vec<Option<LiteralValue>>, crate::engine::CycleTelemetry)> {
+        let cfg = EvalConfig {
+            max_threads: Some(threads),
+            enable_parallel: threads > 1,
+            ..iterate_cfg(10, 0.001)
+        };
+        let mut engine = Engine::new(TestWorkbook::new(), cfg);
+        // Mixed workbook: converging pair, divergent pair, accumulator,
+        // phantom pair, and downstream readers.
+        set_formula(&mut engine, "Sheet1", 1, 1, "=0.5*10+0.5*B1");
+        set_formula(&mut engine, "Sheet1", 1, 2, "=0.5*A1+0.5*20");
+        set_formula(&mut engine, "Sheet1", 2, 1, "=B2+1");
+        set_formula(&mut engine, "Sheet1", 2, 2, "=A2+1");
+        set_value(&mut engine, "Sheet1", 3, 1, LiteralValue::Number(5.0));
+        set_formula(&mut engine, "Sheet1", 3, 2, "=B3+A3");
+        set_value(&mut engine, "Sheet1", 4, 1, LiteralValue::Boolean(true));
+        set_formula(&mut engine, "Sheet1", 4, 2, "=IF(A4,555,C4)");
+        set_formula(&mut engine, "Sheet1", 4, 3, "=IF(A4,B4,999)");
+        set_formula(&mut engine, "Sheet1", 5, 1, "=A1+A2+B3");
+
+        // Two recalcs: the second exercises the per-recalc redirty schedule.
+        let mut out = Vec::new();
+        for _ in 0..2 {
+            engine.evaluate_all().unwrap();
+            let mut values = Vec::new();
+            for r in 1..=5u32 {
+                for c in 1..=3u32 {
+                    values.push(engine.get_cell_value("Sheet1", r, c));
+                }
+            }
+            let mut telemetry = engine.last_cycle_telemetry().clone();
+            telemetry.elapsed_ms = 0;
+            out.push((values, telemetry));
+        }
+        out
+    }
+
+    let baseline = build_and_run(1);
+    for threads in [1usize, 2, 8] {
+        for run in 0..2 {
+            let out = build_and_run(threads);
+            assert_eq!(out, baseline, "threads={threads} run={run}");
+        }
+    }
+}


### PR DESCRIPTION
Implements the core of RFC #113 on top of the runtime cycle detection from #112: `CyclePolicy::Iterate { max_iterations, max_change }` (Excel defaults 100 / 0.001). When a live cycle is witnessed under `Iterate`, the SCC keeps running Gauss–Seidel passes — members in fixed order, write-through commits, live edges re-recorded every pass so guards can flip mid-convergence — until the spec convergence test passes or the pass budget is reached. Capping is not an error: last values stand, telemetry records it. Phantom SCCs behave byte-identically under both policies. Opt-in as before; default config untouched.

## The two load-bearing semantics

**Accumulator/dirty resolution**: after one recalc an SCC would be clean and skipped forever, breaking Excel's accumulator contract (`B1 = =B1+A1` with `max_iterations: 1` must add A1 once per recalc). Iterating SCCs now register into a per-recalc redirty set applied alongside volatiles at every flow's end (`redirty_for_next_recalc` replaces all nine `redirty_volatiles` sites; downstream dependents re-fire via `mark_dirty`). The set is per-recalc and self-healing: break the cycle and the next recalc settles phantom, nothing re-registers, and the chain stops — pinned by a test asserting `computed_vertices == 0` two recalcs after the break.

**Pass counting**: pass 1 has already run at the witness point, so the policy arm checks the budget before any iteration pass and the convergence test only runs once a previous-pass baseline exists. `max_iterations: 1` therefore means literally one evaluation per member per recalc — proven with a counting function. Acyclic settle keeps its separate defensive budget so `Error`-mode behavior is bit-identical.

## Convergence (spec table, implemented exactly)

Numeric-class on f64 serials: strict `|Δ| < max_change` (absolute, Excel semantics). Boolean/Text exact; Error-vs-Error by kind; any type transition = not converged; identical-bit NaN converges with a telemetry flag; arrays element-wise. Each rule has a dedicated unit test including the exact strict-`<` boundary.

## Enabler deviation (scoped)

Direct self-references (`=A1+1` in A1, dense self-covering ranges) were rejected at ingest, which would make the accumulator and self-reference patterns unreachable. Under Runtime + Iterate **only**, ingest now accepts them (Excel parity with iteration enabled); every other config keeps the rejection, locked by existing tests. Cycles through named ranges remain ingest-rejected as before.

## Config & telemetry

`CycleConfig::validate()` (public `Result`) enforced by panic at engine construction (matching the codebase's infallible-constructor pattern); invalid combos: `max_iterations == 0`, non-finite/negative `max_change`, `Iterate` + `Static`. Telemetry gains `iterated_sccs`, `converged_sccs`, `max_abs_delta_at_stop`, NaN flag (`capped_sccs` existed). Sample, converged linear system: 9 passes, Δ-at-stop 3.8e-4, values at the analytic fixed point.

## Tests

45 new: the full convergence matrix; self-reference exact small caps; arithmetic-routing convergence asserted against the closed-form fixed point; divergent pair caps without error; accumulator across three recalcs via both evaluate_all and the demand path (plus downstream propagation and the cycle-break self-heal); self-referential timestamp with deterministic clock; range and whole-column self-inclusion growth-then-cap; error-in-cycle convergence and escape; volatile pass-stability; INDIRECT-in-iterating-SCC with the replan bound asserted; seeded property tests — contractive random linear systems converge to Gaussian-elimination solutions at 1e-6, expansive systems cap finite; guard flips mid-iteration; per-policy phantom parity (byte-identical telemetry); config validation; cancellation between passes; determinism across `max_threads` {1,2,8}.

Full workspace suite (CI exclusions): **2536 passed, 0 failed** (clean-main baseline 2491 verified + 45). fmt/clippy clean.

## Bench gate (interleaved A/B vs main)

linear-rollup 200k and finance-recalc: mixed direction, within noise (3 rounds each). `probe-scc-phantom-pairs` runtime mode (the most sensitive probe): init 47.7/55.3/50.2 vs 52.6/53.8/44.3 ms, fully mixed — the policy arm adds nothing to phantom or acyclic paths.

Known divergence flagged: under a wall clock (non-deterministic mode), NOW() inside an iterating cycle can drift between passes — pre-existing per-call sampling, noted against the spec's once-per-recalc rule; deterministic mode is pass-stable (tested).

Follow-ups (next PRs): `calcPr` XLSX round-trip + Python/WASM config surface; `scc_iterate_*` bench scenarios.

