### PR TITLE
perf(workbook): append changelog old-state directly — removes O(N²) batch patch scan (506→112 ms at 20k)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -601,9 +601,13 @@ where
             // Safety: `log_ptr` comes from a unique `&mut ChangeLog` in `Engine::action_with_logger`.
             let log = unsafe { &mut *log_ptr };
             self.engine.edit_with_logger(log, |editor| {
-                editor.set_cell_value(addr, value.clone());
+                editor.set_cell_value_with_old_state(
+                    addr,
+                    value.clone(),
+                    old_value.clone(),
+                    old_formula.clone(),
+                );
             });
-            log.patch_last_cell_event_old_state(addr, old_value.clone(), old_formula.clone());
             self.engine
                 .record_formula_plane_structural_change(StructuralScope::Cell {
                     sheet: addr.sheet_id,
@@ -675,9 +679,8 @@ where
             // Safety: `log_ptr` comes from a unique `&mut ChangeLog` in `Engine::action_with_logger`.
             let log = unsafe { &mut *log_ptr };
             self.engine.edit_with_logger(log, |editor| {
-                editor.set_cell_formula(addr, ast.clone());
+                editor.set_cell_formula_with_old_state(addr, ast.clone(), old_value, old_formula);
             });
-            log.patch_last_cell_event_old_state(addr, old_value, old_formula);
             self.engine
                 .record_formula_plane_structural_change(StructuralScope::Cell {
                     sheet: addr.sheet_id,

--- a/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
@@ -301,42 +301,6 @@ impl ChangeLog {
         &self.events
     }
 
-    pub fn patch_last_cell_event_old_state(
-        &mut self,
-        addr: CellRef,
-        old_value: Option<LiteralValue>,
-        old_formula: Option<ASTNode>,
-    ) {
-        // Walk backwards to find the most recent SetValue/SetFormula for this cell.
-        // This is used by Arrow-canonical callers that must capture old_value/old_formula
-        // from Arrow truth (graph value cache may be disabled).
-        for ev in self.events.iter_mut().rev() {
-            match ev {
-                ChangeEvent::SetValue {
-                    addr: a,
-                    old_value: ov,
-                    old_formula: of,
-                    ..
-                }
-                | ChangeEvent::SetFormula {
-                    addr: a,
-                    old_value: ov,
-                    old_formula: of,
-                    ..
-                } if *a == addr => {
-                    if ov.is_none() {
-                        *ov = old_value;
-                    }
-                    if of.is_none() {
-                        *of = old_formula;
-                    }
-                    break;
-                }
-                _ => {}
-            }
-        }
-    }
-
     pub fn event_meta(&self, index: usize) -> Option<&ChangeEventMeta> {
         self.metas.get(index)
     }

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -1396,12 +1396,36 @@ impl<'g> VertexEditor<'g> {
 
     /// Set a cell value, creating the vertex if it doesn't exist
     pub fn set_cell_value(&mut self, cell_ref: CellRef, value: LiteralValue) -> VertexId {
+        self.set_cell_value_with_old_state(cell_ref, value, None, None)
+    }
+
+    /// Like [`set_cell_value`](Self::set_cell_value), but lets the caller
+    /// supply old state captured from an external source of truth (e.g. the
+    /// Arrow store, whose values are invisible here when the graph value cache
+    /// is disabled) for the change-log event.
+    ///
+    /// Precedence matches the historical append-then-patch flow
+    /// (`ChangeLog::patch_last_cell_event_old_state`): state the editor
+    /// captures from the graph wins; caller-supplied state only fills fields
+    /// the graph left `None`.
+    pub fn set_cell_value_with_old_state(
+        &mut self,
+        cell_ref: CellRef,
+        value: LiteralValue,
+        fallback_old_value: Option<LiteralValue>,
+        fallback_old_formula: Option<ASTNode>,
+    ) -> VertexId {
         let sheet_name = self.graph.sheet_name(cell_ref.sheet_id).to_string();
 
-        // Capture old state before modification (value + formula).
+        // Capture old state before modification (value + formula); fall back
+        // to caller-supplied state for anything the graph cannot see.
         let old_id = self.graph.get_vertex_id_for_address(&cell_ref).copied();
-        let old_value = old_id.and_then(|id| self.graph.get_value(id));
-        let old_formula = old_id.and_then(|id| self.get_formula_ast(id));
+        let old_value = old_id
+            .and_then(|id| self.graph.get_value(id))
+            .or(fallback_old_value);
+        let old_formula = old_id
+            .and_then(|id| self.get_formula_ast(id))
+            .or(fallback_old_formula);
 
         // If this cell currently anchors a spill, clear the spill first and log it.
         // This keeps spill ownership maps and children consistent under undo/redo.
@@ -1458,12 +1482,32 @@ impl<'g> VertexEditor<'g> {
 
     /// Set a cell formula, creating the vertex if it doesn't exist
     pub fn set_cell_formula(&mut self, cell_ref: CellRef, formula: ASTNode) -> VertexId {
+        self.set_cell_formula_with_old_state(cell_ref, formula, None, None)
+    }
+
+    /// Like [`set_cell_formula`](Self::set_cell_formula), but lets the caller
+    /// supply old state captured from an external source of truth (e.g. the
+    /// Arrow store) for the change-log event. Same precedence as
+    /// [`set_cell_value_with_old_state`](Self::set_cell_value_with_old_state):
+    /// graph-captured state wins, caller state only fills `None` fields.
+    pub fn set_cell_formula_with_old_state(
+        &mut self,
+        cell_ref: CellRef,
+        formula: ASTNode,
+        fallback_old_value: Option<LiteralValue>,
+        fallback_old_formula: Option<ASTNode>,
+    ) -> VertexId {
         let sheet_name = self.graph.sheet_name(cell_ref.sheet_id).to_string();
 
-        // Capture old state before modification (value + formula).
+        // Capture old state before modification (value + formula); fall back
+        // to caller-supplied state for anything the graph cannot see.
         let old_id = self.graph.get_vertex_id_for_address(&cell_ref).copied();
-        let old_value = old_id.and_then(|id| self.graph.get_value(id));
-        let old_formula = old_id.and_then(|id| self.get_formula_ast(id));
+        let old_value = old_id
+            .and_then(|id| self.graph.get_value(id))
+            .or(fallback_old_value);
+        let old_formula = old_id
+            .and_then(|id| self.get_formula_ast(id))
+            .or(fallback_old_formula);
 
         // If this cell currently anchors a spill, clear it before updating the formula.
         let spill_snapshot =

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -2139,11 +2139,9 @@ impl Workbook {
                 .and_then(|(ast, _)| ast);
 
             self.engine.edit_with_logger(&mut self.log, |editor| {
-                editor.set_cell_value(cell, value.clone());
+                editor.set_cell_value_with_old_state(cell, value.clone(), old_value, old_formula);
             });
 
-            self.log
-                .patch_last_cell_event_old_state(cell, old_value, old_formula);
             self.mirror_value_to_overlay(sheet, row, col, &value);
             self.engine.clear_staged_formula_text(sheet, row, col);
             if let Some(before) = staged_before {
@@ -2194,11 +2192,9 @@ impl Workbook {
                     let old_formula = self.engine.get_cell(sheet, row, col).and_then(|(a, _)| a);
 
                     self.engine.edit_with_logger(&mut self.log, |editor| {
-                        editor.set_cell_formula(cell, ast);
+                        editor.set_cell_formula_with_old_state(cell, ast, old_value, old_formula);
                     });
 
-                    self.log
-                        .patch_last_cell_event_old_state(cell, old_value, old_formula);
                     self.engine.clear_staged_formula_text(sheet, row, col);
                     if let Some(before) = staged_before {
                         self.record_staged_formula_cell_change(sheet, row, col, before, None);
@@ -2365,7 +2361,9 @@ impl Workbook {
             let defer_graph_building = self.engine.config.defer_graph_building;
 
             // Capture per-cell old state from Arrow truth BEFORE applying the bulk edit.
-            // In canonical mode the graph value cache is empty, so ChangeLog old_value must be patched.
+            // In canonical mode the graph value cache is empty, so the editor cannot see
+            // old values itself; we pass the captured state through to the editor so it
+            // lands on the ChangeLog events directly (no post-hoc log scan).
             // `staged_before` is the cell's staged formula text prior to the edit, used to
             // record a per-cell staged-formula delta for undo/redo (see #126).
             #[allow(clippy::type_complexity)]
@@ -2394,9 +2392,23 @@ impl Workbook {
 
             self.engine
                 .edit_with_logger(&mut self.log, |editor| -> Result<(), IoError> {
-                    for (r, c, d, cell, _old_value, _old_formula, _staged_before) in items.iter() {
+                    for (r, c, d, cell, old_value, old_formula, _staged_before) in items.iter() {
+                        // Old state captured from Arrow truth rides on the cell's
+                        // LAST graph edit of this batch item (matching the historical
+                        // patch-last-event semantics): the formula edit when one goes
+                        // through the editor, otherwise the value edit.
+                        let formula_via_editor = d.formula.is_some() && !defer_graph_building;
                         if let Some(v) = d.value.clone() {
-                            editor.set_cell_value(*cell, v.clone());
+                            if formula_via_editor {
+                                editor.set_cell_value(*cell, v.clone());
+                            } else {
+                                editor.set_cell_value_with_old_state(
+                                    *cell,
+                                    v.clone(),
+                                    old_value.clone(),
+                                    old_formula.clone(),
+                                );
+                            }
                             // If a formula is also being set for this cell, do not mirror the
                             // provided value into the delta overlay. In Arrow-truth mode that
                             // would mask the computed formula result.
@@ -2415,21 +2427,17 @@ impl Workbook {
                                 };
                                 let ast = formualizer_parse::parser::parse(&with_eq)
                                     .map_err(|e| IoError::from_backend("parser", e))?;
-                                editor.set_cell_formula(*cell, ast);
+                                editor.set_cell_formula_with_old_state(
+                                    *cell,
+                                    ast,
+                                    old_value.clone(),
+                                    old_formula.clone(),
+                                );
                             }
                         }
                     }
                     Ok(())
                 })?;
-
-            // Patch old_value/old_formula for each cell's last SetValue/SetFormula event.
-            for (_r, _c, _d, cell, old_value, old_formula, _staged_before) in items.iter().rev() {
-                self.log.patch_last_cell_event_old_state(
-                    *cell,
-                    old_value.clone(),
-                    old_formula.clone(),
-                );
-            }
 
             for (r, c, v) in overlay_ops {
                 self.mirror_value_to_overlay(sheet, r, c, &v);
@@ -2552,18 +2560,17 @@ impl Workbook {
             }
 
             self.engine.edit_with_logger(&mut self.log, |editor| {
-                for (_r, _c, v, cell, _old_value, _old_formula, _staged_before) in items.iter() {
-                    editor.set_cell_value(*cell, v.clone());
+                for (_r, _c, v, cell, old_value, old_formula, _staged_before) in items.iter() {
+                    // Old state captured from Arrow truth rides directly on the
+                    // event (graph-captured state wins; this only fills `None`).
+                    editor.set_cell_value_with_old_state(
+                        *cell,
+                        v.clone(),
+                        old_value.clone(),
+                        old_formula.clone(),
+                    );
                 }
             });
-
-            for (_r, _c, _v, cell, old_value, old_formula, _staged_before) in items.iter().rev() {
-                self.log.patch_last_cell_event_old_state(
-                    *cell,
-                    old_value.clone(),
-                    old_formula.clone(),
-                );
-            }
 
             for (r, c, v, _cell, _old_value, _old_formula, staged_before) in items {
                 self.mirror_value_to_overlay(sheet, r, c, &v);

--- a/crates/formualizer-workbook/tests/changelog_batch_old_state.rs
+++ b/crates/formualizer-workbook/tests/changelog_batch_old_state.rs
@@ -1,0 +1,396 @@
+//! Event-log equivalence + undo/redo tests for changelog old-state capture on
+//! BATCH edit paths (`write_range`, `set_values`).
+//!
+//! Context: in Arrow-truth mode the graph value cache is disabled, so the
+//! graph-level `VertexEditor` cannot capture `old_value` on its own. The
+//! workbook captures old state from Arrow truth before the batch and (before
+//! the O(N^2) fix) patched it into the log afterwards via
+//! `patch_last_cell_event_old_state`. These tests pin the EXACT event-log
+//! content produced by that append-then-patch flow (goldens derived from the
+//! pre-fix code at 16b1fa8d) so the direct pass-through implementation can be
+//! proven byte-for-byte equivalent.
+
+use std::collections::BTreeMap;
+
+use formualizer_common::LiteralValue;
+use formualizer_eval::engine::ChangeEvent;
+use formualizer_workbook::Workbook;
+use formualizer_workbook::traits::CellData;
+
+fn wb_changelog_graph_mode() -> Workbook {
+    // Changelog on, defer_graph_building OFF so formulas go through the
+    // VertexEditor (and write_range emits SetFormula events).
+    let mut cfg = formualizer_workbook::WorkbookConfig::interactive();
+    cfg.eval.defer_graph_building = false;
+    Workbook::new_with_config(cfg)
+}
+
+/// Render one change event as a stable, content-complete line.
+fn render_event(ev: &ChangeEvent) -> String {
+    let fmt_ast = |a: &Option<formualizer_parse::ASTNode>| match a {
+        Some(ast) => format!("Some({})", formualizer_parse::pretty::canonical_formula(ast)),
+        None => "None".to_string(),
+    };
+    match ev {
+        ChangeEvent::SetValue {
+            addr,
+            old_value,
+            old_formula,
+            new,
+        } => format!(
+            "SetValue addr=({},{},{}) old_value={:?} old_formula={} new={:?}",
+            addr.sheet_id,
+            addr.coord.row(),
+            addr.coord.col(),
+            old_value,
+            fmt_ast(old_formula),
+            new
+        ),
+        ChangeEvent::SetFormula {
+            addr,
+            old_value,
+            old_formula,
+            new,
+        } => format!(
+            "SetFormula addr=({},{},{}) old_value={:?} old_formula={} new={}",
+            addr.sheet_id,
+            addr.coord.row(),
+            addr.coord.col(),
+            old_value,
+            fmt_ast(old_formula),
+            formualizer_parse::pretty::canonical_formula(new)
+        ),
+        ChangeEvent::CompoundStart { description, .. } => {
+            format!("CompoundStart {description}")
+        }
+        ChangeEvent::CompoundEnd { .. } => "CompoundEnd".to_string(),
+        ChangeEvent::SpillCleared { .. } => "SpillCleared".to_string(),
+        other => format!(
+            "Other({})",
+            // Variant name only; payload content is not under test here.
+            format!("{other:?}")
+                .split([' ', '(', '{'])
+                .next()
+                .unwrap_or("?")
+        ),
+    }
+}
+
+fn assert_numeric_eq(v: Option<LiteralValue>, expected: f64) {
+    match v {
+        Some(LiteralValue::Number(n)) => assert!((n - expected).abs() < 1e-9, "{n} != {expected}"),
+        Some(LiteralValue::Int(i)) => assert!(((i as f64) - expected).abs() < 1e-9),
+        other => panic!("expected numeric {expected}, got {other:?}"),
+    }
+}
+
+fn render_log_from(wb: &Workbook, mark: usize) -> Vec<String> {
+    wb.changelog().events()[mark..]
+        .iter()
+        .map(render_event)
+        .collect()
+}
+
+/// Seed a workbook with a mix of values, formulas and a spill anchor, then
+/// evaluate so Arrow truth holds computed results. Returns the changelog mark
+/// (length) after seeding.
+fn seed(wb: &mut Workbook) -> usize {
+    wb.add_sheet("S").unwrap();
+    wb.set_value("S", 1, 1, LiteralValue::Int(10)).unwrap(); // A1 = 10
+    wb.set_formula("S", 1, 2, "=A1*2").unwrap(); // B1 = formula
+    wb.set_value("S", 1, 3, LiteralValue::Int(5)).unwrap(); // C1 = 5
+    wb.set_formula("S", 1, 4, "=A1+C1").unwrap(); // D1 = formula
+    wb.set_formula("S", 1, 5, "=SEQUENCE(2,1)").unwrap(); // E1 spills E1:E2
+    wb.evaluate_all().unwrap();
+    wb.changelog().events().len()
+}
+
+/// Golden event log for the `write_range` batch path (changelog on, graph
+/// mode). Mixed batch: value-over-value, value-over-formula,
+/// formula-over-value, formula-over-formula, value-over-spill-anchor, and a
+/// single cell receiving BOTH a value and a formula in one batch (two events
+/// for one cell — only the last one historically received the patched old
+/// state).
+#[test]
+fn write_range_batch_event_log_golden() {
+    let mut wb = wb_changelog_graph_mode();
+    let mark = seed(&mut wb);
+
+    let mut cells: BTreeMap<(u32, u32), CellData> = BTreeMap::new();
+    cells.insert((1, 1), CellData::from_value(LiteralValue::Int(11))); // A1: value over value
+    cells.insert((1, 2), CellData::from_value(LiteralValue::Int(7))); // B1: value over formula
+    cells.insert(
+        (1, 3),
+        CellData {
+            value: None,
+            formula: Some("=A1*3".into()),
+            style: None,
+        },
+    ); // C1: formula over value
+    cells.insert(
+        (1, 4),
+        CellData {
+            value: None,
+            formula: Some("=A1*4".into()),
+            style: None,
+        },
+    ); // D1: formula over formula
+    cells.insert((1, 5), CellData::from_value(LiteralValue::Int(99))); // E1: value over spill anchor
+    cells.insert(
+        (1, 6),
+        CellData {
+            value: Some(LiteralValue::Int(1)),
+            formula: Some("=A1+1".into()),
+            style: None,
+        },
+    ); // F1: value AND formula in the same batch item
+    cells.insert((1, 7), CellData::from_value(LiteralValue::Int(2))); // G1: fresh cell
+
+    wb.write_range("S", (1, 1), cells).unwrap();
+
+    let got = render_log_from(&wb, mark);
+    let expected = vec![
+        "SetValue addr=(1,0,0) old_value=Some(Number(10.0)) old_formula=None new=Int(11)",
+        "SetValue addr=(1,0,1) old_value=Some(Number(20.0)) old_formula=Some(=A1 * 2) new=Int(7)",
+        "SetFormula addr=(1,0,2) old_value=Some(Number(5.0)) old_formula=None new==A1 * 3",
+        "SetFormula addr=(1,0,3) old_value=Some(Number(15.0)) old_formula=Some(=A1 + C1) new==A1 * 4",
+        "CompoundStart SetValueWithSpillClear sheet=1 row=0 col=4",
+        "SpillCleared",
+        "SetValue addr=(1,0,4) old_value=Some(Number(1.0)) old_formula=Some(=SEQUENCE(2, 1)) new=Int(99)",
+        "CompoundEnd",
+        "SetValue addr=(1,0,5) old_value=None old_formula=None new=Int(1)",
+        "SetFormula addr=(1,0,5) old_value=None old_formula=None new==A1 + 1",
+        "SetValue addr=(1,0,6) old_value=None old_formula=None new=Int(2)",
+    ];
+    assert_eq!(
+        got, expected,
+        "write_range batch changelog content diverged from pre-fix golden"
+    );
+}
+
+/// Golden event log for the `set_values` batch path (changelog on, graph
+/// mode): values over value/formula/spill-anchor/fresh cells.
+#[test]
+fn set_values_batch_event_log_golden() {
+    let mut wb = wb_changelog_graph_mode();
+    let mark = seed(&mut wb);
+
+    // Rectangle A1:F1 — covers value-over-value (A1), value-over-formula
+    // (B1, D1), value-over-value (C1), value-over-spill-anchor (E1), fresh (F1).
+    wb.set_values(
+        "S",
+        1,
+        1,
+        &[vec![
+            LiteralValue::Int(21),
+            LiteralValue::Int(22),
+            LiteralValue::Int(23),
+            LiteralValue::Int(24),
+            LiteralValue::Int(25),
+            LiteralValue::Int(26),
+        ]],
+    )
+    .unwrap();
+
+    let got = render_log_from(&wb, mark);
+    let expected = vec![
+        "SetValue addr=(1,0,0) old_value=Some(Number(10.0)) old_formula=None new=Int(21)",
+        "SetValue addr=(1,0,1) old_value=Some(Number(20.0)) old_formula=Some(=A1 * 2) new=Int(22)",
+        "SetValue addr=(1,0,2) old_value=Some(Number(5.0)) old_formula=None new=Int(23)",
+        "SetValue addr=(1,0,3) old_value=Some(Number(15.0)) old_formula=Some(=A1 + C1) new=Int(24)",
+        "CompoundStart SetValueWithSpillClear sheet=1 row=0 col=4",
+        "SpillCleared",
+        "SetValue addr=(1,0,4) old_value=Some(Number(1.0)) old_formula=Some(=SEQUENCE(2, 1)) new=Int(25)",
+        "CompoundEnd",
+        "SetValue addr=(1,0,5) old_value=None old_formula=None new=Int(26)",
+    ];
+    assert_eq!(
+        got, expected,
+        "set_values batch changelog content diverged from pre-fix golden"
+    );
+}
+
+/// Golden for the interactive default (defer_graph_building ON): write_range
+/// values are graph edits, formulas are STAGED (no editor event). A cell with
+/// both value+formula emits only the SetValue event, which historically
+/// received the patched old state (it is the cell's last event).
+#[test]
+fn write_range_batch_event_log_golden_deferred() {
+    let mut wb = Workbook::new(); // interactive: changelog on, defer on
+    wb.add_sheet("S").unwrap();
+    wb.set_value("S", 1, 1, LiteralValue::Int(10)).unwrap(); // A1
+    wb.set_value("S", 1, 2, LiteralValue::Int(20)).unwrap(); // B1
+    let mark = wb.changelog().events().len();
+
+    let mut cells: BTreeMap<(u32, u32), CellData> = BTreeMap::new();
+    cells.insert(
+        (1, 1),
+        CellData {
+            value: Some(LiteralValue::Int(11)),
+            formula: Some("=B1*2".into()),
+            style: None,
+        },
+    ); // A1: value (graph) + formula (staged)
+    cells.insert((1, 2), CellData::from_value(LiteralValue::Int(21))); // B1: value over value
+    cells.insert(
+        (1, 3),
+        CellData {
+            value: None,
+            formula: Some("=B1*3".into()),
+            style: None,
+        },
+    ); // C1: staged formula only — no graph event
+    wb.write_range("S", (1, 1), cells).unwrap();
+
+    let got = render_log_from(&wb, mark);
+    let expected = vec![
+        "SetValue addr=(1,0,0) old_value=Some(Number(10.0)) old_formula=None new=Int(11)",
+        "SetValue addr=(1,0,1) old_value=Some(Number(20.0)) old_formula=None new=Int(21)",
+        "Other(StagedFormulaCellChanged)",
+        "Other(StagedFormulaCellChanged)",
+    ];
+    assert_eq!(
+        got, expected,
+        "deferred write_range changelog content diverged from pre-fix golden"
+    );
+    assert_eq!(wb.get_formula("S", 1, 1), Some("=B1*2".to_string()));
+    assert_eq!(wb.get_formula("S", 1, 3), Some("=B1*3".to_string()));
+}
+
+/// Undo/redo round-trip across batched set_values + write_range with the
+/// changelog on. Undo must restore the exact pre-batch state (values AND
+/// formulas AND staged text); redo must reapply. Includes the repeated-cell
+/// case (same cell receives value+formula inside one write_range batch).
+#[test]
+fn undo_redo_batched_writes_round_trip() {
+    let mut wb = wb_changelog_graph_mode();
+
+    wb.add_sheet("S").unwrap();
+    wb.set_value("S", 1, 1, LiteralValue::Int(10)).unwrap(); // A1 value
+    wb.set_formula("S", 1, 2, "=A1*2").unwrap(); // B1 formula
+    wb.set_value("S", 1, 3, LiteralValue::Int(5)).unwrap(); // C1 value
+    wb.set_formula("S", 1, 4, "=A1+C1").unwrap(); // D1 formula
+    wb.evaluate_all().unwrap();
+
+    let pre_b1_val = wb.get_value("S", 1, 2);
+    let pre_d1_val = wb.get_value("S", 1, 4);
+
+    // Action 1: write_range mixed batch (incl. same-cell value+formula at F1).
+    wb.begin_action("batch write_range");
+    let mut cells: BTreeMap<(u32, u32), CellData> = BTreeMap::new();
+    cells.insert((1, 1), CellData::from_value(LiteralValue::Int(11)));
+    cells.insert((1, 2), CellData::from_value(LiteralValue::Int(7)));
+    cells.insert(
+        (1, 4),
+        CellData {
+            value: None,
+            formula: Some("=A1*4".into()),
+            style: None,
+        },
+    );
+    cells.insert(
+        (1, 6),
+        CellData {
+            value: Some(LiteralValue::Int(1)),
+            formula: Some("=A1+1".into()),
+            style: None,
+        },
+    );
+    wb.write_range("S", (1, 1), cells).unwrap();
+    wb.end_action();
+
+    // Action 2: set_values rectangle over A1:C1.
+    wb.begin_action("batch set_values");
+    wb.set_values(
+        "S",
+        1,
+        1,
+        &[vec![
+            LiteralValue::Int(31),
+            LiteralValue::Int(32),
+            LiteralValue::Int(33),
+        ]],
+    )
+    .unwrap();
+    wb.end_action();
+
+    // Final state.
+    assert_numeric_eq(wb.get_value("S", 1, 1), 31.0);
+    assert_numeric_eq(wb.get_value("S", 1, 2), 32.0);
+    assert_numeric_eq(wb.get_value("S", 1, 3), 33.0);
+    assert_eq!(wb.get_formula("S", 1, 2), None);
+    assert_eq!(wb.get_formula("S", 1, 4), Some("=A1 * 4".to_string()));
+    assert_eq!(wb.get_formula("S", 1, 6), Some("=A1 + 1".to_string()));
+
+    // Undo both batches -> exact pre-batch state. (Computed results of restored
+    // formulas refresh on the next evaluation, as on any formula edit.)
+    wb.undo().unwrap();
+    wb.undo().unwrap();
+    assert_numeric_eq(wb.get_value("S", 1, 1), 10.0);
+    assert_eq!(wb.get_formula("S", 1, 2), Some("=A1 * 2".to_string()));
+    assert_numeric_eq(wb.get_value("S", 1, 3), 5.0);
+    assert_eq!(wb.get_formula("S", 1, 4), Some("=A1 + C1".to_string()));
+    wb.evaluate_all().unwrap();
+    assert_eq!(wb.get_value("S", 1, 2), pre_b1_val);
+    assert_eq!(wb.get_value("S", 1, 4), pre_d1_val);
+    assert_eq!(wb.get_formula("S", 1, 6), None);
+    assert!(matches!(
+        wb.get_value("S", 1, 6),
+        None | Some(LiteralValue::Empty)
+    ));
+
+    // Redo both batches -> final state again.
+    wb.redo().unwrap();
+    wb.redo().unwrap();
+    assert_numeric_eq(wb.get_value("S", 1, 1), 31.0);
+    assert_numeric_eq(wb.get_value("S", 1, 2), 32.0);
+    assert_numeric_eq(wb.get_value("S", 1, 3), 33.0);
+    assert_eq!(wb.get_formula("S", 1, 4), Some("=A1 * 4".to_string()));
+    assert_eq!(wb.get_formula("S", 1, 6), Some("=A1 + 1".to_string()));
+}
+
+/// Undo/redo for the interactive default (deferred graph build): batched
+/// write_range stages formulas; undo must restore prior staged text exactly.
+#[test]
+fn undo_redo_batched_writes_staged_text_round_trip() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").unwrap();
+    wb.set_formula("S", 1, 1, "1+1").unwrap(); // A1 staged
+    wb.set_value("S", 1, 2, LiteralValue::Int(20)).unwrap(); // B1 value
+
+    wb.begin_action("batch");
+    let mut cells: BTreeMap<(u32, u32), CellData> = BTreeMap::new();
+    cells.insert(
+        (1, 1),
+        CellData {
+            value: None,
+            formula: Some("=2+2".into()),
+            style: None,
+        },
+    ); // A1: replace staged text
+    cells.insert((1, 2), CellData::from_value(LiteralValue::Int(21))); // B1: value over value
+    cells.insert(
+        (1, 3),
+        CellData {
+            value: Some(LiteralValue::Int(3)),
+            formula: Some("=3+3".into()),
+            style: None,
+        },
+    ); // C1: value + staged formula on the same cell
+    wb.write_range("S", (1, 1), cells).unwrap();
+    wb.end_action();
+
+    assert_eq!(wb.get_formula("S", 1, 1), Some("=2+2".to_string()));
+    assert_numeric_eq(wb.get_value("S", 1, 2), 21.0);
+    assert_eq!(wb.get_formula("S", 1, 3), Some("=3+3".to_string()));
+
+    wb.undo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("1+1".to_string()));
+    assert_numeric_eq(wb.get_value("S", 1, 2), 20.0);
+    assert_eq!(wb.get_formula("S", 1, 3), None);
+
+    wb.redo().unwrap();
+    assert_eq!(wb.get_formula("S", 1, 1), Some("=2+2".to_string()));
+    assert_numeric_eq(wb.get_value("S", 1, 2), 21.0);
+    assert_eq!(wb.get_formula("S", 1, 3), Some("=3+3".to_string()));
+}

--- a/crates/formualizer-workbook/tests/changelog_batch_old_state.rs
+++ b/crates/formualizer-workbook/tests/changelog_batch_old_state.rs
@@ -28,7 +28,10 @@ fn wb_changelog_graph_mode() -> Workbook {
 /// Render one change event as a stable, content-complete line.
 fn render_event(ev: &ChangeEvent) -> String {
     let fmt_ast = |a: &Option<formualizer_parse::ASTNode>| match a {
-        Some(ast) => format!("Some({})", formualizer_parse::pretty::canonical_formula(ast)),
+        Some(ast) => format!(
+            "Some({})",
+            formualizer_parse::pretty::canonical_formula(ast)
+        ),
         None => "None".to_string(),
     };
     match ev {


### PR DESCRIPTION
## Summary

Removes the changelog old-state patching dance and with it the last measured batch-edit superlinearity: `ChangeLog::patch_last_cell_event_old_state` walked the event log backwards per cell, so batch paths that append all N events first and patch afterward paid ~N²/2 comparisons. Identified as the dominant residue in #139's probe (changelog-on batch arm: ~470 ms of scan at 20k cells).

## Design

Old state now rides with the append instead of being patched in afterward. `VertexEditor` gains `set_cell_value_with_old_state` / `set_cell_formula_with_old_state` (the plain methods are thin `(None, None)` wrappers); precedence is `graph_captured.or(caller_fallback)` at event construction, byte-for-byte the patch's fill-only-if-None semantics, in both graph-cache and Arrow-truth modes. All six patch call sites converted (workbook single-edit `set_value`/`set_formula`, batch `write_range_inner`/`set_values_inner`, and the two engine Action paths), both post-hoc patch loops deleted, and `patch_last_cell_event_old_state` removed entirely — zero callers remain.

One intentional divergence: when an item produced no graph event (staged-formula-only cell in deferred mode, or a failed edit), the old reverse scan could fill `None` fields on a stale event from a previous operation. That misfire no longer happens.

## Measured (probe-edit-storm, changelog-on batch arm, release)

| K | before | after |
|---|---|---|
| 1,000 | 4.9 ms | 3.9 ms |
| 5,000 | 48.3 ms | 26.7 ms |
| 20,000 | 506.0 ms | 112.3 ms |

20k/5k scaling drops from ~10.5x (superlinear) to ~4.2x (linear); the remaining gap to the changelog-off arm (~65 ms at 20k) is linear event-recording cost. Per-cell and changelog-off arms unchanged. probe-finance-recalc smoke: p50 6.43 -> 6.03 ms, checksums equal.

## Tests

`crates/formualizer-workbook/tests/changelog_batch_old_state.rs` — 5 tests whose goldens were derived by running the bodies on base 16b1fa8d first, pinned, then confirmed unchanged after the fix: exact event-log equality for mixed write_range batches (value/formula overwrite matrix, spill-anchor overwrite with SpillCleared compound, same-cell value+formula), set_values batches, the deferred/staged-formula default path, and undo/redo round-trips for values, formulas, and staged text.

## Gates

cargo fmt --check clean; workspace clippy (-D warnings, CI exclusions) clean; workspace tests pass, zero failures; portable-wasm facade check clean.

Refs #139 (deferred-dirty scope; this removes the residue it exposed), #128 (changelog deltas).
