### PR TITLE
docs(site): cycle detection + iterative calculation guides, reference, and interactive sandboxes

### DIFF
--- a/docs-site/content/docs/core-concepts/dependency-graph-and-recalc.mdx
+++ b/docs-site/content/docs/core-concepts/dependency-graph-and-recalc.mdx
@@ -46,6 +46,8 @@ Recalc order: B1 then C1
 
 Cycles are detected during graph construction. When a circular dependency is found, the anchor cell receives a `#CIRC!` error. The dependency graph uses topological sorting; if sorting fails (cycle detected), the involved cells are marked with the circular reference error. Downstream dependents of a cycle cell also receive errors.
 
+This is the default `Static` behavior. Two opt-in modes change it: [runtime cycle detection](/docs/guides/circular-references-and-cycle-detection) lets guarded/routing-switch cycles resolve to values, and [iterative calculation](/docs/guides/iterative-calculation) settles genuinely circular cycles Excel-style. See the [Cycle Configuration Reference](/docs/reference/cycle-config) for the full surface.
+
 ## Partial recalculation
 
 For a 10,000-row sheet where only one input cell changes, the engine marks only the dependent subgraph dirty. If only 50 cells depend on that input (directly or transitively), only those 50 are re-evaluated rather than all 10,000 rows. The `evaluate_cells` API allows targeting specific cells for even more precise control.

