### PR TITLE
perf(builtins): IFERROR/IFNA short-circuit, SEQUENCE/RANDARRAY allocation guard, quickselect order statistics (~12x LARGE)

### DIFF
--- a/crates/formualizer-eval/src/builtins/logical_ext.rs
+++ b/crates/formualizer-eval/src/builtins/logical_ext.rs
@@ -287,10 +287,13 @@ pub struct IfErrorFn; // IFERROR(value, fallback)
 /// Variadic: false
 /// Signature: IFERROR(arg1: any@scalar, arg2: any@scalar)
 /// Arg schema: arg1{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}; arg2{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}
-/// Caps: PURE
+/// Caps: PURE, SHORT_CIRCUIT
 /// [formualizer-docgen:schema:end]
 impl Function for IfErrorFn {
-    func_caps!(PURE);
+    // SHORT_CIRCUIT: dispatch must not eagerly evaluate the fallback arm —
+    // the eval body below evaluates arg0 first and touches arg1 only when
+    // arg0 produced an error (same defect class as the IF fix in #118).
+    func_caps!(PURE, SHORT_CIRCUIT);
     fn name(&self) -> &'static str {
         "IFERROR"
     }
@@ -370,10 +373,12 @@ pub struct IfNaFn; // IFNA(value, fallback)
 /// Variadic: false
 /// Signature: IFNA(arg1: any@scalar, arg2: any@scalar)
 /// Arg schema: arg1{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}; arg2{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}
-/// Caps: PURE
+/// Caps: PURE, SHORT_CIRCUIT
 /// [formualizer-docgen:schema:end]
 impl Function for IfNaFn {
-    func_caps!(PURE);
+    // SHORT_CIRCUIT: the fallback arm is evaluated only when arg0 is #N/A;
+    // all other values/errors pass through without touching arg1.
+    func_caps!(PURE, SHORT_CIRCUIT);
     fn name(&self) -> &'static str {
         "IFNA"
     }

--- a/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
@@ -29,6 +29,42 @@ use formualizer_common::{ArgKind, ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_macros::func_caps;
 use std::collections::HashMap;
 
+/* ─────────────────── generated-array allocation guard ───────────────────
+ *
+ * Generator functions (SEQUENCE, RANDARRAY) materialize their full result
+ * as `Vec<Vec<LiteralValue>>` before the engine ever sees it, so dimension
+ * args taken from user input must be guarded BEFORE allocating — e.g.
+ * `=SEQUENCE(1e6,1e6)` would otherwise attempt a 10^12-cell allocation.
+ *
+ * Cap rationale:
+ * - Per-dimension: Excel sheet limits (1,048,576 rows × 16,384 cols — the
+ *   same values as `EvalConfig::default().max_sheet_rows/max_sheet_cols`).
+ *   A generated array larger than a sheet can never spill successfully
+ *   (`SpillBoundsPolicy::Strict`), so it is `#NUM!` unconditionally.
+ * - Total cells: 2^24 (16,777,216). `LiteralValue` is ≥32 bytes, so this
+ *   already bounds the transient allocation near ~0.5 GiB — three orders
+ *   of magnitude above the engine's default spill cap
+ *   (`SpillConfig::max_spill_cells` = 10,000) which would reject the
+ *   result downstream anyway. Anything larger risks OOM before that
+ *   downstream guard can run.
+ */
+const GENERATED_ARRAY_MAX_ROWS: i64 = 1_048_576;
+const GENERATED_ARRAY_MAX_COLS: i64 = 16_384;
+const GENERATED_ARRAY_MAX_CELLS: i64 = 1 << 24;
+
+/// Returns `Some(#NUM!)` when a `rows x cols` generated array exceeds the
+/// allocation guard; uses checked arithmetic so overflowing products fail
+/// closed. Callers have already rejected `rows <= 0 || cols <= 0`.
+fn generated_array_too_large(rows: i64, cols: i64) -> Option<ExcelError> {
+    if rows > GENERATED_ARRAY_MAX_ROWS || cols > GENERATED_ARRAY_MAX_COLS {
+        return Some(ExcelError::new(ExcelErrorKind::Num));
+    }
+    match rows.checked_mul(cols) {
+        Some(total) if total <= GENERATED_ARRAY_MAX_CELLS => None,
+        _ => Some(ExcelError::new(ExcelErrorKind::Num)),
+    }
+}
+
 /* ───────────────────────── helpers ───────────────────────── */
 
 pub fn super_wildcard_match(pattern: &str, text: &str) -> bool {
@@ -1398,6 +1434,10 @@ impl Function for RandArrayFn {
             return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
                 ExcelError::new(ExcelErrorKind::Value),
             )));
+        }
+
+        if let Some(e) = generated_array_too_large(rows, cols) {
+            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
         }
 
         let mut rng = ctx.rng_for_current(self.function_salt());
@@ -2937,8 +2977,9 @@ impl Function for SequenceFn {
                 ExcelError::new(ExcelErrorKind::Value),
             )));
         }
-        let total = rows.saturating_mul(cols);
-        // TODO(perf): guard extremely large allocations (#NUM!).
+        if let Some(e) = generated_array_too_large(rows, cols) {
+            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
+        }
         let mut out: Vec<Vec<LiteralValue>> = Vec::with_capacity(rows as usize);
         let mut current = start;
         for _r in 0..rows {
@@ -3933,6 +3974,148 @@ mod tests {
             }
             _ => panic!("expected array"),
         }
