### PR TITLE
fix(eval): pre-ship shore-up for iterative calculation — clock snapshot, Python telemetry, persistence pins

### DIFF
--- a/bindings/python/formualizer/__init__.pyi
+++ b/bindings/python/formualizer/__init__.pyi
@@ -9,6 +9,7 @@ __all__ = [
     "ASTNode",
     "Cell",
     "CellRef",
+    "CycleTelemetry",
     "EvaluationConfig",
     "EvaluationPlan",
     "ExcelError",
@@ -141,6 +142,77 @@ class CellRef:
     def from_string(cls, reference: builtins.str, default_sheet: typing.Optional[builtins.str] = None) -> CellRef: ...
     def __repr__(self) -> builtins.str: ...
     def __str__(self) -> builtins.str: ...
+
+@typing.final
+class CycleTelemetry:
+    r"""
+    Per-recalc telemetry from runtime SCC evaluation (RFC #113, spec §10).
+    
+    Read-only snapshot of the engine's `CycleTelemetry`, taken by
+    `Workbook.last_cycle_telemetry()`. Counters reset at the start of every
+    evaluation request.
+    """
+    @property
+    def static_sccs(self) -> builtins.int:
+        r"""
+        SCC tasks executed (static SCCs that reached Runtime evaluation).
+        """
+    @property
+    def phantom_sccs(self) -> builtins.int:
+        r"""
+        SCC tasks whose live subgraph was acyclic — values produced.
+        """
+    @property
+    def live_cycles_witnessed(self) -> builtins.int:
+        r"""
+        Distinct live cycles witnessed across all SCC tasks.
+        """
+    @property
+    def circ_cells_stamped(self) -> builtins.int:
+        r"""
+        Cells stamped `#CIRC!` by Runtime SCC tasks.
+        """
+    @property
+    def settle_passes_total(self) -> builtins.int:
+        r"""
+        Evaluation sweeps over (subsets of) SCC members, totalled across tasks.
+        """
+    @property
+    def max_passes_single_scc(self) -> builtins.int:
+        r"""
+        Largest pass count any single SCC task needed.
+        """
+    @property
+    def iterated_sccs(self) -> builtins.int:
+        r"""
+        SCC tasks that entered iterative calculation.
+        """
+    @property
+    def converged_sccs(self) -> builtins.int:
+        r"""
+        Iterating SCC tasks that stopped because every member converged.
+        """
+    @property
+    def capped_sccs(self) -> builtins.int:
+        r"""
+        SCC tasks that stopped at a pass cap (NOT an error under iterate).
+        """
+    @property
+    def max_abs_delta_at_stop(self) -> builtins.float:
+        r"""
+        Largest |delta| observed in any member's final-pass convergence check.
+        """
+    @property
+    def nan_converged(self) -> builtins.int:
+        r"""
+        Identical-bit NaN comparisons treated as converged (spec §6 NaN rule).
+        """
+    @property
+    def elapsed_ms(self) -> builtins.int:
+        r"""
+        Wall-clock milliseconds spent inside Runtime SCC tasks.
+        """
+    def __repr__(self) -> builtins.str: ...
 
 @typing.final
 class EvaluationConfig:
@@ -1176,6 +1248,31 @@ class Workbook:
         ```
         """
     def evaluate_all(self) -> None: ...
+    def last_cycle_telemetry(self) -> CycleTelemetry:
+        r"""
+        Telemetry from runtime SCC / iterative-calculation evaluation during
+        the most recent evaluation request (RFC #113, spec §10).
+        
+        Mirrors the engine accessor of the same name: counters reset at the
+        start of every evaluation request, so this always describes the LAST
+        `evaluate_all()` / `evaluate_cell(s)` call. All-zero when cycle
+        detection is `"static"` or nothing cyclic was evaluated.
+        
+        Example:
+        ```python
+            import formualizer as fz
+        
+            cfg = fz.EvaluationConfig()
+            cfg.cycle_policy = "iterate"
+            wb = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))
+            s = wb.sheet("S")
+            s.set_formula(1, 1, "=B1+1")
+            s.set_formula(1, 2, "=A1/2")
+            wb.evaluate_all()
+            t = wb.last_cycle_telemetry()
+            print(t.iterated_sccs, t.converged_sccs, t.capped_sccs)
+        ```
+        """
     def evaluate_cells(self, targets: list) -> typing.Any: ...
     def get_eval_plan(self, targets: list, *, build_graph_if_needed: builtins.bool = True) -> EvaluationPlan: ...
     def cancel(self) -> None: ...

--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -699,6 +699,38 @@ impl PyWorkbook {
         Ok(())
     }
 
+    /// Telemetry from runtime SCC / iterative-calculation evaluation during
+    /// the most recent evaluation request (RFC #113, spec §10).
+    ///
+    /// Mirrors the engine accessor of the same name: counters reset at the
+    /// start of every evaluation request, so this always describes the LAST
+    /// `evaluate_all()` / `evaluate_cell(s)` call. All-zero when cycle
+    /// detection is `"static"` or nothing cyclic was evaluated.
+    ///
+    /// Example:
+    /// ```python
+    ///     import formualizer as fz
+    ///
+    ///     cfg = fz.EvaluationConfig()
+    ///     cfg.cycle_policy = "iterate"
+    ///     wb = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))
+    ///     s = wb.sheet("S")
+    ///     s.set_formula(1, 1, "=B1+1")
+    ///     s.set_formula(1, 2, "=A1/2")
+    ///     wb.evaluate_all()
+    ///     t = wb.last_cycle_telemetry()
+    ///     print(t.iterated_sccs, t.converged_sccs, t.capped_sccs)
+    /// ```
+    pub fn last_cycle_telemetry(&self) -> PyResult<PyCycleTelemetry> {
+        let wb = self
+            .inner
+            .read()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        Ok(PyCycleTelemetry::from_engine(
+            wb.engine().last_cycle_telemetry(),
+        ))
+    }
+
     pub fn evaluate_cells(
         &self,
         py: Python<'_>,
@@ -1042,7 +1074,99 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyWorkbook>()?;
     m.add_class::<PyWorkbookConfig>()?;
     m.add_class::<PyRangeAddress>()?;
+    m.add_class::<PyCycleTelemetry>()?;
     Ok(())
+}
+
+/// Per-recalc telemetry from runtime SCC evaluation (RFC #113, spec §10).
+///
+/// Read-only snapshot of the engine's `CycleTelemetry`, taken by
+/// `Workbook.last_cycle_telemetry()`. Counters reset at the start of every
+/// evaluation request.
+#[gen_stub_pyclass]
+#[pyclass(name = "CycleTelemetry", module = "formualizer")]
+#[derive(Clone, Debug)]
+pub struct PyCycleTelemetry {
+    /// SCC tasks executed (static SCCs that reached Runtime evaluation).
+    #[pyo3(get)]
+    pub static_sccs: usize,
+    /// SCC tasks whose live subgraph was acyclic — values produced.
+    #[pyo3(get)]
+    pub phantom_sccs: usize,
+    /// Distinct live cycles witnessed across all SCC tasks.
+    #[pyo3(get)]
+    pub live_cycles_witnessed: usize,
+    /// Cells stamped `#CIRC!` by Runtime SCC tasks.
+    #[pyo3(get)]
+    pub circ_cells_stamped: usize,
+    /// Evaluation sweeps over (subsets of) SCC members, totalled across tasks.
+    #[pyo3(get)]
+    pub settle_passes_total: usize,
+    /// Largest pass count any single SCC task needed.
+    #[pyo3(get)]
+    pub max_passes_single_scc: usize,
+    /// SCC tasks that entered iterative calculation.
+    #[pyo3(get)]
+    pub iterated_sccs: usize,
+    /// Iterating SCC tasks that stopped because every member converged.
+    #[pyo3(get)]
+    pub converged_sccs: usize,
+    /// SCC tasks that stopped at a pass cap (NOT an error under iterate).
+    #[pyo3(get)]
+    pub capped_sccs: usize,
+    /// Largest |delta| observed in any member's final-pass convergence check.
+    #[pyo3(get)]
+    pub max_abs_delta_at_stop: f64,
+    /// Identical-bit NaN comparisons treated as converged (spec §6 NaN rule).
+    #[pyo3(get)]
+    pub nan_converged: usize,
+    /// Wall-clock milliseconds spent inside Runtime SCC tasks.
+    #[pyo3(get)]
+    pub elapsed_ms: u64,
+}
+
+impl PyCycleTelemetry {
+    pub(crate) fn from_engine(t: &formualizer::eval::engine::CycleTelemetry) -> Self {
+        Self {
+            static_sccs: t.static_sccs,
+            phantom_sccs: t.phantom_sccs,
+            live_cycles_witnessed: t.live_cycles_witnessed,
+            circ_cells_stamped: t.circ_cells_stamped,
+            settle_passes_total: t.settle_passes_total,
+            max_passes_single_scc: t.max_passes_single_scc,
+            iterated_sccs: t.iterated_sccs,
+            converged_sccs: t.converged_sccs,
+            capped_sccs: t.capped_sccs,
+            max_abs_delta_at_stop: t.max_abs_delta_at_stop,
+            nan_converged: t.nan_converged,
+            elapsed_ms: u64::try_from(t.elapsed_ms).unwrap_or(u64::MAX),
+        }
+    }
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyCycleTelemetry {
+    fn __repr__(&self) -> String {
+        format!(
+            "CycleTelemetry(static_sccs={}, phantom_sccs={}, live_cycles_witnessed={}, \
+             circ_cells_stamped={}, settle_passes_total={}, max_passes_single_scc={}, \
+             iterated_sccs={}, converged_sccs={}, capped_sccs={}, \
+             max_abs_delta_at_stop={}, nan_converged={}, elapsed_ms={})",
+            self.static_sccs,
+            self.phantom_sccs,
+            self.live_cycles_witnessed,
+            self.circ_cells_stamped,
+            self.settle_passes_total,
+            self.max_passes_single_scc,
+            self.iterated_sccs,
+            self.converged_sccs,
+            self.capped_sccs,
+            self.max_abs_delta_at_stop,
+            self.nan_converged,
+            self.elapsed_ms,
+        )
+    }
 }
 
 // Compatibility types used by engine/sheet wrappers

--- a/bindings/python/tests/test_cycle_telemetry.py
+++ b/bindings/python/tests/test_cycle_telemetry.py
@@ -1,0 +1,96 @@
+"""Cycle telemetry surface on Workbook (RFC #113, spec §10).
+
+`Workbook.last_cycle_telemetry()` mirrors the engine accessor of the same
+name: per-recalc counters from runtime SCC / iterative-calculation
+evaluation, reset at the start of every evaluation request.
+"""
+
+import pytest
+
+import formualizer as fz
+
+
+def _iterate_workbook(max_iterations=100, max_change=0.001):
+    cfg = fz.EvaluationConfig()
+    cfg.cycle_policy = "iterate"
+    cfg.iterate_max_iterations = max_iterations
+    cfg.iterate_max_change = max_change
+    return fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))
+
+
+def test_telemetry_zero_before_any_evaluation():
+    wb = fz.Workbook()
+    t = wb.last_cycle_telemetry()
+    assert t.static_sccs == 0
+    assert t.iterated_sccs == 0
+    assert t.converged_sccs == 0
+    assert t.capped_sccs == 0
+    assert t.settle_passes_total == 0
+    assert t.max_abs_delta_at_stop == 0.0
+    assert t.nan_converged == 0
+
+
+def test_convergent_pair_reports_converged_scc():
+    # Convergent arithmetic cycle (spec §7.4): B1 = 0.5*A1 + 0.5*C1,
+    # C1 = 0.5*B1 + 0.5*D1; A1=10, D1=20 -> B1=40/3, C1=50/3.
+    wb = _iterate_workbook()
+    wb.add_sheet("S")
+    wb.set_value("S", 1, 1, 10)  # A1
+    wb.set_value("S", 1, 4, 20)  # D1
+    wb.set_formula("S", 1, 2, "=0.5*A1 + 0.5*C1")  # B1
+    wb.set_formula("S", 1, 3, "=0.5*B1 + 0.5*D1")  # C1
+    wb.evaluate_all()
+
+    assert wb.get_value("S", 1, 2) == pytest.approx(40.0 / 3.0, abs=0.01)
+
+    t = wb.last_cycle_telemetry()
+    assert t.iterated_sccs == 1
+    assert t.converged_sccs == 1
+    assert t.capped_sccs == 0
+    assert t.live_cycles_witnessed >= 1
+    assert t.settle_passes_total >= 2
+    assert t.max_passes_single_scc >= 2
+    # The final-pass delta passed the convergence test.
+    assert 0.0 <= t.max_abs_delta_at_stop < 0.001
+    assert t.elapsed_ms >= 0
+
+
+def test_divergent_accumulator_reports_capped_scc():
+    # A1 = A1 + 1 never converges (delta is always 1): the SCC stops at the
+    # Excel max_iterations cap, keeping the last value (NOT an error).
+    wb = _iterate_workbook(max_iterations=25, max_change=0.001)
+    wb.add_sheet("S")
+    wb.set_formula("S", 1, 1, "=A1+1")
+    wb.evaluate_all()
+
+    assert wb.get_value("S", 1, 1) == pytest.approx(25.0)
+
+    t = wb.last_cycle_telemetry()
+    assert t.iterated_sccs == 1
+    assert t.converged_sccs == 0
+    assert t.capped_sccs == 1
+    assert t.max_passes_single_scc == 25
+    assert t.max_abs_delta_at_stop == pytest.approx(1.0)
+
+
+def test_telemetry_resets_per_evaluation_request():
+    wb = _iterate_workbook(max_iterations=25, max_change=0.001)
+    wb.add_sheet("S")
+    wb.set_formula("S", 1, 1, "=A1+1")
+    wb.evaluate_all()
+    assert wb.last_cycle_telemetry().capped_sccs == 1
+
+    # An acyclic-only request leaves no cycle counters behind.
+    wb.set_value("S", 1, 1, 0)
+    wb.set_formula("S", 2, 1, "=A1+1")
+    wb.evaluate_all()
+    t = wb.last_cycle_telemetry()
+    assert t.iterated_sccs == 0
+    assert t.capped_sccs == 0
+
+
+def test_telemetry_repr_is_informative():
+    wb = fz.Workbook()
+    r = repr(wb.last_cycle_telemetry())
+    assert r.startswith("CycleTelemetry(")
+    assert "converged_sccs=0" in r

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -352,7 +352,11 @@ pub struct Engine<R> {
     resolver: R,
     pub config: EvalConfig,
     workbook_load_limits: crate::engine::WorkbookLoadLimits,
-    clock: Arc<dyn crate::timezone::ClockProvider>,
+    /// Clock for volatile date/time builtins, wrapped in a per-recalc
+    /// snapshot: sampled once at the start of every evaluation request
+    /// ([`Self::begin_evaluation_request`]) so all `NOW()`/`TODAY()` reads in
+    /// one recalc — including SCC iteration passes — agree (spec §7.11).
+    clock: crate::timezone::SnapshotClock,
     thread_pool: Option<Arc<rayon::ThreadPool>>,
     pub recalc_epoch: u64,
     snapshot_id: std::sync::atomic::AtomicU64,
@@ -1393,7 +1397,7 @@ where
             resolver,
             config,
             workbook_load_limits: crate::engine::WorkbookLoadLimits::default(),
-            clock,
+            clock: crate::timezone::SnapshotClock::new(clock),
             thread_pool,
             recalc_epoch: 0,
             snapshot_id: std::sync::atomic::AtomicU64::new(1),
@@ -1470,7 +1474,7 @@ where
             resolver,
             config,
             workbook_load_limits: crate::engine::WorkbookLoadLimits::default(),
-            clock,
+            clock: crate::timezone::SnapshotClock::new(clock),
             thread_pool: Some(thread_pool),
             recalc_epoch: 0,
             snapshot_id: std::sync::atomic::AtomicU64::new(1),
@@ -1538,13 +1542,18 @@ where
         &self.last_cycle_telemetry
     }
 
