### PR TITLE
perf(eval): hotpath hunt — iterative Tarjan, exponential dispatch fix, multi-source dirty marking, aggregate inf sanitization

### DIFF
--- a/crates/formualizer-eval/src/builtins/math/aggregate.rs
+++ b/crates/formualizer-eval/src/builtins/math/aggregate.rs
@@ -125,9 +125,9 @@ impl Function for SumFn {
                 }
             }
         }
-        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            total,
-        )))
+        Ok(crate::traits::CalcValue::Scalar(
+            super::super::utils::aggregate_result(total),
+        ))
     }
 }
 
@@ -366,9 +366,9 @@ impl Function for AverageFn {
                 ExcelError::new_div(),
             )));
         }
-        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            sum / (cnt as f64),
-        )))
+        Ok(crate::traits::CalcValue::Scalar(
+            super::super::utils::aggregate_result(sum / (cnt as f64)),
+        ))
     }
 }
 
@@ -534,9 +534,9 @@ impl Function for SumProductFn {
                 total += prod;
             }
         }
-        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            total,
-        )))
+        Ok(crate::traits::CalcValue::Scalar(
+            super::super::utils::aggregate_result(total),
+        ))
     }
 }
 
@@ -1211,25 +1211,27 @@ impl AggregateCollector {
     }
 
     fn finalize(self, op: AggregateOp) -> LiteralValue {
+        use super::super::utils::aggregate_result;
         match op {
             AggregateOp::Average => {
                 if self.numeric_values.is_empty() {
                     LiteralValue::Error(ExcelError::new_div())
                 } else {
                     let sum = self.numeric_values.iter().copied().sum::<f64>();
-                    LiteralValue::Number(sum / (self.numeric_values.len() as f64))
+                    aggregate_result(sum / (self.numeric_values.len() as f64))
                 }
             }
+            // Counts cannot overflow to non-finite; keep them branch-free.
             AggregateOp::Count => LiteralValue::Number(self.numeric_values.len() as f64),
             AggregateOp::CountA => LiteralValue::Number(self.counta as f64),
-            AggregateOp::Max => LiteralValue::Number(
+            AggregateOp::Max => aggregate_result(
                 self.numeric_values
                     .iter()
                     .copied()
                     .reduce(f64::max)
                     .unwrap_or(0.0),
             ),
-            AggregateOp::Min => LiteralValue::Number(
+            AggregateOp::Min => aggregate_result(
                 self.numeric_values
                     .iter()
                     .copied()
@@ -1240,24 +1242,24 @@ impl AggregateCollector {
                 if self.numeric_values.is_empty() {
                     LiteralValue::Number(0.0)
                 } else {
-                    LiteralValue::Number(self.numeric_values.iter().copied().product::<f64>())
+                    aggregate_result(self.numeric_values.iter().copied().product::<f64>())
                 }
             }
             AggregateOp::StdevSample => match Self::variance(&self.numeric_values, true) {
-                Ok(v) => LiteralValue::Number(v.sqrt()),
+                Ok(v) => aggregate_result(v.sqrt()),
                 Err(e) => LiteralValue::Error(e),
             },
             AggregateOp::StdevPopulation => match Self::variance(&self.numeric_values, false) {
-                Ok(v) => LiteralValue::Number(v.sqrt()),
+                Ok(v) => aggregate_result(v.sqrt()),
                 Err(e) => LiteralValue::Error(e),
             },
-            AggregateOp::Sum => LiteralValue::Number(self.numeric_values.iter().copied().sum()),
+            AggregateOp::Sum => aggregate_result(self.numeric_values.iter().copied().sum()),
             AggregateOp::VarSample => match Self::variance(&self.numeric_values, true) {
-                Ok(v) => LiteralValue::Number(v),
+                Ok(v) => aggregate_result(v),
                 Err(e) => LiteralValue::Error(e),
             },
             AggregateOp::VarPopulation => match Self::variance(&self.numeric_values, false) {
-                Ok(v) => LiteralValue::Number(v),
+                Ok(v) => aggregate_result(v),
                 Err(e) => LiteralValue::Error(e),
             },
         }

--- a/crates/formualizer-eval/src/builtins/math/criteria_aggregates.rs
+++ b/crates/formualizer-eval/src/builtins/math/criteria_aggregates.rs
@@ -656,9 +656,10 @@ fn eval_if_family<'a, 'b>(
     }
 
     match agg_type {
-        AggregationType::Sum => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            total_sum,
-        ))),
+        AggregationType::Sum => Ok(crate::traits::CalcValue::Scalar(
+            super::super::utils::aggregate_result(total_sum),
+        )),
+        // Counts cannot overflow to non-finite; keep them branch-free.
         AggregationType::Count => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
             total_count as f64,
         ))),
@@ -668,9 +669,9 @@ fn eval_if_family<'a, 'b>(
                     ExcelError::new_div(),
                 )))
             } else {
-                Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-                    total_sum / total_count as f64,
-                )))
+                Ok(crate::traits::CalcValue::Scalar(
+                    super::super::utils::aggregate_result(total_sum / total_count as f64),
+                ))
             }
         }
     }

--- a/crates/formualizer-eval/src/builtins/math/reduction.rs
+++ b/crates/formualizer-eval/src/builtins/math/reduction.rs
@@ -131,9 +131,9 @@ impl Function for MinFn {
                 }
             }
         }
-        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            mv.unwrap_or(0.0),
-        )))
+        Ok(crate::traits::CalcValue::Scalar(
+            super::super::utils::aggregate_result(mv.unwrap_or(0.0)),
+        ))
     }
 }
 
@@ -261,9 +261,9 @@ impl Function for MaxFn {
                 }
             }
         }
-        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            mv.unwrap_or(0.0),
-        )))
+        Ok(crate::traits::CalcValue::Scalar(
+            super::super::utils::aggregate_result(mv.unwrap_or(0.0)),
+        ))
     }
 }
 

--- a/crates/formualizer-eval/src/builtins/utils.rs
+++ b/crates/formualizer-eval/src/builtins/utils.rs
@@ -5,6 +5,19 @@ use std::sync::LazyLock;
 /// Small epsilon used to detect near-zero denominators in trig/hyperbolic functions.
 pub const EPSILON_NEAR_ZERO: f64 = 1e-12;
 