+    }
+
+    #[test]
+    fn generated_array_guard_boundaries() {
+        // Exactly at the total-cells cap: allowed (4096 * 4096 == 2^24).
+        assert!(generated_array_too_large(4096, 4096).is_none());
+        // One past the cap: #NUM!.
+        assert!(generated_array_too_large(4096, 4097).is_some());
+        // Per-dimension Excel sheet limits.
+        assert!(generated_array_too_large(1_048_576, 1).is_none());
+        assert!(generated_array_too_large(1_048_577, 1).is_some());
+        assert!(generated_array_too_large(1, 16_384).is_none());
+        assert!(generated_array_too_large(1, 16_385).is_some());
+        // checked_mul overflow path fails closed.
+        assert!(generated_array_too_large(i64::MAX, i64::MAX).is_some());
+    }
+
+    #[test]
+    fn sequence_oversized_returns_num_error_quickly() {
+        let wb = TestWorkbook::new().with_function(Arc::new(SequenceFn));
+        let ctx = wb.interpreter();
+        let f = ctx.context.get_function("", "SEQUENCE").unwrap();
+        // =SEQUENCE(1e6, 1e6): 10^12 cells must fail fast, not allocate.
+        let rows = lit(LiteralValue::Number(1e6));
+        let cols = lit(LiteralValue::Number(1e6));
+        let args = vec![
+            ArgumentHandle::new(&rows, &ctx),
+            ArgumentHandle::new(&cols, &ctx),
+        ];
+        let started = std::time::Instant::now();
+        let v = f
+            .dispatch(&args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        let elapsed = started.elapsed();
+        match v {
+            LiteralValue::Error(e) => {
+                assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Num)
+            }
+            other => panic!("expected #NUM! got {other:?}"),
+        }
+        assert!(
+            elapsed.as_millis() < 250,
+            "oversized SEQUENCE must short-circuit, took {elapsed:?}"
+        );
+
+        // Total-cells cap: full-sheet request (1,048,576 x 16,384) is #NUM!.
+        let rows = lit(LiteralValue::Int(1_048_576));
+        let cols = lit(LiteralValue::Int(16_384));
+        let args = vec![
+            ArgumentHandle::new(&rows, &ctx),
+            ArgumentHandle::new(&cols, &ctx),
+        ];
+        match f
+            .dispatch(&args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal()
+        {
+            LiteralValue::Error(e) => {
+                assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Num)
+            }
+            other => panic!("expected #NUM! got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sequence_large_but_legal_succeeds() {
+        // A full Excel column (1,048,576 x 1) stays under the cap and works.
+        let wb = TestWorkbook::new().with_function(Arc::new(SequenceFn));
+        let ctx = wb.interpreter();
+        let f = ctx.context.get_function("", "SEQUENCE").unwrap();
+        let rows = lit(LiteralValue::Int(1_048_576));
+        let args = vec![ArgumentHandle::new(&rows, &ctx)];
+        match f
+            .dispatch(&args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal()
+        {
+            LiteralValue::Array(a) => {
+                assert_eq!(a.len(), 1_048_576);
+                assert_eq!(a[0][0], LiteralValue::Number(1.0));
+            }
+            other => panic!("expected array got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sequence_negative_and_zero_dims_keep_value_error() {
+        let wb = TestWorkbook::new().with_function(Arc::new(SequenceFn));
+        let ctx = wb.interpreter();
+        let f = ctx.context.get_function("", "SEQUENCE").unwrap();
+        for (r, c) in [(0i64, 5i64), (-3, 5), (5, 0), (5, -1)] {
+            let rows = lit(LiteralValue::Int(r));
+            let cols = lit(LiteralValue::Int(c));
+            let args = vec![
+                ArgumentHandle::new(&rows, &ctx),
+                ArgumentHandle::new(&cols, &ctx),
+            ];
+            match f
+                .dispatch(&args, &ctx.function_context(None))
+                .unwrap()
+                .into_literal()
+            {
+                LiteralValue::Error(e) => {
+                    assert_eq!(
+                        e.kind,
+                        formualizer_common::ExcelErrorKind::Value,
+                        "SEQUENCE({r},{c})"
+                    )
+                }
+                other => panic!("expected #VALUE! for SEQUENCE({r},{c}), got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn randarray_oversized_returns_num_error_quickly() {
+        let wb = TestWorkbook::new().with_function(Arc::new(RandArrayFn));
+        let ctx = wb.interpreter();
+        let f = ctx.context.get_function("", "RANDARRAY").unwrap();
+        let rows = lit(LiteralValue::Number(1e6));
+        let cols = lit(LiteralValue::Number(1e6));
+        let args = vec![
+            ArgumentHandle::new(&rows, &ctx),
+            ArgumentHandle::new(&cols, &ctx),
+        ];
+        let started = std::time::Instant::now();
+        let v = f
+            .dispatch(&args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        let elapsed = started.elapsed();
+        match v {
+            LiteralValue::Error(e) => {
+                assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Num)
+            }
+            other => panic!("expected #NUM! got {other:?}"),
+        }
+        assert!(
+            elapsed.as_millis() < 250,
+            "oversized RANDARRAY must short-circuit, took {elapsed:?}"
+        );
     }
 
     #[test]

--- a/crates/formualizer-eval/src/builtins/stats/mod.rs
+++ b/crates/formualizer-eval/src/builtins/stats/mod.rs
@@ -5,8 +5,12 @@
 //! PERCENTILE.INC, PERCENTILE.EXC, QUARTILE.INC, QUARTILE.EXC.
 //!
 //! Notes:
-//! - We currently materialize numeric values into a Vec<f64>. For large ranges this could be
-//!   optimized with streaming selection algorithms (nth_element / partial sort). TODO(perf).
+//! - We materialize numeric values into a Vec<f64>. Functions that need only one or two order
+//!   statistics (LARGE, SMALL, MEDIAN, PERCENTILE.INC/.EXC, QUARTILE.INC/.EXC) use quickselect
+//!   (`select_nth_unstable_by`) instead of a full sort. Functions that need the complete sorted
+//!   order keep the sort: RANK.EQ/RANK.AVG (positional scan), MODE.SNGL/MODE.MULT (run-length
+//!   over sorted order), TRIMMEAN (f64 summation order over the sorted middle slice must stay
+//!   bit-identical), PERCENTRANK.INC/.EXC (interpolating scan), FREQUENCY (sorted bins).
 //! - Text/boolean coercion nuance: For Excel statistical functions, values coming from range
 //!   references should ignore text and logical values (they are skipped), while direct scalar
 //!   arguments still coerce (e.g. =STDEV(1,TRUE) treats TRUE as 1). This file now implements that
@@ -87,36 +91,79 @@ fn collect_numeric_stats(args: &[ArgumentHandle]) -> Result<Vec<f64>, ExcelError
     Ok(out)
 }
 
-fn percentile_inc(sorted: &[f64], p: f64) -> Result<f64, ExcelError> {
-    if sorted.is_empty() {
+/* ─────────────── order-statistic selection (quickselect) ───────────────
+ *
+ * LARGE/SMALL/MEDIAN and the PERCENTILE/QUARTILE family need at most two
+ * adjacent order statistics, so a full O(n log n) sort is wasted work;
+ * `select_nth_unstable_by` (quickselect) finds them in expected O(n).
+ *
+ * The comparator is byte-for-byte the one used by the full sorts it
+ * replaces (`partial_cmp().unwrap()`): `collect_numeric_stats` only yields
+ * coerced finite numerics, and a NaN would have panicked the old sort the
+ * same way. Ties are exact duplicates for f64s compared `Equal` (modulo
+ * the ±0.0 sign bit), so the selected element is bit-identical to the
+ * sorted element at the same index.
+ */
+
+/// k-th order statistic (0-based, ascending). Reorders `nums` in place.
+fn nth_smallest(nums: &mut [f64], k: usize) -> f64 {
+    let (_, kth, _) = nums.select_nth_unstable_by(k, |a, b| a.partial_cmp(b).unwrap());
+    *kth
+}
+
+/// The adjacent order statistics (k, k+1) ascending: one quickselect for k,
+/// then the (k+1)-th is the minimum of the right partition.
+/// Requires `k + 1 < nums.len()`.
+fn adjacent_smallest(nums: &mut [f64], k: usize) -> (f64, f64) {
+    let (_, kth, right) = nums.select_nth_unstable_by(k, |a, b| a.partial_cmp(b).unwrap());
+    let kth = *kth;
+    let mut next = right[0];
+    for &v in &right[1..] {
+        if v < next {
+            next = v;
+        }
+    }
+    (kth, next)
+}
+
+/// PERCENTILE.INC over unsorted data (reorders `nums`): rank = p*(n-1) on
+/// the ascending order needs at most the two adjacent order statistics
+/// around the rank. The interpolation formula is unchanged from the old
+/// full-sort implementation.
+fn percentile_inc(nums: &mut [f64], p: f64) -> Result<f64, ExcelError> {
+    if nums.is_empty() {
         return Err(ExcelError::new_num());
     }
     if !(0.0..=1.0).contains(&p) {
         return Err(ExcelError::new_num());
     }
-    if sorted.len() == 1 {
-        return Ok(sorted[0]);
+    if nums.len() == 1 {
+        return Ok(nums[0]);
     }
-    let n = sorted.len() as f64;
+    let n = nums.len() as f64;
     let rank = p * (n - 1.0); // 0-based rank
     let lo = rank.floor() as usize;
     let hi = rank.ceil() as usize;
     if lo == hi {
-        return Ok(sorted[lo]);
+        return Ok(nth_smallest(nums, lo));
     }
+    // hi == lo + 1 whenever rank is fractional.
     let frac = rank - (lo as f64);
-    Ok(sorted[lo] + (sorted[hi] - sorted[lo]) * frac)
+    let (lo_v, hi_v) = adjacent_smallest(nums, lo);
+    Ok(lo_v + (hi_v - lo_v) * frac)
 }
 
-fn percentile_exc(sorted: &[f64], p: f64) -> Result<f64, ExcelError> {
-    // Excel PERCENTILE.EXC requires 0 < p < 1 and uses (n+1) basis; invalid if rank<1 or >n
-    if sorted.is_empty() {
+/// PERCENTILE.EXC over unsorted data (reorders `nums`); (n+1) rank basis,
+/// invalid when rank < 1 or > n. Same selection strategy as
+/// [`percentile_inc`]; interpolation formula unchanged.
+fn percentile_exc(nums: &mut [f64], p: f64) -> Result<f64, ExcelError> {
+    if nums.is_empty() {
         return Err(ExcelError::new_num());
     }
     if !(0.0..=1.0).contains(&p) || p <= 0.0 || p >= 1.0 {
         return Err(ExcelError::new_num());
     }
-    let n = sorted.len() as f64;
+    let n = nums.len() as f64;
     let rank = p * (n + 1.0); // 1..n domain
     if rank < 1.0 || rank > n {
         return Err(ExcelError::new_num());
@@ -124,12 +171,13 @@ fn percentile_exc(sorted: &[f64], p: f64) -> Result<f64, ExcelError> {
     let lo = rank.floor();
     let hi = rank.ceil();
     if (lo - hi).abs() < f64::EPSILON {
-        return Ok(sorted[(lo as usize) - 1]);
+        return Ok(nth_smallest(nums, (lo as usize) - 1));
     }
+    // hi_idx == lo_idx + 1 whenever rank is fractional.
     let frac = rank - lo;
     let lo_idx = (lo as usize) - 1;
-    let hi_idx = (hi as usize) - 1;
-    Ok(sorted[lo_idx] + (sorted[hi_idx] - sorted[lo_idx]) * frac)
+    let (lo_v, hi_v) = adjacent_smallest(nums, lo_idx);
+    Ok(lo_v + (hi_v - lo_v) * frac)
 }
 
 /// Returns the rank position of a number within a data set, with ties sharing the same rank.
@@ -464,10 +512,10 @@ impl Function for LARGE {
                 ExcelError::new_num(),
             )));
         }
-        nums.sort_by(|a, b| b.partial_cmp(a).unwrap());
-        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            nums[(k as usize) - 1],
-        )))
+        // k-th largest == (n-k)-th smallest: quickselect instead of full sort.
+        let idx = nums.len() - k as usize;
+        let v = nth_smallest(&mut nums, idx);
+        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v)))
     }
 }
 
@@ -564,10 +612,9 @@ impl Function for SMALL {
                 ExcelError::new_num(),
             )));
         }
