### PR TITLE
feat(wasm): cycle config on plain constructor + lastCycleTelemetry(); fix wasm32 clock panic from #134

### DIFF
--- a/bindings/wasm/src/index.ts
+++ b/bindings/wasm/src/index.ts
@@ -300,6 +300,56 @@ export interface SheetPortEvaluateOptions {
   deterministicTimezone?: DeterministicTimezone;
 }
 
+/**
+ * Options accepted by the `Workbook` constructor and the
+ * `fromJsonWithOptions` / `fromXlsxBytesWithOptions` loaders.
+ */
+export interface WorkbookLoadOptions {
+  /** Opt into experimental FormulaPlane span evaluation. */
+  spanEvaluation?: boolean;
+  /** Cycle detection mode (spec §2). */
+  cycleDetection?: 'static' | 'runtime';
+  /** Cycle policy for live cycles (spec §2). `'iterate'` implies runtime detection. */
+  cyclePolicy?: 'error' | 'iterate';
+  /** Iterative-calculation max passes per SCC per recalc (Excel default 100). */
+  iterateMaxIterations?: number;
+  /** Iterative-calculation absolute convergence threshold (Excel default 0.001). */
+  iterateMaxChange?: number;
+}
+
+/**
+ * Per-recalc telemetry from runtime SCC / iterative-calculation evaluation
+ * (RFC #113, spec §10). Counters reset at the start of every evaluation
+ * request; all-zero when cycle detection is `'static'` or nothing cyclic
+ * was evaluated.
+ */
+export interface CycleTelemetry {
+  /** SCC tasks executed (static SCCs that reached Runtime evaluation). */
+  staticSccs: number;
+  /** SCC tasks whose live subgraph was acyclic - values produced. */
+  phantomSccs: number;
+  /** Distinct live cycles witnessed across all SCC tasks. */
+  liveCyclesWitnessed: number;
+  /** Cells stamped `#CIRC!` by Runtime SCC tasks. */
+  circCellsStamped: number;
+  /** Evaluation sweeps over (subsets of) SCC members, totalled across tasks. */
+  settlePassesTotal: number;
+  /** Largest pass count any single SCC task needed. */
+  maxPassesSingleScc: number;
+  /** SCC tasks that entered iterative calculation. */
+  iteratedSccs: number;
+  /** Iterating SCC tasks that stopped because every member converged. */
+  convergedSccs: number;
+  /** SCC tasks that stopped at a pass cap (NOT an error under iterate). */
+  cappedSccs: number;
+  /** Largest |delta| observed in any member's final-pass convergence check. */
+  maxAbsDeltaAtStop: number;
+  /** Identical-bit NaN comparisons treated as converged (spec §6 NaN rule). */
+  nanConverged: number;
+  /** Wall-clock milliseconds spent inside Runtime SCC tasks. */
+  elapsedMs: number;
+}
+
 export interface WorkbookApi extends wasm.Workbook {
   registerFunction(
     name: string,
@@ -308,12 +358,13 @@ export interface WorkbookApi extends wasm.Workbook {
   ): void;
   unregisterFunction(name: string): void;
   listFunctions(): RegisteredFunctionInfo[];
+  lastCycleTelemetry(): CycleTelemetry;
 }
 
 export type XlsxBytesSource = Uint8Array | ArrayBufferLike;
 
 export type WorkbookConstructor = {
-  new (): WorkbookApi;
+  new (options?: WorkbookLoadOptions): WorkbookApi;
   fromJson(json: string): WorkbookApi;
   fromXlsxBytes(bytes: XlsxBytesSource): WorkbookApi;
   prototype: WorkbookApi;
@@ -329,7 +380,7 @@ export type SheetPortSessionConstructor = {
 };
 
 const rawWorkbookCtor = wasm.Workbook as unknown as {
-  new (): WorkbookApi;
+  new (options?: WorkbookLoadOptions): WorkbookApi;
   fromJson(json: string): WorkbookApi;
   fromXlsxBytes(bytes: Uint8Array): WorkbookApi;
   prototype: WorkbookApi;

--- a/bindings/wasm/src/workbook.rs
+++ b/bindings/wasm/src/workbook.rs
@@ -521,9 +521,22 @@ impl Drop for Workbook {
 
 #[wasm_bindgen]
 impl Workbook {
+    /// Construct an empty workbook, optionally with load options, e.g.
+    /// `{ cyclePolicy: "iterate", iterateMaxIterations: 50 }` to enable
+    /// iterative calculation for circular references (RFC #113, spec §2).
+    ///
+    /// `new Workbook()` (no arguments) behaves exactly as before: the
+    /// missing/undefined/null options map to the default interactive config.
     #[wasm_bindgen(constructor)]
-    pub fn new() -> Workbook {
-        Workbook::default()
+    pub fn new(options: Option<JsValue>) -> Result<Workbook, JsValue> {
+        let cfg = workbook_config_from_options(options)?;
+        Ok(Workbook {
+            inner: Arc::new(RwLock::new(
+                formualizer::workbook::Workbook::new_with_config(cfg),
+            )),
+            cancel_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            callback_ids: Arc::new(RwLock::new(BTreeMap::new())),
+        })
     }
 
     /// Construct from a JSON workbook string (feature: json)
@@ -1066,6 +1079,79 @@ impl Workbook {
             .map_err(|_| js_error("failed to lock workbook for write"))?
             .redo()
             .map_err(|e| js_error(format!("redo failed: {e}")))
+    }
+
+    /// Telemetry from runtime SCC / iterative-calculation evaluation during
+    /// the most recent evaluation request (RFC #113, spec §10).
+    ///
+    /// Mirrors the engine accessor of the same name: counters reset at the
+    /// start of every evaluation request, so this always describes the LAST
+    /// `evaluateAll()` / `evaluateCell(s)` call. All-zero when cycle
+    /// detection is `"static"` or nothing cyclic was evaluated.
+    #[wasm_bindgen(js_name = "lastCycleTelemetry")]
+    pub fn last_cycle_telemetry(&self) -> Result<JsValue, JsValue> {
+        let wb = self
+            .inner
+            .read()
+            .map_err(|_| js_error("failed to lock workbook for read"))?;
+        let t = wb.engine().last_cycle_telemetry();
+
+        let obj = js_sys::Object::new();
+        set(&obj, "staticSccs", JsValue::from_f64(t.static_sccs as f64))?;
+        set(
+            &obj,
+            "phantomSccs",
+            JsValue::from_f64(t.phantom_sccs as f64),
+        )?;
+        set(
+            &obj,
+            "liveCyclesWitnessed",
+            JsValue::from_f64(t.live_cycles_witnessed as f64),
+        )?;
+        set(
+            &obj,
+            "circCellsStamped",
+            JsValue::from_f64(t.circ_cells_stamped as f64),
+        )?;
+        set(
+            &obj,
+            "settlePassesTotal",
+            JsValue::from_f64(t.settle_passes_total as f64),
+        )?;
+        set(
+            &obj,
+            "maxPassesSingleScc",
+            JsValue::from_f64(t.max_passes_single_scc as f64),
+        )?;
+        set(
+            &obj,
+            "iteratedSccs",
+            JsValue::from_f64(t.iterated_sccs as f64),
+        )?;
+        set(
+            &obj,
+            "convergedSccs",
+            JsValue::from_f64(t.converged_sccs as f64),
+        )?;
+        set(&obj, "cappedSccs", JsValue::from_f64(t.capped_sccs as f64))?;
+        set(
+            &obj,
+            "maxAbsDeltaAtStop",
+            JsValue::from_f64(t.max_abs_delta_at_stop),
+        )?;
+        set(
+            &obj,
+            "nanConverged",
+            JsValue::from_f64(t.nan_converged as f64),
+        )?;
+        // u128 -> u64 saturation mirrors the Python binding; the u64 -> f64
+        // conversion is then lossless for any realistic duration.
+        set(
+            &obj,
+            "elapsedMs",
+            JsValue::from_f64(u64::try_from(t.elapsed_ms).unwrap_or(u64::MAX) as f64),
+        )?;
+        Ok(obj.into())
     }
 
     pub(crate) fn inner_arc(&self) -> Arc<RwLock<formualizer::workbook::Workbook>> {

--- a/bindings/wasm/tests/wasm.rs
+++ b/bindings/wasm/tests/wasm.rs
@@ -313,7 +313,7 @@ fn test_error_handling() {
 
 #[wasm_bindgen_test]
 fn test_workbook_rejects_zero_based_coords() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
 
     let err = wb
@@ -336,7 +336,7 @@ fn test_workbook_rejects_zero_based_coords() {
 
 #[wasm_bindgen_test]
 fn test_sheet_rejects_zero_based_coords() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
     let sheet = wb.sheet("Sheet1".to_string()).unwrap();
 
@@ -361,7 +361,7 @@ fn test_array_formula() {
 
 #[wasm_bindgen_test]
 fn test_get_eval_plan_builds_graph_by_default_for_deferred_workbooks() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
     wb.set_value("Sheet1".to_string(), 1, 1, JsValue::from_f64(123.0))
         .unwrap();
@@ -386,7 +386,7 @@ fn test_get_eval_plan_builds_graph_by_default_for_deferred_workbooks() {
 
 #[wasm_bindgen_test]
 fn test_get_eval_plan_can_disable_implicit_graph_build() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
     wb.set_value("Sheet1".to_string(), 1, 1, JsValue::from_f64(123.0))
         .unwrap();
@@ -415,7 +415,7 @@ fn test_get_eval_plan_can_disable_implicit_graph_build() {
 
 #[wasm_bindgen_test]
 fn test_workbook_sheet_eval() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Data".to_string()).unwrap();
     // Set values via workbook
     wb.set_value("Data".to_string(), 1, 1, JsValue::from_f64(1.0))
@@ -463,7 +463,7 @@ fn test_workbook_from_xlsx_bytes_evaluates_formula() {
 
 #[wasm_bindgen_test]
 fn test_register_simple_function_and_evaluate() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
 
     let callback = Function::new_with_args("a, b", "return a + b;");
@@ -489,7 +489,7 @@ fn test_register_simple_function_and_evaluate() {
 
 #[wasm_bindgen_test]
 fn test_case_insensitive_name_lookup_and_unregistration() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
 
     let callback = Function::new_with_args("x", "return x + 1;");
@@ -521,7 +521,7 @@ fn test_case_insensitive_name_lookup_and_unregistration() {
 
 #[wasm_bindgen_test]
 fn test_override_builtin_requires_explicit_opt_in() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
 
     let blocked = wb.register_function(
@@ -561,7 +561,7 @@ fn test_override_builtin_requires_explicit_opt_in() {
 
 #[wasm_bindgen_test]
 fn test_register_array_mapping_behavior() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
 
     wb.set_value("Sheet1".to_string(), 1, 1, JsValue::from_f64(1.0))
@@ -607,7 +607,7 @@ fn test_register_array_mapping_behavior() {
 
 #[wasm_bindgen_test]
 fn test_register_function_js_throw_maps_to_excel_error() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
 
     let callback = Function::new_with_args("x", "throw new Error('kaboom\\ninternal');");
@@ -639,7 +639,7 @@ fn test_register_function_js_throw_maps_to_excel_error() {
 
 #[wasm_bindgen_test]
 fn test_unregister_function_behavior() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Sheet1".to_string()).unwrap();
 
     let callback = Function::new_with_args("", "return 7;");
@@ -667,7 +667,7 @@ fn test_unregister_function_behavior() {
 
 #[wasm_bindgen_test]
 fn test_list_functions_metadata_contents() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
 
     wb.register_function(
         "alpha".to_string(),
@@ -721,7 +721,7 @@ fn test_list_functions_metadata_contents() {
 
 #[wasm_bindgen_test]
 fn test_changelog_undo_redo() {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("S".to_string()).unwrap();
     wb.set_changelog_enabled(true).unwrap();
     wb.set_value("S".to_string(), 1, 1, JsValue::from_f64(10.0))
@@ -818,7 +818,7 @@ ports:
 "#;
 
 fn build_sheetport_workbook() -> Workbook {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Inputs".to_string()).unwrap();
     wb.add_sheet("Outputs".to_string()).unwrap();
 
@@ -834,7 +834,7 @@ fn build_sheetport_workbook() -> Workbook {
 }
 
 fn build_now_today_workbook() -> Workbook {
-    let wb = Workbook::new();
+    let wb = Workbook::new(None).unwrap();
     wb.add_sheet("Outputs".to_string()).unwrap();
     wb.set_formula("Outputs".to_string(), 1, 1, "NOW()".to_string())
         .unwrap();
@@ -1083,6 +1083,109 @@ fn test_sheetport_session_rejects_non_integer_rng_seed() {
             .unwrap()
             .contains("non-negative safe integer")
     );
+}
+
+const CYCLE_TELEMETRY_KEYS: [&str; 12] = [
+    "staticSccs",
+    "phantomSccs",
+    "liveCyclesWitnessed",
+    "circCellsStamped",
+    "settlePassesTotal",
+    "maxPassesSingleScc",
+    "iteratedSccs",
+    "convergedSccs",
+    "cappedSccs",
+    "maxAbsDeltaAtStop",
+    "nanConverged",
+    "elapsedMs",
+];
+
+#[wasm_bindgen_test]
+fn test_constructor_without_options_constructs_and_evaluates() {
+    let wb = Workbook::new(None).unwrap();
+    wb.add_sheet("Sheet1".to_string()).unwrap();
+    wb.set_value("Sheet1".to_string(), 1, 1, JsValue::from_f64(2.0))
+        .unwrap();
+    wb.set_formula("Sheet1".to_string(), 1, 2, "=A1*3".to_string())
+        .unwrap();
+
+    let value = wb.evaluate_cell("Sheet1".to_string(), 1, 2).unwrap();
+    assert_eq!(value.as_f64().unwrap(), 6.0);
+}
+
+#[wasm_bindgen_test]
+fn test_constructor_with_iterate_options_converges_and_reports_telemetry() {
+    let options = Object::new();
+    set_prop(&options, "cyclePolicy", JsValue::from_str("iterate"));
+    set_prop(&options, "iterateMaxIterations", JsValue::from_f64(50.0));
+    set_prop(&options, "iterateMaxChange", JsValue::from_f64(0.0001));
+
+    let wb = Workbook::new(Some(options.into())).unwrap();
+    wb.add_sheet("S".to_string()).unwrap();
+    // Convergent circular pair: A1 = B1*0.5 + 1, B1 = A1*0.5 + 1 -> both 2.
+    wb.set_formula("S".to_string(), 1, 1, "=B1*0.5+1".to_string())
+        .unwrap();
+    wb.set_formula("S".to_string(), 1, 2, "=A1*0.5+1".to_string())
+        .unwrap();
+    wb.evaluate_all().unwrap();
+
+    let sheet = wb.sheet("S".to_string()).unwrap();
+    let a1 = sheet.get_value(1, 1).unwrap().as_f64().unwrap();
+    let b1 = sheet.get_value(1, 2).unwrap().as_f64().unwrap();
+    assert!(
+        (a1 - 2.0).abs() < 0.01,
+        "A1 should converge near 2, got {a1}"
+    );
+    assert!(
+        (b1 - 2.0).abs() < 0.01,
+        "B1 should converge near 2, got {b1}"
+    );
+
+    let telemetry: Object = wb.last_cycle_telemetry().unwrap().dyn_into().unwrap();
+    assert!(js_get_f64(&telemetry, "iteratedSccs") >= 1.0);
+    assert!(js_get_f64(&telemetry, "convergedSccs") >= 1.0);
+}
+
+#[wasm_bindgen_test]
+fn test_constructor_with_invalid_cycle_policy_throws() {
+    let options = Object::new();
+    set_prop(&options, "cyclePolicy", JsValue::from_str("bogus"));
+
+    let err = Workbook::new(Some(options.into()))
+        .err()
+        .expect("constructor should reject bogus cyclePolicy");
+    let error: js_sys::Error = err.dyn_into().unwrap();
+    assert!(
+        error
+            .message()
+            .as_string()
+            .unwrap()
+            .contains("invalid cyclePolicy")
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_last_cycle_telemetry_without_cycles_is_all_zero() {
+    let wb = Workbook::new(None).unwrap();
+    wb.add_sheet("Sheet1".to_string()).unwrap();
+    wb.set_value("Sheet1".to_string(), 1, 1, JsValue::from_f64(1.0))
+        .unwrap();
+    wb.set_formula("Sheet1".to_string(), 1, 2, "=A1+1".to_string())
+        .unwrap();
+    wb.evaluate_all().unwrap();
+
+    let telemetry: Object = wb.last_cycle_telemetry().unwrap().dyn_into().unwrap();
+    for key in CYCLE_TELEMETRY_KEYS {
+        assert!(
+            Reflect::has(&telemetry, &JsValue::from_str(key)).unwrap(),
+            "telemetry should expose key {key}"
+        );
+        assert_eq!(
+            js_get_f64(&telemetry, key),
+            0.0,
+            "telemetry key {key} should be zero without cycles"
+        );
+    }
 }
 
 #[wasm_bindgen_test]

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -94,9 +94,13 @@ default = ["system-clock"]
 system-clock = ["chrono/clock"]
 
 # js-runtime: opt into browser/wasm-bindgen execution environment.
-# Activates web-time (performance.now Instant) and JS-backed getrandom entropy.
+# Activates web-time (performance.now Instant), JS-backed getrandom entropy,
+# and chrono's JS Date clock (`wasmbind`) so the system-clock profile's
+# ambient `Local::now()` / `Utc::now()` (e.g. the per-recalc volatile clock
+# sample) works on wasm32-unknown-unknown instead of panicking with
+# "time not implemented on this platform".
 # Used by the formualizer-wasm binding crate; NOT enabled by default.
-js-runtime = ["dep:web-time", "dep:getrandom", "dep:getrandom02"]
+js-runtime = ["dep:web-time", "dep:getrandom", "dep:getrandom02", "chrono/wasmbind"]
 
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
 tracing_chrome = ["tracing", "dep:tracing-chrome"]


### PR DESCRIPTION
## Summary

Closes the two WASM gaps noted in the iterative-calc docs work (#137): the plain `new Workbook()` constructor could not set cycle configuration (only the `fromJsonWithOptions` / `fromXlsxBytesWithOptions` loaders could), and WASM had no cycle-telemetry surface at all (Python has had both since #131/#134).

Also fixes a pre-existing CI breakage this PR's gate would otherwise sit on: the WASM workflow has been red on main for the last 4 runs (since #134, last green #131). `Engine::begin_evaluation_request()` refreshes the snapshot clock via `chrono::Local::now()`, which panics on wasm32-unknown-unknown ("time not implemented on this platform"). Enabling `chrono/wasmbind` under the existing `js-runtime` feature routes the clock through JS `Date`; the `portable-wasm` profile is unaffected. Verified locally: `wasm-pack test --node` went from 14 passed / 23 failed (same signature as main CI) to 37 passed / 0 failed.

## API surface

`new Workbook(options?)` now accepts the same options object as the loaders: `{ spanEvaluation?, cycleDetection: "static" | "runtime", cyclePolicy: "error" | "iterate", iterateMaxIterations?, iterateMaxChange? }`, routed through the existing `workbook_config_from_options()` (same validation, same iterate-implies-runtime promotion, same error style). No-arg construction is byte-identical to before.

`workbook.lastCycleTelemetry()` returns a plain object with the full 12-field telemetry in camelCase (`staticSccs`, `phantomSccs`, `liveCyclesWitnessed`, `circCellsStamped`, `settlePassesTotal`, `maxPassesSingleScc`, `iteratedSccs`, `convergedSccs`, `cappedSccs`, `maxAbsDeltaAtStop`, `nanConverged`, `elapsedMs`), mirroring Python's `last_cycle_telemetry()` including the `elapsed_ms` saturation. House-style `js_sys::Object` + `Reflect::set`, matching `eval_plan_to_js`.

TS facade: new exported `WorkbookLoadOptions` and `CycleTelemetry` interfaces; constructor and `WorkbookApi` typings updated.

## Tests

4 new wasm-bindgen-test cases: no-options construction unchanged; iterate options on a convergent pair (A1=B1*0.5+1, B1=A1*0.5+1 → both ≈ 2) with `iteratedSccs >= 1` and `convergedSccs >= 1` in telemetry; invalid `cyclePolicy` throws; no-cycle telemetry has all 12 keys zeroed.

## Validation

cargo fmt --check clean; clippy -p formualizer-wasm (wasm32 target, -D warnings) clean; portable-wasm facade check (-D warnings) clean; workspace test suite (CI exclusions) 2621 passed / 0 failed; wasm-pack build --target bundler clean; wasm-pack test --node 37/37; pnpm build:ts clean.

Refs #113 (iterative calculation), follow-ups noted in the #137 docs work.