+/// Final non-finite guard for numeric aggregate results (SUM/MIN/MAX/...):
+/// Excel never surfaces inf/NaN — an overflowed aggregate is `#NUM\!`, the
+/// same parity rule operators already apply via `coercion::sanitize_numeric`.
+/// One branch per aggregate CALL (apply to the finished reduction, never per
+/// element — arrow kernels stay untouched).
+pub fn aggregate_result(n: f64) -> LiteralValue {
+    if n.is_finite() {
+        LiteralValue::Number(n)
+    } else {
+        LiteralValue::Error(ExcelError::new_num())
+    }
+}
+
 /// Coerce a `LiteralValue` to `f64` using Excel semantics.
 /// - Number/Int map to f64
 /// - Boolean maps to 1.0/0.0

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -57,13 +57,68 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 type StagedFormulaEntry = (u32, u32, String);
-// NOTE(#126): the per-sheet `Vec` makes `stage_formula_text`/`clear_staged_formula_text`/
-// `get_staged_formula_text` O(staged-on-sheet) per call. The changelog O(N^2) regression
-// (full before/after snapshots per edit) is fixed via per-cell `StagedFormulaCellChanged`
-// deltas. Converting this Vec to a `(row,col)`-keyed map would make the residual lookups
-// O(1), but it threads through `build_graph_all`/`build_graph_for_sheets`/ingest records,
-// so it is intentionally left as a separate, contained follow-up.
-type StagedFormulaMap = std::collections::HashMap<String, Vec<StagedFormulaEntry>>;
+
+/// Per-sheet staged-formula store (NOTE(#126) follow-up).
+///
+/// Ingest consumers (`build_graph_all`/`build_graph_for_sheets`) walk staged
+/// entries in INSERTION order, so the order-preserving `Vec` stays the
+/// canonical storage; a `(row, col) → index` map removes the linear dup-scan
+/// that made `stage_formula_text`/`get_staged_formula_text` O(staged-on-sheet)
+/// per call (O(n²) for an n-formula deferred load on one sheet — ~570 ms for
+/// 50k stages, release, before the index). `stage`/`get` are O(1);
+/// `remove` keeps the old O(n) `Vec::remove` (rare path, order preserved).
+#[derive(Debug, Default, Clone)]
+pub(crate) struct StagedSheet {
+    entries: Vec<StagedFormulaEntry>,
+    index: FxHashMap<(u32, u32), usize>,
+}
+
+impl StagedSheet {
+    fn stage(&mut self, row: u32, col: u32, text: String) {
+        match self.index.entry((row, col)) {
+            std::collections::hash_map::Entry::Occupied(slot) => {
+                self.entries[*slot.get()].2 = text;
+            }
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(self.entries.len());
+                self.entries.push((row, col, text));
+            }
+        }
+    }
+
+    fn remove(&mut self, row: u32, col: u32) -> Option<String> {
+        let idx = self.index.remove(&(row, col))?;
+        let (_, _, text) = self.entries.remove(idx);
+        // `Vec::remove` shifted everything after `idx` left by one.
+        for slot in self.index.values_mut() {
+            if *slot > idx {
+                *slot -= 1;
+            }
+        }
+        Some(text)
+    }
+
+    fn get(&self, row: u32, col: u32) -> Option<&str> {
+        self.index
+            .get(&(row, col))
+            .map(|&i| self.entries[i].2.as_str())
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Consume into the insertion-ordered entry list (ingest order).
+    fn into_entries(self) -> Vec<StagedFormulaEntry> {
+        self.entries
+    }
+}
+
+type StagedFormulaMap = std::collections::HashMap<String, StagedSheet>;
 
 fn producer_dirty_to_span_dirty(
     dirty: ProducerDirtyDomain,
@@ -2895,32 +2950,22 @@ where
     }
 
     pub fn staged_formula_count(&self) -> usize {
-        self.staged_formulas.values().map(Vec::len).sum()
+        self.staged_formulas.values().map(StagedSheet::len).sum()
     }
 
     /// Stage a formula text instead of inserting into the graph (used when deferring is enabled).
     pub fn stage_formula_text(&mut self, sheet: &str, row: u32, col: u32, text: String) {
-        let entries = self.staged_formulas.entry(sheet.to_string()).or_default();
-        if let Some((_, _, existing)) = entries
-            .iter_mut()
-            .find(|(existing_row, existing_col, _)| *existing_row == row && *existing_col == col)
-        {
-            *existing = text;
-        } else {
-            entries.push((row, col, text));
-        }
+        self.staged_formulas
+            .entry(sheet.to_string())
+            .or_default()
+            .stage(row, col, text);
     }
 
     pub fn clear_staged_formula_text(&mut self, sheet: &str, row: u32, col: u32) -> Option<String> {
         let mut removed = None;
         let mut remove_sheet = false;
         if let Some(entries) = self.staged_formulas.get_mut(sheet) {
-            if let Some(idx) = entries.iter().position(|(existing_row, existing_col, _)| {
-                *existing_row == row && *existing_col == col
-            }) {
-                let (_, _, text) = entries.remove(idx);
-                removed = Some(text);
-            }
+            removed = entries.remove(row, col);
             remove_sheet = entries.is_empty();
         }
         if remove_sheet {
@@ -2937,19 +2982,16 @@ where
         let Some(entries) = self.staged_formulas.remove(old) else {
             return;
         };
-        for (row, col, text) in entries {
+        for (row, col, text) in entries.into_entries() {
             self.stage_formula_text(new, row, col, text);
         }
     }
 
     /// Get a staged formula text for a given cell if present (cloned).
     pub fn get_staged_formula_text(&self, sheet: &str, row: u32, col: u32) -> Option<String> {
-        self.staged_formulas.get(sheet).and_then(|v| {
-            v.iter()
-                .rev()
-                .find(|(r, c, _)| *r == row && *c == col)
-                .map(|(_, _, s)| s.clone())
-        })
+        self.staged_formulas
+            .get(sheet)
+            .and_then(|v| v.get(row, col).map(str::to_owned))
     }
 
     pub fn formula_parse_diagnostics(&self) -> &[FormulaParseDiagnostic] {
@@ -3619,7 +3661,7 @@ where
                 rustc_hash::FxHashMap::default();
             cache.reserve(4096);
 
-            for (row, col, txt) in entries {
+            for (row, col, txt) in entries.into_entries() {
                 let key = if txt.starts_with('=') {
                     txt
                 } else {
@@ -3668,7 +3710,7 @@ where
         let mut collected: StagedFormulaBatches = Vec::new();
         for s in sheets {
             if let Some(entries) = self.staged_formulas.remove(s) {
-                collected.push((s.to_string(), entries));
+                collected.push((s.to_string(), entries.into_entries()));
             }
         }
 
@@ -11369,13 +11411,10 @@ where
         let col = cell.coord.col() + 1;
 
         if let Some(entries) = self.staged_formulas.get(sheet_name)
-            && let Some((_, _, text)) = entries
-                .iter()
-                .rev()
-                .find(|(r, c, _)| *r == row && *c == col)
+            && let Some(text) = entries.get(row, col)
         {
             return Ok(Some(if text.starts_with('=') {
-                text.clone()
+                text.to_owned()
             } else {
                 format!("={text}")
             }));

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -173,6 +173,12 @@ pub struct DependencyGraph {
     dirty_vertices: FxHashSet<VertexId>,
     volatile_vertices: FxHashSet<VertexId>,
 
+    /// Monotonic count of vertices processed by dirty-propagation BFS loops
+    /// (`mark_dirty_many` / `mark_dirty_many_value_cells`). Cheap plain
+    /// counter used by perf-shape tests to assert propagation work is
+    /// O(component), not O(sources × component).
+    dirty_propagation_visits: u64,
+
     /// Vertices explicitly marked as #REF! by structural operations.
     ///
     /// In Arrow-truth mode, the dependency graph does not cache cell/formula values.
@@ -1055,6 +1061,7 @@ impl DependencyGraph {
             cell_to_vertex: std::collections::HashMap::with_hasher(CoordBuildHasher),
             load_packed_to_vertex: std::collections::HashMap::with_hasher(CoordBuildHasher),
             dirty_vertices: FxHashSet::default(),
+            dirty_propagation_visits: 0,
             volatile_vertices: FxHashSet::default(),
             ref_error_vertices: FxHashSet::default(),
             formula_to_range_deps: FxHashMap::default(),
@@ -2089,50 +2096,71 @@ impl DependencyGraph {
 
     /// Mark vertex dirty and propagate to dependents
     fn mark_dirty(&mut self, vertex_id: VertexId) -> Vec<VertexId> {
+        self.mark_dirty_many(&[vertex_id])
+    }
+
+    /// Multi-source `mark_dirty`: one BFS with a shared seen-set across all
+    /// sources, marking exactly the union of per-source `mark_dirty` calls
+    /// but visiting every vertex at most once per call.
+    ///
+    /// Loop-of-`mark_dirty` callers (volatile redirty, iterative-SCC redirty)
+    /// pay O(sources × component) without this — measured quadratic by the
+    /// iterate edge corpus. A BFS that early-stops at already-`is_dirty`
+    /// vertices would also fix that, but it is NOT safe in general: several
+    /// call sites set the dirty flag WITHOUT propagating to dependents
+    /// (`DependencyGraph::set_dirty`, `mark_dependents_dirty`, names.rs
+    /// binding invalidation, eval.rs demand-driven re-marks), so "dirty"
+    /// does not imply "my dependents are already dirty". The per-call shared
+    /// seen-set needs no such invariant.
+    pub(crate) fn mark_dirty_many(&mut self, vertex_ids: &[VertexId]) -> Vec<VertexId> {
         let mut affected = FxHashSet::default();
         let mut to_visit = Vec::new();
         let mut visited_for_propagation = FxHashSet::default();
 
-        // Only mark the source vertex as dirty if it's a formula
-        // Value cells don't get marked dirty themselves but are still affected
-        let is_formula = matches!(
-            self.store.kind(vertex_id),
-            VertexKind::FormulaScalar
-                | VertexKind::FormulaArray
-                | VertexKind::NamedScalar
-                | VertexKind::NamedArray
-        );
+        for &vertex_id in vertex_ids {
+            // Only mark the source vertex as dirty if it's a formula.
+            // Value cells don't get marked dirty themselves but are still
+            // affected.
+            let is_formula = matches!(
+                self.store.kind(vertex_id),
+                VertexKind::FormulaScalar
+                    | VertexKind::FormulaArray
+                    | VertexKind::NamedScalar
+                    | VertexKind::NamedArray
+            );
 
-        if is_formula {
-            to_visit.push(vertex_id);
-        } else {
-            // Value cells are affected (for tracking) but not marked dirty
-            affected.insert(vertex_id);
-        }
-
-        // Initial propagation from direct and range dependents
-        {
-            // Get dependents (vertices that depend on this vertex)
-            if let Some(dependents) = self.dependents_slice(vertex_id) {
-                to_visit.extend(dependents.iter().copied());
+            if is_formula {
+                to_visit.push(vertex_id);
             } else {
-                let dependents = self.get_dependents(vertex_id);
-                to_visit.extend(dependents);
+                // Value cells are affected (for tracking) but not marked dirty
+                affected.insert(vertex_id);
             }
 
-            if let Some(name_set) = self.cell_to_name_dependents.get(&vertex_id) {
-                for &name_vertex in name_set {
-                    to_visit.push(name_vertex);
+            // Initial propagation from direct and range dependents
+            {
+                // Get dependents (vertices that depend on this vertex)
+                if let Some(dependents) = self.dependents_slice(vertex_id) {
+                    to_visit.extend(dependents.iter().copied());
+                } else {
+                    let dependents = self.get_dependents(vertex_id);
+                    to_visit.extend(dependents);
                 }
-            }
 
-            to_visit.extend(self.collect_range_dependents_for_vertex(vertex_id));
+                if let Some(name_set) = self.cell_to_name_dependents.get(&vertex_id) {
+                    for &name_vertex in name_set {
+                        to_visit.push(name_vertex);
+                    }
+                }
+
+                to_visit.extend(self.collect_range_dependents_for_vertex(vertex_id));
+            }
         }
 
         while let Some(id) = to_visit.pop() {
             if !visited_for_propagation.insert(id) {
                 continue; // Already processed
             }
+            self.dirty_propagation_visits += 1;
             affected.insert(id);
 
             // Mark vertex as dirty
@@ -2153,6 +2181,12 @@ impl DependencyGraph {
 
         // Return as Vec for compatibility
         affected.into_iter().collect()
+    }
+
+    /// Total vertices processed by dirty-propagation BFS loops since graph
+    /// creation (perf-shape observability; see `dirty_propagation_visits`).
+    pub(crate) fn dirty_propagation_visits(&self) -> u64 {
+        self.dirty_propagation_visits
     }
 
     /// Get all vertices that need evaluation
@@ -2194,11 +2228,12 @@ impl DependencyGraph {
     }
 
     /// Re-marks all volatile vertices as dirty for the next evaluation cycle.
+    /// One multi-source propagation: many volatiles feeding one dependent
+    /// component used to pay O(volatiles × component) (a full `mark_dirty`
+    /// BFS per volatile); `mark_dirty_many` visits the component once.
     pub(crate) fn redirty_volatiles(&mut self) {
         let volatile_ids: Vec<VertexId> = self.volatile_vertices.iter().copied().collect();
-        for id in volatile_ids {
-            self.mark_dirty(id);
-        }
+        let _ = self.mark_dirty_many(&volatile_ids);
     }
 
     /// Re-marks members of iterating SCCs (and, via propagation, their
@@ -2206,19 +2241,20 @@ impl DependencyGraph {
     /// redirty that keeps `CyclePolicy::Iterate` cells re-evaluating every
     /// recalc (RFC #113; spec §4/§7.6). Vertices deleted since the recalc
     /// are skipped.
+    ///
+    /// One multi-source propagation: the old per-member `mark_dirty` loop was
+    /// O(|SCC|²) per recalc for a large SCC (a converged 1000-member ring
+    /// cost ~42 ms per no-op recalc, release); an interim `!is_dirty` skip
+    /// fixed that but leaned on dirty-flag semantics that non-propagating
+    /// `set_dirty` callers do not uphold. The shared seen-set in
+    /// `mark_dirty_many` is O(component) without any such invariant.
     pub(crate) fn redirty_iterative_members(&mut self, members: &[VertexId]) {
-        for &id in members {
-            // Skip members an earlier propagation already dirtied:
-            // `mark_dirty`'s BFS marks every transitive dependent, so the
-            // FIRST member of an SCC dirties the whole (strongly connected)
-            // component plus downstream, and re-walking from each remaining
-            // member is pure rework — O(|SCC|²) per recalc for one large SCC
-            // (measured quadratic by the iterate edge corpus: a converged
-            // 1000-member ring cost ~42 ms per no-op recalc, release).
-            if self.vertex_exists(id) && !self.is_dirty(id) {
-                let _ = self.mark_dirty(id);
-            }
-        }
+        let live: Vec<VertexId> = members
+            .iter()
+            .copied()
+            .filter(|&id| self.vertex_exists(id))
+            .collect();
+        let _ = self.mark_dirty_many(&live);
     }
 
     fn get_or_create_vertex(
@@ -3066,6 +3102,7 @@ impl DependencyGraph {
             if !visited_for_propagation.insert(id) {
                 continue;
             }
+            self.dirty_propagation_visits += 1;
             affected.insert(id);
             self.store.set_dirty(id, true);
             to_visit.extend(self.edges.in_edges(id));

--- a/crates/formualizer-eval/src/engine/scheduler.rs
+++ b/crates/formualizer-eval/src/engine/scheduler.rs
@@ -268,9 +268,11 @@ impl<'a> Scheduler<'a> {
                     if !vertex_set.contains(&dependency) {
                         continue;
                     }
-                    if !indices.contains_key(&dependency) {
+                    if let std::collections::hash_map::Entry::Vacant(slot) =
+                        indices.entry(dependency)
+                    {
                         // Not yet visited: descend (the recursive call).
-                        indices.insert(dependency, index_counter);
+                        slot.insert(index_counter);
                         lowlinks.insert(dependency, index_counter);
                         index_counter += 1;
                         stack.push(dependency);

--- a/crates/formualizer-eval/src/engine/scheduler.rs
+++ b/crates/formualizer-eval/src/engine/scheduler.rs
@@ -165,6 +165,172 @@ impl<'a> Scheduler<'a> {
 
     /// Tarjan's strongly connected components algorithm
     pub fn tarjan_scc(&self, vertices: &[VertexId]) -> Result<Vec<Vec<VertexId>>, ExcelError> {
+        self.tarjan_scc_impl(vertices, None)
+    }
+
+    /// Tarjan with virtual deps
+    fn tarjan_scc_with_virtual(
+        &self,
+        vertices: &[VertexId],
+        vdeps: &FxHashMap<VertexId, Vec<VertexId>>,
+    ) -> Result<Vec<Vec<VertexId>>, ExcelError> {
+        self.tarjan_scc_impl(vertices, Some(vdeps))
+    }
+
+    /// Iterative Tarjan over the scheduled subgraph, optionally honoring
+    /// per-pass virtual dependency edges.
+    ///
+    /// The DFS uses an explicit frame stack (vertex, dependency list, next
+    /// edge offset) instead of recursion, so depth is bounded by heap, not
+    /// the thread stack — the recursive predecessor SIGABRTed around depth
+    /// ~1500 in debug (2 MiB test stacks) on large SCCs AND on plain acyclic
+    /// chains whose dependencies point at higher vertex ids (see
+    /// `engine/tests/iterate_corpus_scale.rs`).
+    ///
+    /// Determinism contract: SCC emission order and within-SCC member order
+    /// are byte-identical to the recursive version (pinned by the
+    /// differential test in `engine/tests/tarjan_differential.rs` and the
+    /// ordering invariants in `engine/tests/schedule_units.rs`):
+    /// * dependencies are walked in adjacency order (base slice/Vec, then
+    ///   the vertex's virtual deps, exactly as the recursive code iterated);
+    /// * a vertex's SCC is emitted when its frame is exhausted and
+    ///   `lowlink == index` (the same program point as the recursive
+    ///   post-order emission);
+    /// * SCC members are popped off the Tarjan stack in the same order.
+    fn tarjan_scc_impl(
+        &self,
+        vertices: &[VertexId],
+        vdeps: Option<&FxHashMap<VertexId, Vec<VertexId>>>,
+    ) -> Result<Vec<Vec<VertexId>>, ExcelError> {
+        /// One vertex's dependency list, materialized once per DFS frame.
+        enum DepList<'g> {
+            Slice(&'g [VertexId]),
+            Owned(Vec<VertexId>),
+        }
+        impl DepList<'_> {
+            #[inline]
+            fn get(&self, i: usize) -> Option<VertexId> {
+                match self {
+                    DepList::Slice(s) => s.get(i).copied(),
+                    DepList::Owned(v) => v.get(i).copied(),
+                }
+            }
+        }
+
+        let deps_of = |vertex: VertexId| -> DepList<'_> {
+            // Edge order must match the recursive implementation: the base
+            // adjacency (zero-copy slice when available), with the vertex's
+            // virtual deps appended when present.
+            if let Some(extra) = vdeps.and_then(|m| m.get(&vertex)) {
+                let mut combined: Vec<VertexId> =
+                    if let Some(base) = self.graph.dependencies_slice(vertex) {
+                        base.to_vec()
+                    } else {
+                        self.graph.get_dependencies(vertex)
+                    };
+                combined.extend(extra.iter().copied());
+                DepList::Owned(combined)
+            } else if let Some(base) = self.graph.dependencies_slice(vertex) {
+                DepList::Slice(base)
+            } else {
+                DepList::Owned(self.graph.get_dependencies(vertex))
+            }
+        };
+
+        let mut index_counter = 0usize;
+        let mut stack: Vec<VertexId> = Vec::new();
+        let mut indices: FxHashMap<VertexId, usize> = FxHashMap::default();
+        let mut lowlinks: FxHashMap<VertexId, usize> = FxHashMap::default();
+        let mut on_stack: FxHashSet<VertexId> = FxHashSet::default();
+        let mut sccs: Vec<Vec<VertexId>> = Vec::new();
+        let vertex_set: FxHashSet<VertexId> = vertices.iter().copied().collect();
+
+        // Explicit DFS frames: (vertex, its dependency list, next edge offset).
+        let mut frames: Vec<(VertexId, DepList<'_>, usize)> = Vec::new();
+
+        for &root in vertices {
+            if indices.contains_key(&root) {
+                continue;
+            }
+            indices.insert(root, index_counter);
+            lowlinks.insert(root, index_counter);
+            index_counter += 1;
+            stack.push(root);
+            on_stack.insert(root);
+            frames.push((root, deps_of(root), 0));
+
+            while let Some(frame) = frames.last_mut() {
+                let vertex = frame.0;
+                if let Some(dependency) = frame.1.get(frame.2) {
+                    frame.2 += 1;
+                    // Only consider dependencies that are part of the current
+                    // scheduling task.
+                    if !vertex_set.contains(&dependency) {
+                        continue;
+                    }
+                    if !indices.contains_key(&dependency) {
+                        // Not yet visited: descend (the recursive call).
+                        indices.insert(dependency, index_counter);
+                        lowlinks.insert(dependency, index_counter);
+                        index_counter += 1;
+                        stack.push(dependency);
+                        on_stack.insert(dependency);
+                        frames.push((dependency, deps_of(dependency), 0));
+                    } else if on_stack.contains(&dependency) {
+                        // On the Tarjan stack: in the current SCC.
+                        let dep_index = indices[&dependency];
+                        lowlinks.insert(vertex, lowlinks[&vertex].min(dep_index));
+                    }
+                } else {
+                    // Vertex exhausted: emit its SCC if it is a root, then
+                    // return to the parent frame, folding the child lowlink in
+                    // (the post-recursion `min(lowlink[v], lowlink[dep])`).
+                    let vertex_lowlink = lowlinks[&vertex];
+                    if vertex_lowlink == indices[&vertex] {
+                        let mut scc = Vec::new();
+                        loop {
+                            let w = stack.pop().unwrap();
+                            on_stack.remove(&w);
+                            scc.push(w);
+                            if w == vertex {
+                                break;
+                            }
+                        }
+                        sccs.push(scc);
+                    }
+                    frames.pop();
+                    if let Some(parent) = frames.last() {
+                        let parent_vertex = parent.0;
+                        lowlinks
+                            .insert(parent_vertex, lowlinks[&parent_vertex].min(vertex_lowlink));
+                    }
+                }
+            }
+        }
+
+        Ok(sccs)
+    }
+
+    /// Test-only visibility shim over the private virtual-deps entry, used by
+    /// the differential test in `engine/tests/tarjan_differential.rs`.
+    #[cfg(test)]
+    pub(crate) fn tarjan_scc_with_virtual_for_tests(
+        &self,
+        vertices: &[VertexId],
+        vdeps: &FxHashMap<VertexId, Vec<VertexId>>,
+    ) -> Result<Vec<Vec<VertexId>>, ExcelError> {
+        self.tarjan_scc_with_virtual(vertices, vdeps)
+    }
+
+    /// Recursive reference implementation, retained ONLY for the differential
+    /// test (`engine/tests/tarjan_differential.rs`) that proves the iterative
+    /// rewrite emits byte-identical SCC output. Never call on deep graphs
+    /// without a large stack: it overflows around depth ~1500 in debug.
+    #[cfg(test)]
+    pub(crate) fn tarjan_scc_recursive_reference(
+        &self,
+        vertices: &[VertexId],
+    ) -> Result<Vec<Vec<VertexId>>, ExcelError> {
         let mut index_counter = 0;
         let mut stack = Vec::new();
         let mut indices = FxHashMap::default();
@@ -191,8 +357,10 @@ impl<'a> Scheduler<'a> {
         Ok(sccs)
     }
 
-    /// Tarjan with virtual deps
-    fn tarjan_scc_with_virtual(
+    /// Recursive reference with virtual deps; see
+    /// [`Self::tarjan_scc_recursive_reference`].
+    #[cfg(test)]
+    pub(crate) fn tarjan_scc_with_virtual_recursive_reference(
         &self,
         vertices: &[VertexId],
         vdeps: &FxHashMap<VertexId, Vec<VertexId>>,
@@ -224,6 +392,8 @@ impl<'a> Scheduler<'a> {
         Ok(sccs)
     }
 
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
     fn tarjan_visit(
         &self,
         vertex: VertexId,
@@ -317,6 +487,8 @@ impl<'a> Scheduler<'a> {
         Ok(())
     }
 
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
     fn tarjan_visit_with_virtual(
         &self,
         vertex: VertexId,

--- a/crates/formualizer-eval/src/engine/scheduler.rs
+++ b/crates/formualizer-eval/src/engine/scheduler.rs
@@ -237,64 +237,85 @@ impl<'a> Scheduler<'a> {
             }
         };
 
-        let mut index_counter = 0usize;
-        let mut stack: Vec<VertexId> = Vec::new();
-        let mut indices: FxHashMap<VertexId, usize> = FxHashMap::default();
-        let mut lowlinks: FxHashMap<VertexId, usize> = FxHashMap::default();
-        let mut on_stack: FxHashSet<VertexId> = FxHashSet::default();
+        // Compact the candidate set into dense local ids once, up front. All
+        // per-edge / per-frame bookkeeping (index, lowlink, on-stack) then
+        // becomes a plain array op instead of an FxHashMap probe; the only
+        // remaining hash per edge is the `VertexId -> local id` membership
+        // lookup, which doubles as the old `vertex_set.contains` filter.
+        // `VertexId` is a `u32` newtype, so `u32` local ids cannot overflow.
+        const UNVISITED: u32 = u32::MAX;
+        let mut local_of: FxHashMap<VertexId, u32> =
+            FxHashMap::with_capacity_and_hasher(vertices.len(), Default::default());
+        let mut vertex_of_local: Vec<VertexId> = Vec::with_capacity(vertices.len());
+        for &v in vertices {
+            if let std::collections::hash_map::Entry::Vacant(slot) = local_of.entry(v) {
+                slot.insert(vertex_of_local.len() as u32);
+                vertex_of_local.push(v);
+            }
+        }
+        let n = vertex_of_local.len();
+
+        let mut index_counter: u32 = 0;
+        let mut indices: Vec<u32> = vec![UNVISITED; n];
+        let mut lowlinks: Vec<u32> = vec![0; n];
+        let mut on_stack: Vec<bool> = vec![false; n];
+        let mut stack: Vec<u32> = Vec::with_capacity(n);
         let mut sccs: Vec<Vec<VertexId>> = Vec::new();
-        let vertex_set: FxHashSet<VertexId> = vertices.iter().copied().collect();
 
-        // Explicit DFS frames: (vertex, its dependency list, next edge offset).
-        let mut frames: Vec<(VertexId, DepList<'_>, usize)> = Vec::new();
+        // Explicit DFS frames: (local id, its dependency list, next edge
+        // offset). Pre-sized to the worst case (one frame per vertex, e.g. a
+        // single deep chain) so deep schedules never re-grow the stack.
+        let mut frames: Vec<(u32, DepList<'_>, u32)> = Vec::with_capacity(n);
 
-        for &root in vertices {
-            if indices.contains_key(&root) {
+        for &root_vertex in vertices {
+            let root = local_of[&root_vertex];
+            if indices[root as usize] != UNVISITED {
                 continue;
             }
-            indices.insert(root, index_counter);
-            lowlinks.insert(root, index_counter);
+            indices[root as usize] = index_counter;
+            lowlinks[root as usize] = index_counter;
             index_counter += 1;
             stack.push(root);
-            on_stack.insert(root);
-            frames.push((root, deps_of(root), 0));
+            on_stack[root as usize] = true;
+            frames.push((root, deps_of(root_vertex), 0));
 
             while let Some(frame) = frames.last_mut() {
-                let vertex = frame.0;
-                if let Some(dependency) = frame.1.get(frame.2) {
+                let vertex = frame.0 as usize;
+                if let Some(dep_vertex) = frame.1.get(frame.2 as usize) {
                     frame.2 += 1;
                     // Only consider dependencies that are part of the current
                     // scheduling task.
-                    if !vertex_set.contains(&dependency) {
+                    let Some(&dep) = local_of.get(&dep_vertex) else {
                         continue;
-                    }
-                    if let std::collections::hash_map::Entry::Vacant(slot) =
-                        indices.entry(dependency)
-                    {
+                    };
+                    let d = dep as usize;
+                    if indices[d] == UNVISITED {
                         // Not yet visited: descend (the recursive call).
-                        slot.insert(index_counter);
-                        lowlinks.insert(dependency, index_counter);
+                        indices[d] = index_counter;
+                        lowlinks[d] = index_counter;
                         index_counter += 1;
-                        stack.push(dependency);
-                        on_stack.insert(dependency);
-                        frames.push((dependency, deps_of(dependency), 0));
-                    } else if on_stack.contains(&dependency) {
+                        stack.push(dep);
+                        on_stack[d] = true;
+                        frames.push((dep, deps_of(dep_vertex), 0));
+                    } else if on_stack[d] {
                         // On the Tarjan stack: in the current SCC.
-                        let dep_index = indices[&dependency];
-                        lowlinks.insert(vertex, lowlinks[&vertex].min(dep_index));
+                        let dep_index = indices[d];
+                        if dep_index < lowlinks[vertex] {
+                            lowlinks[vertex] = dep_index;
+                        }
                     }
                 } else {
                     // Vertex exhausted: emit its SCC if it is a root, then
                     // return to the parent frame, folding the child lowlink in
                     // (the post-recursion `min(lowlink[v], lowlink[dep])`).
-                    let vertex_lowlink = lowlinks[&vertex];
-                    if vertex_lowlink == indices[&vertex] {
+                    let vertex_lowlink = lowlinks[vertex];
+                    if vertex_lowlink == indices[vertex] {
                         let mut scc = Vec::new();
                         loop {
                             let w = stack.pop().unwrap();
-                            on_stack.remove(&w);
-                            scc.push(w);
-                            if w == vertex {
+                            on_stack[w as usize] = false;
+                            scc.push(vertex_of_local[w as usize]);
+                            if w as usize == vertex {
                                 break;
                             }
                         }
@@ -302,9 +323,10 @@ impl<'a> Scheduler<'a> {
                     }
                     frames.pop();
                     if let Some(parent) = frames.last() {
-                        let parent_vertex = parent.0;
-                        lowlinks
-                            .insert(parent_vertex, lowlinks[&parent_vertex].min(vertex_lowlink));
+                        let p = parent.0 as usize;
+                        if vertex_lowlink < lowlinks[p] {
+                            lowlinks[p] = vertex_lowlink;
+                        }
                     }
                 }
             }

--- a/crates/formualizer-eval/src/engine/tests/iterate_corpus_numeric.rs
+++ b/crates/formualizer-eval/src/engine/tests/iterate_corpus_numeric.rs
@@ -124,14 +124,14 @@ fn operator_overflow_mid_iteration_stabilizes_as_num_error_and_converges() {
 }
 
 #[test]
-fn aggregate_leaked_infinity_pins_the_scc_at_a_permanent_cap() {
-    // SUM does not sanitize overflow, so `Number(inf)` leaks into the cycle:
-    // B1 = MAX(SUM(A1:A2), C1), C1 = B1 with A1 = A2 = 1e308. Both members
-    // commit +inf on pass 1 and never change again — but |inf − inf| = NaN
-    // fails the §6 numeric test, so the SCC caps at max_iterations, and does
-    // so again on EVERY subsequent recalc (the per-recalc redirty re-fires
-    // iterating SCCs). Pinned as spec-§6-correct; flagged in the findings
-    // report as a perf trap + Excel divergence (Excel would show #NUM!).
+fn aggregate_overflow_sanitizes_to_num_error_and_scc_converges() {
+    // SUM (like every numeric aggregate now) sanitizes a non-finite result
+    // to `#NUM!` — Excel parity, matching operator arithmetic. The historic
+    // leak (`Number(inf)` committed into the cycle) pinned this SCC at a
+    // PERMANENT cap: |inf − inf| = NaN fails the §6 numeric test, so every
+    // recalc burned the full pass budget. With the sanitizer, the error
+    // propagates around the cycle and `#NUM!` vs `#NUM!` converges by
+    // error-kind (§6) in a handful of passes.
     let mut engine = iterate_engine(7, 0.001);
     set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(1.0e308));
     set_value(&mut engine, "Sheet1", 2, 1, LiteralValue::Number(1.0e308));
@@ -139,32 +139,57 @@ fn aggregate_leaked_infinity_pins_the_scc_at_a_permanent_cap() {
     set_formula(&mut engine, "Sheet1", 1, 3, "=B1"); // C1
     engine.evaluate_all().unwrap();
 
-    // Documents the leak itself: the committed value really is +inf.
-    assert_eq!(
-        engine.get_cell_value("Sheet1", 1, 2),
-        Some(LiteralValue::Number(f64::INFINITY)),
-        "SUM/MAX leak unsanitized +inf (Excel would have produced #NUM!)"
-    );
+    // SUM(A1:A2) overflows → #NUM!; MAX propagates it; C1 mirrors it.
+    assert_eq!(err_kind(&engine, "Sheet1", 1, 2), ExcelErrorKind::Num);
+    assert_eq!(err_kind(&engine, "Sheet1", 1, 3), ExcelErrorKind::Num);
     let t = engine.last_cycle_telemetry();
     assert_eq!(t.iterated_sccs, 1);
-    assert_eq!(t.converged_sccs, 0, "inf vs inf must not converge (§6)");
-    assert_eq!(t.capped_sccs, 1);
-    assert_eq!(t.settle_passes_total, 7, "runs the full pass budget");
+    assert_eq!(t.converged_sccs, 1, "same-kind errors converge (§6)");
+    assert_eq!(t.capped_sccs, 0, "no longer pinned at the pass-budget cap");
+    assert!(
+        t.settle_passes_total <= 6,
+        "overflow → error → convergence must be quick, got {} passes",
+        t.settle_passes_total
+    );
 
-    // Permanent: a no-edit recalc burns the full budget again.
+    // And stays converged: a no-edit recalc does NOT burn the pass budget
+    // (the old leak capped at 7 passes on every recalc, forever).
     engine.evaluate_all().unwrap();
     let t = engine.last_cycle_telemetry();
-    assert_eq!(t.capped_sccs, 1);
-    assert_eq!(t.settle_passes_total, 7);
+    assert_eq!(t.converged_sccs, 1);
+    assert_eq!(t.capped_sccs, 0);
+    assert!(t.settle_passes_total <= 6);
+}
+
+#[test]
+fn acyclic_aggregate_overflow_is_num_error_excel_parity() {
+    // Aggregate overflow parity outside any cycle: SUM/AVERAGE over values
+    // that overflow f64, and MAX/MIN fed the resulting error, all surface
+    // #NUM!/the propagated error — never Number(inf).
+    let mut engine = iterate_engine(100, 0.001);
+    set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(1.0e308));
+    set_value(&mut engine, "Sheet1", 2, 1, LiteralValue::Number(1.0e308));
+    set_formula(&mut engine, "Sheet1", 1, 2, "=SUM(A1:A2)"); // B1
+    set_formula(&mut engine, "Sheet1", 2, 2, "=AVERAGE(A1:A2)*2"); // B2 (avg finite ×2 overflow stays operator territory)
+    set_formula(&mut engine, "Sheet1", 3, 2, "=MAX(B1,0)"); // B3: error propagates
+    set_formula(&mut engine, "Sheet1", 4, 2, "=SUMIF(A1:A2,\">0\")"); // B4
+    set_formula(&mut engine, "Sheet1", 5, 2, "=SUBTOTAL(9,A1:A2)"); // B5
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(err_kind(&engine, "Sheet1", 1, 2), ExcelErrorKind::Num);
+    assert_eq!(err_kind(&engine, "Sheet1", 2, 2), ExcelErrorKind::Num);
+    assert_eq!(err_kind(&engine, "Sheet1", 3, 2), ExcelErrorKind::Num);
+    assert_eq!(err_kind(&engine, "Sheet1", 4, 2), ExcelErrorKind::Num);
+    assert_eq!(err_kind(&engine, "Sheet1", 5, 2), ExcelErrorKind::Num);
 }
 
 #[test]
 fn sign_oscillating_infinity_caps_deterministically() {
-    // B1 = -C1, C1 = MAX(B1, SUM(A1:A2)) with the SUM forcing +inf into the
-    // cycle: C1 pins at +inf, B1 at −inf (unary negation of inf is not an
-    // operator overflow — the value is already non-finite... but `-C1`
-    // sanitizes too, so expect #NUM! if it does). This test pins whichever
-    // behavior is real: see asserts below (unary minus DOES sanitize).
+    // B1 = -C1, C1 = MAX(B1, SUM(A1:A2)) with the SUM overflowing: SUM now
+    // sanitizes its non-finite result to #NUM! directly (historically the
+    // +inf leaked into MAX and only `-C1`'s operator sanitization produced
+    // the error). Either way the cycle settles on same-kind errors and
+    // converges (§6).
     let mut engine = iterate_engine(5, 0.001);
     set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(1.0e308));
     set_value(&mut engine, "Sheet1", 2, 1, LiteralValue::Number(1.0e308));
@@ -172,9 +197,8 @@ fn sign_oscillating_infinity_caps_deterministically() {
     set_formula(&mut engine, "Sheet1", 1, 3, "=MAX(B1,SUM(A1:A2))"); // C1
     engine.evaluate_all().unwrap();
 
-    // Unary minus routes through numeric sanitization: −inf → #NUM!.
     assert_eq!(err_kind(&engine, "Sheet1", 1, 2), ExcelErrorKind::Num);
-    // C1 = MAX(#NUM!, inf) propagates the error.
+    // C1 = MAX(B1, #NUM!) propagates the error.
     assert_eq!(err_kind(&engine, "Sheet1", 1, 3), ExcelErrorKind::Num);
     let t = engine.last_cycle_telemetry();
     assert_eq!(t.iterated_sccs, 1);

--- a/crates/formualizer-eval/src/engine/tests/iterate_corpus_scale.rs
+++ b/crates/formualizer-eval/src/engine/tests/iterate_corpus_scale.rs
@@ -180,9 +180,9 @@ fn granularity_shapes_converge_with_expected_telemetry() {
     engine.evaluate_all().unwrap(); // converged-stable recalc
     let many_small_recalc = recalc0.elapsed();
 
-    // 1 × 500-member SCC (ring). NOT 2000: the scheduler's recursive Tarjan
-    // overflows the 2 MiB test-thread stack well before that depth in debug —
-    // see the `tarjan_recursion_overflows_*` repros below.
+    // 1 × 500-member SCC (ring). (Historical: 2000 used to SIGABRT the
+    // recursive Tarjan in debug — now iterative, pinned by the depth
+    // regression tests below; 500 kept for comparable shape timings.)
     let t1 = std::time::Instant::now();
     let mut engine = Engine::new(TestWorkbook::new(), iterate_cfg(100, 0.001));
     build_ring(&mut engine, 1, 500);
@@ -230,26 +230,24 @@ fn granularity_shapes_converge_with_expected_telemetry() {
     );
 }
 
-/* ───────────── BUG REPRO: recursive Tarjan stack overflow ─────────────── */
+/* ───────────── REGRESSION: deep graphs through the (iterative) Tarjan ─── */
 //
-// `Scheduler::tarjan_visit` (scheduler.rs) recurses once per dependency hop.
-// Any SCC of size k forces recursion depth k, and — independent of cycles —
-// any dependency chain visited AGAINST vertex-id order does too (the root
-// loop walks vertices in id order; a chain whose dependencies point at
-// higher ids recurses its full length). Debug builds abort (SIGABRT, stack
-// overflow) around depth ~1500 on the default 2 MiB test stack; release
-// stacks die at larger but still-reachable depths. Real-world trigger:
-// "totals above data" sheets (formulas referencing rows below) and any
-// large iterating SCC. Fix direction: iterative DFS like
-// `live_graph::analyze_live_graph` (already iterative). The fix touches
-// both `tarjan_visit` and `tarjan_visit_with_virtual` and must preserve
-// SCC emission order (schedule determinism) — left for a follow-up, with
-// these repros pinning it.
+// `Scheduler::tarjan_visit` used to recurse once per dependency hop: any SCC
+// of size k forced recursion depth k, and — independent of cycles — so did
+// any dependency chain visited AGAINST vertex-id order (the root loop walks
+// vertices in id order; a chain whose dependencies point at higher ids
+// recursed its full length). Debug builds SIGABRTed around depth ~1500 on
+// the default 2 MiB test stack; real-world trigger: "totals above data"
+// sheets and any large iterating SCC. The scheduler's Tarjan is now
+// iterative (explicit frame stack, `Scheduler::tarjan_scc_impl`) with SCC
+// output byte-identical to the recursive version (differential-tested in
+// `tarjan_differential.rs`); these tests pin the depth fix.
 
 #[test]
 fn forward_built_deep_chain_is_fine_control() {
     // Control: same 2000 depth, dependencies pointing at LOWER ids — the
-    // id-order root loop visits dependencies first, recursion stays shallow.
+    // id-order root loop visits dependencies first, DFS stays shallow even
+    // in the old recursive implementation.
     let mut engine = Engine::new(TestWorkbook::new(), iterate_cfg(100, 0.001));
     set_value(&mut engine, "Sheet1", 1, 1, LiteralValue::Number(1.0));
     for r in 2..=2000u32 {
@@ -260,8 +258,8 @@ fn forward_built_deep_chain_is_fine_control() {
 }
 
 #[test]
-#[ignore = "BUG (pre-existing, scheduler): recursive tarjan_visit overflows the stack on a 2000-member SCC — SIGABRT in debug; see module comment"]
 fn tarjan_recursion_overflows_on_2000_member_scc() {
+    // Formerly #[ignore]d SIGABRT repro (recursive Tarjan, stack overflow).
     let mut engine = Engine::new(TestWorkbook::new(), iterate_cfg(100, 0.001));
     build_ring(&mut engine, 1, 2000);
     engine.evaluate_all().unwrap();
@@ -269,8 +267,8 @@ fn tarjan_recursion_overflows_on_2000_member_scc() {
 }
 
 #[test]
-#[ignore = "BUG (pre-existing, scheduler): recursive tarjan_visit overflows the stack on a reverse-built 2000-deep ACYCLIC chain — not cycle-specific; see module comment"]
 fn tarjan_recursion_overflows_on_reverse_built_acyclic_chain() {
+    // Formerly #[ignore]d SIGABRT repro (recursive Tarjan, stack overflow).
     let mut engine = Engine::new(TestWorkbook::new(), iterate_cfg(100, 0.001));
     for r in 1..2000u32 {
         set_formula(&mut engine, "Sheet1", r, 1, &format!("=A{}+1", r + 1));
@@ -281,14 +279,40 @@ fn tarjan_recursion_overflows_on_reverse_built_acyclic_chain() {
 }
 
 #[test]
+fn tarjan_handles_10_000_deep_reverse_chain_in_debug() {
+    // Depth regression gate for the iterative Tarjan: a "totals above data"
+    // 10_000-deep acyclic chain (every dependency points at a HIGHER vertex
+    // id, so the id-order root loop dives the full depth) schedules and
+    // evaluates on the default debug test stack. The old recursive DFS died
+    // ~6.7× shallower than this.
+    //
+    // Build shape: pre-create rows 1..=depth as values (ascending ids), then
+    // overwrite rows 1..depth with formulas in DESCENDING row order. Same
+    // final graph as an ascending formula build, but each edit-time
+    // `mark_dirty` sees no formula dependents yet, keeping graph
+    // construction O(n) (an ascending build pays the no-early-stop dirty
+    // re-walk per edit — O(n²), ~100 s in debug at this depth).
+    let mut engine = Engine::new(TestWorkbook::new(), iterate_cfg(100, 0.001));
+    let depth = 10_000u32;
+    for r in 1..=depth {
+        set_value(&mut engine, "Sheet1", r, 1, LiteralValue::Number(1.0));
+    }
+    for r in (1..depth).rev() {
+        set_formula(&mut engine, "Sheet1", r, 1, &format!("=A{}+1", r + 1));
+    }
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 1, 1), depth as f64);
+}
+
+#[test]
 fn ring_stable_recalc_cost_scales_linearly_probe() {
     // Perf-shape probe (printed, not gated): a converged ring's no-edit
     // recalc must scale ~linearly in SCC size. Before the
     // `redirty_iterative_members` already-dirty skip this was quadratic
     // (each member's `mark_dirty` re-walked the whole component): release
     // numbers were 12 ms / 42 ms / 83 ms for 500/1000/1500 members; after
-    // the fix ~0.6 ms / 1.2 ms / 2.4 ms. Sizes stay below the recursive-
-    // Tarjan debug stack limit (see the overflow repros above).
+    // the fix ~0.6 ms / 1.2 ms / 2.4 ms. (Sizes predate the iterative
+    // Tarjan; kept small so the probe stays debug-fast.)
     for size in [200u32, 400, 800] {
         let mut engine = Engine::new(TestWorkbook::new(), iterate_cfg(100, 0.001));
         build_ring(&mut engine, 1, size);

--- a/crates/formualizer-eval/src/engine/tests/mark_dirty_multi_source.rs
+++ b/crates/formualizer-eval/src/engine/tests/mark_dirty_multi_source.rs
@@ -1,0 +1,176 @@
+//! Multi-source dirty propagation (`DependencyGraph::mark_dirty_many`).
+//!
+//! Loop-of-`mark_dirty` callers paid O(sources × component): every source
+//! re-walked the whole dependent component. The volatile redirty was the
+//! worst realistic shape (every recalc, for every volatile). The fix is one
+//! BFS with a per-call shared seen-set — NOT an early-stop at already-dirty
+//! vertices, because several call sites set the dirty flag without
+//! propagating (`DependencyGraph::set_dirty`, `mark_dependents_dirty`,
+//! names.rs invalidation), so "dirty" does not imply "dependents dirty".
+//!
+//! Work is asserted via `dirty_propagation_visits` (BFS visit counts), never
+//! wall time.
+
+use crate::engine::{CycleConfig, DependencyGraph, Engine, EvalConfig, VertexId};
+use crate::test_workbook::TestWorkbook;
+use formualizer_parse::parser::parse;
+
+fn set_formula(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, f: &str) {
+    engine
+        .set_cell_formula(sheet, row, col, parse(f).expect("parse"))
+        .expect("set formula");
+}
+
+/* ───────────── volatile redirty visits the component once ─────────────── */
+
+#[test]
+fn volatile_redirty_is_one_component_walk_not_one_per_volatile() {
+    // 50 volatiles all feeding one shared 200-formula chain. The per-recalc
+    // volatile redirty used to run a full BFS per volatile: ≥ 50 × 200 =
+    // 10_000 visits per recalc. One multi-source walk visits each vertex at
+    // most once: ~(50 volatiles + 201 chain) ≈ 251 visits.
+    crate::builtins::random::register_builtins();
+    let volatiles = 50u32;
+    let chain = 200u32;
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for r in 1..=volatiles {
+        set_formula(&mut engine, "Sheet1", r, 1, "=RAND()");
+    }
+    // B1 collects all volatiles; B2..B{chain+1} chain off it.
+    set_formula(
+        &mut engine,
+        "Sheet1",
+        1,
+        2,
+        &format!("=SUM(A1:A{volatiles})"),
+    );
+    for r in 2..=(chain + 1) {
+        set_formula(&mut engine, "Sheet1", r, 2, &format!("=B{}+1", r - 1));
+    }
+
+    engine.evaluate_all().unwrap();
+    let after_first = engine.graph.dirty_propagation_visits();
+    let t = std::time::Instant::now();
+    engine.evaluate_all().unwrap();
+    let recalc = t.elapsed();
+    let delta = engine.graph.dirty_propagation_visits() - after_first;
+    eprintln!(
+        "[mark-dirty-multi] volatile-heavy recalc: {recalc:?}, {delta} BFS visits \
+         ({volatiles} volatiles × {chain}-chain component)"
+    );
+
+    let component = (volatiles + chain + 1) as u64;
+    assert!(
+        delta <= 2 * component,
+        "second recalc's redirty must be ~one component walk \
+         (≈{component} visits), got {delta} (quadratic was ≥ {})",
+        (volatiles as u64) * (chain as u64)
+    );
+}
+
+/* ───────────── iterative-SCC redirty stays one walk (no dirty-flag lean) ─ */
+
+#[test]
+fn iterative_scc_redirty_is_one_component_walk() {
+    // 400-member ring: the per-recalc iterative redirty marks all members.
+    // With the multi-source walk this is ~400 visits, independent of any
+    // dirty-flag state left behind by other marking paths.
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_cycle(CycleConfig::iterate(100, 0.001)),
+    );
+    let size = 400u32;
+    set_formula(&mut engine, "Sheet1", 1, 1, &format!("=0.5*A{size}+1"));
+    for r in 2..=size {
+        set_formula(&mut engine, "Sheet1", r, 1, &format!("=A{}", r - 1));
+    }
+
+    engine.evaluate_all().unwrap();
+    let after_first = engine.graph.dirty_propagation_visits();
+    engine.evaluate_all().unwrap();
+    let delta = engine.graph.dirty_propagation_visits() - after_first;
+
+    assert!(
+        delta <= 3 * size as u64,
+        "stable-ring recalc redirty must be ~one component walk \
+         (≈{size} visits), got {delta} (quadratic was ≥ {})",
+        (size as u64) * (size as u64) / 2
+    );
+}
+
+/* ───────────── union semantics: multi-source == N single-source calls ─── */
+
+/// Build the same small mesh twice and compare one `mark_dirty_many` over all
+/// sources against sequential single-source calls: the affected union, the
+/// dirty flags, and the evaluation set must be identical.
+#[test]
+fn mark_dirty_many_equals_sequential_single_source_marks() {
+    fn build() -> (DependencyGraph, Vec<VertexId>) {
+        use super::common::abs_cell_ref;
+        let mut graph = DependencyGraph::new();
+        // Values A1..A4; diamond B1=A1+A2, B2=A2+A3, C1=B1+B2, D1=C1, and an
+        // untouched island E1=A4.
+        for r in 1..=4u32 {
+            graph
+                .set_cell_value(
+                    "Sheet1",
+                    r,
+                    1,
+                    formualizer_common::LiteralValue::Int(r as i64),
+                )
+                .unwrap();
+        }
+        graph
+            .set_cell_formula("Sheet1", 1, 2, parse("=A1+A2").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 2, 2, parse("=A2+A3").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 1, 3, parse("=B1+B2").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 1, 4, parse("=C1").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 1, 5, parse("=A4").unwrap())
+            .unwrap();
+        // Sources: value cells A1, A2 (mixed kinds) and formula B2.
+        let ids = [(1u32, 1u32), (2, 1), (2, 2)]
+            .iter()
+            .map(|&(r, c)| {
+                *graph
+                    .cell_to_vertex()
+                    .get(&abs_cell_ref(0, r, c))
+                    .expect("vertex")
+            })
+            .collect();
+        (graph, ids)
+    }
+
+    let (mut g_multi, sources) = build();
+    let mut multi_affected = g_multi.mark_dirty_many(&sources);
+    multi_affected.sort_unstable();
+    let mut multi_eval = g_multi.get_evaluation_vertices();
+    multi_eval.sort_unstable();
+
+    let (mut g_seq, sources_seq) = build();
+    assert_eq!(sources, sources_seq, "deterministic vertex ids");
+    let mut seq_affected: Vec<VertexId> = Vec::new();
+    for &s in &sources_seq {
+        seq_affected.extend(g_seq.mark_dirty_many(&[s]));
+    }
+    seq_affected.sort_unstable();
+    seq_affected.dedup();
+    let mut seq_eval = g_seq.get_evaluation_vertices();
+    seq_eval.sort_unstable();
+
+    assert_eq!(
+        multi_affected, seq_affected,
+        "multi-source affected set must equal the union of single-source sets"
+    );
+    assert_eq!(
+        multi_eval, seq_eval,
+        "dirty evaluation set must be identical"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -18,6 +18,7 @@ mod graph_internal_helpers;
 mod layer_evaluation;
 mod load_fast_mappings;
 //mod mark_dirty_benchmarks;
+mod mark_dirty_multi_source;
 mod parallel;
 mod range_dependencies;
 mod range_property_tests;

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -42,6 +42,7 @@ mod stripe_tests;
 mod striped_dirty_propagation;
 mod structural_op_clears_computed_values;
 mod tables;
+mod tarjan_differential;
 mod tarjan_scc;
 mod topo_layers;
 mod transactions;

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -38,6 +38,7 @@ mod row_operations;
 mod sheet_duplication_named_range_dependents;
 mod sheet_management;
 mod sources;
+mod staged_formula_scaling;
 mod stripe_streaming_integration;
 mod stripe_tests;
 mod striped_dirty_propagation;

--- a/crates/formualizer-eval/src/engine/tests/short_circuit_dispatch.rs
+++ b/crates/formualizer-eval/src/engine/tests/short_circuit_dispatch.rs
@@ -112,7 +112,7 @@ fn non_short_circuit_dispatch_evaluates_each_argument_subtree_once() {
             f = format!("SUM({f})");
         }
         engine
-            .set_cell_formula("Sheet1", 1, 1, parse(&format!("={f}")).unwrap())
+            .set_cell_formula("Sheet1", 1, 1, parse(format!("={f}").as_str()).unwrap())
             .unwrap();
         engine.evaluate_all().unwrap();
         assert_eq!(

--- a/crates/formualizer-eval/src/engine/tests/short_circuit_dispatch.rs
+++ b/crates/formualizer-eval/src/engine/tests/short_circuit_dispatch.rs
@@ -85,3 +85,40 @@ fn if_arity_error_is_preserved_with_lazy_dispatch() {
         "arity failure must not evaluate arguments"
     );
 }
+
+/* ──────────── eager validation must not re-evaluate arguments ─────────── */
+
+#[test]
+fn non_short_circuit_dispatch_evaluates_each_argument_subtree_once() {
+    // The eager-validation sibling of the SHORT_CIRCUIT bug: for
+    // non-short-circuit functions, `Function::dispatch` runs
+    // `validate_and_prepare`, which evaluates every argument — and then
+    // discards the prepared args before `eval` evaluates them again. Without
+    // the `ArgumentHandle::value` memo this compounded to 2^depth
+    // evaluations of the innermost node for nested calls (measured: depth
+    // 12 ⇒ 4096 evaluations of COUNTING() inside nested SUMs). Pin: exactly
+    // one evaluation regardless of nesting depth.
+    use crate::engine::{Engine, EvalConfig};
+    use formualizer_parse::parser::parse;
+
+    for depth in [1usize, 4, 12] {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let wb = TestWorkbook::new()
+            .with_function(Arc::new(crate::builtins::math::SumFn))
+            .with_function(Arc::new(CountFn(counter.clone())));
+        let mut engine = Engine::new(wb, EvalConfig::default());
+        let mut f = "COUNTING()".to_string();
+        for _ in 0..depth {
+            f = format!("SUM({f})");
+        }
+        engine
+            .set_cell_formula("Sheet1", 1, 1, parse(&format!("={f}")).unwrap())
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "depth {depth}: dispatch validation must not re-evaluate argument subtrees"
+        );
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/staged_formula_scaling.rs
+++ b/crates/formualizer-eval/src/engine/tests/staged_formula_scaling.rs
@@ -1,0 +1,62 @@
+//! Staged-formula store scaling (NOTE(#126) follow-up).
+//!
+//! `stage_formula_text` used a per-sheet `Vec` with a linear dup-scan per
+//! call: O(staged-on-sheet) per stage, O(n²) for an n-formula deferred load
+//! on one sheet (the xlsx-load path stages every formula). The store now
+//! keeps the same insertion-ordered `Vec` (ingest order is consumer-visible)
+//! plus a `(row, col) → index` map, making stage/get/overwrite O(1).
+//!
+//! Shape probe: timings are printed for the findings report; correctness
+//! (overwrite-in-place, insertion order, removal) is asserted.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+
+#[test]
+fn staging_many_formulas_one_sheet_is_linear_probe() {
+    let n: u32 = 50_000;
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+
+    let t = std::time::Instant::now();
+    for i in 0..n {
+        let row = 1 + i / 100;
+        let col = 1 + (i % 100);
+        engine.stage_formula_text("Sheet1", row, col, format!("=A{row}+{col}"));
+    }
+    let stage_fresh = t.elapsed();
+
+    // Overwrite a slice of them (the dup-scan path).
+    let t = std::time::Instant::now();
+    for i in 0..(n / 5) {
+        let row = 1 + i / 100;
+        let col = 1 + (i % 100);
+        engine.stage_formula_text("Sheet1", row, col, format!("=B{row}+{col}"));
+    }
+    let stage_overwrite = t.elapsed();
+
+    eprintln!(
+        "[staged-scaling] stage {n} fresh: {stage_fresh:?} | overwrite {}: {stage_overwrite:?}",
+        n / 5
+    );
+
+    // Overwrites replaced in place — no duplicate entries.
+    assert_eq!(engine.staged_formula_count(), n as usize);
+    assert_eq!(
+        engine.get_staged_formula_text("Sheet1", 1, 1),
+        Some("=B1+1".to_string()),
+        "overwrite must replace the staged text in place"
+    );
+    assert_eq!(
+        engine.get_staged_formula_text("Sheet1", 500, 100),
+        Some("=A500+100".to_string()),
+        "non-overwritten entries keep their original text"
+    );
+
+    // Removal still works and updates the count.
+    assert_eq!(
+        engine.clear_staged_formula_text("Sheet1", 1, 1),
+        Some("=B1+1".to_string())
+    );
+    assert_eq!(engine.clear_staged_formula_text("Sheet1", 1, 1), None);
+    assert_eq!(engine.staged_formula_count(), n as usize - 1);
+}

--- a/crates/formualizer-eval/src/engine/tests/tarjan_differential.rs
+++ b/crates/formualizer-eval/src/engine/tests/tarjan_differential.rs
@@ -207,13 +207,13 @@ fn run_deep_shape_differential() {
             deps[base].push(base - 1);
         }
     }
-    for i in 3 * ring..n {
+    for (i, dep) in deps.iter_mut().enumerate().take(n).skip(3 * ring) {
         // Reverse tail: each tail vertex depends on the NEXT tail vertex;
         // the last tail vertex depends into ring 0.
         if i + 1 < n {
-            deps[i].push(i + 1);
+            dep.push(i + 1);
         } else {
-            deps[i].push(0);
+            dep.push(0);
         }
     }
     let (graph, mut roots) = build_graph(n, &deps);

--- a/crates/formualizer-eval/src/engine/tests/tarjan_differential.rs
+++ b/crates/formualizer-eval/src/engine/tests/tarjan_differential.rs
@@ -1,0 +1,242 @@
+//! Differential proof for the iterative Tarjan rewrite (scheduler.rs).
+//!
+//! The scheduler's recursive `tarjan_visit`/`tarjan_visit_with_virtual` were
+//! rewritten with an explicit work stack (stack-overflow fix: a ~2000-deep
+//! reverse-built chain or SCC SIGABRTed debug builds). Schedules must stay
+//! deterministic, so the rewrite's HARD CONSTRAINT is byte-identical output:
+//! same SCC emission order, same within-SCC member order.
+//!
+//! This module keeps the recursive implementation alive behind `#[cfg(test)]`
+//! (`Scheduler::tarjan_scc_recursive_reference{,_with_virtual}`) and asserts
+//! `Vec<Vec<VertexId>>` equality over seeded random graphs — including deep
+//! chains (both directions), rings/self-loops (via virtual deps), and
+//! multi-SCC meshes — plus randomized root-iteration orders. Everything is
+//! seeded (xorshift64*), no wall-clock anywhere. The recursive reference runs
+//! inside a 64 MiB thread so the *reference's* depth limit doesn't constrain
+//! the shapes we can compare.
+
+use crate::engine::{DependencyGraph, Scheduler, VertexId};
+use formualizer_parse::parser::parse;
+use rustc_hash::FxHashMap;
+
+/* ─────────────────────────── seeded rng ──────────────────────────── */
+
+struct XorShift64Star(u64);
+
+impl XorShift64Star {
+    fn new(seed: u64) -> Self {
+        // Avoid the all-zero fixed point.
+        Self(seed.wrapping_mul(2685821657736338717).max(1))
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(2685821657736338717)
+    }
+    /// Uniform-ish in `0..bound` (bound > 0).
+    fn below(&mut self, bound: usize) -> usize {
+        (self.next_u64() % bound as u64) as usize
+    }
+    fn shuffle<T>(&mut self, items: &mut [T]) {
+        for i in (1..items.len()).rev() {
+            items.swap(i, self.below(i + 1));
+        }
+    }
+}
+
+/* ─────────────────────── graph construction ──────────────────────── */
+
+/// Build a `DependencyGraph` whose vertex `i` (cell `A{i+1}`) depends on
+/// `deps[i]` (other vertex indices; `i == j` is skipped — direct self-refs
+/// are rejected at edit time, self-loops are exercised via virtual deps).
+/// Returns the graph and the vertex ids in index order.
+fn build_graph(n: usize, deps: &[Vec<usize>]) -> (DependencyGraph, Vec<VertexId>) {
+    use super::common::abs_cell_ref;
+    assert_eq!(deps.len(), n);
+    let mut graph = DependencyGraph::new();
+    for (i, dep_rows) in deps.iter().enumerate() {
+        let row = (i + 1) as u32;
+        let refs: Vec<String> = dep_rows
+            .iter()
+            .filter(|&&j| j != i)
+            .map(|&j| format!("A{}", j + 1))
+            .collect();
+        if refs.is_empty() {
+            graph
+                .set_cell_formula("Sheet1", row, 1, parse("=1").unwrap())
+                .unwrap();
+        } else {
+            let formula = format!("={}", refs.join("+"));
+            graph
+                .set_cell_formula("Sheet1", row, 1, parse(&formula).unwrap())
+                .unwrap();
+        }
+    }
+    let ids: Vec<VertexId> = (0..n)
+        .map(|i| {
+            *graph
+                .cell_to_vertex()
+                .get(&abs_cell_ref(0, (i + 1) as u32, 1))
+                .expect("vertex for cell")
+        })
+        .collect();
+    (graph, ids)
+}
+
+/// Assert byte-identical SCC output between the recursive reference and the
+/// iterative implementation, for both the plain and the virtual-deps entry.
+fn assert_differential(
+    graph: &DependencyGraph,
+    roots: &[VertexId],
+    vdeps: &FxHashMap<VertexId, Vec<VertexId>>,
+    label: &str,
+) {
+    let scheduler = Scheduler::new(graph);
+
+    let reference = scheduler
+        .tarjan_scc_recursive_reference(roots)
+        .expect("recursive tarjan");
+    let iterative = scheduler.tarjan_scc(roots).expect("iterative tarjan");
+    assert_eq!(
+        reference, iterative,
+        "[{label}] plain tarjan_scc diverged from the recursive reference"
+    );
+
+    let reference_v = scheduler
+        .tarjan_scc_with_virtual_recursive_reference(roots, vdeps)
+        .expect("recursive tarjan (virtual)");
+    let iterative_v = scheduler
+        .tarjan_scc_with_virtual_for_tests(roots, vdeps)
+        .expect("iterative tarjan (virtual)");
+    assert_eq!(
+        reference_v, iterative_v,
+        "[{label}] tarjan_scc_with_virtual diverged from the recursive reference"
+    );
+}
+
+/* ───────────────────────────── the test ──────────────────────────── */
+
+fn run_random_differential() {
+    // 220 seeded random graphs: mixed density, virtual deps (incl.
+    // self-loops), and randomized root orders.
+    for seed in 0..220u64 {
+        let mut rng = XorShift64Star::new(seed.wrapping_add(0x9E3779B97F4A7C15));
+        let n = 2 + rng.below(60);
+
+        // Random adjacency: 0..=3 deps per vertex, pointing anywhere
+        // (higher ids included — the reverse-direction shape that used to
+        // overflow). Duplicate edges are kept: the dependency extractor may
+        // dedup, but both implementations see the same final adjacency.
+        let mut deps: Vec<Vec<usize>> = Vec::with_capacity(n);
+        for _ in 0..n {
+            let k = rng.below(4);
+            deps.push((0..k).map(|_| rng.below(n)).collect());
+        }
+        let (graph, ids) = build_graph(n, &deps);
+
+        // Virtual deps over ~1/3 of vertices; ~1/4 of those get a self-loop
+        // (only reachable through vdeps — edit-time checks reject direct
+        // self-references).
+        let mut vdeps: FxHashMap<VertexId, Vec<VertexId>> = FxHashMap::default();
+        for (i, &id) in ids.iter().enumerate() {
+            if rng.below(3) == 0 {
+                let mut extra: Vec<VertexId> =
+                    (0..1 + rng.below(2)).map(|_| ids[rng.below(n)]).collect();
+                if rng.below(4) == 0 {
+                    extra.push(ids[i]); // self-loop
+                }
+                vdeps.insert(id, extra);
+            }
+        }
+
+        // Root order 1: ascending vertex id (the production order).
+        let mut roots = ids.clone();
+        roots.sort_unstable();
+        assert_differential(&graph, &roots, &vdeps, &format!("seed {seed} sorted"));
+
+        // Root order 2: seeded shuffle (the contract must hold for any
+        // caller-supplied order).
+        rng.shuffle(&mut roots);
+        assert_differential(&graph, &roots, &vdeps, &format!("seed {seed} shuffled"));
+    }
+}
+
+fn run_deep_shape_differential() {
+    let no_vdeps: FxHashMap<VertexId, Vec<VertexId>> = FxHashMap::default();
+
+    // Reverse-built 3000-deep acyclic chain (deps point at HIGHER ids):
+    // the shape that crashed the recursive scheduler at production depth.
+    let n = 3000;
+    let deps: Vec<Vec<usize>> = (0..n)
+        .map(|i| if i + 1 < n { vec![i + 1] } else { vec![] })
+        .collect();
+    let (graph, mut roots) = build_graph(n, &deps);
+    roots.sort_unstable();
+    assert_differential(&graph, &roots, &no_vdeps, "reverse chain 3000");
+
+    // Forward-built chain (control: shallow even for the reference).
+    let deps: Vec<Vec<usize>> = (0..n)
+        .map(|i| if i > 0 { vec![i - 1] } else { vec![] })
+        .collect();
+    let (graph, mut roots) = build_graph(n, &deps);
+    roots.sort_unstable();
+    assert_differential(&graph, &roots, &no_vdeps, "forward chain 3000");
+
+    // One 2500-member ring (single deep SCC).
+    let n = 2500;
+    let deps: Vec<Vec<usize>> = (0..n).map(|i| vec![(i + 1) % n]).collect();
+    let (graph, mut roots) = build_graph(n, &deps);
+    roots.sort_unstable();
+    assert_differential(&graph, &roots, &no_vdeps, "ring 2500");
+
+    // Multi-SCC mesh: three 400-member rings bridged in a chain, plus a
+    // 400-deep reverse tail feeding the first ring.
+    let ring = 400;
+    let n = 4 * ring;
+    let mut deps: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for block in 0..3 {
+        let base = block * ring;
+        for i in 0..ring {
+            deps[base + i].push(base + (i + 1) % ring);
+        }
+        if block > 0 {
+            // Bridge: this ring's first member depends on the previous ring.
+            deps[base].push(base - 1);
+        }
+    }
+    for i in 3 * ring..n {
+        // Reverse tail: each tail vertex depends on the NEXT tail vertex;
+        // the last tail vertex depends into ring 0.
+        if i + 1 < n {
+            deps[i].push(i + 1);
+        } else {
+            deps[i].push(0);
+        }
+    }
+    let (graph, mut roots) = build_graph(n, &deps);
+    roots.sort_unstable();
+    // Self-loop on one singleton via vdeps for good measure.
+    let mut vdeps: FxHashMap<VertexId, Vec<VertexId>> = FxHashMap::default();
+    vdeps.insert(roots[0], vec![roots[0]]);
+    assert_differential(&graph, &roots, &vdeps, "3 rings + reverse tail");
+}
+
+#[test]
+fn iterative_tarjan_is_byte_identical_to_recursive_reference() {
+    // The recursive REFERENCE needs headroom for the deep shapes (it
+    // overflows ~1500 frames on a default 2 MiB test stack), so the whole
+    // differential runs on a 64 MiB thread.
+    std::thread::Builder::new()
+        .name("tarjan-differential".into())
+        .stack_size(64 * 1024 * 1024)
+        .spawn(|| {
+            run_random_differential();
+            run_deep_shape_differential();
+        })
+        .expect("spawn differential thread")
+        .join()
+        .expect("differential thread panicked");
+}

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -238,6 +238,15 @@ pub struct ArgumentHandle<'a, 'b> {
     interp: &'a Interpreter<'b>,
     cached_ast: std::cell::OnceCell<ASTNode>,
     cached_ref: std::cell::OnceCell<ReferenceType>,
+    /// Memoized result of [`Self::value`]. `Function::dispatch` evaluates
+    /// every argument once during schema validation and the function's `eval`
+    /// evaluates it again — without this cache that re-entry compounds to
+    /// 2^depth evaluations of the innermost node for nested non-short-circuit
+    /// calls (measured: depth 12 ⇒ 4096 evaluations). The handle is created
+    /// per call site and per evaluation, so the memo can never go stale
+    /// across recalcs. `value_with_env` is intentionally NOT memoized (the
+    /// local env changes the result).
+    cached_value: std::cell::OnceCell<Result<crate::traits::CalcValue<'b>, ExcelError>>,
 }
 
 impl<'a, 'b> ArgumentHandle<'a, 'b> {
@@ -247,6 +256,7 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
             interp,
             cached_ast: std::cell::OnceCell::new(),
             cached_ref: std::cell::OnceCell::new(),
+            cached_value: std::cell::OnceCell::new(),
         }
     }
 
@@ -265,10 +275,17 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
             interp,
             cached_ast: std::cell::OnceCell::new(),
             cached_ref: std::cell::OnceCell::new(),
+            cached_value: std::cell::OnceCell::new(),
         }
     }
 
     pub fn value(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+        self.cached_value
+            .get_or_init(|| self.compute_value())
+            .clone()
+    }
+
+    fn compute_value(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
         match &self.expr {
             ArgumentExpr::Ast(node) => {
                 if let ASTNodeType::Literal(ref v) = node.node_type {


### PR DESCRIPTION
The hotpath/quadratic hunt seeded by the edge-case corpus (#135). Five findings, all fixed, refs #112/#113.

**1. Crash: recursive Tarjan → iterative, and faster than the original.** `tarjan_visit` recursed per dependency hop — ~2000-deep graphs SIGABRT'd, including *reverse-built acyclic chains* (plain "totals above data" workbooks). Rewritten with an explicit frame stack, then optimized with one-time id compaction so indices/lowlinks/on-stack become dense `Vec`s instead of per-edge hash probes. Equivalence proven by a differential test: 880 byte-identical SCC-output comparisons against the retained recursive reference (seeded random graphs × root orders × plain/virtual variants, plus deep chains/rings/meshes); both `#[ignore]`d crash repros un-ignored and a 10,000-deep regression test added. Net perf: linear-rollup 200k evaluate is **~9-13% faster than main** (the dense arrays beat the recursive baseline outright, 4/4 and 3/3 interleaved rounds across two machines/sessions).

**2. Exponential: dispatch validation re-evaluated arguments.** `Function::dispatch`'s `validate_and_prepare` evaluated every argument, discarded the results, then `eval` re-evaluated — 2× per nesting level, i.e. **2^depth evaluations of the innermost node** (depth 12 = 4096×). Fixed with a `OnceCell` memo on `ArgumentHandle::value` (per-call-site handle, cannot go stale; the env-parameterized variant is deliberately unmemoized). Pinned with a counting function: 1 evaluation at any depth.

**3. Multi-source dirty marking.** `redirty_volatiles` ran a full BFS per volatile with no early stop — O(volatiles × component) every recalc. The survey found a naive early-stop is **unsafe** (a dozen non-propagating dirty setters violate "dirty ⇒ dependents dirty" — including the skip #135 introduced, which leaned on that invariant). Replaced with `mark_dirty_many`: one BFS, shared seen-set, provably equal to the union of per-source calls with no invariant dependence. 50 volatiles → 200-cell chain: 10,100 BFS visits → 251 (920µs → 449µs per recalc), counter-pinned.

**4. Aggregate non-finite sanitization (Excel parity).** SUM/AVERAGE/SUMPRODUCT/MIN/MAX, the SUBTOTAL/AGGREGATE collector ops, and the SUMIF/AVERAGEIF family leaked `Number(inf)` where Excel yields `#NUM!`. One `is_finite` branch on the finished reduction per call (arrow kernels untouched). The corpus's inf-pinned-SCC perf trap resolves as designed: the cycle now converges by error-kind in ≤6 passes instead of burning its full pass budget every recalc forever.

**5. Staged-formula dup-scan.** The `NOTE(#126)` linear scan: 50k staged formulas 572ms → 10.5ms (54×) via a coordinate→index map alongside the insertion-ordered Vec (ingest order is consumer-visible, preserved).

Documented-not-fixed, for the record: per-edit `mark_dirty` in ascending edit loops remains O(n²) cross-call (needs a bulk-edit API — the safe multi-source fix can't help across calls); `get_eval_plan` builds a schedule per call (inherent to a preview API); warm vertex evaluation verified clone-free (arena AST ids).

Validation: full workspace suite (CI exclusions) **2621 passed, 0 failed** (+2 un-ignored crash repros, +8 new); fmt/clippy/wasm-facade clean. Bench gates: linear-rollup improvement above; finance-recalc and the scc probes mixed-direction within noise across 8 interleaved rounds.