-        nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-            nums[(k as usize) - 1],
-        )))
+        // k-th smallest: quickselect instead of full sort.
+        let v = nth_smallest(&mut nums, k as usize - 1);
+        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v)))
     }
 }
 
@@ -645,13 +692,14 @@ impl Function for MEDIAN {
                 ExcelError::new_num(),
             )));
         }
-        nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // Middle one/two order statistics: quickselect instead of full sort.
         let n = nums.len();
         let mid = n / 2;
         let med = if n % 2 == 1 {
-            nums[mid]
+            nth_smallest(&mut nums, mid)
         } else {
-            (nums[mid - 1] + nums[mid]) / 2.0
+            let (lo, hi) = adjacent_smallest(&mut nums, mid - 1);
+            (lo + hi) / 2.0
         };
         Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(med)))
     }
@@ -1323,8 +1371,7 @@ impl Function for PercentileInc {
                 ExcelError::new_num(),
             )));
         }
-        nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        match percentile_inc(&nums, p) {
+        match percentile_inc(&mut nums, p) {
             Ok(v) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v))),
             Err(e) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e))),
         }
@@ -1420,8 +1467,7 @@ impl Function for PercentileExc {
                 ExcelError::new_num(),
             )));
         }
-        nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        match percentile_exc(&nums, p) {
+        match percentile_exc(&mut nums, p) {
             Ok(v) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v))),
             Err(e) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e))),
         }