--- a/docs-site/content/docs/guides/circular-references-and-cycle-detection.mdx
+++ b/docs-site/content/docs/guides/circular-references-and-cycle-detection.mdx
@@ -1,0 +1,141 @@
+---
+title: Circular References and Runtime Cycle Detection
+description: Resolve guarded and routing-switch cycles to values with runtime cycle detection, while real cycles still surface #CIRC!.
+---
+
+By default, Formualizer treats every statically circular group of cells as an error: it stamps each member `#CIRC!` the moment the dependency graph closes a loop. That is correct for genuine circular references, but it is too aggressive for a common class of spreadsheet that is only *structurally* circular — the live data path never actually loops.
+
+**Runtime cycle detection** (RFC [#112](https://github.com/PSU3D0/formualizer/pull/112)) keeps the static cycle as a *candidate*, then watches the edges that actually fire during evaluation. If the live edges are acyclic, the cells get ordinary values; only cells that participate in a real, live cycle receive `#CIRC!`.
+
+## The problem: guarded and routing-switch cycles
+
+Consider the classic guarded pair from discussion [#99](https://github.com/PSU3D0/formualizer/discussions/99):
+
+```text
+A1 = TRUE              (a boolean guard)
+A2 = IF(A1, 555, A3)
+A3 = IF(A1, A2, 999)
+```
+
+A2 references A3 and A3 references A2, so the *static* graph has a cycle. But for any concrete value of the guard, only one branch of each `IF` is live:
+
+- `A1 = TRUE`  → A2 takes `555`, A3 takes `A2` → both resolve to `555`.
+- `A1 = FALSE` → A2 takes `A3`, A3 takes `999` → both resolve to `999`.
+
+The same shape shows up in routing switches (a `CHOOSE`/`SWITCH` that selects one of several mutually-referencing branches) and in many financial models. Under static detection these all collapse to `#CIRC!`, even though no value ever depends on itself.
+
+## Static vs Runtime detection
+
+`CycleDetection` has two modes:
+
+| Mode | Behavior | Default |
+|------|----------|---------|
+| `Static` | Every static SCC is stamped `#CIRC!` on sight. No live-edge machinery runs. | Yes |
+| `Runtime` | Static SCCs are candidates; members evaluate with live-edge recording, and only *live* cycles get the policy verdict. | Opt-in |
+
+`Static` remains the default, byte-for-byte compatible with prior releases. `Runtime` is strictly opt-in.
+
+Under `Runtime`, a static SCC whose live edges turn out to be acyclic is called a **phantom cycle**. Phantom cycles produce ordinary values; they are not errors and do not count toward cycle telemetry.
+
+## Try it
+
+Toggle the guard cell and watch the values flip. Switch the detection mode to **Static** to see the same workbook collapse to `#CIRC!`.
+
+<GuardedPairSandbox />
+
+## Configuration
+
+Runtime detection is set on the engine's cycle config. The policy for *live* cycles stays `Error` here — we are only changing how candidates are confirmed, not what happens to real cycles.
+
+<CodeTabs
+  title="Enable runtime cycle detection"
+  rust={`use formualizer_eval::engine::{CycleConfig, CycleDetection, CyclePolicy, EvalConfig};
+use formualizer_workbook::{Workbook, WorkbookConfig};
+
+let mut cfg = WorkbookConfig::interactive();
+cfg.eval = cfg.eval.with_cycle(CycleConfig {
+    detection: CycleDetection::Runtime,
+    policy: CyclePolicy::Error, // live cycles still produce #CIRC!
+});
+
+let mut wb = Workbook::new_with_config(cfg);
+wb.add_sheet("Sheet1")?;
+wb.set_value("Sheet1", 1, 1, true.into())?;            // A1 guard
+wb.set_formula("Sheet1", 2, 1, "=IF(A1,555,A3)")?;     // A2
+wb.set_formula("Sheet1", 3, 1, "=IF(A1,A2,999)")?;     // A3
+wb.evaluate_all()?;
+assert_eq!(wb.evaluate_cell("Sheet1", 2, 1)?, 555.0.into());`}
+  python={`import formualizer as fz
+
+cfg = fz.EvaluationConfig()
+cfg.cycle_detection = "runtime"   # "static" (default) | "runtime"
+cfg.cycle_policy = "error"        # live cycles still produce #CIRC!
+
+wb = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))
+wb.add_sheet("Sheet1")
+wb.set_value("Sheet1", 1, 1, True)              # A1 guard
+wb.set_formula("Sheet1", 2, 1, "=IF(A1,555,A3)")  # A2
+wb.set_formula("Sheet1", 3, 1, "=IF(A1,A2,999)")  # A3
+wb.evaluate_all()
+assert wb.get_value("Sheet1", 2, 1) == 555.0`}
+  ts={`import init, { Workbook } from "formualizer";
+
+await init();
+
+// The cycle config flows through the *load* entry points
+// (fromJsonWithOptions / fromXlsxBytesWithOptions), not the plain
+// constructor. Build a small JSON workbook and pass the options.
+const json = JSON.stringify({
+  version: 1,
+  sheets: {
+    Sheet1: {
+      cells: [
+        { row: 1, col: 1, value: { type: "Boolean", value: true } }, // A1
+        { row: 2, col: 1, formula: "=IF(A1,555,A3)" },                // A2
+        { row: 3, col: 1, formula: "=IF(A1,A2,999)" },                // A3
+      ],
+    },
+  },
+});
+
+const wb = Workbook.fromJsonWithOptions(json, { cycleDetection: "runtime" });
+wb.evaluateAll();
+console.log(wb.evaluateCell("Sheet1", 2, 1)); // 555`}
+  runnable={false}
+/>
+
+<Callout type="info">
+In the WASM binding, cycle config is accepted only through the load entry points
+(`fromJsonWithOptions`, `fromXlsxBytesWithOptions`). The plain `new Workbook()`
+constructor always uses the default (`Static` / `Error`). Build a JSON or XLSX
+workbook and load it with options to opt into runtime detection.
+</Callout>
+
+## What changes (and what does not)
+
+- **Phantom cycles produce values.** A static SCC whose live edges are acyclic resolves to ordinary values.
+- **Real cycles still get `#CIRC!`.** A genuinely live cycle (for example `A1 = B1 + 1`, `B1 = A1 + 1`) is confined to its live-cycle members and stamped `#CIRC!`.
+- **Blast radius is the live cycle, not the static SCC.** Only cells on the live loop are stamped. A member of the static SCC that is *not* on the live loop keeps its value.
+- **Direct self-reference is still rejected at edit time.** Writing `=A1+1` into `A1` is refused when the formula is set ("Self-reference detected") in both modes; runtime detection does not relax that ingest rule. (Iterative calculation is the exception — see the [iterative calculation guide](/docs/guides/iterative-calculation).)
+- **Determinism is preserved.** Members are evaluated in a stable order, so a given workbook + guard state always produces the same values.
+
+## Telemetry
+
+Under runtime detection the engine records per-recalc cycle counters. The Python binding exposes them via `Workbook.last_cycle_telemetry()`:
+
+```python
+t = wb.last_cycle_telemetry()
+print(t.static_sccs)          # static SCCs considered this recalc
+print(t.phantom_sccs)         # SCCs that turned out acyclic at runtime
+print(t.live_cycles_witnessed)
+print(t.circ_cells_stamped)   # cells stamped #CIRC!
+```
+
+The WASM binding does not expose telemetry today; its cycle surface is config-only.
+
+## Related
+
+- [Iterative Calculation (Excel Parity)](/docs/guides/iterative-calculation)
+- [Cycle Configuration Reference](/docs/reference/cycle-config)
+- [Dependency Graph and Recalculation](/docs/core-concepts/dependency-graph-and-recalc)
+- [Errors and Types](/docs/reference/errors-and-types)

--- a/docs-site/content/docs/guides/index.mdx
+++ b/docs-site/content/docs/guides/index.mdx
@@ -8,6 +8,8 @@ Use this section when you already know the basics and need concrete integration 
 ## In this section
 
 - [Workbook Edits and Batching](/docs/guides/workbook-edits-and-batching): grouped writes, undo boundaries, and evaluation patterns.
+- [Circular References and Runtime Cycle Detection](/docs/guides/circular-references-and-cycle-detection): resolve guarded and routing-switch cycles to values.
+- [Iterative Calculation (Excel Parity)](/docs/guides/iterative-calculation): convergent cycles, accumulators, and `calcPr` round-trip.
 - [Custom Functions (Rust, Python, JS)](/docs/guides/custom-functions-rust-python-js): callback registration semantics and runtime parity.
 - [WASM Plugins: Inspect, Attach, Bind](/docs/guides/wasm-plugins-inspect-attach-bind): Rust plugin lifecycle with feature/runtime gating.
 - [LET/LAMBDA and Callables](/docs/guides/let-lambda-and-callables): currently implemented callable semantics and edge cases.

--- a/docs-site/content/docs/guides/iterative-calculation.mdx
+++ b/docs-site/content/docs/guides/iterative-calculation.mdx
@@ -1,0 +1,153 @@
+---
+title: Iterative Calculation (Excel Parity)
+description: Enable Excel-style iterative calculation for convergent cycles, accumulators, and self-referential timestamps, with convergence semantics and XLSX calcPr round-trip.
+---
+
+Some spreadsheets *intentionally* depend on a value computed from themselves: a circular interest calculation, a mutual fixed-point, an accumulator that advances one step per recalc, or a self-referential timestamp. Excel supports these through **iterative calculation** — it re-runs the circular group until the numbers settle or a pass budget is exhausted.
+
+Formualizer ships the same behavior under `CyclePolicy::Iterate` (RFC [#113](https://github.com/PSU3D0/formualizer/pull/113)). It builds on [runtime cycle detection](/docs/guides/circular-references-and-cycle-detection): iteration requires `CycleDetection::Runtime`, and selecting the iterate policy promotes detection to runtime automatically.
+
+## Enabling iterative calculation
+
+Iterative calculation has two knobs, with Excel's defaults:
+
+- **`max_iterations`** — total passes per cycle per recalc (Excel default **100**). `1` means each member evaluates exactly once per recalc (the accumulator contract). `0` is a config error.
+- **`max_change`** — the absolute convergence threshold (Excel default **0.001**). A member is settled when `|Δ| < max_change`. Negative or non-finite values are config errors.
+
+<CodeTabs
+  title="Enable Excel-default iterative calculation"
+  rust={`use formualizer_eval::engine::CycleConfig;
+use formualizer_workbook::{Workbook, WorkbookConfig};
+
+let mut cfg = WorkbookConfig::interactive();
+// Runtime detection + Iterate { max_iterations: 100, max_change: 0.001 }
+cfg.eval = cfg.eval.with_cycle(CycleConfig::iterate_excel_defaults());
+// ...or explicit knobs: CycleConfig::iterate(50, 0.0001)
+
+let mut wb = Workbook::new_with_config(cfg);`}
+  python={`import formualizer as fz
+
+cfg = fz.EvaluationConfig()
+cfg.cycle_policy = "iterate"        # promotes detection to "runtime"
+cfg.iterate_max_iterations = 100    # Excel default
+cfg.iterate_max_change = 0.001      # Excel default
+
+wb = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))`}
+  ts={`import init, { Workbook } from "formualizer";
+
+await init();
+
+// Cycle config flows through the load entry points. Setting cyclePolicy
+// "iterate" (or any iterate* knob) implies runtime detection.
+const wb = Workbook.fromJsonWithOptions(json, {
+  cyclePolicy: "iterate",
+  iterateMaxIterations: 100,
+  iterateMaxChange: 0.001,
+});`}
+  runnable={false}
+/>
+
+## Convergence semantics, in user terms
+
+- **`max_change` is absolute.** A member converges when its value moves by less than `max_change` between passes — there is no relative/percentage mode. The comparison is strict (`|Δ| < max_change`), matching Excel.
+- **Members run in a stable order, committing as they go.** Within a pass the engine evaluates each cycle member in order and commits each result before the next member runs (Gauss–Seidel), so later members in the same pass already see the updated values.
+- **Hitting the cap is not an error.** When a cycle does not converge within `max_iterations` passes, the engine keeps the last values and moves on — exactly like Excel. Telemetry records it as a "capped" cycle, but no `#CIRC!` is stamped.
+
+## Worked examples
+
+### Circular interest / mutual fixed-point
+
+A pair that settles on a fixed point: `B1 = 0.5*A1 + 0.5*C1`, `C1 = 0.5*B1 + 0.5*D1`, with `A1 = 10`, `D1 = 20`. The exact solution is `B1 = 40/3 ≈ 13.3333`, `C1 = 50/3 ≈ 16.6667`. Drag the max-change slider to watch convergence tighten or loosen.
+
+<ConvergentCycleSandbox />
+
+<CodeTabs
+  title="Convergent pair + read telemetry (Python)"
+  python={`import formualizer as fz
+
+cfg = fz.EvaluationConfig()
+cfg.cycle_policy = "iterate"
+wb = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))
+wb.add_sheet("S")
+wb.set_value("S", 1, 1, 10)   # A1
+wb.set_value("S", 1, 4, 20)   # D1
+wb.set_formula("S", 1, 2, "=0.5*A1 + 0.5*C1")  # B1
+wb.set_formula("S", 1, 3, "=0.5*B1 + 0.5*D1")  # C1
+wb.evaluate_all()
+
+assert abs(wb.get_value("S", 1, 2) - 40 / 3) < 0.01
+
+t = wb.last_cycle_telemetry()
+print("converged:", t.converged_sccs == 1)   # did it converge?
+print("capped:", t.capped_sccs)               # 0 -> settled before the cap
+print("final delta:", t.max_abs_delta_at_stop)`}
+  runnable={false}
+/>
+
+### The accumulator (`=A2+1`, one step per recalc)
+
+With `max_iterations: 1`, a self-referential cell advances exactly one step per recalculation request. Click **Recalc** to tick it up by one each time.
+
+<AccumulatorSandbox />
+
+<CodeTabs
+  title="Accumulator advances once per recalc"
+  python={`import formualizer as fz
+
+cfg = fz.EvaluationConfig()
+cfg.cycle_policy = "iterate"
+cfg.iterate_max_iterations = 1   # one pass per recalc
+wb = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))
+wb.add_sheet("S")
+wb.set_formula("S", 1, 1, "=A1+1")
+
+wb.evaluate_all()
+assert wb.get_value("S", 1, 1) == 1.0   # one step
+wb.evaluate_all()
+assert wb.get_value("S", 1, 1) == 2.0   # another step
+
+# The accumulator never converges, so each recalc caps at one pass.
+assert wb.last_cycle_telemetry().capped_sccs == 1`}
+  runnable={false}
+/>
+
+<Callout type="info">
+With iterative calculation enabled, a direct self-reference like `=A1+1` in `A1`
+is accepted at edit time — this is the one case where the normal
+"Self-reference detected" ingest rejection is lifted, matching Excel.
+</Callout>
+
+### The self-referential timestamp
+
+A cell that stamps "now" the first time it is touched and then holds steady is the iterative form of an audit timestamp: `=IF(A1=0, NOW(), A1)`. With iteration enabled and the input guard transitioning once, the cell records a value and subsequent recalcs leave it in place (the live edge keeps reading the already-stamped value). This is the iterative-calculation idiom behind Excel's "timestamp on entry" trick.
+
+## Reading convergence telemetry
+
+The engine records a `CycleTelemetry` snapshot per recalc, reset at the start of every evaluation request. Useful fields for answering "did it converge?":
+
+| Field | Meaning |
+|-------|---------|
+| `iterated_sccs` | cycles that ran the iterate policy this recalc |
+| `converged_sccs` | cycles that settled within the cap |
+| `capped_sccs` | cycles that hit `max_iterations` (kept last values, not an error) |
+| `settle_passes_total` | total passes across all cycles |
+| `max_passes_single_scc` | worst-case passes for one cycle |
+| `max_abs_delta_at_stop` | largest per-member delta at the stopping point |
+| `elapsed_ms` | wall time spent in cycle settling |
+
+The Python binding exposes this via `Workbook.last_cycle_telemetry()` (see examples above). **The WASM binding is config-only today** — it accepts the iterate config but does not yet surface telemetry.
+
+## XLSX `calcPr` round-trip
+
+Iterative calculation is part of the workbook file format. Formualizer round-trips the `<calcPr>` element (spec §9):
+
+- **Save:** when the active policy is `Iterate`, the written `.xlsx` carries `iterate="1" iterateCount="<max_iterations>" iterateDelta="<max_change>"`. Files saved with iteration enabled open correctly in Excel with the same settings.
+- **Load:** when a loaded `.xlsx` has `iterate="1"`, the engine adopts `Iterate { max_iterations: iterateCount ?? 100, max_change: iterateDelta ?? 0.001 }` and promotes detection to `Runtime`. Files saved by Excel with iteration enabled open correctly here.
+- **File-wins precedence on load.** A loaded file with `iterate="1"` turns iteration on even if your config requested the `Error` policy — the file's calculation settings take precedence. A file with `iterate="0"` (or no `<calcPr>`) leaves your configured policy untouched.
+
+## Related
+
+- [Circular References and Runtime Cycle Detection](/docs/guides/circular-references-and-cycle-detection)
+- [Cycle Configuration Reference](/docs/reference/cycle-config)
+- [Workbook Edits and Batching](/docs/guides/workbook-edits-and-batching)
+- [Python API Map](/docs/reference/python-api-map)

--- a/docs-site/content/docs/guides/meta.json
+++ b/docs-site/content/docs/guides/meta.json
@@ -4,6 +4,8 @@
     "index",
     "workbook-edits-and-batching",
     "large-workbook-performance",
+    "circular-references-and-cycle-detection",
+    "iterative-calculation",
     "custom-functions-rust-python-js",
     "wasm-plugins-inspect-attach-bind",
     "let-lambda-and-callables",

--- a/docs-site/content/docs/reference/cycle-config.mdx
+++ b/docs-site/content/docs/reference/cycle-config.mdx
@@ -1,0 +1,117 @@
+---
+title: Cycle Configuration Reference
+description: The CycleConfig surface — detection modes, policies, iterative-calculation knobs, and how it maps across Rust, Python, and JS/WASM.
+---
+
+Cycle handling is configured through `CycleConfig`, nested under the engine's `EvalConfig` (and therefore reachable from `WorkbookConfig.eval`). It has two parts: a **detection mode** and a **policy** for live cycles.
+
+```text
+CycleConfig {
+  detection: CycleDetection,  // Static (default) | Runtime
+  policy:    CyclePolicy,      // Error (default) | Iterate { max_iterations, max_change }
+}
+```
+
+See the guides for the conceptual model:
+
+- [Circular References and Runtime Cycle Detection](/docs/guides/circular-references-and-cycle-detection)
+- [Iterative Calculation (Excel Parity)](/docs/guides/iterative-calculation)
+
+## `CycleDetection`
+
+| Value | Behavior |
+|-------|----------|
+| `Static` *(default)* | Every static SCC is stamped `#CIRC!`. No live-edge machinery runs. Byte-for-byte compatible with prior releases. |
+| `Runtime` | Static SCCs are candidates; members evaluate with live-edge recording, and only *live* cycles get the policy verdict. Phantom (live-acyclic) SCCs produce ordinary values. |
+
+## `CyclePolicy`
+
+Applies to cycles confirmed *live* under `Runtime` detection.
+
+| Value | Behavior |
+|-------|----------|
+| `Error` *(default)* | Live cycles produce `#CIRC!`. |
+| `Iterate { max_iterations, max_change }` | Excel-style iterative calculation. Live cycles run repeated passes until every member converges or the pass cap is reached. Requires `Runtime` detection. |
+
+### Iterate knobs
+
+| Knob | Excel default | Notes |
+|------|---------------|-------|
+| `max_iterations` | `100` | Total passes per cycle per recalc (pass 1 included). `1` = each member evaluates once per recalc (accumulator contract). `0` is a config error. |
+| `max_change` | `0.001` | Absolute per-member convergence threshold (`|Δ| < max_change`, strict). Negative or non-finite is a config error. |
+
+## Validation rules
+
+A `CycleConfig` is rejected at build time (engine construction, `with_cycle`, or the binding setter) when:
+
+- `Iterate` is combined with `detection: Static` (iteration requires `Runtime`).
+- `Iterate` has `max_iterations == 0`.
+- `Iterate` has a negative or non-finite `max_change`.
+
+Selecting the iterate policy through a binding promotes detection to `Runtime` automatically, so you rarely set both by hand.
+
+## Surface map
+
+<CodeTabs
+  title="Equivalent configuration in each binding"
+  rust={`use formualizer_eval::engine::{CycleConfig, CycleDetection, CyclePolicy};
+
+// Runtime detection only (live cycles still #CIRC!)
+let cfg = CycleConfig { detection: CycleDetection::Runtime, policy: CyclePolicy::Error };
+
+// Excel-default iterative calculation (Runtime + 100 / 0.001)
+let cfg = CycleConfig::iterate_excel_defaults();
+
+// Explicit knobs
+let cfg = CycleConfig::iterate(50, 0.0001);
+
+// Applied via EvalConfig::with_cycle (panics on invalid combos)
+let eval = formualizer_eval::engine::EvalConfig::default().with_cycle(cfg);`}
+  python={`import formualizer as fz
+
+cfg = fz.EvaluationConfig()
+cfg.cycle_detection = "static" | "runtime"   # mode
+cfg.cycle_policy = "error" | "iterate"        # policy ("iterate" -> runtime)
+cfg.iterate_max_iterations = 100              # only meaningful when iterating
+cfg.iterate_max_change = 0.001
+
+wb = fz.Workbook(config=fz.WorkbookConfig(eval_config=cfg))`}
+  ts={`// JS/WASM accepts cycle config only on the load entry points.
+// The plain \`new Workbook()\` constructor always uses defaults.
+const wb = Workbook.fromJsonWithOptions(json, {
+  cycleDetection: "runtime",       // "static" | "runtime"
+  cyclePolicy: "iterate",          // "error" | "iterate" (implies runtime)
+  iterateMaxIterations: 100,
+  iterateMaxChange: 0.001,
+});
+// Also available: Workbook.fromXlsxBytesWithOptions(bytes, options)`}
+  runnable={false}
+/>
+
+## Binding parity notes
+
+| Capability | Rust | Python | JS/WASM |
+|-----------|------|--------|---------|
+| Set detection mode | ✅ | ✅ `cycle_detection` | ✅ `cycleDetection` (load only) |
+| Set policy / iterate knobs | ✅ | ✅ `cycle_policy`, `iterate_*` | ✅ `cyclePolicy`, `iterate*` (load only) |
+| Configure on programmatic (empty) workbook | ✅ | ✅ `Workbook(config=...)` | ❌ constructor takes no options |
+| Read `CycleTelemetry` | ✅ `engine().last_cycle_telemetry()` | ✅ `wb.last_cycle_telemetry()` | ❌ config-only today |
+| XLSX `<calcPr>` round-trip | ✅ | ✅ (via load/save) | ✅ (via `fromXlsxBytesWithOptions`) |
+
+## XLSX `<calcPr>` mapping
+
+| `<calcPr>` attribute | `CycleConfig` |
+|----------------------|---------------|
+| `iterate="1"` | `policy = Iterate`, `detection = Runtime` |
+| `iterateCount="N"` | `max_iterations = N` (defaults to 100 if absent) |
+| `iterateDelta="D"` | `max_change = D` (defaults to 0.001 if absent) |
+| `iterate="0"` / absent `<calcPr>` | config left unchanged on load |
+
+On load, a file with `iterate="1"` wins over a configured `Error` policy (file-wins precedence). On save, an active `Iterate` policy writes the matching `iterate`/`iterateCount`/`iterateDelta` attributes.
+
+## Related
+
+- [Errors and Types](/docs/reference/errors-and-types)
+- [Rust API Map](/docs/reference/rust-api-map)
+- [Python API Map](/docs/reference/python-api-map)
+- [JS/WASM API Map](/docs/reference/js-wasm-api-map)

--- a/docs-site/content/docs/reference/index.mdx
+++ b/docs-site/content/docs/reference/index.mdx
@@ -10,6 +10,7 @@ Use these pages to answer two questions quickly: what surface exists, and where 
 - [Rust API Map](/docs/reference/rust-api-map)
 - [Python API Map](/docs/reference/python-api-map)
 - [JS/WASM API Map](/docs/reference/js-wasm-api-map)
+- [Cycle Configuration Reference](/docs/reference/cycle-config)
 - [Errors and Types](/docs/reference/errors-and-types)
 
 Related sections:

--- a/docs-site/content/docs/reference/meta.json
+++ b/docs-site/content/docs/reference/meta.json
@@ -5,6 +5,7 @@
     "rust-api-map",
     "python-api-map",
     "js-wasm-api-map",
+    "cycle-config",
     "errors-and-types",
     "functions"
   ]

--- a/docs-site/src/components/playground/cycle-sandbox.tsx
+++ b/docs-site/src/components/playground/cycle-sandbox.tsx
@@ -1,0 +1,504 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { loadFormualizer } from "@/lib/wasm/formualizer-loader";
+
+/**
+ * Interactive demos for runtime cycle detection + iterative calculation
+ * (RFCs #112 / #113).
+ *
+ * The new cycle config (`cycleDetection` / `cyclePolicy` /
+ * `iterateMaxIterations` / `iterateMaxChange`) flows through
+ * `Workbook.fromJsonWithOptions(json, options)`. That entry point exists in
+ * published 0.6.x, but the cycle *behavior* it drives only ships in the
+ * post-#131 engine. We therefore feature-detect at runtime: a known-convergent
+ * cycle that still returns `#CIRC!` means the loaded wasm predates the feature,
+ * and the demo renders a "requires a newer build" banner instead of misleading
+ * output.
+ */
+
+type WasmModule = Awaited<ReturnType<typeof loadFormualizer>>;
+type WasmWorkbook = {
+  evaluateAll: () => void;
+  evaluateCell: (sheet: string, row: number, col: number) => unknown;
+};
+
+type CellSpec =
+  | { row: number; col: number; value: number | boolean }
+  | { row: number; col: number; formula: string };
+
+type CycleOptions = {
+  cyclePolicy?: "error" | "iterate";
+  cycleDetection?: "static" | "runtime";
+  iterateMaxIterations?: number;
+  iterateMaxChange?: number;
+};
+
+const SHEET = "Sheet1";
+
+function colToIndex(col: string): number {
+  let n = 0;
+  for (let i = 0; i < col.length; i++) n = n * 26 + (col.charCodeAt(i) - 64);
+  return n;
+}
+
+/** Translate "A1"/"C2" refs into the JSON workbook cell coordinates. */
+function ref(
+  addr: string,
+  payload: { value: number | boolean } | { formula: string },
+): CellSpec {
+  const m = addr.match(/^([A-Z]+)([0-9]+)$/);
+  if (!m) throw new Error(`bad ref ${addr}`);
+  return { row: Number(m[2]), col: colToIndex(m[1]), ...payload } as CellSpec;
+}
+
+function buildJson(cells: CellSpec[]): string {
+  return JSON.stringify({
+    version: 1,
+    sheets: {
+      [SHEET]: {
+        cells: cells.map((c) => {
+          if ("formula" in c)
+            return { row: c.row, col: c.col, formula: c.formula };
+          const value =
+            typeof c.value === "boolean"
+              ? { type: "Boolean", value: c.value }
+              : { type: "Number", value: c.value };
+          return { row: c.row, col: c.col, value };
+        }),
+      },
+    },
+  });
+}
+
+function readCell(wb: WasmWorkbook, addr: string): string {
+  const m = addr.match(/^([A-Z]+)([0-9]+)$/);
+  if (!m) return "—";
+  const out = wb.evaluateCell(SHEET, Number(m[2]), colToIndex(m[1]));
+  if (out === null || out === undefined) return "—";
+  if (typeof out === "number")
+    return Number.isInteger(out) ? String(out) : out.toFixed(4);
+  return String(out);
+}
+
+function evaluate(
+  mod: WasmModule,
+  cells: CellSpec[],
+  options: CycleOptions | null,
+): WasmWorkbook {
+  const json = buildJson(cells);
+  const Workbook = (
+    mod as unknown as {
+      Workbook: {
+        fromJson: (j: string) => WasmWorkbook;
+        fromJsonWithOptions: (j: string, o: unknown) => WasmWorkbook;
+      };
+    }
+  ).Workbook;
+  const wb = options
+    ? Workbook.fromJsonWithOptions(json, options)
+    : Workbook.fromJson(json);
+  wb.evaluateAll();
+  return wb;
+}
+
+/**
+ * Probe whether the loaded wasm honors iterative calculation. A convergent
+ * arithmetic cycle (B1 = 0.5*A1 + 0.5*C1, C1 = 0.5*B1 + 0.5*D1; A1=10, D1=20)
+ * settles to B1 ≈ 13.333 once the feature is present, and returns `#CIRC!`
+ * otherwise.
+ */
+function probeIterativeSupport(mod: WasmModule): boolean {
+  try {
+    const wb = evaluate(
+      mod,
+      [
+        ref("A1", { value: 10 }),
+        ref("D1", { value: 20 }),
+        ref("B1", { formula: "=0.5*A1 + 0.5*C1" }),
+        ref("C1", { formula: "=0.5*B1 + 0.5*D1" }),
+      ],
+      {
+        cyclePolicy: "iterate",
+        iterateMaxIterations: 100,
+        iterateMaxChange: 0.001,
+      },
+    );
+    const b1 = readCell(wb, "B1");
+    return !b1.startsWith("#") && Math.abs(Number(b1) - 40 / 3) < 0.1;
+  } catch {
+    return false;
+  }
+}
+
+function StatusBanner({ supported }: { supported: boolean | null }) {
+  if (supported === null) return null;
+  if (supported) {
+    return (
+      <div className="mb-4 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300">
+        ✓ Live: this page is running runtime cycle detection in your browser via
+        the formualizer WASM build.
+      </div>
+    );
+  }
+  return (
+    <div className="mb-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+      The installed <code>formualizer</code> WASM package does not yet implement
+      runtime cycle detection / iterative calculation, so these demos fall back
+      to read-only previews. They light up automatically once the docs site
+      upgrades to the first release that ships RFC #112 / #113 (the{" "}
+      <code>fromJsonWithOptions</code> cycle config). Until then, the values
+      shown are the documented expected outputs, not live evaluation.
+    </div>
+  );
+}
+
+function Grid({
+  rows,
+}: {
+  rows: { label: string; value: string; note?: string }[];
+}) {
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="w-full border-collapse text-sm">
+        <thead className="bg-fd-muted/50">
+          <tr>
+            <th className="border-b px-3 py-1.5 text-left font-medium text-fd-muted-foreground">
+              Cell
+            </th>
+            <th className="border-b px-3 py-1.5 text-left font-medium text-fd-muted-foreground">
+              Value
+            </th>
+            <th className="border-b px-3 py-1.5 text-left font-medium text-fd-muted-foreground">
+              Notes
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {rows.map((r) => (
+            <tr key={r.label}>
+              <td className="px-3 py-1.5 font-mono text-xs text-fd-muted-foreground">
+                {r.label}
+              </td>
+              <td
+                className={`px-3 py-1.5 font-mono text-xs ${
+                  r.value.startsWith("#")
+                    ? "text-rose-600 dark:text-rose-400"
+                    : "text-fd-foreground"
+                }`}
+              >
+                {r.value}
+              </td>
+              <td className="px-3 py-1.5 text-xs text-fd-muted-foreground">
+                {r.note ?? ""}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* ───────────────────────── (a) Guarded pair (#99) ───────────────────────── */
+
+/**
+ * Discussion #99: A1 is a boolean guard, A2/A3 form a static SCC whose live
+ * edges depend on the guard. Under runtime detection the SCC is a *phantom*
+ * cycle and produces values; under static detection it is stamped `#CIRC!`.
+ */
+export function GuardedPairSandbox() {
+  const [mod, setMod] = useState<WasmModule | null>(null);
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [guard, setGuard] = useState(true);
+  const [mode, setMode] = useState<"runtime" | "static">("runtime");
+
+  useEffect(() => {
+    let cancelled = false;
+    loadFormualizer().then((m) => {
+      if (cancelled) return;
+      setMod(m);
+      setSupported(probeIterativeSupport(m));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const cells = useMemo<CellSpec[]>(
+    () => [
+      ref("A1", { value: guard }),
+      ref("A2", { formula: "=IF(A1,555,A3)" }),
+      ref("A3", { formula: "=IF(A1,A2,999)" }),
+    ],
+    [guard],
+  );
+
+  const rows = useMemo(() => {
+    // Expected values, used both as the live target and as the static preview.
+    const expected = {
+      runtime: guard ? { A2: "555", A3: "555" } : { A2: "999", A3: "999" },
+      static: { A2: "#CIRC!", A3: "#CIRC!" },
+    } as const;
+
+    if (supported && mod) {
+      try {
+        const wb = evaluate(mod, cells, { cycleDetection: mode });
+        return [
+          {
+            label: "A1 (guard)",
+            value: String(guard).toUpperCase(),
+            note: "boolean input",
+          },
+          { label: "A2", value: readCell(wb, "A2"), note: "=IF(A1,555,A3)" },
+          { label: "A3", value: readCell(wb, "A3"), note: "=IF(A1,A2,999)" },
+        ];
+      } catch (e) {
+        return [{ label: "error", value: String(e), note: "" }];
+      }
+    }
+
+    const exp = expected[mode];
+    return [
+      {
+        label: "A1 (guard)",
+        value: String(guard).toUpperCase(),
+        note: "boolean input",
+      },
+      { label: "A2", value: exp.A2, note: "=IF(A1,555,A3)" },
+      { label: "A3", value: exp.A3, note: "=IF(A1,A2,999)" },
+    ];
+  }, [supported, mod, cells, mode, guard]);
+
+  return (
+    <div className="my-6 rounded-xl border bg-fd-card p-4">
+      <StatusBanner supported={supported} />
+      <div className="mb-3 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setGuard((g) => !g)}
+          className="rounded-md bg-fd-primary px-3 py-1.5 text-xs font-medium text-fd-primary-foreground shadow-sm hover:bg-fd-primary/90"
+        >
+          Toggle guard (A1 = {String(guard).toUpperCase()})
+        </button>
+        <div className="flex gap-1 rounded-md border bg-fd-background/50 p-0.5">
+          {(["runtime", "static"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={`rounded-sm px-2.5 py-1 text-xs font-semibold transition-colors ${
+                mode === m
+                  ? "bg-fd-primary text-fd-primary-foreground shadow-sm"
+                  : "text-fd-muted-foreground hover:bg-fd-muted"
+              }`}
+            >
+              {m === "runtime" ? "Runtime detection" : "Static detection"}
+            </button>
+          ))}
+        </div>
+      </div>
+      <Grid rows={rows} />
+      <p className="mt-3 text-xs text-fd-muted-foreground">
+        Under <strong>runtime</strong> detection, only the live edges count —
+        the guarded pair is a phantom cycle and resolves to a value. Flip to{" "}
+        <strong>static</strong> detection (today's default) and the same SCC is
+        stamped <code>#CIRC!</code> on sight.
+      </p>
+    </div>
+  );
+}
+
+/* ─────────────── (b) Convergent circular interest with slider ─────────────── */
+
+/**
+ * A mutual fixed-point: B1 = 0.5*A1 + 0.5*C1, C1 = 0.5*B1 + 0.5*D1, with
+ * A1 = 10, D1 = 20. The exact fixed point is B1 = 40/3, C1 = 50/3. A coarser
+ * max-change threshold stops earlier with a slightly looser result.
+ */
+export function ConvergentCycleSandbox() {
+  const [mod, setMod] = useState<WasmModule | null>(null);
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [maxChange, setMaxChange] = useState(0.001);
+  const [maxIterations, setMaxIterations] = useState(100);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadFormualizer().then((m) => {
+      if (cancelled) return;
+      setMod(m);
+      setSupported(probeIterativeSupport(m));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const cells = useMemo<CellSpec[]>(
+    () => [
+      ref("A1", { value: 10 }),
+      ref("D1", { value: 20 }),
+      ref("B1", { formula: "=0.5*A1 + 0.5*C1" }),
+      ref("C1", { formula: "=0.5*B1 + 0.5*D1" }),
+    ],
+    [],
+  );
+
+  const rows = useMemo(() => {
+    if (supported && mod) {
+      try {
+        const wb = evaluate(mod, cells, {
+          cyclePolicy: "iterate",
+          iterateMaxIterations: maxIterations,
+          iterateMaxChange: maxChange,
+        });
+        return [
+          { label: "A1", value: "10", note: "input" },
+          { label: "D1", value: "20", note: "input" },
+          { label: "B1", value: readCell(wb, "B1"), note: "=0.5*A1 + 0.5*C1" },
+          { label: "C1", value: readCell(wb, "C1"), note: "=0.5*B1 + 0.5*D1" },
+        ];
+      } catch (e) {
+        return [{ label: "error", value: String(e), note: "" }];
+      }
+    }
+    return [
+      { label: "A1", value: "10", note: "input" },
+      { label: "D1", value: "20", note: "input" },
+      {
+        label: "B1",
+        value: (40 / 3).toFixed(4),
+        note: "fixed point ≈ 13.3333",
+      },
+      {
+        label: "C1",
+        value: (50 / 3).toFixed(4),
+        note: "fixed point ≈ 16.6667",
+      },
+    ];
+  }, [supported, mod, cells, maxChange, maxIterations]);
+
+  return (
+    <div className="my-6 rounded-xl border bg-fd-card p-4">
+      <StatusBanner supported={supported} />
+      <div className="mb-4 space-y-3">
+        <label className="block text-xs font-medium text-fd-muted-foreground">
+          Max change (absolute convergence threshold):{" "}
+          <span className="font-mono">{maxChange}</span>
+          <input
+            type="range"
+            min={-6}
+            max={0}
+            step={1}
+            value={Math.log10(maxChange)}
+            onChange={(e) => setMaxChange(10 ** Number(e.target.value))}
+            className="mt-1 w-full"
+          />
+        </label>
+        <label className="block text-xs font-medium text-fd-muted-foreground">
+          Max iterations: <span className="font-mono">{maxIterations}</span>
+          <input
+            type="range"
+            min={1}
+            max={200}
+            step={1}
+            value={maxIterations}
+            onChange={(e) => setMaxIterations(Number(e.target.value))}
+            className="mt-1 w-full"
+          />
+        </label>
+      </div>
+      <Grid rows={rows} />
+      <p className="mt-3 text-xs text-fd-muted-foreground">
+        The pair converges to its fixed point (B1 = 40/3, C1 = 50/3). A coarser{" "}
+        <code>iterateMaxChange</code> stops a pass or two earlier; hitting the
+        iteration cap keeps the last values and is <strong>not</strong> an
+        error.
+      </p>
+    </div>
+  );
+}
+
+/* ─────────────────────────── (c) Accumulator ─────────────────────────── */
+
+/**
+ * The Excel accumulator: A1 = A1 + 1 with maxIterations = 1 advances exactly
+ * once per recalc. Each "Recalc" click is one full evaluation request, so the
+ * counter ticks up by one.
+ */
+export function AccumulatorSandbox() {
+  const [mod, setMod] = useState<WasmModule | null>(null);
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadFormualizer().then((m) => {
+      if (cancelled) return;
+      setMod(m);
+      setSupported(probeIterativeSupport(m));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Live path: rebuild a workbook seeded with the prior value and run one pass.
+  const recalc = useCallback(() => {
+    if (supported && mod) {
+      try {
+        const wb = evaluate(
+          mod,
+          [
+            ref("A1", { value: count }),
+            ref("B1", { formula: "=A1" }),
+            ref("A2", { formula: "=A2+1" }),
+          ],
+          {
+            cyclePolicy: "iterate",
+            iterateMaxIterations: 1,
+            iterateMaxChange: 0.001,
+          },
+        );
+        const next = Number(readCell(wb, "A2"));
+        setCount(Number.isFinite(next) ? next : count + 1);
+        return;
+      } catch {
+        // fall through to the preview increment
+      }
+    }
+    setCount((c) => c + 1);
+  }, [supported, mod, count]);
+
+  return (
+    <div className="my-6 rounded-xl border bg-fd-card p-4">
+      <StatusBanner supported={supported} />
+      <div className="mb-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={recalc}
+          className="rounded-md bg-fd-primary px-3 py-1.5 text-xs font-medium text-fd-primary-foreground shadow-sm hover:bg-fd-primary/90"
+        >
+          Recalc (F9)
+        </button>
+        <span className="text-xs text-fd-muted-foreground">
+          one recalc = one pass under <code>iterateMaxIterations: 1</code>
+        </span>
+      </div>
+      <Grid
+        rows={[
+          {
+            label: "A2",
+            value: String(count),
+            note: "=A2+1 — advances once per recalc",
+          },
+        ]}
+      />
+      <p className="mt-3 text-xs text-fd-muted-foreground">
+        With <code>iterateMaxIterations: 1</code> a self-referential accumulator
+        advances exactly one step per recalculation request, mirroring Excel's
+        manual F9 accumulator pattern.
+      </p>
+    </div>
+  );
+}

--- a/docs-site/src/mdx-components.tsx
+++ b/docs-site/src/mdx-components.tsx
@@ -1,11 +1,16 @@
-import defaultMdxComponents from 'fumadocs-ui/mdx';
-import type { MDXComponents } from 'mdx/types';
-import { FunctionMeta } from '@/components/reference/function-meta';
-import { FunctionPageSchema } from '@/components/reference/function-page-schema';
-import { FunctionSandbox } from '@/components/reference/function-sandbox';
-import { CodeTabs } from '@/components/code/code-tabs';
-import { RunnableCode } from '@/components/code/runnable-code';
-import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import type { MDXComponents } from "mdx/types";
+import { CodeTabs } from "@/components/code/code-tabs";
+import { RunnableCode } from "@/components/code/runnable-code";
+import {
+  AccumulatorSandbox,
+  ConvergentCycleSandbox,
+  GuardedPairSandbox,
+} from "@/components/playground/cycle-sandbox";
+import { FunctionMeta } from "@/components/reference/function-meta";
+import { FunctionPageSchema } from "@/components/reference/function-page-schema";
+import { FunctionSandbox } from "@/components/reference/function-sandbox";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
@@ -15,6 +20,9 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     FunctionSandbox,
     CodeTabs,
     RunnableCode,
+    GuardedPairSandbox,
+    ConvergentCycleSandbox,
+    AccumulatorSandbox,
     Tab,
     Tabs,
     ...components,


### PR DESCRIPTION
Documentation for the #112/#113 features.

**New pages**: a guide for circular references & runtime cycle detection (the #99 routing-switch problem, Static vs Runtime, phantom vs live cycles, blast radius, per-language config); a guide for iterative calculation (Excel-parity defaults, convergence semantics in user terms, worked examples for circular interest, the accumulator pattern, and the self-referential timestamp — values drawn verbatim from the engine's test suite; reading CycleTelemetry from Python; XLSX calcPr round-trip with file-wins precedence); and a CycleConfig reference (knobs, validation rules, per-binding parity table, calcPr attribute mapping). Core-concepts page cross-linked.

**Interactive sandboxes** (three components following the existing FunctionSandbox patterns): the #99 guarded pair with a guard toggle and a Runtime↔Static mode switch; a convergent mutual fixed-point with max-change/max-iterations sliders; the accumulator with a per-click Recalc button.

**Feature-detection, deliberately**: the published `formualizer@0.6.0` wasm accepts the new cycle options on `fromJsonWithOptions` but silently ignores them (the behavior merged post-0.6.0 in #131) — verified empirically. The sandboxes runtime-probe a convergent cycle; until the next npm release they render documented expected outputs behind a "requires a newer formualizer build" banner and light up automatically afterwards. Two binding gaps surfaced and documented: the plain wasm `new Workbook()` cannot set cycle config (only the `*WithOptions` constructors can), and wasm has no telemetry surface yet.

Validation: `bun install`/`bun run build` clean (1410 pages, new pages emit correctly with SSR'd controls), `types:check` clean, touched files biome-clean (pre-existing baseline lint debt untouched, verified identical via stash). No blog post — no blog convention exists on main. Docs-only change; engine untouched.
