### PR TITLE
perf(workbook): deferred-dirty scope — batch edits run one multi-source propagation (up to 270x)

### DIFF
--- a/crates/formualizer-bench-core/src/bin/probe-edit-storm.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-edit-storm.rs
@@ -1,0 +1,337 @@
+//! Standing probe for bulk-edit dirty-propagation cost ("edit storm").
+//!
+//! Shape under test: K input value cells (`A1:AK`) all feed ONE shared
+//! downstream component — a fan-in-32 rollup tree of `SUM`s over the inputs
+//! plus a K-long arithmetic chain hanging off the rollup root, so the
+//! component downstream of every single input is O(K).
+//!
+//! Each public edit (`Workbook::set_value`) runs a full dirty-propagation
+//! BFS over that component, so a per-cell edit loop is O(K × component) =
+//! O(K²). The batch APIs (`Workbook::set_values`) historically looped the
+//! same single-edit primitive, inheriting the quadratic cost; the deferred-
+//! dirty scope collapses the batch to ONE multi-source BFS = O(component).
+//!
+//! The probe measures, per K and per changelog mode:
+//!   (a) per-cell loop:  K × `wb.set_value(...)`        (edit_ms)
+//!   (b) batch:          one  `wb.set_values(...)` call (edit_ms)
+//! plus the recalc after each edit storm, with value self-checks (rollup
+//! root and chain tail must reflect the new inputs).
+//!
+//! Run (release):
+//! ```bash
+//! cargo run --release -p formualizer-bench-core --features formualizer_runner \
+//!   --bin probe-edit-storm -- --k-list 1000,5000,20000 --changelog both
+//! ```
+
+#[cfg(feature = "formualizer_runner")]
+use std::time::Instant;
+
+#[cfg(feature = "formualizer_runner")]
+use anyhow::{Result, bail};
+#[cfg(feature = "formualizer_runner")]
+use clap::Parser;
+#[cfg(feature = "formualizer_runner")]
+use formualizer_workbook::{LiteralValue, Workbook, WorkbookConfig};
+#[cfg(feature = "formualizer_runner")]
+use serde::Serialize;
+
+#[cfg(not(feature = "formualizer_runner"))]
+fn main() {
+    eprintln!(
+        "This binary requires feature `formualizer_runner`: cargo run -p formualizer-bench-core --features formualizer_runner --bin probe-edit-storm -- ..."
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let report = run_probe(&cli)?;
+    println!("{}", serde_json::to_string(&report)?);
+    Ok(())
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Parser)]
+#[command(about = "Bulk-edit dirty-propagation probe (per-cell loop vs batch set_values)")]
+struct Cli {
+    /// Comma-separated input counts to sweep.
+    #[arg(long, default_value = "1000,5000,20000")]
+    k_list: String,
+
+    /// Changelog modes to measure: `off`, `on`, or `both`.
+    /// `off` = `WorkbookConfig::ephemeral()` (engine fast path);
+    /// `on`  = ephemeral + changelog (the `edit_with_logger` path).
+    #[arg(long, default_value = "both")]
+    changelog: String,
+
+    /// Skip the per-cell loop arm (useful once the quadratic baseline is on
+    /// record and only the batch arm is being tracked).
+    #[arg(long, default_value_t = false)]
+    skip_per_cell: bool,
+
+    #[arg(long, default_value = "phase-candidate")]
+    label: String,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
+struct EditStormProbeReport {
+    label: String,
+    fan_in: usize,
+    scenarios: Vec<ScenarioReport>,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
+struct ScenarioReport {
+    k: usize,
+    changelog: bool,
+    /// Total formula count in the shared component (rollup tree + chain).
+    component_formulas: usize,
+    arms: Vec<ArmReport>,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
+struct ArmReport {
+    /// "per_cell" (K × set_value) or "batch" (one set_values).
+    arm: &'static str,
+    build_ms: f64,
+    initial_eval_ms: f64,
+    /// Wall time of the edit storm itself (the measured quantity).
+    edit_ms: f64,
+    /// Wall time of the recalc that consumes the dirtied component.
+    recalc_ms: f64,
+    /// Root of the rollup tree after the edit recalc (must equal 2K).
+    root_after: f64,
+    /// Chain tail after the edit recalc (must equal 2K + chain_len - 1).
+    chain_tail_after: f64,
+}
+
+#[cfg(feature = "formualizer_runner")]
+const SHEET: &str = "Sheet1";
+#[cfg(feature = "formualizer_runner")]
+const FAN_IN: usize = 32;
+
+/// Column layout: inputs in col 1; rollup tree levels in cols 2, 3, ...;
+/// chain in `chain_col` (first free column after the tree levels).
+#[cfg(feature = "formualizer_runner")]
+struct Fixture {
+    k: usize,
+    chain_col: u32,
+    chain_len: usize,
+    root_col: u32,
+    component_formulas: usize,
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn col_letter(col: u32) -> String {
+    // 1-based column index -> A1 letters.
+    let mut c = col;
+    let mut out = Vec::new();
+    while c > 0 {
+        let rem = ((c - 1) % 26) as u8;
+        out.push(b'A' + rem);
+        c = (c - 1) / 26;
+    }
+    out.reverse();
+    String::from_utf8(out).unwrap()
+}
+
+/// Build the workbook: K inputs (=1), fan-in-32 SUM rollup tree, K-long
+/// chain off the root. Values are inserted before any formula exists and
+/// formulas bottom-up, so build cost stays near-linear even without the
+/// batch fix (each set_formula propagates into a not-yet-built downstream).
+#[cfg(feature = "formualizer_runner")]
+fn build_fixture(wb: &mut Workbook, k: usize) -> Result<Fixture> {
+    // Inputs.
+    let rows: Vec<Vec<LiteralValue>> = (0..k).map(|_| vec![LiteralValue::Int(1)]).collect();
+    wb.set_values(SHEET, 1, 1, &rows)
+        .map_err(|e| anyhow::anyhow!("seed inputs: {e}"))?;
+
+    // Rollup tree: level L in column 1+L sums fan-in-32 groups of level L-1.
+    let mut formula_count = 0usize;
+    let mut level_col = 1u32;
+    let mut level_count = k;
+    while level_count > 1 {
+        let next_col = level_col + 1;
+        let next_count = level_count.div_ceil(FAN_IN);
+        let src = col_letter(level_col);
+        for j in 0..next_count {
+            let start = j * FAN_IN + 1;
+            let end = ((j + 1) * FAN_IN).min(level_count);
+            wb.set_formula(
+                SHEET,
+                j as u32 + 1,
+                next_col,
+                &format!("=SUM({src}{start}:{src}{end})"),
+            )
+            .map_err(|e| anyhow::anyhow!("tree formula: {e}"))?;
+            formula_count += 1;
+        }
+        level_col = next_col;
+        level_count = next_count;
+    }
+    let root_col = level_col;
+
+    // Chain off the root, K cells long, in the next free column.
+    let chain_col = root_col + 1;
+    let chain_len = k;
+    let root = format!("{}1", col_letter(root_col));
+    let chain = col_letter(chain_col);
+    wb.set_formula(SHEET, 1, chain_col, &format!("={root}+0"))
+        .map_err(|e| anyhow::anyhow!("chain head: {e}"))?;
+    formula_count += 1;
+    for i in 2..=chain_len {
+        wb.set_formula(SHEET, i as u32, chain_col, &format!("={chain}{}+1", i - 1))
+            .map_err(|e| anyhow::anyhow!("chain formula: {e}"))?;
+        formula_count += 1;
+    }
+
+    Ok(Fixture {
+        k,
+        chain_col,
+        chain_len,
+        root_col,
+        component_formulas: formula_count,
+    })
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn num(wb: &Workbook, row: u32, col: u32) -> Result<f64> {
+    match wb.get_value(SHEET, row, col) {
+        Some(LiteralValue::Number(n)) => Ok(n),
+        Some(LiteralValue::Int(i)) => Ok(i as f64),
+        other => bail!("expected number at r{row}c{col}, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn check_fixture(wb: &Workbook, fx: &Fixture, input_value: f64) -> Result<(f64, f64)> {
+    let expected_root = input_value * fx.k as f64;
+    let root = num(wb, 1, fx.root_col)?;
+    if (root - expected_root).abs() > 1e-6 {
+        bail!("rollup root {root} != expected {expected_root}");
+    }
+    let expected_tail = expected_root + (fx.chain_len as f64 - 1.0);
+    let tail = num(wb, fx.chain_len as u32, fx.chain_col)?;
+    if (tail - expected_tail).abs() > 1e-6 {
+        bail!("chain tail {tail} != expected {expected_tail}");
+    }
+    Ok((root, tail))
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn make_workbook(changelog: bool) -> Workbook {
+    let mut config = WorkbookConfig::ephemeral();
+    config.enable_changelog = changelog;
+    Workbook::new_with_config(config)
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn run_arm(k: usize, changelog: bool, arm: &'static str) -> Result<(ArmReport, usize)> {
+    let mut wb = make_workbook(changelog);
+    let build_start = Instant::now();
+    let fx = build_fixture(&mut wb, k)?;
+    let build_ms = build_start.elapsed().as_secs_f64() * 1000.0;
+
+    let eval_start = Instant::now();
+    wb.evaluate_all()
+        .map_err(|e| anyhow::anyhow!("initial evaluate_all: {e}"))?;
+    let initial_eval_ms = eval_start.elapsed().as_secs_f64() * 1000.0;
+    check_fixture(&wb, &fx, 1.0)?;
+
+    // Edit storm: rewrite every input to 2.
+    let edit_ms = match arm {
+        "per_cell" => {
+            let start = Instant::now();
+            for r in 1..=k as u32 {
+                wb.set_value(SHEET, r, 1, LiteralValue::Number(2.0))
+                    .map_err(|e| anyhow::anyhow!("per-cell set_value: {e}"))?;
+            }
+            start.elapsed().as_secs_f64() * 1000.0
+        }
+        "batch" => {
+            let rows: Vec<Vec<LiteralValue>> =
+                (0..k).map(|_| vec![LiteralValue::Number(2.0)]).collect();
+            let start = Instant::now();
+            wb.set_values(SHEET, 1, 1, &rows)
+                .map_err(|e| anyhow::anyhow!("batch set_values: {e}"))?;
+            start.elapsed().as_secs_f64() * 1000.0
+        }
+        other => bail!("unknown arm {other}"),
+    };
+
+    let recalc_start = Instant::now();
+    wb.evaluate_all()
+        .map_err(|e| anyhow::anyhow!("post-edit evaluate_all: {e}"))?;
+    let recalc_ms = recalc_start.elapsed().as_secs_f64() * 1000.0;
+    let (root_after, chain_tail_after) = check_fixture(&wb, &fx, 2.0)?;
+
+    Ok((
+        ArmReport {
+            arm,
+            build_ms,
+            initial_eval_ms,
+            edit_ms,
+            recalc_ms,
+            root_after,
+            chain_tail_after,
+        },
+        fx.component_formulas,
+    ))
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn run_probe(cli: &Cli) -> Result<EditStormProbeReport> {
+    let ks: Vec<usize> = cli
+        .k_list
+        .split(',')
+        .map(|s| s.trim().parse::<usize>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| anyhow::anyhow!("--k-list parse: {e}"))?;
+    if ks.is_empty() || ks.iter().any(|&k| k < FAN_IN) {
+        bail!("--k-list needs at least one K >= {FAN_IN}");
+    }
+    let changelog_modes: Vec<bool> = match cli.changelog.as_str() {
+        "off" => vec![false],
+        "on" => vec![true],
+        "both" => vec![false, true],
+        other => bail!("--changelog must be off|on|both, got {other}"),
+    };
+
+    let mut scenarios = Vec::new();
+    for &k in &ks {
+        for &changelog in &changelog_modes {
+            let mut arms = Vec::new();
+            let mut component_formulas = 0usize;
+            let arm_names: &[&'static str] = if cli.skip_per_cell {
+                &["batch"]
+            } else {
+                &["per_cell", "batch"]
+            };
+            for &arm in arm_names {
+                let (report, formulas) = run_arm(k, changelog, arm)?;
+                eprintln!(
+                    "[edit-storm] k={k} changelog={changelog} arm={arm}: edit {:.1} ms, recalc {:.1} ms (build {:.1} ms, initial eval {:.1} ms)",
+                    report.edit_ms, report.recalc_ms, report.build_ms, report.initial_eval_ms
+                );
+                component_formulas = formulas;
+                arms.push(report);
+            }
+            scenarios.push(ScenarioReport {
+                k,
+                changelog,
+                component_formulas,
+                arms,
+            });
+        }
+    }
+
+    Ok(EditStormProbeReport {
+        label: cli.label.clone(),
+        fan_in: FAN_IN,
+        scenarios,
+    })
+}

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -7439,6 +7439,31 @@ where
         self.graph.end_batch();
     }
 
+    /// Begin a deferred-dirty scope for a multi-edit batch: while active,
+    /// every edit's dirty propagation queues its sources instead of running
+    /// a full BFS per edit, and the outermost `end_deferred_dirty` flushes
+    /// the union with ONE multi-source propagation (O(component) instead of
+    /// O(edits × component)). See `DependencyGraph::begin_deferred_dirty`.
+    ///
+    /// Callers MUST run `end_deferred_dirty` on every exit path, including
+    /// error returns; evaluation entry points `debug_assert` no scope leaked.
+    pub fn begin_deferred_dirty(&mut self) {
+        self.graph.begin_deferred_dirty();
+    }
+
+    /// End a deferred-dirty scope, flushing the queued propagation when the
+    /// outermost scope closes. See `Engine::begin_deferred_dirty`.
+    pub fn end_deferred_dirty(&mut self) {
+        let _ = self.graph.end_deferred_dirty();
+    }
+
+    /// Total vertices processed by dirty-propagation BFS loops since graph
+    /// creation. Perf-shape observability only (cross-crate tests assert
+    /// batched edits propagate O(component), not O(edits × component)).
+    pub fn dirty_propagation_visits(&self) -> u64 {
+        self.graph.dirty_propagation_visits()
+    }
+
     /// Evaluate a single vertex.
     /// This is the core of the sequential evaluation logic for Milestone 3.1.
     #[inline]
@@ -8815,6 +8840,11 @@ where
 
     /// Evaluate all dirty/volatile vertices
     pub fn evaluate_all(&mut self) -> Result<EvalResult, ExcelError> {
+        debug_assert!(
+            !self.graph.deferred_dirty_active(),
+            "deferred-dirty scope leaked into evaluate_all: a begin_deferred_dirty \
+             was not balanced by end_deferred_dirty"
+        );
         self.lookup_index_cache.reset_counters();
         let _source_cache = self.source_cache_session();
         self.validate_deterministic_mode()?;
@@ -9125,6 +9155,11 @@ where
         &mut self,
         targets: &[(&str, u32, u32)],
     ) -> Result<Vec<Option<LiteralValue>>, ExcelError> {
+        debug_assert!(
+            !self.graph.deferred_dirty_active(),
+            "deferred-dirty scope leaked into evaluate_cells: a begin_deferred_dirty \
+             was not balanced by end_deferred_dirty"
+        );
         self.validate_deterministic_mode()?;
         if targets.is_empty() {
             return Ok(Vec::new());

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -1530,6 +1530,10 @@ impl<'g> VertexEditor<'g> {
         let mut summary = RangeSummary::default();
 
         self.begin_batch();
+        // One multi-source dirty propagation for the whole rectangle instead
+        // of a full BFS per cell (the loop body cannot error, so the scope
+        // always closes before returning).
+        self.graph.begin_deferred_dirty();
 
         for (row_offset, row_values) in values.iter().enumerate() {
             for (col_offset, value) in row_values.iter().enumerate() {
@@ -1548,6 +1552,7 @@ impl<'g> VertexEditor<'g> {
             }
         }
 
+        let _ = self.graph.end_deferred_dirty();
         self.commit_batch();
 
         Ok(summary)

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -179,6 +179,15 @@ pub struct DependencyGraph {
     /// O(component), not O(sources × component).
     dirty_propagation_visits: u64,
 
+    /// Nesting depth of active deferred-dirty scopes (`begin_deferred_dirty`
+    /// / `end_deferred_dirty`). While > 0, dirty-propagation entry points
+    /// queue their sources in `deferred_dirty_pending` instead of running a
+    /// BFS per call; the outermost `end_deferred_dirty` flushes the union in
+    /// ONE multi-source `mark_dirty_many`.
+    deferred_dirty_depth: u32,
+    /// Sources queued while a deferred-dirty scope is active.
+    deferred_dirty_pending: Vec<VertexId>,
+
     /// Vertices explicitly marked as #REF! by structural operations.
     ///
     /// In Arrow-truth mode, the dependency graph does not cache cell/formula values.
@@ -1062,6 +1071,8 @@ impl DependencyGraph {
             load_packed_to_vertex: std::collections::HashMap::with_hasher(CoordBuildHasher),
             dirty_vertices: FxHashSet::default(),
             dirty_propagation_visits: 0,
+            deferred_dirty_depth: 0,
+            deferred_dirty_pending: Vec::new(),
             volatile_vertices: FxHashSet::default(),
             ref_error_vertices: FxHashSet::default(),
             formula_to_range_deps: FxHashMap::default(),
@@ -2112,7 +2123,17 @@ impl DependencyGraph {
     /// binding invalidation, eval.rs demand-driven re-marks), so "dirty"
     /// does not imply "my dependents are already dirty". The per-call shared
     /// seen-set needs no such invariant.
+    ///
+    /// While a deferred-dirty scope is active (`begin_deferred_dirty`), the
+    /// call queues its sources for the end-of-scope flush and returns ONLY
+    /// the sources as the "affected" set (the full transitive set is
+    /// produced once by the flush). Loop-of-edits callers must not rely on
+    /// per-edit transitive affected sets inside such a scope.
     pub(crate) fn mark_dirty_many(&mut self, vertex_ids: &[VertexId]) -> Vec<VertexId> {
+        if self.deferred_dirty_depth > 0 {
+            self.deferred_dirty_pending.extend_from_slice(vertex_ids);
+            return vertex_ids.to_vec();
+        }
         let mut affected = FxHashSet::default();
         let mut to_visit = Vec::new();
         let mut visited_for_propagation = FxHashSet::default();
@@ -2187,6 +2208,62 @@ impl DependencyGraph {
     /// creation (perf-shape observability; see `dirty_propagation_visits`).
     pub(crate) fn dirty_propagation_visits(&self) -> u64 {
         self.dirty_propagation_visits
+    }
+
+    /// Begin a deferred-dirty scope for a multi-edit batch.
+    ///
+    /// While active, `mark_dirty` / `mark_dirty_many` /
+    /// `mark_dirty_many_value_cells` queue their sources instead of running a
+    /// BFS per call; the outermost `end_deferred_dirty` flushes the queued
+    /// union with ONE multi-source `mark_dirty_many`. Union semantics equal
+    /// the sequential per-edit calls (pinned by
+    /// `mark_dirty_many_equals_sequential_single_source_marks` plus the
+    /// deferred-scope tests): any dependent edge removed mid-batch belongs to
+    /// a vertex that was itself edited mid-batch, and edited vertices are
+    /// themselves pending sources, so the flush covers everything a per-edit
+    /// propagation would have reached.
+    ///
+    /// Nesting is depth-counted. The scope also enters the CSR edge batch
+    /// (`begin_batch`) so edge-heavy batches amortize delta rebuilds (#127).
+    ///
+    /// Callers MUST guarantee `end_deferred_dirty` runs on every exit path
+    /// (including `?` early returns): a leaked scope would silently swallow
+    /// future propagations. Evaluation entry points `debug_assert` that no
+    /// scope is active.
+    pub fn begin_deferred_dirty(&mut self) {
+        self.edges.begin_batch();
+        self.deferred_dirty_depth += 1;
+    }
+
+    /// End a deferred-dirty scope. When the outermost scope ends, runs ONE
+    /// multi-source propagation over every source queued while deferred and
+    /// returns its full affected set (sources pointing at vertices deleted
+    /// mid-batch are skipped). Inner (nested) ends return an empty set.
+    pub fn end_deferred_dirty(&mut self) -> Vec<VertexId> {
+        debug_assert!(
+            self.deferred_dirty_depth > 0,
+            "end_deferred_dirty without matching begin_deferred_dirty"
+        );
+        self.edges.end_batch();
+        self.deferred_dirty_depth = self.deferred_dirty_depth.saturating_sub(1);
+        if self.deferred_dirty_depth > 0 {
+            return Vec::new();
+        }
+        let pending = std::mem::take(&mut self.deferred_dirty_pending);
+        if pending.is_empty() {
+            return Vec::new();
+        }
+        let live: Vec<VertexId> = pending
+            .into_iter()
+            .filter(|&id| self.vertex_exists(id))
+            .collect();
+        self.mark_dirty_many(&live)
+    }
+
+    /// True while a deferred-dirty scope is active (see
+    /// `begin_deferred_dirty`). Evaluation must never start in this state.
+    pub fn deferred_dirty_active(&self) -> bool {
+        self.deferred_dirty_depth > 0
     }
 
     /// Get all vertices that need evaluation
@@ -3047,6 +3124,18 @@ impl DependencyGraph {
     fn mark_dirty_many_value_cells(&mut self, vertex_ids: &[VertexId]) -> Vec<VertexId> {
         if vertex_ids.is_empty() {
             return Vec::new();
+        }
+
+        // Deferred-dirty scope (e.g. a spill clear inside a batched
+        // `set_values`): queue the sources for the end-of-scope flush. The
+        // general `mark_dirty_many` flush handles value-cell sources via its
+        // per-source kind check, so one pending list serves both entry
+        // points. (The flush's per-source range-dependent collection is a
+        // subset of this path's bounding-rect collection, which conservatively
+        // over-dirties; the per-source union is the exact required set.)
+        if self.deferred_dirty_depth > 0 {
+            self.deferred_dirty_pending.extend_from_slice(vertex_ids);
+            return vertex_ids.to_vec();
         }
 
         // Fold pending deltas once so the propagation loop below can use the

--- a/crates/formualizer-eval/src/engine/tests/deferred_dirty.rs
+++ b/crates/formualizer-eval/src/engine/tests/deferred_dirty.rs
@@ -1,0 +1,257 @@
+//! Deferred-dirty scope (`DependencyGraph::begin_deferred_dirty` /
+//! `end_deferred_dirty`): batched multi-edit APIs queue dirty-propagation
+//! sources and flush them as ONE multi-source `mark_dirty_many` instead of
+//! running a full BFS per edit (O(edits × component) → O(component)).
+//!
+//! Union semantics of the single multi-source flush vs sequential per-edit
+//! marks is pinned by `mark_dirty_many_equals_sequential_single_source_marks`
+//! (mark_dirty_multi_source.rs); these tests pin (a) that the *scope* yields
+//! the same dirty/evaluation state as sequential edits, (b) the O(component)
+//! visit count, and (c) flush-on-error / no-leak behavior.
+//!
+//! Work is asserted via `dirty_propagation_visits`, never wall time.
+
+use crate::engine::{DependencyGraph, Engine, EvalConfig, VertexId};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn set_formula(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, f: &str) {
+    engine
+        .set_cell_formula(sheet, row, col, parse(f).expect("parse"))
+        .expect("set formula");
+}
+
+/* ─────────── batched edits are one component walk, not N walks ────────── */
+
+#[test]
+fn deferred_scope_batch_is_one_component_walk_not_one_per_edit() {
+    // 200 inputs all feed one shared component: B1 = SUM(A1:A200) plus a
+    // 200-formula chain off B1. A per-edit loop pays ≥ 200 × 201 visits;
+    // the deferred scope's single flush visits the component once.
+    let inputs = 200u32;
+    let chain = 200u32;
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for r in 1..=inputs {
+        engine
+            .set_cell_value("Sheet1", r, 1, LiteralValue::Int(1))
+            .unwrap();
+    }
+    set_formula(&mut engine, "Sheet1", 1, 2, &format!("=SUM(A1:A{inputs})"));
+    for r in 2..=(chain + 1) {
+        set_formula(&mut engine, "Sheet1", r, 2, &format!("=B{}+1", r - 1));
+    }
+    engine.evaluate_all().unwrap();
+
+    let before = engine.dirty_propagation_visits();
+    engine.begin_deferred_dirty();
+    for r in 1..=inputs {
+        engine
+            .set_cell_value("Sheet1", r, 1, LiteralValue::Int(2))
+            .unwrap();
+    }
+    engine.end_deferred_dirty();
+    let delta = engine.dirty_propagation_visits() - before;
+    eprintln!(
+        "[deferred-dirty] batched {inputs} edits: {delta} BFS visits \
+         ({}-component; per-edit loop was ≥ {})",
+        chain + 1,
+        inputs as u64 * (chain + 1) as u64
+    );
+
+    let component = (chain + 1) as u64; // B1 + chain (inputs are value cells)
+    assert!(
+        delta <= 2 * component + inputs as u64,
+        "deferred batch must be ~one component walk (≈{component} visits), \
+         got {delta} (quadratic was ≥ {})",
+        inputs as u64 * component
+    );
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(2.0 * inputs as f64)),
+        "rollup must see the new inputs"
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", chain + 1, 2),
+        Some(LiteralValue::Number(2.0 * inputs as f64 + chain as f64)),
+        "chain tail must see the new inputs"
+    );
+}
+
+/* ───── scope == sequential edits: identical dirty/evaluation state ────── */
+
+/// Mixed shared + disjoint downstream structure, formulas overwriting values
+/// and vice versa. The deferred scope must leave the graph in EXACTLY the
+/// state sequential per-edit calls produce: same evaluation set, same
+/// affected union.
+#[test]
+fn deferred_scope_equals_sequential_edits() {
+    fn build() -> DependencyGraph {
+        let mut graph = DependencyGraph::new();
+        // Values A1..A6.
+        for r in 1..=6u32 {
+            graph
+                .set_cell_value("Sheet1", r, 1, LiteralValue::Int(r as i64))
+                .unwrap();
+        }
+        // Shared diamond over A1..A3: B1=A1+A2, B2=A2+A3, C1=B1+B2, D1=C1.
+        graph
+            .set_cell_formula("Sheet1", 1, 2, parse("=A1+A2").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 2, 2, parse("=A2+A3").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 1, 3, parse("=B1+B2").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 1, 4, parse("=C1").unwrap())
+            .unwrap();
+        // Disjoint island: E1=A5, E2=E1+1. A4/A6 untouched by any formula.
+        graph
+            .set_cell_formula("Sheet1", 1, 5, parse("=A5").unwrap())
+            .unwrap();
+        graph
+            .set_cell_formula("Sheet1", 2, 5, parse("=E1+1").unwrap())
+            .unwrap();
+        // B3 is a formula the edit batch will OVERWRITE with a value.
+        graph
+            .set_cell_formula("Sheet1", 3, 2, parse("=A1*2").unwrap())
+            .unwrap();
+        graph.clear_dirty_flags(&graph.get_evaluation_vertices());
+        graph
+    }
+
+    // The edit batch: values into shared inputs (A1, A2), value over a
+    // formula (B3), formula over a value (A6 -> formula reading A4), and a
+    // disjoint-island input (A5).
+    fn apply_edits(graph: &mut DependencyGraph) -> Vec<VertexId> {
+        let mut affected = Vec::new();
+        affected.extend(
+            graph
+                .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(10))
+                .unwrap()
+                .affected_vertices,
+        );
+        affected.extend(
+            graph
+                .set_cell_value("Sheet1", 2, 1, LiteralValue::Int(20))
+                .unwrap()
+                .affected_vertices,
+        );
+        affected.extend(
+            graph
+                .set_cell_value("Sheet1", 3, 2, LiteralValue::Int(99))
+                .unwrap()
+                .affected_vertices,
+        );
+        affected.extend(
+            graph
+                .set_cell_formula("Sheet1", 6, 1, parse("=A4+1").unwrap())
+                .unwrap()
+                .affected_vertices,
+        );
+        affected.extend(
+            graph
+                .set_cell_value("Sheet1", 5, 1, LiteralValue::Int(50))
+                .unwrap()
+                .affected_vertices,
+        );
+        affected
+    }
+
+    let mut g_seq = build();
+    let mut seq_affected = apply_edits(&mut g_seq);
+    seq_affected.sort_unstable();
+    seq_affected.dedup();
+    let mut seq_eval = g_seq.get_evaluation_vertices();
+    seq_eval.sort_unstable();
+
+    let mut g_def = build();
+    g_def.begin_deferred_dirty();
+    let _per_edit_sources = apply_edits(&mut g_def);
+    let mut def_affected = g_def.end_deferred_dirty();
+    def_affected.sort_unstable();
+    def_affected.dedup();
+    let mut def_eval = g_def.get_evaluation_vertices();
+    def_eval.sort_unstable();
+
+    assert_eq!(
+        def_eval, seq_eval,
+        "deferred scope must produce the identical dirty evaluation set"
+    );
+    assert_eq!(
+        def_affected, seq_affected,
+        "the flush's affected set must equal the union of sequential per-edit sets"
+    );
+}
+
+/* ─────────────── nesting + no-leak / post-scope behavior ──────────────── */
+
+#[test]
+fn nested_scopes_flush_once_at_outermost_end() {
+    let mut graph = DependencyGraph::new();
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    graph
+        .set_cell_formula("Sheet1", 1, 2, parse("=A1+1").unwrap())
+        .unwrap();
+    graph.clear_dirty_flags(&graph.get_evaluation_vertices());
+
+    graph.begin_deferred_dirty();
+    graph.begin_deferred_dirty();
+    graph
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(2))
+        .unwrap();
+    let inner = graph.end_deferred_dirty();
+    assert!(inner.is_empty(), "inner end must not flush");
+    assert!(graph.deferred_dirty_active(), "outer scope still active");
+    assert!(
+        graph.get_evaluation_vertices().is_empty(),
+        "no propagation may run while any scope is active"
+    );
+    let outer = graph.end_deferred_dirty();
+    assert!(!graph.deferred_dirty_active());
+    assert!(!outer.is_empty(), "outermost end flushes the propagation");
+    assert_eq!(
+        graph.get_evaluation_vertices().len(),
+        1,
+        "B1 dirty after flush"
+    );
+}
+
+#[test]
+fn propagation_is_normal_after_scope_ends() {
+    // A single edit AFTER a closed scope must propagate immediately (a
+    // dangling deferral would silently swallow it).
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    set_formula(&mut engine, "Sheet1", 1, 2, "=A1*10");
+    engine.evaluate_all().unwrap();
+
+    engine.begin_deferred_dirty();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(2))
+        .unwrap();
+    engine.end_deferred_dirty();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(20.0))
+    );
+
+    // Plain single edit, no scope: must propagate on its own.
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(3))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(30.0))
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -7,6 +7,7 @@ mod clock_snapshot;
 mod common;
 mod cross_sheet_named_range_first_cell;
 mod cycle_detection;
+mod deferred_dirty;
 mod demand_driven;
 mod dependency;
 mod deterministic_clock;

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -2341,6 +2341,22 @@ impl Workbook {
         _start: (u32, u32),
         cells: BTreeMap<(u32, u32), crate::traits::CellData>,
     ) -> Result<(), IoError> {
+        // Deferred-dirty scope: one multi-source propagation for the whole
+        // batch instead of a full BFS per cell (see Engine::begin_deferred_dirty).
+        // The unconditional end_deferred_dirty below flushes on every exit
+        // path, including the `?` error returns inside the inner body.
+        self.engine.begin_deferred_dirty();
+        let result = self.write_range_inner(sheet, _start, cells);
+        self.engine.end_deferred_dirty();
+        result
+    }
+
+    fn write_range_inner(
+        &mut self,
+        sheet: &str,
+        _start: (u32, u32),
+        cells: BTreeMap<(u32, u32), crate::traits::CellData>,
+    ) -> Result<(), IoError> {
         if self.enable_changelog {
             let sheet_id = self
                 .engine
@@ -2484,6 +2500,23 @@ impl Workbook {
         start_col: u32,
         rows: &[Vec<LiteralValue>],
     ) -> Result<(), IoError> {
+        // Deferred-dirty scope: one multi-source propagation for the whole
+        // batch instead of a full BFS per cell (see Engine::begin_deferred_dirty).
+        // The unconditional end_deferred_dirty below flushes on every exit
+        // path, including the `?` error returns inside the inner body.
+        self.engine.begin_deferred_dirty();
+        let result = self.set_values_inner(sheet, start_row, start_col, rows);
+        self.engine.end_deferred_dirty();
+        result
+    }
+
+    fn set_values_inner(
+        &mut self,
+        sheet: &str,
+        start_row: u32,
+        start_col: u32,
+        rows: &[Vec<LiteralValue>],
+    ) -> Result<(), IoError> {
         if self.enable_changelog {
             let sheet_id = self
                 .engine
@@ -2559,6 +2592,23 @@ impl Workbook {
 
     // Batch set formulas in a rectangle starting at (start_row,start_col)
     pub fn set_formulas(
+        &mut self,
+        sheet: &str,
+        start_row: u32,
+        start_col: u32,
+        rows: &[Vec<String>],
+    ) -> Result<(), IoError> {
+        // Deferred-dirty scope: one multi-source propagation for the whole
+        // batch instead of a full BFS per cell (see Engine::begin_deferred_dirty).
+        // The unconditional end_deferred_dirty below flushes on every exit
+        // path, including the `?` error returns inside the inner body.
+        self.engine.begin_deferred_dirty();
+        let result = self.set_formulas_inner(sheet, start_row, start_col, rows);
+        self.engine.end_deferred_dirty();
+        result
+    }
+
+    fn set_formulas_inner(
         &mut self,
         sheet: &str,
         start_row: u32,

--- a/crates/formualizer-workbook/tests/bulk_edit_dirty.rs
+++ b/crates/formualizer-workbook/tests/bulk_edit_dirty.rs
@@ -1,0 +1,252 @@
+//! Batched workbook edits (`set_values` / `set_formulas` / `write_range`)
+//! run ONE deferred multi-source dirty propagation instead of a full BFS per
+//! cell (O(edits × component) → O(component)); see
+//! `Engine::begin_deferred_dirty`. Python's `set_values_batch` /
+//! `set_formulas_batch` wrap these APIs and inherit the behavior.
+//!
+//! Perf shape is asserted via `Engine::dirty_propagation_visits` (BFS visit
+//! counts), never wall time. Exact dirty-set/affected-set equality with
+//! sequential edits is pinned at the graph level
+//! (formualizer-eval `engine::tests::deferred_dirty`); here we pin the
+//! workbook surface: visit scaling, per-cell vs batch value equivalence,
+//! undo of a batched action, and flush-on-error.
+
+use formualizer_workbook::{LiteralValue, Workbook, WorkbookConfig};
+
+const SHEET: &str = "Sheet1";
+const INPUTS: u32 = 200;
+const CHAIN: u32 = 200;
+
+fn workbook(changelog: bool) -> Workbook {
+    let mut config = WorkbookConfig::ephemeral();
+    config.enable_changelog = changelog;
+    Workbook::new_with_config(config)
+}
+
+fn num(wb: &Workbook, row: u32, col: u32) -> f64 {
+    match wb.get_value(SHEET, row, col) {
+        Some(LiteralValue::Number(n)) => n,
+        Some(LiteralValue::Int(i)) => i as f64,
+        other => panic!("expected number at r{row}c{col}, got {other:?}"),
+    }
+}
+
+/// K inputs in column A all feed one shared component: B1 = SUM(A1:AK) plus
+/// a CHAIN-long arithmetic chain off B1. Disjoint island: D1 = C1 + 1 off
+/// input C1 (untouched by the batch edits unless a test edits it).
+fn build_rollup(wb: &mut Workbook) {
+    let rows: Vec<Vec<LiteralValue>> = (0..INPUTS).map(|_| vec![LiteralValue::Int(1)]).collect();
+    wb.set_values(SHEET, 1, 1, &rows).unwrap();
+    wb.set_formula(SHEET, 1, 2, &format!("=SUM(A1:A{INPUTS})"))
+        .unwrap();
+    for r in 2..=(CHAIN + 1) {
+        wb.set_formula(SHEET, r, 2, &format!("=B{}+1", r - 1))
+            .unwrap();
+    }
+    wb.set_value(SHEET, 1, 3, LiteralValue::Int(7)).unwrap();
+    wb.set_formula(SHEET, 1, 4, "=C1+1").unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(num(wb, 1, 2), INPUTS as f64);
+    assert_eq!(num(wb, CHAIN + 1, 2), (INPUTS + CHAIN) as f64);
+}
+
+fn assert_post_edit_state(wb: &Workbook, input_value: f64) {
+    assert_eq!(num(wb, 1, 2), input_value * INPUTS as f64, "rollup root");
+    assert_eq!(
+        num(wb, CHAIN + 1, 2),
+        input_value * INPUTS as f64 + CHAIN as f64,
+        "chain tail"
+    );
+}
+
+/* ─────────────── visit scaling: O(component), not O(N × component) ────── */
+
+fn batched_set_values_visits_o_component(changelog: bool) {
+    let mut wb = workbook(changelog);
+    build_rollup(&mut wb);
+
+    let before = wb.engine().dirty_propagation_visits();
+    let rows: Vec<Vec<LiteralValue>> = (0..INPUTS)
+        .map(|_| vec![LiteralValue::Number(2.0)])
+        .collect();
+    wb.set_values(SHEET, 1, 1, &rows).unwrap();
+    let delta = wb.engine().dirty_propagation_visits() - before;
+    eprintln!(
+        "[bulk-edit-dirty] batched set_values (changelog={changelog}): {delta} BFS visits \
+         ({INPUTS} inputs × {}-component; per-cell loop was ≥ {})",
+        CHAIN + 1,
+        INPUTS as u64 * (CHAIN + 1) as u64
+    );
+
+    let component = (CHAIN + 1) as u64; // B1 + chain (inputs are value cells)
+    assert!(
+        delta <= 2 * component + INPUTS as u64,
+        "batched set_values (changelog={changelog}) must be ~one component walk \
+         (≈{component} visits), got {delta} (per-cell loop was ≥ {})",
+        INPUTS as u64 * component
+    );
+
+    wb.evaluate_all().unwrap();
+    assert_post_edit_state(&wb, 2.0);
+}
+
+#[test]
+fn batched_set_values_visits_are_o_component_no_changelog() {
+    batched_set_values_visits_o_component(false);
+}
+
+#[test]
+fn batched_set_values_visits_are_o_component_with_changelog() {
+    batched_set_values_visits_o_component(true);
+}
+
+#[test]
+fn batched_set_formulas_visits_are_o_component() {
+    // Rewrite every chain formula (same text) in one batch: each edit's
+    // propagation reaches the rest of the chain, so a per-cell loop is
+    // O(CHAIN²); the deferred flush walks the chain once.
+    let mut wb = workbook(false);
+    build_rollup(&mut wb);
+
+    let before = wb.engine().dirty_propagation_visits();
+    let rows: Vec<Vec<String>> = (2..=(CHAIN + 1))
+        .map(|r| vec![format!("=B{}+1", r - 1)])
+        .collect();
+    wb.set_formulas(SHEET, 2, 2, &rows).unwrap();
+    let delta = wb.engine().dirty_propagation_visits() - before;
+    eprintln!(
+        "[bulk-edit-dirty] batched set_formulas: {delta} BFS visits \
+         ({CHAIN}-chain rewrite; per-cell loop was ≥ {})",
+        (CHAIN as u64) * (CHAIN as u64) / 2
+    );
+
+    let component = (CHAIN + 1) as u64;
+    assert!(
+        delta <= 3 * component,
+        "batched set_formulas must be ~one component walk (≈{component} visits), \
+         got {delta} (per-cell loop was ≥ {})",
+        (CHAIN as u64) * (CHAIN as u64) / 2
+    );
+
+    wb.evaluate_all().unwrap();
+    assert_post_edit_state(&wb, 1.0);
+}
+
+/* ─────────── per-cell loop vs batch: identical post-recalc values ─────── */
+
+#[test]
+fn batch_equals_per_cell_loop_values() {
+    // Shared + disjoint downstream structure; the edit set includes values
+    // overwriting a formula cell and a formula overwriting a value cell.
+    fn apply_per_cell(wb: &mut Workbook) {
+        for r in 1..=INPUTS {
+            wb.set_value(SHEET, r, 1, LiteralValue::Number(3.0))
+                .unwrap();
+        }
+        // Value over formula (D1 was =C1+1), formula over value (C1 was 7).
+        wb.set_value(SHEET, 1, 4, LiteralValue::Number(99.0))
+            .unwrap();
+        wb.set_formula(SHEET, 1, 3, "=B1*2").unwrap();
+    }
+    fn apply_batch(wb: &mut Workbook) {
+        let rows: Vec<Vec<LiteralValue>> = (0..INPUTS)
+            .map(|_| vec![LiteralValue::Number(3.0)])
+            .collect();
+        wb.set_values(SHEET, 1, 1, &rows).unwrap();
+        wb.set_values(SHEET, 1, 4, &[vec![LiteralValue::Number(99.0)]])
+            .unwrap();
+        wb.set_formulas(SHEET, 1, 3, &[vec!["=B1*2".to_string()]])
+            .unwrap();
+    }
+
+    let mut wb_seq = workbook(false);
+    build_rollup(&mut wb_seq);
+    apply_per_cell(&mut wb_seq);
+    wb_seq.evaluate_all().unwrap();
+
+    let mut wb_batch = workbook(false);
+    build_rollup(&mut wb_batch);
+    apply_batch(&mut wb_batch);
+    wb_batch.evaluate_all().unwrap();
+
+    for (r, c) in (1..=(CHAIN + 1))
+        .map(|r| (r, 2u32))
+        .chain([(1u32, 3u32), (1, 4)])
+        .chain((1..=INPUTS).map(|r| (r, 1u32)))
+    {
+        assert_eq!(
+            wb_seq.get_value(SHEET, r, c),
+            wb_batch.get_value(SHEET, r, c),
+            "value mismatch at r{r}c{c}"
+        );
+    }
+    assert_eq!(num(&wb_batch, 1, 3), 2.0 * 3.0 * INPUTS as f64);
+}
+
+/* ───────────────────────── changelog / undo ───────────────────────────── */
+
+#[test]
+fn undo_restores_pre_batch_values() {
+    let mut wb = workbook(true);
+    build_rollup(&mut wb);
+
+    wb.begin_action("bulk input update");
+    let rows: Vec<Vec<LiteralValue>> = (0..INPUTS)
+        .map(|_| vec![LiteralValue::Number(5.0)])
+        .collect();
+    wb.set_values(SHEET, 1, 1, &rows).unwrap();
+    wb.end_action();
+    wb.evaluate_all().unwrap();
+    assert_post_edit_state(&wb, 5.0);
+
+    wb.undo().unwrap();
+    for r in 1..=INPUTS {
+        assert_eq!(
+            num(&wb, r, 1),
+            1.0,
+            "input r{r} must be restored by one undo of the batched action"
+        );
+    }
+    wb.evaluate_all().unwrap();
+    assert_post_edit_state(&wb, 1.0);
+
+    wb.redo().unwrap();
+    wb.evaluate_all().unwrap();
+    assert_post_edit_state(&wb, 5.0);
+}
+
+/* ─────────────────────────── error-path flush ─────────────────────────── */
+
+#[test]
+fn mid_batch_error_flushes_scope_and_later_edits_propagate() {
+    // Row 2's formula fails to parse → set_formulas errors mid-batch. The
+    // deferred scope must still flush (row 1's edit propagates), and the
+    // graph must be fully consistent: a subsequent SINGLE edit propagates
+    // normally and evaluation entry sees no active deferral (debug_assert).
+    let mut wb = workbook(false);
+    build_rollup(&mut wb);
+
+    let rows = vec![
+        vec!["=SUM(A1:A10)*1000".to_string()],
+        vec!["=THIS IS NOT A FORMULA ((".to_string()],
+        vec!["=A1+1".to_string()],
+    ];
+    let err = wb.set_formulas(SHEET, 10, 6, &rows);
+    assert!(err.is_err(), "mid-batch parse failure must surface");
+
+    // Row 1 of the failed batch was applied before the error; its dirty
+    // marking must have been flushed, so a recalc evaluates it.
+    wb.evaluate_all().unwrap();
+    assert_eq!(num(&wb, 10, 6), 10_000.0, "pre-error edit must evaluate");
+
+    // Subsequent single edit must propagate through the shared component.
+    wb.set_value(SHEET, 1, 1, LiteralValue::Number(2.0))
+        .unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(num(&wb, 1, 2), (INPUTS + 1) as f64, "rollup sees the edit");
+    assert_eq!(
+        num(&wb, 10, 6),
+        11_000.0,
+        "failed-batch survivor re-evaluates"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the last known programmatic-edit quadratic: batch edit APIs (`Workbook::set_values`, `set_formulas`, `write_range`, and the editor's `set_range_values`) ran a full dirty-propagation BFS per cell, so N edits sharing downstream structure cost O(N × component) — the cross-call sibling of the in-call quadratics fixed in #136. Python's `set_values_batch` / `set_formulas_batch` wrap these and inherit the fix unchanged.

## Design

`DependencyGraph` gains a depth-counted deferred-dirty scope (`begin_deferred_dirty` / `end_deferred_dirty`). While active, both propagation entry points (`mark_dirty_many` and the value-cells variant used by spill clears) queue their sources instead of BFS-ing per call; the outermost end flushes the union with ONE multi-source `mark_dirty_many` — the union equivalence already pinned by `mark_dirty_many_equals_sequential_single_source_marks`. The scope also enters the CSR edge batch (#127) so edge-heavy batches amortize delta rebuilds.

Safety: the workbook entry points use a wrapper pattern (begin → inner body → unconditional end → propagate result) so every `?` early return still flushes, and `evaluate_all` / `evaluate_cells` `debug_assert` that no scope leaked. The early-stop-at-dirty alternative remains unsound for the reasons documented at the `mark_dirty_many` definition; this scope needs no such invariant. Per-edit `affected_vertices` inside a scope are the edited sources only (the sole in-loop consumers take the edited vertex anyway); the flush returns the full transitive set. Single-cell `set_value` / `set_formula` are untouched.

## Measured (probe-edit-storm, K inputs feeding a shared rollup; edit-storm wall time, release)

| K | changelog | batch before | batch after | speedup |
|---|---|---|---|---|
| 1,000 | off | 47.7 ms | 2.2 ms | 22x |
| 1,000 | on | 47.1 ms | 4.8 ms | 10x |
| 5,000 | off | 1,023.7 ms | 16.1 ms | 64x |
| 5,000 | on | 1,064.6 ms | 49.7 ms | 21x |
| 20,000 | off | 15,859.2 ms | 58.7 ms | 270x |
| 20,000 | on | 16,093.0 ms | 530.2 ms | 30x |

Recalc results and value self-checks identical before/after; the per-cell loop arm is unchanged by design (single edits keep exact per-edit propagation).

Counter evidence: batched `set_values` over 200 inputs sharing a 201-vertex component performs 201 BFS visits (vs >= 40,200 for the per-cell loop); `set_formulas` over a 200-chain rewrite performs 200 (vs >= 20,000).

## Tests

4 new engine tests (`engine/tests/deferred_dirty.rs`): O(component) visit scaling, sequential equivalence, nesting flushes once at outermost end, propagation normal after scope ends. 6 new workbook tests (`tests/bulk_edit_dirty.rs`): visits scaling with changelog on and off, value + dirty-set equivalence vs per-cell loops on mixed shared/disjoint structure, undo/redo of a batched action, mid-batch-error still flushes and leaves the graph consistent.

## Gates

cargo fmt --check clean; workspace clippy (-D warnings, CI exclusions) clean; workspace tests 2631 passed / 0 failed; portable-wasm facade check clean. Standing perf gate vs main (interleaved A/B, both probes exercise the unbatched single-edit hot path): finance-recalc recalc_p50 median 6.27 ms base vs 6.25 ms branch over 8 alternations; linear-rollup 200k eval_ms median 695.4 vs 703.1 over 6 alternations, mixed direction — noise.

## Follow-up noted

With propagation fixed, the changelog-on batch residue (4.8 -> 49.7 -> 530 ms across 1k/5k/20k) is dominated by the pre-existing per-cell old-state capture in the changelog path — a separate, smaller quadratic worth its own pass.

Refs #136 (in-call multi-source propagation), #127 (CSR batch), #128 (changelog deltas).