@@ -1526,17 +1572,15 @@ impl Function for QuartileInc {
                 ExcelError::new_num(),
             )));
         }
-        nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let p = match q_i {
             0 => {
-                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-                    nums[0],
-                )));
+                let v = nth_smallest(&mut nums, 0);
+                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v)));
             }
             4 => {
-                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-                    nums[nums.len() - 1],
-                )));
+                let idx = nums.len() - 1;
+                let v = nth_smallest(&mut nums, idx);
+                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v)));
             }
             1 => 0.25,
             2 => 0.5,
@@ -1547,7 +1591,7 @@ impl Function for QuartileInc {
                 )));
             }
         };
-        match percentile_inc(&nums, p) {
+        match percentile_inc(&mut nums, p) {
             Ok(v) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v))),
             Err(e) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e))),
         }
@@ -1653,7 +1697,6 @@ impl Function for QuartileExc {
                 ExcelError::new_num(),
             )));
         }
-        nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let p = match q_i {
             1 => 0.25,
             2 => 0.5,
@@ -1664,7 +1707,7 @@ impl Function for QuartileExc {
                 )));
             }
         };
-        match percentile_exc(&nums, p) {
+        match percentile_exc(&mut nums, p) {
             Ok(v) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(v))),
             Err(e) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e))),
         }