-    /// Reset per-recalc cycle telemetry. Called at the start of every
-    /// evaluation request that walks schedule units.
-    fn reset_cycle_telemetry(&mut self) {
+    /// Begin a new evaluation request: reset per-recalc cycle telemetry and
+    /// take the per-recalc volatile clock sample. Called at the start of
+    /// every evaluation request that walks schedule units.
+    fn begin_evaluation_request(&mut self) {
         self.last_cycle_telemetry = CycleTelemetry::default();
         // Defensive: consumed at the end of the previous request; a request
         // that errored out mid-walk must not leak its members into this one.
         self.pending_iterative_redirty.clear();
+        // Spec §7.11: NOW()/TODAY() sample the clock ONCE per recalc; every
+        // read within this request (including SCC iteration passes) observes
+        // this sample.
+        self.clock.refresh();
     }
 
     /// End-of-recalc redirty: volatile vertices (as always) plus members of
@@ -1875,8 +1884,19 @@ where
     ) -> Result<(), ExcelError> {
         let clock = mode.build_clock()?;
         self.config.deterministic_mode = mode;
-        self.clock = clock;
+        self.clock = crate::timezone::SnapshotClock::new(clock);
         Ok(())
+    }
+
+    /// Inject a custom [`ClockProvider`](crate::timezone::ClockProvider) for
+    /// volatile date/time builtins (`NOW()`, `TODAY()`).
+    ///
+    /// The provider is the clock *source*; per spec §7.11 the engine samples
+    /// it once at the start of every evaluation request and all reads within
+    /// that recalc (including SCC iteration passes) observe the frozen
+    /// sample.
+    pub fn set_clock(&mut self, clock: Arc<dyn crate::timezone::ClockProvider>) {
+        self.clock = crate::timezone::SnapshotClock::new(clock);
     }
 
     fn validate_deterministic_mode(&self) -> Result<(), ExcelError> {
@@ -8009,7 +8029,7 @@ where
         #[cfg(feature = "tracing")]
         let _span_eval = tracing::info_span!("evaluate_until", targets = targets.len()).entered();
         let start = crate::instant::FzInstant::now();
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         // Fold any pending edge deltas once so scheduling/eval reads use the
         // zero-allocation CSR slices (#125 write-cheap / read-flush split).
         self.graph.flush_pending_edge_deltas();
@@ -8115,7 +8135,7 @@ where
         let _span_eval =
             tracing::info_span!("evaluate_until_with_delta", targets = targets.len()).entered();
         let start = crate::instant::FzInstant::now();
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         self.graph.flush_pending_edge_deltas();
         let _source_cache = self.source_cache_session();
 
@@ -8212,7 +8232,7 @@ where
 
     /// Evaluate using a previously constructed plan. This avoids rebuilding layer schedules for each run.
     pub fn evaluate_recalc_plan(&mut self, plan: &RecalcPlan) -> Result<EvalResult, ExcelError> {
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         let _source_cache = self.source_cache_session();
         self.validate_deterministic_mode()?;
         if self.config.defer_graph_building {
@@ -8299,7 +8319,7 @@ where
         // so the duplicate reset is harmless. The composed legacy primitive
         // below intentionally does not reset, so `evaluate_legacy_cycle_prepass`
         // counts survive into the final telemetry.
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         // The FormulaPlane coordinator is now selected by mode for evaluate_all.
         // SingletonUnique formulas intentionally remain legacy graph vertices;
         // when no spans are active, execute through the private legacy primitive
@@ -8735,7 +8755,7 @@ where
     /// coordinator; the coordinator itself composes with private legacy
     /// primitives for legacy-only work.
     fn evaluate_all_coordinator(&mut self) -> Result<EvalResult, ExcelError> {
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental {
             return self.evaluate_authoritative_formula_plane_all();
         }
@@ -8778,10 +8798,12 @@ where
     /// `AuthoritativeExperimental` mode. This is now an internal primitive; it
     /// must not be invoked directly from public APIs.
     ///
-    /// Does NOT reset `last_cycle_telemetry`: the FormulaPlane coordinator
-    /// composes this primitive *after* `evaluate_legacy_cycle_prepass` may
-    /// have accumulated counts (G8 demotion path); resets happen at the
-    /// public entry points / coordinators instead.
+    /// Does NOT call `begin_evaluation_request` (cycle-telemetry reset +
+    /// per-recalc clock sample): the FormulaPlane coordinator composes this
+    /// primitive *after* `evaluate_legacy_cycle_prepass` may have accumulated
+    /// counts (G8 demotion path), and both sub-passes belong to ONE request /
+    /// one clock sample; request begin happens at the public entry points /
+    /// coordinators instead.
     fn evaluate_all_legacy_impl(&mut self) -> Result<EvalResult, ExcelError> {
         self.reset_virtual_dep_telemetry_if_disabled();
         #[cfg(feature = "tracing")]
@@ -8871,7 +8893,7 @@ where
         &mut self,
         delta: &mut DeltaCollector,
     ) -> Result<EvalResult, ExcelError> {
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         let _source_cache = self.source_cache_session();
         if self.config.defer_graph_building {
             self.build_graph_all()?;
@@ -9546,7 +9568,7 @@ where
         &mut self,
         cancel_flag: &AtomicBool,
     ) -> Result<EvalResult, ExcelError> {
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         let _source_cache = self.source_cache_session();
         self.validate_deterministic_mode()?;
         if self.config.defer_graph_building {
@@ -9708,7 +9730,7 @@ where
         cancel_flag: &AtomicBool,
     ) -> Result<EvalResult, ExcelError> {
         let start = crate::instant::FzInstant::now();
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         self.graph.flush_pending_edge_deltas();
         if self.graph.formula_authority().active_span_count() > 0 {
             if cancel_flag.load(Ordering::Relaxed) {
@@ -11104,7 +11126,7 @@ where
     R: EvaluationContext,
 {
     fn clock(&self) -> &dyn crate::timezone::ClockProvider {
-        self.clock.as_ref()
+        &self.clock
     }
 
     fn thread_pool(&self) -> Option<&Arc<rayon::ThreadPool>> {
@@ -14022,7 +14044,7 @@ where
     /// This is the same flow as `evaluate_all` but threads a ChangeLog through
     /// every effect application so that spill commits/clears are captured.
     pub fn evaluate_all_logged(&mut self, log: &mut ChangeLog) -> Result<EvalResult, ExcelError> {
-        self.reset_cycle_telemetry();
+        self.begin_evaluation_request();
         let _source_cache = self.source_cache_session();
         self.validate_deterministic_mode()?;
         if self.config.defer_graph_building {

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1717,6 +1717,15 @@ impl DependencyGraph {
         // the self-edge forms a single-vertex SCC that the scheduler emits as
         // a Cycle unit and `evaluate_scc_unit` iterates (RFC #113, spec §7.1/
         // §7.6/§7.8). Everywhere else the edit-time rejection stands.
+        //
+        // Scope note (persistence contract, pinned by
+        // `formualizer-workbook/tests/cycle_persistence.rs`): this rejection
+        // is an INTERACTIVE-EDIT nicety only. Bulk load paths
+        // (`ingest_formula_batches` → `BulkIngestBuilder`, incl. staged
+        // `build_graph_all`) intentionally do not perform it, so workbooks
+        // saved with self-references under an Iterate config always reload —
+        // under any cycle config — and resolve to `#CIRC!`/iteration at
+        // evaluation time per the loaded policy.
         if new_dependencies.contains(&addr_vertex_id) && !self.config.cycle.allows_self_dependency()
         {
             return Err(ExcelError::new(ExcelErrorKind::Circ)

--- a/crates/formualizer-eval/src/engine/tests/clock_snapshot.rs
+++ b/crates/formualizer-eval/src/engine/tests/clock_snapshot.rs
@@ -1,0 +1,185 @@
+//! Per-recalc volatile clock snapshot (spec
+//! `formualizer-cycle-semantics-spec.md` §7.11).
+//!
+//! Excel samples the clock ONCE per recalculation: `NOW()`/`TODAY()` agree
+//! across every cell of one recalc — including all iteration passes of an
+//! iterating SCC — and only advance on the NEXT recalc. These tests drive the
+//! engine with a `TickingClock` that advances on every `now()` call, so any
+//! per-call sampling (the old raw-`SystemClock` behaviour) is caught
+//! deterministically.
+
+use crate::engine::{CycleConfig, Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use crate::timezone::{ClockProvider, TimeZoneSpec};
+use chrono::{Duration, NaiveDateTime, TimeZone};
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Adversarial clock: every `now()` call advances by `step`. If volatile
+/// builtins sample per call instead of per recalc, two reads disagree.
+#[derive(Debug)]
+struct TickingClock {
+    start: NaiveDateTime,
+    step: Duration,
+    calls: AtomicU64,
+    timezone: TimeZoneSpec,
+}
+
+impl TickingClock {
+    fn new(start: NaiveDateTime, step: Duration) -> Self {
+        Self {
+            start,
+            step,
+            calls: AtomicU64::new(0),
+            timezone: TimeZoneSpec::Utc,
+        }
+    }
+}
+
+impl ClockProvider for TickingClock {
+    fn timezone(&self) -> &TimeZoneSpec {
+        &self.timezone
+    }
+
+    fn now(&self) -> NaiveDateTime {
+        let n = self.calls.fetch_add(1, Ordering::SeqCst) as i32;
+        self.start + self.step * n
+    }
+}
+
+fn start_instant() -> NaiveDateTime {
+    chrono::Utc
+        .with_ymd_and_hms(2025, 6, 1, 12, 0, 0)
+        .single()
+        .expect("valid timestamp")
+        .naive_utc()
+}
+
+fn set_formula(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, f: &str) {
+    engine
+        .set_cell_formula(sheet, row, col, parse(f).expect("parse"))
+        .expect("set formula");
+}
+
+fn num(engine: &Engine<TestWorkbook>, sheet: &str, row: u32, col: u32) -> f64 {
+    match engine.get_cell_value(sheet, row, col) {
+        Some(LiteralValue::Number(n)) => n,
+        other => panic!("expected number at {sheet} r{row}c{col}, got {other:?}"),
+    }
+}
+
+/// Two NOW() cells in one acyclic recalc observe the same instant, even when
+/// the underlying clock advances between calls (spec §7.11: one sample per
+/// recalc). A second recalc observes a LATER instant (NOW stays volatile
+/// across recalcs).
+#[test]
+fn now_agrees_across_cells_within_one_recalc_and_advances_across_recalcs() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    // Each now() call advances a full day, far above any rounding noise.
+    engine.set_clock(Arc::new(TickingClock::new(
+        start_instant(),
+        Duration::days(1),
+    )));
+
+    set_formula(&mut engine, "Sheet1", 1, 1, "=NOW()");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=NOW()");
+    engine.evaluate_all().unwrap();
+
+    let a1_first = num(&engine, "Sheet1", 1, 1);
+    let a2_first = num(&engine, "Sheet1", 2, 1);
+    assert_eq!(
+        a1_first, a2_first,
+        "two NOW() cells in one recalc must observe the same clock sample"
+    );
+
+    // NOW() is volatile: the next recalc re-samples and must see a later time.
+    engine.evaluate_all().unwrap();
+    let a1_second = num(&engine, "Sheet1", 1, 1);
+    assert!(
+        a1_second > a1_first,
+        "NOW() must advance across recalcs (got {a1_first} then {a1_second})"
+    );
+    assert_eq!(num(&engine, "Sheet1", 1, 1), num(&engine, "Sheet1", 2, 1));
+}
+
+/// NOW() inside an iterating SCC observes the same instant on every settle
+/// pass of one recalc (spec §7.11: iteration passes reuse the sample).
+///
+/// `A1 = A1*0 + NOW()` is a direct self-reference: pass 1 computes NOW, pass
+/// 2 recomputes and the convergence test compares the two passes. With the
+/// clock stepping a full day per call (serial Δ = 1.0 ≫ max_change = 0.001),
+/// per-pass sampling can never converge and the SCC caps out; a per-recalc
+/// snapshot converges on pass 2 with Δ = 0.
+#[test]
+fn now_is_stable_across_iteration_passes_within_one_recalc() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_cycle(CycleConfig::iterate(100, 0.001)),
+    );
+    engine.set_clock(Arc::new(TickingClock::new(
+        start_instant(),
+        Duration::days(1),
+    )));
+
+    set_formula(&mut engine, "Sheet1", 1, 1, "=A1*0+NOW()");
+    engine.evaluate_all().unwrap();
+
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(
+        t.iterated_sccs, 1,
+        "self-referent NOW() cell must enter iterative calculation"
+    );
+    assert_eq!(
+        t.converged_sccs, 1,
+        "NOW() must be frozen within the recalc so the SCC converges \
+         (telemetry: {t:?})"
+    );
+    assert_eq!(t.capped_sccs, 0, "no pass cap expected (telemetry: {t:?})");
+    assert_eq!(
+        t.max_abs_delta_at_stop, 0.0,
+        "both passes must observe the identical clock sample"
+    );
+
+    let first = num(&engine, "Sheet1", 1, 1);
+
+    // Iterating SCC members are redirtied volatile-like: the next recalc
+    // re-samples the clock and must observe a strictly later NOW().
+    engine.evaluate_all().unwrap();
+    let t = engine.last_cycle_telemetry();
+    assert_eq!(
+        (t.iterated_sccs, t.converged_sccs, t.capped_sccs),
+        (1, 1, 0)
+    );
+    let second = num(&engine, "Sheet1", 1, 1);
+    assert!(
+        second > first,
+        "NOW() must advance across recalcs (got {first} then {second})"
+    );
+}
+
+/// TODAY() shares the per-recalc sample with NOW() (both read the engine
+/// clock snapshot): a midnight-straddling drift between two cells of one
+/// recalc is impossible.
+#[test]
+fn today_and_now_share_one_sample_per_recalc() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    // Start just before midnight; one clock step crosses the date boundary.
+    let start = chrono::Utc
+        .with_ymd_and_hms(2025, 6, 1, 23, 59, 59)
+        .single()
+        .unwrap()
+        .naive_utc();
+    engine.set_clock(Arc::new(TickingClock::new(start, Duration::hours(1))));
+
+    set_formula(&mut engine, "Sheet1", 1, 1, "=TODAY()");
+    set_formula(&mut engine, "Sheet1", 2, 1, "=INT(NOW())");
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        num(&engine, "Sheet1", 1, 1),
+        num(&engine, "Sheet1", 2, 1),
+        "TODAY() and INT(NOW()) must agree within one recalc"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -3,6 +3,7 @@ mod arena_debug;
 mod cancellation;
 mod change_log;
 mod changelog_replay;
+mod clock_snapshot;
 mod common;
 mod cross_sheet_named_range_first_cell;
 mod cycle_detection;

--- a/crates/formualizer-eval/src/timezone.rs
+++ b/crates/formualizer-eval/src/timezone.rs
@@ -154,3 +154,56 @@ impl ClockProvider for FixedClock {
         self.now_in_timezone()
     }
 }
+
+/// Per-recalc snapshotting wrapper around a [`ClockProvider`]
+/// (spec `formualizer-cycle-semantics-spec.md` §7.11).
+///
+/// Excel samples the clock ONCE per recalculation: every `NOW()` / `TODAY()`
+/// call within a single recalc — including all iteration passes of an
+/// iterating SCC — observes the same instant, and the sample only advances on
+/// the next recalculation. A raw `SystemClock` violates this (each call reads
+/// the OS clock, so `NOW()` drifts between SCC settle passes and even between
+/// two cells of one acyclic pass).
+///
+/// The engine wraps its configured clock in `SnapshotClock` and calls
+/// [`SnapshotClock::refresh`] once at the start of every evaluation request;
+/// builtins then read the frozen sample via the normal `ClockProvider` API.
+#[derive(Debug)]
+pub struct SnapshotClock {
+    inner: std::sync::Arc<dyn ClockProvider>,
+    /// Timezone cloned from `inner` at construction so `timezone()` can hand
+    /// out a reference without locking.
+    timezone: TimeZoneSpec,
+    /// The frozen per-recalc sample. RwLock (not Cell) because evaluation may
+    /// read the clock from rayon worker threads.
+    sample: std::sync::RwLock<NaiveDateTime>,
+}
+
+impl SnapshotClock {
+    /// Wrap `inner`, taking an initial sample immediately.
+    pub fn new(inner: std::sync::Arc<dyn ClockProvider>) -> Self {
+        let timezone = inner.timezone().clone();
+        let sample = inner.now();
+        Self {
+            inner,
+            timezone,
+            sample: std::sync::RwLock::new(sample),
+        }
+    }
+
+    /// Re-sample the underlying clock. Called once per evaluation request.
+    pub fn refresh(&self) {
+        let now = self.inner.now();
+        *self.sample.write().expect("clock sample lock poisoned") = now;
+    }
+}
+
+impl ClockProvider for SnapshotClock {
+    fn timezone(&self) -> &TimeZoneSpec {
+        &self.timezone
+    }
+
+    fn now(&self) -> NaiveDateTime {
+        *self.sample.read().expect("clock sample lock poisoned")
+    }
+}

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -2958,6 +2958,28 @@ impl Workbook {
     }
 
     // Loading via streaming ingest (Arrow base + graph formulas)
+    /// Load a workbook from a backend reader.
+    ///
+    /// # Cycle-config precedence (spec §9, RFC #113)
+    ///
+    /// When the file carries `<calcPr iterate="1">` (XLSX backends), the
+    /// FILE'S iterative-calculation settings override the cycle config in
+    /// `config` — including an explicit caller `Static`/`Error` choice. The
+    /// calcPr element is the document's persisted calculation setting and
+    /// governs how the document computes, matching how Excel opens files.
+    /// A file with `iterate` absent/`0` (or a backend with no calc settings
+    /// at all, e.g. JSON/CSV) leaves the caller's cycle config untouched.
+    /// Callers that must force a policy can adjust the engine config after
+    /// load.
+    ///
+    /// # Self-references in loaded content
+    ///
+    /// Bulk load never rejects formulas for cycle reasons: a direct
+    /// self-reference (`A1 = =A1+1`) loads under ANY cycle config and is
+    /// resolved at evaluation time (`#CIRC!` under the default policy,
+    /// iterated under `Runtime`+`Iterate`). The eager self-reference
+    /// rejection is an interactive-edit nicety on `set_formula`, never a
+    /// load-path gate (see `tests/cycle_persistence.rs`).
     pub fn from_reader<B>(
         backend: B,
         strategy: LoadStrategy,

--- a/crates/formualizer-workbook/tests/calamine/calcpr.rs
+++ b/crates/formualizer-workbook/tests/calamine/calcpr.rs
@@ -141,6 +141,38 @@ fn from_reader_iterate_on_applies_runtime_iterate_config() {
     );
 }
 
+/// Precedence decision (pinned): when the file says `iterate="1"`, the FILE
+/// WINS over an explicit caller cycle config. The calcPr element is the
+/// document's persisted calculation setting — matching how Excel opens files:
+/// the workbook's own iterative-calculation switch governs, not the
+/// application state of whoever opens it. Callers that need to force a
+/// policy can set `engine_mut().config` / rebuild after load.
+#[test]
+fn from_reader_file_iterate_wins_over_explicit_caller_static_config() {
+    let bytes = inject_calc_pr(
+        &simple_fixture(),
+        r#"<calcPr calcId="122211" iterate="1" iterateCount="13" iterateDelta="0.02"/>"#,
+    );
+    let adapter = CalamineAdapter::open_bytes(bytes).unwrap();
+    // Caller explicitly demands the Static/Error compat combo…
+    let mut cfg = WorkbookConfig::ephemeral();
+    cfg.eval.cycle = CycleConfig {
+        detection: CycleDetection::Static,
+        policy: CyclePolicy::Error,
+    };
+    let wb = Workbook::from_reader(adapter, LoadStrategy::EagerAll, cfg).unwrap();
+    // …but the file's persisted iterate setting governs.
+    let cycle = wb.engine().config.cycle;
+    assert_eq!(cycle.detection, CycleDetection::Runtime);
+    assert_eq!(
+        cycle.policy,
+        CyclePolicy::Iterate {
+            max_iterations: 13,
+            max_change: 0.02,
+        }
+    );
+}
+
 #[test]
 fn from_reader_iterate_off_leaves_caller_cycle_config_untouched() {
     let adapter = CalamineAdapter::open_bytes(simple_fixture()).unwrap();

--- a/crates/formualizer-workbook/tests/cycle_persistence.rs
+++ b/crates/formualizer-workbook/tests/cycle_persistence.rs
@@ -1,0 +1,190 @@
+//! Persistence round-trips for ingest-relaxed self-references (RFC #113).
+//!
+//! PR #130 relaxed the *interactive edit* rejection of direct self-references
+//! (`A1 = =A1+1`) to ACCEPT them under `Runtime` detection +
+//! `CyclePolicy::Iterate`. A workbook containing such a formula can be saved
+//! through backends that do NOT persist cycle configuration (JSON, CSV) and
+//! reloaded under a config where the interactive edit would be rejected.
+//!
+//! Contract pinned here (the "ingest-time rejection is an interactive-edit
+//! nicety, never a load-path gate" shape):
+//!
+//! - Bulk load paths (`Workbook::from_reader` → `ingest_formula_batches`, both
+//!   the eager and the `defer_graph_building` staged variants) accept
+//!   self-referential formulas under ANY cycle config. Loading never
+//!   hard-fails on a self-reference and never drops the formula.
+//! - What the cell *evaluates to* is decided by the loaded engine's cycle
+//!   policy: `#CIRC!` under the default (`Static` detection / `Error`
+//!   policy), iterated values under `Runtime` + `Iterate`.
+//! - Only the interactive `set_formula` / `set_cell_formula` edit path
+//!   rejects self-references eagerly (and only when the active config
+//!   disallows them) — that is a UX nicety for immediate feedback, not a
+//!   persistence gate.
+
+#![cfg(feature = "json")]
+
+use formualizer_eval::engine::CycleConfig;
+use formualizer_workbook::backends::JsonAdapter;
+use formualizer_workbook::traits::{CellData, SpreadsheetReader, SpreadsheetWriter};
+use formualizer_workbook::{LiteralValue, LoadStrategy, Workbook, WorkbookConfig};
+
+fn iterate_config(max_iterations: u32, max_change: f64) -> WorkbookConfig {
+    let mut config = WorkbookConfig::ephemeral();
+    config.eval = config
+        .eval
+        .with_cycle(CycleConfig::iterate(max_iterations, max_change));
+    config
+}
+
+fn num(wb: &Workbook, sheet: &str, row: u32, col: u32) -> f64 {
+    match wb.get_value(sheet, row, col) {
+        Some(LiteralValue::Number(n)) => n,
+        Some(LiteralValue::Int(i)) => i as f64,
+        other => panic!("expected number at {sheet} r{row}c{col}, got {other:?}"),
+    }
+}
+
+/// JSON bytes for a workbook containing the self-reference `A1 = =A1+1` plus
+/// an ordinary dependent `B1 = =A1*2`, authored through the backend writer
+/// (which, like the on-disk format, performs no cycle validation).
+fn json_with_self_reference() -> Vec<u8> {
+    let mut adapter = JsonAdapter::new();
+    adapter.create_sheet("Sheet1").unwrap();
+    adapter
+        .write_cell("Sheet1", 1, 1, CellData::from_formula("=A1+1"))
+        .unwrap();
+    adapter
+        .write_cell("Sheet1", 1, 2, CellData::from_formula("=A1*2"))
+        .unwrap();
+    adapter.save_to_bytes().unwrap()
+}
+
+/* ──────────────── direction 1: iterate workbook → default reload ─────────── */
+
+/// A workbook built under Runtime+Iterate containing `A1 = =A1+1`, saved via
+/// the JSON backend (which does not carry cycle config), reloaded with the
+/// DEFAULT config: the load must NOT hard-fail, the formula must survive, and
+/// the cell yields `#CIRC!` under the default Static/Error policy.
+#[test]
+fn iterate_workbook_self_ref_json_reload_under_default_config_yields_circ() {
+    // Build + iterate under Runtime+Iterate (interactive set_formula accepts
+    // the self-reference under this config — the #130 relaxation).
+    let mut wb = Workbook::new_with_config(iterate_config(10, 0.001));
+    wb.add_sheet("Sheet1").unwrap();
+    wb.set_formula("Sheet1", 1, 1, "=A1+1").unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(num(&wb, "Sheet1", 1, 1), 10.0, "capped accumulator");
+
+    // Save through the JSON backend: formula text + last value, NO cycle config.
+    let mut adapter = JsonAdapter::new();
+    adapter.create_sheet("Sheet1").unwrap();
+    adapter
+        .write_cell(
+            "Sheet1",
+            1,
+            1,
+            CellData {
+                value: wb.get_value("Sheet1", 1, 1),
+                formula: wb.get_formula("Sheet1", 1, 1),
+                style: None,
+            },
+        )
+        .unwrap();
+    let bytes = adapter.save_to_bytes().unwrap();
+
+    // Reload with the DEFAULT config (Static detection, Error policy).
+    let adapter = JsonAdapter::open_bytes(bytes).unwrap();
+    let mut reloaded =
+        Workbook::from_reader(adapter, LoadStrategy::EagerAll, WorkbookConfig::ephemeral())
+            .expect("bulk load must accept the self-reference (no load-path gate)");
+
+    // The formula survived the round-trip… (text is canonicalized by the
+    // printer — "=A1 + 1" — so compare whitespace-insensitively)
+    let formula = reloaded
+        .get_formula("Sheet1", 1, 1)
+        .expect("self-referential formula must not be dropped on load");
+    assert_eq!(formula.replace(' ', ""), "=A1+1");
+
+    // …and the default cycle policy stamps it #CIRC at evaluation time.
+    reloaded.evaluate_all().unwrap();
+    match reloaded.get_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => {
+            assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Circ)
+        }
+        other => panic!("expected #CIRC! under default policy, got {other:?}"),
+    }
+}
+
+/* ──────────────── direction 2: default-authored file → iterate reload ────── */
+
+/// A JSON file containing a self-reference (authored externally; the format
+/// itself never validated it) loaded under Runtime+Iterate: the cycle
+/// iterates per the loaded engine's config.
+#[test]
+fn json_self_ref_loaded_under_iterate_config_iterates() {
+    let adapter = JsonAdapter::open_bytes(json_with_self_reference()).unwrap();
+    let mut wb = Workbook::from_reader(adapter, LoadStrategy::EagerAll, iterate_config(7, 0.001))
+        .expect("load");
+    wb.evaluate_all().unwrap();
+    // Empty→0 seed, 7 capped passes of +1 (spec §4/§7.6).
+    assert_eq!(num(&wb, "Sheet1", 1, 1), 7.0);
+    assert_eq!(
+        num(&wb, "Sheet1", 1, 2),
+        14.0,
+        "dependent reads final value"
+    );
+}
+
+/// Same file loaded under the DEFAULT config: load succeeds, evaluation
+/// stamps `#CIRC!` on the cycle member; the acyclic dependent consumes it.
+#[test]
+fn json_self_ref_loaded_under_default_config_yields_circ() {
+    let adapter = JsonAdapter::open_bytes(json_with_self_reference()).unwrap();
+    let mut wb =
+        Workbook::from_reader(adapter, LoadStrategy::EagerAll, WorkbookConfig::ephemeral())
+            .expect("bulk load must accept the self-reference (no load-path gate)");
+    wb.evaluate_all().unwrap();
+    match wb.get_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => {
+            assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Circ)
+        }
+        other => panic!("expected #CIRC! under default policy, got {other:?}"),
+    }
+}
+
+/// The staged/deferred ingest variant (`defer_graph_building: true`, the
+/// Interactive-mode load path) must behave identically: no load-path gate,
+/// `#CIRC!` at evaluation under the default policy.
+#[test]
+fn json_self_ref_deferred_graph_build_under_default_config_yields_circ() {
+    let adapter = JsonAdapter::open_bytes(json_with_self_reference()).unwrap();
+    let mut wb = Workbook::from_reader(
+        adapter,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .expect("staged load must accept the self-reference");
+    wb.evaluate_all().unwrap();
+    match wb.get_value("Sheet1", 1, 1) {
+        Some(LiteralValue::Error(e)) => {
+            assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Circ)
+        }
+        other => panic!("expected #CIRC! under default policy, got {other:?}"),
+    }
+}
+
+/* ─────────── contrast: the interactive edit path still rejects ───────────── */
+
+/// The #130 relaxation is config-scoped: under the default config the
+/// interactive `set_formula` path still rejects a direct self-reference
+/// eagerly. This is the "edit nicety" half of the contract pinned above.
+#[test]
+fn interactive_set_formula_still_rejects_self_ref_under_default_config() {
+    let mut wb = Workbook::new_with_config(WorkbookConfig::ephemeral());
+    wb.add_sheet("Sheet1").unwrap();
+    let err = wb.set_formula("Sheet1", 1, 1, "=A1+1");
+    assert!(
+        err.is_err(),
+        "interactive self-reference must be rejected under default config"
+    );
+}


### PR DESCRIPTION
Pre-ship hardening for the iterative-calculation feature (#113, merged #130-#132). Three items.

**1. Volatile clock snapshot per recalc.** Under the default wall clock, `NOW()` sampled per call — so it drifted between iteration passes within one recalc (spec violation flagged in #130) and two `NOW()` cells in one recalc could disagree. A `SnapshotClock` wrapper now samples once per evaluation request (refreshed at every entry point alongside the telemetry reset; the FormulaPlane sub-pass deliberately does not re-refresh — one request, one sample). This is Excel's documented behavior engine-wide. RNG was verified already compliant (epoch-keyed). Tests use an adversarial ticking clock: pass-stable within a recalc (converges instead of capping), advances across recalcs, TODAY/NOW share one sample across a midnight straddle.

**2. `Workbook.last_cycle_telemetry()` in the Python binding.** All twelve CycleTelemetry fields exposed read-only; "did my model converge or cap?" is now answerable from Python. Stubs regenerated (CI diff gate passes); full CI Python flow run locally — ruff, mypy, pytest 55 passed including five new telemetry tests. WASM exposure deliberately skipped: no telemetry surface exists there to mirror; it would be new API design.

**3. Persistence hazards: investigated, NOT broken, now pinned.** The ingest-time self-reference rejection lives only on interactive edit paths — all bulk-load routes (eager and staged) build edges directly. So an iterate-built workbook containing `=A1+1` in A1 saved through a backend that carries no cycle config (e.g. JSON) already reloads under default config without error and yields `#CIRC` — exactly the least-surprise shape. Contract documented at the rejection site and on `from_reader`, pinned by five tests covering both load directions and the still-rejecting interactive edit. Also pinned: `calcPr iterate="1"` wins over an explicit caller `Static` config on load (the document's persisted setting, matching Excel), with the precedence documented on `from_reader`.

Validation: full workspace suite (CI exclusions) 2563 passed, 0 failed (baseline 2554 + 9); fmt/clippy clean; all wasm facade checks clean; bench gate (interleaved A/B, linear-rollup + finance-recalc) within noise.