@@ -10880,5 +10923,223 @@ mod tests_basic_stats {
             .unwrap()
             .into_literal();
         assert_eq!(out, LiteralValue::Number(0.0));
+    }
+}
+
+#[cfg(test)]
+mod tests_selection_vs_sort_oracle {
+    //! Property tests: the quickselect paths must be bit-identical to the
+    //! previous full-sort implementations (the "oracle" below reproduces the
+    //! removed sort-based code exactly).
+
+    use super::*;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    /* ───── full-sort reference oracle (the pre-quickselect implementation) ───── */
+
+    fn sorted_asc(data: &[f64]) -> Vec<f64> {
+        let mut s = data.to_vec();
+        s.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        s
+    }
+
+    fn oracle_large(data: &[f64], k: usize) -> f64 {
+        let mut s = data.to_vec();
+        s.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        s[k - 1]
+    }
+
+    fn oracle_small(data: &[f64], k: usize) -> f64 {
+        sorted_asc(data)[k - 1]
+    }
+
+    fn oracle_median(data: &[f64]) -> f64 {
+        let s = sorted_asc(data);
+        let n = s.len();
+        let mid = n / 2;
+        if n % 2 == 1 {
+            s[mid]
+        } else {
+            (s[mid - 1] + s[mid]) / 2.0
+        }
+    }
+
+    fn oracle_percentile_inc(data: &[f64], p: f64) -> Result<f64, ExcelError> {
+        let sorted = sorted_asc(data);
+        if sorted.is_empty() || !(0.0..=1.0).contains(&p) {
+            return Err(ExcelError::new_num());
+        }
+        if sorted.len() == 1 {
+            return Ok(sorted[0]);
+        }
+        let n = sorted.len() as f64;
+        let rank = p * (n - 1.0);
+        let lo = rank.floor() as usize;
+        let hi = rank.ceil() as usize;
+        if lo == hi {
+            return Ok(sorted[lo]);
+        }
+        let frac = rank - (lo as f64);
+        Ok(sorted[lo] + (sorted[hi] - sorted[lo]) * frac)
+    }
+
+    fn oracle_percentile_exc(data: &[f64], p: f64) -> Result<f64, ExcelError> {
+        let sorted = sorted_asc(data);
+        if sorted.is_empty() || !(0.0..=1.0).contains(&p) || p <= 0.0 || p >= 1.0 {
+            return Err(ExcelError::new_num());
+        }
+        let n = sorted.len() as f64;
+        let rank = p * (n + 1.0);
+        if rank < 1.0 || rank > n {
+            return Err(ExcelError::new_num());
+        }
+        let lo = rank.floor();
+        let hi = rank.ceil();
+        if (lo - hi).abs() < f64::EPSILON {
+            return Ok(sorted[(lo as usize) - 1]);
+        }
+        let frac = rank - lo;
+        let lo_idx = (lo as usize) - 1;
+        let hi_idx = (hi as usize) - 1;
+        Ok(sorted[lo_idx] + (sorted[hi_idx] - sorted[lo_idx]) * frac)
+    }
+
+    fn assert_bits_eq(new: f64, old: f64, what: &str, data: &[f64]) {
+        assert_eq!(
+            new.to_bits(),
+            old.to_bits(),
+            "{what}: selection {new:?} != sort oracle {old:?} for {data:?}"
+        );
+    }
+
+    /// 1000 seeded random vectors (mixed continuous values and a small grid
+    /// to force exact-duplicate ties) x random k / percentile.
+    #[test]
+    fn quickselect_paths_match_full_sort_oracle_bitwise() {
+        let mut rng = SmallRng::seed_from_u64(0x5EED_57A7_u64);
+        for _case in 0..1000 {
+            let n = rng.gen_range(1..=64);
+            let data: Vec<f64> = (0..n)
+                .map(|_| {
+                    if rng.gen_bool(0.35) {
+                        // Tie-heavy grid: exact duplicates are common.
+                        f64::from(rng.gen_range(-4i32..=4)) * 0.5
+                    } else {
+                        rng.gen_range(-1.0e6..1.0e6)
+                    }
+                })
+                .collect();
+
+            // LARGE / SMALL across every k (includes k == 1 and k == n).
+            for k in 1..=n {
+                let mut buf = data.clone();
+                let idx = buf.len() - k;
+                assert_bits_eq(
+                    nth_smallest(&mut buf, idx),
+                    oracle_large(&data, k),
+                    "LARGE",
+                    &data,
+                );
+                let mut buf = data.clone();
+                assert_bits_eq(
+                    nth_smallest(&mut buf, k - 1),
+                    oracle_small(&data, k),
+                    "SMALL",
+                    &data,
+                );
+            }
+
+            // MEDIAN (odd and even n both covered across cases).
+            {
+                let mut buf = data.clone();
+                let mid = buf.len() / 2;
+                let med = if buf.len() % 2 == 1 {
+                    nth_smallest(&mut buf, mid)
+                } else if buf.len() >= 2 {
+                    let (lo, hi) = adjacent_smallest(&mut buf, mid - 1);
+                    (lo + hi) / 2.0
+                } else {
+                    buf[0]
+                };
+                assert_bits_eq(med, oracle_median(&data), "MEDIAN", &data);
+            }
+
+            // PERCENTILE.INC / .EXC with random p, plus the exact endpoints
+            // and quartile points (0.25/0.5/0.75 also covers QUARTILE.*).
+            let ps = [
+                rng.r#gen::<f64>(),
+                0.0,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                rng.gen_range(-0.5..1.5), // sometimes out of range
+            ];
+            for p in ps {
+                let mut buf = data.clone();
+                match (percentile_inc(&mut buf, p), oracle_percentile_inc(&data, p)) {
+                    (Ok(a), Ok(b)) => assert_bits_eq(a, b, "PERCENTILE.INC", &data),
+                    (Err(ea), Err(eb)) => assert_eq!(ea.kind, eb.kind),
+                    (a, b) => panic!("PERCENTILE.INC divergence p={p}: {a:?} vs {b:?}"),
+                }
+                let mut buf = data.clone();
+                match (percentile_exc(&mut buf, p), oracle_percentile_exc(&data, p)) {
+                    (Ok(a), Ok(b)) => assert_bits_eq(a, b, "PERCENTILE.EXC", &data),
+                    (Err(ea), Err(eb)) => assert_eq!(ea.kind, eb.kind),
+                    (a, b) => panic!("PERCENTILE.EXC divergence p={p}: {a:?} vs {b:?}"),
+                }
+            }
+        }
+    }
+
+    /// Empty input keeps the error contract.
+    #[test]
+    fn percentile_empty_input_still_num_error() {
+        let mut empty: Vec<f64> = vec![];
+        assert!(percentile_inc(&mut empty, 0.5).is_err());
+        assert!(percentile_exc(&mut empty, 0.5).is_err());
+    }
+
+    /// Perf probe (run explicitly):
+    /// `cargo test -p formualizer-eval --release --lib large_quickselect_perf_probe -- --ignored --nocapture`
+    #[test]
+    #[ignore = "perf probe; run manually with --release --nocapture"]
+    fn large_quickselect_perf_probe() {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let data: Vec<f64> = (0..100_000).map(|_| rng.gen_range(-1.0e9..1.0e9)).collect();
+        let k = 50usize;
+        let rounds = 50u32;
+
+        let t = std::time::Instant::now();
+        let mut old_v = 0.0;
+        for _ in 0..rounds {
+            let mut s = data.clone();
+            s.sort_by(|a, b| b.partial_cmp(a).unwrap());
+            old_v = s[k - 1];
+        }
+        let old_t = t.elapsed();
+
+        let t = std::time::Instant::now();
+        let mut new_v = 0.0;
+        for _ in 0..rounds {
+            let mut s = data.clone();
+            let idx = s.len() - k;
+            new_v = nth_smallest(&mut s, idx);
+        }
+        let new_t = t.elapsed();
+
+        println!(
+            "LARGE over 100k x{rounds}: full-sort {:?} ({:?}/op), quickselect {:?} ({:?}/op)",
+            old_t,
+            old_t / rounds,
+            new_t,
+            new_t / rounds
+        );
+        assert_eq!(new_v.to_bits(), old_v.to_bits());
+        assert!(
+            new_t < old_t,
+            "quickselect should beat a full sort on 100k values"
+        );
     }
 }

--- a/crates/formualizer-eval/src/engine/tests/iferror_ifna_lazy.rs
+++ b/crates/formualizer-eval/src/engine/tests/iferror_ifna_lazy.rs
@@ -1,0 +1,251 @@
+//! IFERROR/IFNA semantics pins + lazy-dispatch polarity tests.
+//!
+//! IFERROR and IFNA are `SHORT_CIRCUIT` functions (same defect class as the
+//! IF bug fixed in #118): the fallback argument must not be evaluated unless
+//! the value argument produced an error (for IFNA: only `#N/A`). The first
+//! half of this file pins the value/array semantics that must be identical
+//! before and after the lazy-dispatch change; the second half proves
+//! laziness with an evaluation-counting function.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn wb_with_builtins() -> TestWorkbook {
+    TestWorkbook::new()
+        .with_function(Arc::new(crate::builtins::logical_ext::IfErrorFn))
+        .with_function(Arc::new(crate::builtins::logical_ext::IfNaFn))
+}
+
+fn eval_formula(formula: &str) -> LiteralValue {
+    let wb = wb_with_builtins();
+    let interp = wb.interpreter();
+    let ast = parse(formula).unwrap();
+    interp.evaluate_ast(&ast).unwrap().into_literal()
+}
+
+/* ───────────────────── value-semantics pins (pre/post identical) ───────────────────── */
+
+#[test]
+fn iferror_catches_every_error_kind() {
+    for err in [
+        "#DIV/0!", "#N/A", "#NAME?", "#NULL!", "#NUM!", "#REF!", "#VALUE!",
+    ] {
+        let v = eval_formula(&format!("=IFERROR({err},42)"));
+        assert_eq!(v, LiteralValue::Number(42.0), "IFERROR must catch {err}");
+    }
+}
+
+#[test]
+fn ifna_catches_only_na() {
+    assert_eq!(eval_formula("=IFNA(#N/A,42)"), LiteralValue::Number(42.0));
+    for err in ["#DIV/0!", "#NAME?", "#NULL!", "#NUM!", "#REF!", "#VALUE!"] {
+        match eval_formula(&format!("=IFNA({err},42)")) {
+            LiteralValue::Error(e) => {
+                assert_eq!(e.to_string(), err, "IFNA must pass through {err}")
+            }
+            other => panic!("IFNA({err},42) must pass the error through, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn iferror_text_and_number_passthrough() {
+    assert_eq!(
+        eval_formula("=IFERROR(\"ok\",\"fb\")"),
+        LiteralValue::Text("ok".into())
+    );
+    assert_eq!(eval_formula("=IFERROR(0,99)"), LiteralValue::Number(0.0));
+    assert_eq!(
+        eval_formula("=IFNA(\"ok\",\"fb\")"),
+        LiteralValue::Text("ok".into())
+    );
+}
+
+#[test]
+fn iferror_blank_value_arg_passes_through_as_empty() {
+    // A1 is blank; IFERROR(A1, 42) yields the blank (Empty), not the fallback.
+    let wb = TestWorkbook::new();
+    let mut engine = Engine::new(wb, EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=IFERROR(A1,42)").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 2, 2, parse("=IFNA(A1,42)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    let v = engine.get_cell_value("Sheet1", 1, 2);
+    let v2 = engine.get_cell_value("Sheet1", 2, 2);
+    // Blank arg0 is not an error: it passes through as Empty (engine stores
+    // an Empty result as an empty cell), NOT as the fallback.
+    assert!(
+        matches!(v, None | Some(LiteralValue::Empty)),
+        "blank passthrough changed: {v:?}"
+    );
+    assert_eq!(v, v2, "IFERROR and IFNA must agree on blank passthrough");
+}
+
+#[test]
+fn iferror_arity_errors_are_value() {
+    // Too many args: #VALUE! (was enforced by eager validation, now by eval body).
+    for f in ["=IFERROR(1,2,3)", "=IFNA(1,2,3)"] {
+        match eval_formula(f) {
+            LiteralValue::Error(e) => {
+                assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Value)
+            }
+            other => panic!("{f} must be #VALUE!, got {other:?}"),
+        }
+    }
+}
+
+/* ───────────────────── array/spill semantics pin ─────────────────────
+ *
+ * IFERROR is whole-value in this engine: when arg0 evaluates to an array
+ * (e.g. a broadcast division over ranges), the array passes through as-is —
+ * element-wise errors inside the array are NOT replaced by the fallback.
+ * The fallback is used only when arg0 itself is a (scalar) error / eval
+ * failure. This pin guards that the lazy-dispatch change does not alter the
+ * array path. (Laziness applies to the same `args[0].value()` call the eval
+ * body already made; arrays were never materialized differently.)
+ */
+
+#[test]
+fn iferror_array_arg_passes_array_through_with_elementwise_errors() {
+    let wb = TestWorkbook::new();
+    let mut engine = Engine::new(wb, EvalConfig::default());
+    // A1:A3 = 1,2,3 ; B1=1, B2=0 (div error), B3=3
+    for (r, v) in [(1, 1), (2, 2), (3, 3)] {
+        engine
+            .set_cell_value("Sheet1", r, 1, LiteralValue::Int(v))
+            .unwrap();
+    }
+    for (r, v) in [(1, 1), (2, 0), (3, 3)] {
+        engine
+            .set_cell_value("Sheet1", r, 2, LiteralValue::Int(v))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=IFERROR(A1:A3/B1:B3,0)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(1.0))
+    );
+    // Element-wise error inside the array is NOT replaced by the fallback.
+    match engine.get_cell_value("Sheet1", 2, 3) {
+        Some(LiteralValue::Error(e)) => {
+            assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Div)
+        }
+        other => panic!("expected #DIV/0! spilled at C2, got {other:?}"),
+    }
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 3, 3),
+        Some(LiteralValue::Number(1.0))
+    );
+}
+
+/* ───────────────────── laziness polarity tests (#118 pattern) ───────────────────── */
+
+#[derive(Debug)]
+struct CountFn(Arc<AtomicUsize>);
+impl crate::function::Function for CountFn {
+    fn caps(&self) -> crate::function::FnCaps {
+        crate::function::FnCaps::PURE
+    }
+    fn name(&self) -> &'static str {
+        "COUNTING"
+    }
+    fn min_args(&self) -> usize {
+        0
+    }
+    fn eval<'a, 'b, 'c>(
+        &self,
+        _args: &'c [crate::traits::ArgumentHandle<'a, 'b>],
+        _ctx: &dyn crate::traits::FunctionContext<'b>,
+    ) -> Result<crate::traits::CalcValue<'b>, formualizer_common::ExcelError> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(7)))
+    }
+}
+
+fn harness() -> (TestWorkbook, Arc<AtomicUsize>) {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let wb = wb_with_builtins().with_function(Arc::new(CountFn(counter.clone())));
+    (wb, counter)
+}
+
+fn eval_in(wb: &TestWorkbook, formula: &str) -> LiteralValue {
+    let interp = wb.interpreter();
+    let ast = parse(formula).unwrap();
+    interp.evaluate_ast(&ast).unwrap().into_literal()
+}
+
+#[test]
+fn iferror_ok_value_does_not_evaluate_fallback() {
+    let (wb, counter) = harness();
+    let v = eval_in(&wb, "=IFERROR(1,COUNTING())");
+    assert_eq!(v, LiteralValue::Number(1.0));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "IFERROR fallback must not be evaluated when the value arg succeeds"
+    );
+}
+
+#[test]
+fn iferror_error_value_evaluates_fallback_exactly_once() {
+    let (wb, counter) = harness();
+    let v = eval_in(&wb, "=IFERROR(1/0,COUNTING())");
+    assert_eq!(v, LiteralValue::Int(7));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "IFERROR fallback must be evaluated exactly once on error"
+    );
+}
+
+#[test]
+fn ifna_fallback_only_for_na_other_errors_pass_through_unevaluated() {
+    let (wb, counter) = harness();
+
+    // #N/A: fallback taken, evaluated once.
+    let v = eval_in(&wb, "=IFNA(#N/A,COUNTING())");
+    assert_eq!(v, LiteralValue::Int(7));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+    // Non-NA error: passes through, fallback NOT evaluated.
+    let v = eval_in(&wb, "=IFNA(1/0,COUNTING())");
+    match v {
+        LiteralValue::Error(e) => assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Div),
+        other => panic!("expected #DIV/0! passthrough, got {other:?}"),
+    }
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "IFNA fallback must not be evaluated for non-#N/A errors"
+    );
+
+    // Plain value: fallback NOT evaluated.
+    let v = eval_in(&wb, "=IFNA(5,COUNTING())");
+    assert_eq!(v, LiteralValue::Number(5.0));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn nested_iferror_only_evaluates_needed_arms() {
+    let (wb, counter) = harness();
+    // Inner IFERROR succeeds -> outer sees a non-error -> no COUNTING anywhere.
+    let v = eval_in(&wb, "=IFERROR(IFERROR(3,COUNTING()),COUNTING())");
+    assert_eq!(v, LiteralValue::Number(3.0));
+    assert_eq!(counter.load(Ordering::SeqCst), 0);
+
+    // Inner errors -> inner fallback evaluated once; outer sees non-error.
+    let v = eval_in(&wb, "=IFERROR(IFERROR(1/0,COUNTING()),COUNTING())");
+    assert_eq!(v, LiteralValue::Int(7));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -144,6 +144,7 @@ mod visibility_mask_cache;
 mod csr_rebuild_amortization;
 mod demand_subgraph_named_range;
 mod dn_range_xlsx_subgraph;
+mod iferror_ifna_lazy;
 mod iterate_corpus_chains;
 mod iterate_corpus_interactions;
 mod iterate_corpus_numeric;


### PR DESCRIPTION
## Summary

Three independent function-level fixes from the verified shortlist of the Arrow/function-hotpath reconnaissance.

## 1. IFERROR/IFNA lazy short-circuit dispatch

`IfErrorFn` and `IfNaFn` declared `PURE` only, so dispatch's eager validation evaluated the fallback arm even when the value arg succeeded — the same defect class as the IF bug fixed in #118. Both now declare `SHORT_CIRCUIT`; the eval bodies already implemented the lazy semantics, so the fix is the capability flag plus pinning. Polarity tests (the #118 counting-function pattern) prove it: pre-change, 3 polarity tests failed with fallback evaluation counts of 1-2 where 0 was expected; post-change all pass. IFNA's fallback is evaluated only for #N/A; other errors pass through without touching it. Array behavior pinned before the change: IFERROR is whole-value here (a broadcast array with element-wise errors passes through; fallback not applied per element), and that path is the same lazy `args[0].value()` call, so behavior is identical.

## 2. SEQUENCE/RANDARRAY allocation guard

Closes the documented `TODO(perf): guard extremely large allocations` — `=SEQUENCE(1e6, 1e6)` previously attempted the full materialization (OOM-class). New `generated_array_too_large` guard before allocation in SEQUENCE and RANDARRAY: per-dimension Excel sheet limits (1,048,576 x 16,384 — anything larger can never spill under strict bounds), a total-cells cap of 2^24 (bounds the transient buffer at ~0.5 GiB, three orders of magnitude above the default `max_spill_cells` that rejects results downstream anyway), checked multiplication failing closed. The 1e6 x 1e6 case now returns #NUM! in ~0 ms; full-column `SEQUENCE(1048576)` still works.

## 3. Quickselect for order statistics

Closes the documented stats TODO: LARGE, SMALL, MEDIAN, PERCENTILE.INC/.EXC, and QUARTILE.INC/.EXC now use `select_nth_unstable_by` (1-2 order statistics) instead of a full sort. Functions that genuinely need full sorted order keep it (RANK.*, MODE.*, PERCENTRANK.*, FREQUENCY, and TRIMMEAN — whose summation order must stay bit-identical). Property test: 1,000 seeded tie-heavy vectors x every k / random + endpoint percentiles, bitwise-equal (`f64::to_bits`) against the removed full-sort implementation as oracle. Measured: LARGE over 100k values, 3.28 ms -> 273 us per call (~12x).

## Gates

fmt clean; workspace clippy (-D warnings, CI exclusions) clean; workspace tests pass (formualizer-eval 1961 passed, 0 failures); portable-wasm facade check clean. Standing perf gate vs main (4 interleaved A/B rounds): finance-recalc means 230.5 vs 230.2 ms and load-envelope mixed-direction — noise, pass; checksums identical.

Refs #118 (short-circuit dispatch), recon shortlist from the iterative-calc perf track.
