### PR TITLE
bench(fp): FormulaPlane span-coverage corpus, probe, and pinning tests — 70% baseline, mixed-mode perf finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ opencode.json
 
 *coverage*
 !tests/formula_tests/extended_coverage.json
+# FormulaPlane span-coverage measurement sources (not coverage artifacts)
+!**/fp_coverage.rs
+!**/probe-fp-coverage.rs
+!**/formula_plane_coverage_pinning.rs
 *.xlsx
 test-wb/
 tickets/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "formualizer-common",
  "formualizer-macros",
  "formualizer-parse",
+ "formualizer-testkit",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "glob",

--- a/crates/formualizer-bench-core/src/bin/probe-fp-coverage.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-fp-coverage.rs
@@ -1,0 +1,416 @@
+//! FormulaPlane span-coverage probe.
+//!
+//! Standing measurement for fingerprint-coverage expansions: on a realistic
+//! mixed workbook (shared `formualizer_testkit::fp_coverage` generator, the
+//! same corpus pinned by the engine test
+//! `formula_plane_coverage_pinning.rs`), reports:
+//!
+//! - what fraction of formula cells get accepted into spans under
+//!   `FormulaPlaneMode::AuthoritativeExperimental`,
+//! - the placement fallback-reason histogram (and the canonical-template
+//!   reject-kind histogram from the diagnostics sidecar),
+//! - wall-clock for load + first eval + warm recalc with FormulaPlane ON vs
+//!   OFF on the same workbook (speedup-per-coverage-point baseline),
+//! - a cell-by-cell ON-vs-OFF value-equality verdict (authoritative mode must
+//!   never change results).
+//!
+//! Run:
+//!
+//! ```bash
+//! cargo run -p formualizer-bench-core --features formualizer_runner \
+//!   --release --bin probe-fp-coverage -- --rows-per-section 2000
+//! ```
+
+#[cfg(not(feature = "formualizer_runner"))]
+fn main() {
+    eprintln!(
+        "This binary requires feature `formualizer_runner`: cargo run -p formualizer-bench-core --features formualizer_runner --release --bin probe-fp-coverage"
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "formualizer_runner")]
+mod probe {
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+    use std::time::Instant;
+
+    use anyhow::{Context, Result};
+    use clap::Parser;
+    use formualizer_eval::engine::{EvalConfig, FormulaPlaneMode};
+    use formualizer_eval::formula_plane::diagnostics::canonical_template_diagnostic;
+    use formualizer_parse::parser::parse;
+    use formualizer_testkit::build_workbook;
+    use formualizer_testkit::fp_coverage::{CoverageWorkbook, SectionVerdict, generate};
+    use formualizer_workbook::{
+        LiteralValue, LoadStrategy, SpreadsheetReader, UmyaAdapter, Workbook, WorkbookConfig,
+    };
+    use serde::Serialize;
+
+    #[derive(Debug, Parser)]
+    #[command(about = "FormulaPlane span-coverage probe over the shared fp_coverage mixed corpus")]
+    pub struct Cli {
+        /// Formula cells per section (10 sections; default ~20k cells total).
+        #[arg(long, default_value_t = 2_000)]
+        rows_per_section: u32,
+        /// Seed perturbing data values (formula structure is seed-independent).
+        #[arg(long, default_value_t = 42)]
+        seed: u64,
+        /// Include generator sections quarantined for authoritative-mode bugs
+        /// (currently none).
+        #[arg(long, default_value_t = false)]
+        include_broken: bool,
+        /// Subset of section names to keep (comma separated); empty = all.
+        #[arg(long, default_value = "")]
+        only: String,
+    }
+
+    #[derive(Debug, Serialize, Clone)]
+    struct ModeTimings {
+        mode: String,
+        load_ms: u128,
+        eval_first_ms: u128,
+        eval_warm_ms: u128,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct SectionReport {
+        name: &'static str,
+        sheet: &'static str,
+        formula_cells: u64,
+        expected_verdict: String,
+        /// Evaluated value of the section's first formula cell (Off mode);
+        /// guards against sections that "pass" equality by erroring in both
+        /// modes (e.g. an unresolved defined name yielding #NAME? twice).
+        sample_value: String,
+        notes: &'static str,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct CoverageReport {
+        formula_cells_seen: u64,
+        accepted_span_cells: u64,
+        legacy_cells: u64,
+        coverage_pct: f64,
+        spans_created: u64,
+        templates_interned: u64,
+        formula_vertices_avoided: u64,
+        ast_roots_avoided: u64,
+        edge_rows_avoided: u64,
+        fallback_reasons: BTreeMap<String, u64>,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct ValueEquality {
+        cells_compared: u64,
+        mismatches: u64,
+        examples: Vec<String>,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct ProbeReport {
+        rows_per_section: u32,
+        seed: u64,
+        total_formula_cells: u64,
+        sections: Vec<SectionReport>,
+        coverage: CoverageReport,
+        /// Canonical-template reject kinds weighted by section cell count
+        /// (template-canonicalization layer, below placement).
+        canonical_reject_kinds: BTreeMap<String, u64>,
+        off: ModeTimings,
+        auth: ModeTimings,
+        speedup_first: f64,
+        speedup_warm: f64,
+        value_equality: ValueEquality,
+    }
+
+    fn build_fixture(corpus: &CoverageWorkbook) -> PathBuf {
+        build_workbook(|book| {
+            for section in &corpus.sections {
+                let _ = book.new_sheet(section.sheet);
+            }
+            let _ = book.new_sheet(formualizer_testkit::fp_coverage::DATA_SHEET);
+
+            for cell in corpus
+                .sections
+                .iter()
+                .flat_map(|s| s.values.iter())
+                .chain(corpus.data_values.iter())
+            {
+                book.get_sheet_by_name_mut(cell.sheet)
+                    .expect("sheet exists")
+                    .get_cell_mut((cell.col, cell.row))
+                    .set_value_number(cell.value);
+            }
+            for cell in corpus.sections.iter().flat_map(|s| s.formulas.iter()) {
+                book.get_sheet_by_name_mut(cell.sheet)
+                    .expect("sheet exists")
+                    .get_cell_mut((cell.col, cell.row))
+                    .set_formula(cell.formula.trim_start_matches('='));
+            }
+            for named in &corpus.named_ranges {
+                let address = format!(
+                    "{}!${}${}:${}${}",
+                    named.sheet,
+                    col_letter(named.start_col),
+                    named.start_row,
+                    col_letter(named.end_col),
+                    named.end_row,
+                );
+                book.get_sheet_by_name_mut(named.sheet)
+                    .expect("named-range sheet exists")
+                    .add_defined_name(named.name, &address)
+                    .expect("add defined name");
+            }
+        })
+    }
+
+    fn col_letter(mut col: u32) -> String {
+        let mut s = String::new();
+        while col > 0 {
+            let rem = ((col - 1) % 26) as u8;
+            s.insert(0, (b'A' + rem) as char);
+            col = (col - 1) / 26;
+        }
+        s
+    }
+
+    struct ModeRun {
+        timings: ModeTimings,
+        values: Vec<Option<LiteralValue>>,
+        coverage: Option<CoverageReport>,
+    }
+
+    fn run_mode(mode: FormulaPlaneMode, path: &Path, corpus: &CoverageWorkbook) -> Result<ModeRun> {
+        let mut config = WorkbookConfig::ephemeral();
+        config.eval = EvalConfig::default().with_formula_plane_mode(mode);
+
+        let load_start = Instant::now();
+        let backend = UmyaAdapter::open_path(path)?;
+        let mut wb = Workbook::from_reader(backend, LoadStrategy::EagerAll, config)?;
+        let load_ms = load_start.elapsed().as_millis();
+
+        let t = Instant::now();
+        wb.evaluate_all()?;
+        let eval_first_ms = t.elapsed().as_millis();
+
+        let t = Instant::now();
+        wb.evaluate_all()?;
+        let eval_warm_ms = t.elapsed().as_millis();
+
+        let mut values = Vec::new();
+        for cell in corpus.sections.iter().flat_map(|s| s.formulas.iter()) {
+            values.push(wb.get_value(cell.sheet, cell.row, cell.col));
+        }
+
+        let coverage = if mode == FormulaPlaneMode::AuthoritativeExperimental {
+            let report = wb.engine().formula_ingest_report_total();
+            let seen = report.formula_cells_seen;
+            let accepted = report.shadow_accepted_span_cells;
+            Some(CoverageReport {
+                formula_cells_seen: seen,
+                accepted_span_cells: accepted,
+                legacy_cells: report.shadow_fallback_cells,
+                coverage_pct: if seen == 0 {
+                    0.0
+                } else {
+                    accepted as f64 * 100.0 / seen as f64
+                },
+                spans_created: report.shadow_spans_created,
+                templates_interned: report.shadow_templates_interned,
+                formula_vertices_avoided: report.graph_formula_vertices_avoided_shadow,
+                ast_roots_avoided: report.ast_roots_avoided_shadow,
+                edge_rows_avoided: report.edge_rows_avoided_shadow,
+                fallback_reasons: report.fallback_reasons.clone(),
+            })
+        } else {
+            None
+        };
+
+        Ok(ModeRun {
+            timings: ModeTimings {
+                mode: format!("{mode:?}"),
+                load_ms,
+                eval_first_ms,
+                eval_warm_ms,
+            },
+            values,
+            coverage,
+        })
+    }
+
+    fn literal_eq(a: &LiteralValue, b: &LiteralValue) -> bool {
+        let num = |v: &LiteralValue| -> Option<f64> {
+            match v {
+                LiteralValue::Number(n) => Some(*n),
+                LiteralValue::Int(i) => Some(*i as f64),
+                LiteralValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+                _ => None,
+            }
+        };
+        match (num(a), num(b)) {
+            (Some(x), Some(y)) => {
+                let scale = x.abs().max(y.abs()).max(1.0);
+                (x - y).abs() <= scale * 1e-9
+            }
+            _ => a == b,
+        }
+    }
+
+    fn ratio(off: f64, auth: f64) -> f64 {
+        if auth <= 0.0 {
+            if off <= 0.0 { 1.0 } else { f64::INFINITY }
+        } else {
+            off / auth
+        }
+    }
+
+    pub fn main() -> Result<()> {
+        let cli = Cli::parse();
+        let mut corpus = generate(cli.rows_per_section, cli.seed, cli.include_broken);
+        if !cli.only.trim().is_empty() {
+            let keep: Vec<&str> = cli.only.split(',').map(str::trim).collect();
+            corpus.sections.retain(|s| keep.contains(&s.name));
+            anyhow::ensure!(
+                !corpus.sections.is_empty(),
+                "--only {:?} matched no sections",
+                cli.only
+            );
+            let kept_sheets: Vec<&str> = corpus.sections.iter().map(|s| s.sheet).collect();
+            corpus
+                .named_ranges
+                .retain(|n| kept_sheets.contains(&n.sheet));
+        }
+        let total_formula_cells = corpus.total_formula_cells();
+        eprintln!(
+            "[probe-fp-coverage] {} sections, {} formula cells, seed {}",
+            corpus.sections.len(),
+            total_formula_cells,
+            cli.seed
+        );
+
+        let path = build_fixture(&corpus);
+
+        let off = run_mode(FormulaPlaneMode::Off, &path, &corpus)?;
+        let auth = run_mode(FormulaPlaneMode::AuthoritativeExperimental, &path, &corpus)?;
+        let coverage = auth.coverage.context("authoritative coverage report")?;
+
+        // Value-equality verdict: authoritative mode must not change results.
+        let mut mismatches = 0u64;
+        let mut examples = Vec::new();
+        let cells: Vec<_> = corpus
+            .sections
+            .iter()
+            .flat_map(|s| s.formulas.iter().map(move |c| (s.name, c)))
+            .collect();
+        for (i, (section, cell)) in cells.iter().enumerate() {
+            let equal = match (&off.values[i], &auth.values[i]) {
+                (Some(a), Some(b)) => literal_eq(a, b),
+                (a, b) => a == b,
+            };
+            if !equal {
+                mismatches += 1;
+                if examples.len() < 10 {
+                    examples.push(format!(
+                        "{section} {}!R{}C{} ({}): off={:?} auth={:?}",
+                        cell.sheet, cell.row, cell.col, cell.formula, off.values[i], auth.values[i]
+                    ));
+                }
+            }
+        }
+
+        // Canonical-template reject kinds, weighted by section size. Every
+        // section is structurally homogeneous, so one representative formula
+        // per section is exact.
+        let mut canonical_reject_kinds: BTreeMap<String, u64> = BTreeMap::new();
+        for section in &corpus.sections {
+            if let Some(cell) = section.formulas.first() {
+                let ast = parse(&cell.formula)?;
+                let diag = canonical_template_diagnostic(&ast, cell.row, cell.col);
+                for kind in diag.reject_kinds {
+                    *canonical_reject_kinds.entry(kind).or_default() +=
+                        section.formulas.len() as u64;
+                }
+            }
+        }
+
+        let report = ProbeReport {
+            rows_per_section: cli.rows_per_section,
+            seed: cli.seed,
+            total_formula_cells,
+            sections: {
+                let mut offset = 0usize;
+                corpus
+                    .sections
+                    .iter()
+                    .map(|s| {
+                        let sample_value = format!("{:?}", off.values[offset]);
+                        offset += s.formulas.len();
+                        SectionReport {
+                            name: s.name,
+                            sheet: s.sheet,
+                            formula_cells: s.formulas.len() as u64,
+                            expected_verdict: match s.verdict {
+                                SectionVerdict::Span => "span".to_string(),
+                                SectionVerdict::Reject { placement_reason } => {
+                                    format!("reject:{placement_reason}")
+                                }
+                            },
+                            sample_value,
+                            notes: s.notes,
+                        }
+                    })
+                    .collect()
+            },
+            coverage,
+            canonical_reject_kinds,
+            speedup_first: ratio(
+                off.timings.eval_first_ms as f64,
+                auth.timings.eval_first_ms as f64,
+            ),
+            speedup_warm: ratio(
+                off.timings.eval_warm_ms as f64,
+                auth.timings.eval_warm_ms as f64,
+            ),
+            off: off.timings,
+            auth: auth.timings,
+            value_equality: ValueEquality {
+                cells_compared: cells.len() as u64,
+                mismatches,
+                examples,
+            },
+        };
+
+        println!("{}", serde_json::to_string_pretty(&report)?);
+
+        eprintln!();
+        eprintln!(
+            "# fp-coverage: {:.1}% span coverage ({}/{} cells, {} spans), first eval {}→{} ms, warm {}→{} ms, value mismatches {}",
+            report.coverage.coverage_pct,
+            report.coverage.accepted_span_cells,
+            report.coverage.formula_cells_seen,
+            report.coverage.spans_created,
+            report.off.eval_first_ms,
+            report.auth.eval_first_ms,
+            report.off.eval_warm_ms,
+            report.auth.eval_warm_ms,
+            report.value_equality.mismatches,
+        );
+        let mut reasons: Vec<_> = report.coverage.fallback_reasons.iter().collect();
+        reasons.sort_by(|a, b| b.1.cmp(a.1));
+        for (reason, count) in reasons.iter().take(5) {
+            eprintln!("  fallback {reason}: {count}");
+        }
+
+        if report.value_equality.mismatches > 0 {
+            eprintln!("ERROR: authoritative mode changed values; see examples in JSON");
+            std::process::exit(1);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn main() -> anyhow::Result<()> {
+    probe::main()
+}

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -78,6 +78,9 @@ serde_json = { workspace = true }
 glob = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1"
+# Pure generators only (fp_coverage); default-features off keeps the umya/xlsx
+# fixture helpers out of the eval dev tree.
+formualizer-testkit = { path = "../formualizer-testkit", default-features = false }
 
 [[bench]]
 name = "interval_tree_bench"

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_coverage_pinning.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_coverage_pinning.rs
@@ -1,0 +1,349 @@
+//! Span-coverage pinning test for the FormulaPlane authoritative placement
+//! verdicts over the shared `formualizer_testkit::fp_coverage` corpus.
+//!
+//! This is the regression net for fingerprint-coverage expansions: every
+//! generator section pins either full span acceptance or a specific
+//! `PlacementFallbackReason`. When a new reference kind gains span support
+//! (named ranges, whole-axis refs, mixed-anchor ranges, ...), exactly one
+//! section's expectation flips here — update the generator's verdict, not the
+//! test logic.
+//!
+//! Each section is ingested into an isolated engine so the global
+//! `FormulaIngestReport` histogram attributes cleanly to that section. Values
+//! are additionally compared cell-by-cell against a `FormulaPlaneMode::Off`
+//! engine: authoritative mode must never change results.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::reference::{CellRef, Coord, RangeRef};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+use formualizer_testkit::fp_coverage::{self, CoverageWorkbook, Section, SectionVerdict, generate};
+
+/// Must be >= 100: non-constant spans below
+/// `MIN_PROMOTED_NON_CONSTANT_SPAN_CELLS` are demoted with `SmallDomain`,
+/// which would mask the verdicts this test pins.
+const ROWS_PER_SECTION: u32 = 120;
+const SEED: u64 = 42;
+
+fn build_engine(
+    mode: FormulaPlaneMode,
+    corpus: &CoverageWorkbook,
+    section: &Section,
+) -> Engine<TestWorkbook> {
+    let cfg = EvalConfig::default().with_formula_plane_mode(mode);
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    // Sections whose sheet carries no literal cells (e.g. cross_sheet) still
+    // need the sheet to exist before formula ingest.
+    engine.add_sheet(section.sheet).unwrap();
+    for cell in &section.values {
+        engine
+            .set_cell_value(
+                cell.sheet,
+                cell.row,
+                cell.col,
+                LiteralValue::Number(cell.value),
+            )
+            .unwrap();
+    }
+    // Shared Data sheet (read by cross_sheet; harmless elsewhere, only set
+    // when the section actually references it to keep engines minimal).
+    if section.name == "cross_sheet" {
+        for cell in &corpus.data_values {
+            engine
+                .set_cell_value(
+                    cell.sheet,
+                    cell.row,
+                    cell.col,
+                    LiteralValue::Number(cell.value),
+                )
+                .unwrap();
+        }
+    }
+    for named in &corpus.named_ranges {
+        if named.sheet != section.sheet {
+            continue;
+        }
+        let sheet_id = engine.graph.sheet_id_mut(named.sheet);
+        let start = CellRef::new(
+            sheet_id,
+            Coord::new(named.start_row - 1, named.start_col - 1, true, true),
+        );
+        let end = CellRef::new(
+            sheet_id,
+            Coord::new(named.end_row - 1, named.end_col - 1, true, true),
+        );
+        engine
+            .define_name(
+                named.name,
+                NamedDefinition::Range(RangeRef::new(start, end)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+    }
+    engine
+}
+
+fn ingest_section(
+    engine: &mut Engine<TestWorkbook>,
+    section: &Section,
+) -> crate::engine::FormulaIngestReport {
+    let mut records = Vec::with_capacity(section.formulas.len());
+    for cell in &section.formulas {
+        let ast = parse(&cell.formula).unwrap_or_else(|e| {
+            panic!("section {}: parse {:?}: {e:?}", section.name, cell.formula)
+        });
+        let ast_id = engine.intern_formula_ast(&ast);
+        records.push(FormulaIngestRecord::new(
+            cell.row,
+            cell.col,
+            ast_id,
+            Some(Arc::<str>::from(cell.formula.as_str())),
+        ));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(section.sheet, records)])
+        .expect("ingest formulas")
+}
+
+fn assert_values_match(
+    section: &Section,
+    auth: &mut Engine<TestWorkbook>,
+    off: &mut Engine<TestWorkbook>,
+) {
+    for cell in &section.formulas {
+        let got = auth.get_cell_value(cell.sheet, cell.row, cell.col);
+        let expected = off.get_cell_value(cell.sheet, cell.row, cell.col);
+        let equal = match (&got, &expected) {
+            (Some(a), Some(b)) => literal_eq(a, b),
+            (a, b) => a == b,
+        };
+        assert!(
+            equal,
+            "section {}: value mismatch at {}!R{}C{} ({}): auth={got:?} off={expected:?}",
+            section.name, cell.sheet, cell.row, cell.col, cell.formula
+        );
+    }
+}
+
+fn as_num(v: &LiteralValue) -> Option<f64> {
+    match v {
+        LiteralValue::Number(n) => Some(*n),
+        LiteralValue::Int(i) => Some(*i as f64),
+        LiteralValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
+fn literal_eq(a: &LiteralValue, b: &LiteralValue) -> bool {
+    match (as_num(a), as_num(b)) {
+        (Some(x), Some(y)) => {
+            let scale = x.abs().max(y.abs()).max(1.0);
+            (x - y).abs() <= scale * 1e-9
+        }
+        _ => a == b,
+    }
+}
+
+#[test]
+fn fp_coverage_corpus_pins_section_verdicts_and_values() {
+    let corpus = generate(ROWS_PER_SECTION, SEED, false);
+    assert_eq!(corpus.sections.len(), fp_coverage::SECTION_COUNT);
+
+    for section in &corpus.sections {
+        let n = section.formulas.len() as u64;
+        assert_eq!(n, ROWS_PER_SECTION as u64, "section {}", section.name);
+
+        let mut auth = build_engine(
+            FormulaPlaneMode::AuthoritativeExperimental,
+            &corpus,
+            section,
+        );
+        let report = ingest_section(&mut auth, section);
+        assert_eq!(
+            report.formula_cells_seen, n,
+            "section {}: formula_cells_seen",
+            section.name
+        );
+
+        match section.verdict {
+            SectionVerdict::Span => {
+                assert_eq!(
+                    report.shadow_accepted_span_cells, n,
+                    "section {}: expected all {n} cells span-accepted; fallback histogram: {:?}",
+                    section.name, report.fallback_reasons
+                );
+                assert_eq!(
+                    report.shadow_fallback_cells, 0,
+                    "section {}: unexpected legacy cells; histogram: {:?}",
+                    section.name, report.fallback_reasons
+                );
+                assert!(
+                    report.shadow_spans_created >= 1,
+                    "section {}: expected at least one span",
+                    section.name
+                );
+            }
+            SectionVerdict::Reject { placement_reason } => {
+                assert_eq!(
+                    report.shadow_accepted_span_cells, 0,
+                    "section {}: expected zero span-accepted cells; histogram: {:?}",
+                    section.name, report.fallback_reasons
+                );
+                let count = report
+                    .fallback_reasons
+                    .get(placement_reason)
+                    .copied()
+                    .unwrap_or(0);
+                assert_eq!(
+                    count, n,
+                    "section {}: expected fallback reason {placement_reason:?} x{n}; histogram: {:?}",
+                    section.name, report.fallback_reasons
+                );
+            }
+        }
+
+        // Authoritative mode must not change values: compare against Off.
+        auth.evaluate_all().expect("evaluate authoritative");
+        let mut off = build_engine(FormulaPlaneMode::Off, &corpus, section);
+        let _ = ingest_section(&mut off, section);
+        off.evaluate_all().expect("evaluate off");
+        assert_values_match(section, &mut auth, &mut off);
+    }
+}
+
+/// Combined run: all sections in one engine; the aggregate histogram is the
+/// sum of the per-section expectations (no cross-section interference).
+#[test]
+fn fp_coverage_corpus_combined_totals() {
+    let corpus = generate(ROWS_PER_SECTION, SEED, false);
+    let n = ROWS_PER_SECTION as u64;
+
+    let cfg =
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    for section in &corpus.sections {
+        engine.add_sheet(section.sheet).unwrap();
+    }
+    for cell in corpus
+        .sections
+        .iter()
+        .flat_map(|s| s.values.iter())
+        .chain(corpus.data_values.iter())
+    {
+        engine
+            .set_cell_value(
+                cell.sheet,
+                cell.row,
+                cell.col,
+                LiteralValue::Number(cell.value),
+            )
+            .unwrap();
+    }
+    for named in &corpus.named_ranges {
+        let sheet_id = engine.graph.sheet_id_mut(named.sheet);
+        let start = CellRef::new(
+            sheet_id,
+            Coord::new(named.start_row - 1, named.start_col - 1, true, true),
+        );
+        let end = CellRef::new(
+            sheet_id,
+            Coord::new(named.end_row - 1, named.end_col - 1, true, true),
+        );
+        engine
+            .define_name(
+                named.name,
+                NamedDefinition::Range(RangeRef::new(start, end)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+    }
+
+    let mut batches = Vec::new();
+    for section in &corpus.sections {
+        let mut records = Vec::new();
+        for cell in &section.formulas {
+            let ast = parse(&cell.formula).unwrap();
+            let ast_id = engine.intern_formula_ast(&ast);
+            records.push(FormulaIngestRecord::new(
+                cell.row,
+                cell.col,
+                ast_id,
+                Some(Arc::<str>::from(cell.formula.as_str())),
+            ));
+        }
+        batches.push(FormulaIngestBatch::new(section.sheet, records));
+    }
+    let report = engine.ingest_formula_batches(batches).expect("ingest");
+
+    let expected_span_sections = corpus
+        .sections
+        .iter()
+        .filter(|s| s.verdict == SectionVerdict::Span)
+        .count() as u64;
+    let expected_reject_sections = corpus.sections.len() as u64 - expected_span_sections;
+
+    assert_eq!(report.formula_cells_seen, corpus.total_formula_cells());
+    assert_eq!(
+        report.shadow_accepted_span_cells,
+        expected_span_sections * n
+    );
+    assert_eq!(report.shadow_fallback_cells, expected_reject_sections * n);
+
+    let mut expected_histogram: BTreeMap<&'static str, u64> = BTreeMap::new();
+    for section in &corpus.sections {
+        if let SectionVerdict::Reject { placement_reason } = section.verdict {
+            *expected_histogram.entry(placement_reason).or_default() += n;
+        }
+    }
+    for (reason, count) in &expected_histogram {
+        assert_eq!(
+            report.fallback_reasons.get(*reason).copied().unwrap_or(0),
+            *count,
+            "combined histogram for {reason}: {:?}",
+            report.fallback_reasons
+        );
+    }
+
+    engine.evaluate_all().expect("evaluate combined");
+}
+
+/// Canonical-template reject kinds per section (template-canonicalization
+/// layer, below placement). Only compiled with `formula_plane_diagnostics`.
+#[cfg(feature = "formula_plane_diagnostics")]
+#[test]
+fn fp_coverage_corpus_pins_canonical_reject_kinds() {
+    let corpus = generate(ROWS_PER_SECTION, SEED, false);
+    for section in &corpus.sections {
+        let cell = section.formulas.first().expect("non-empty section");
+        let ast = parse(&cell.formula).unwrap();
+        let diag = crate::formula_plane::diagnostics::canonical_template_diagnostic(
+            &ast, cell.row, cell.col,
+        );
+        for expected in section.expected_canonical_reject_kinds {
+            assert!(
+                diag.reject_kinds.iter().any(|k| k == expected),
+                "section {}: expected canonical reject kind {expected:?}, got {:?}",
+                section.name,
+                diag.reject_kinds
+            );
+        }
+        if section.expected_canonical_reject_kinds.is_empty()
+            && section.verdict == SectionVerdict::Span
+        {
+            assert!(
+                diag.authority_supported,
+                "section {}: canonical template unexpectedly rejected: {:?}",
+                section.name, diag.reject_reasons
+            );
+        }
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -105,6 +105,7 @@ mod eval_flush_recalc_probe;
 mod formula_edit_propagation;
 mod formula_error_propagation;
 mod formula_overlay_writeback;
+mod formula_plane_coverage_pinning;
 mod formula_plane_cycle_member_exclusion;
 mod formula_plane_demotion_correctness;
 mod formula_plane_dirty_domain_preservation;

--- a/crates/formualizer-testkit/Cargo.toml
+++ b/crates/formualizer-testkit/Cargo.toml
@@ -9,6 +9,12 @@ repository.workspace = true
 documentation.workspace = true
 publish = false
 
+[features]
+# xlsx fixture helpers (umya-backed). Default-on; disable for dependents that
+# only need the pure generators (e.g. formualizer-eval dev-deps).
+default = ["xlsx"]
+xlsx = ["dep:umya-spreadsheet", "dep:tempfile"]
+
 [dependencies]
-tempfile = { workspace = true }
-umya-spreadsheet = "=2.3.2"
+tempfile = { workspace = true, optional = true }
+umya-spreadsheet = { version = "=2.3.2", optional = true }

--- a/crates/formualizer-testkit/src/fp_coverage.rs
+++ b/crates/formualizer-testkit/src/fp_coverage.rs
@@ -1,0 +1,456 @@
+//! Deterministic mixed-workbook generator for FormulaPlane span-coverage
+//! measurement.
+//!
+//! Produces a realistic blend of formula families that real models use, with a
+//! *known expected-support profile* per section: each section is either
+//! expected to be fully accepted into FormulaPlane spans or expected to fall
+//! back to the legacy graph with a specific `PlacementFallbackReason`.
+//!
+//! The generator is representation-agnostic (plain rows/cols/strings, no
+//! spreadsheet backend types) so the same corpus drives:
+//!
+//! - the `probe-fp-coverage` bench-core binary (via an XLSX fixture), and
+//! - the engine pinning test
+//!   (`formualizer-eval/src/engine/tests/formula_plane_coverage_pinning.rs`)
+//!   which is the regression net for upcoming fingerprint expansions. When a
+//!   new reference kind gains span support (e.g. named ranges), exactly one
+//!   section's expectation flips here.
+//!
+//! Layout: every section lives on its own sheet; formula rows are
+//! `2..=rows_per_section + 1` (row 1 is reserved as a header/aux row). The
+//! `cross_sheet` section additionally reads from the shared `Data` sheet.
+//!
+//! NOTE: FormulaPlane only promotes non-constant spans with at least
+//! `MIN_PROMOTED_NON_CONSTANT_SPAN_CELLS` (currently 100) members; callers
+//! that assert `Span` verdicts must use `rows_per_section >= 100`.
+
+/// Shared data sheet read by the `cross_sheet` section.
+pub const DATA_SHEET: &str = "Data";
+
+/// Number of sections emitted with `include_broken = false`.
+///
+/// Useful for sizing: total formula cells = `SECTION_COUNT * rows_per_section`.
+pub const SECTION_COUNT: usize = 10;
+
+/// Expected FormulaPlane placement verdict for every formula cell of a section.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SectionVerdict {
+    /// Every formula cell is expected to be accepted into a span.
+    Span,
+    /// Every formula cell is expected to stay on the legacy graph, recorded
+    /// under this `PlacementFallbackReason` debug name in
+    /// `FormulaIngestReport::fallback_reasons`.
+    Reject { placement_reason: &'static str },
+}
+
+/// A literal input cell.
+#[derive(Clone, Debug)]
+pub struct ValueCell {
+    pub sheet: &'static str,
+    pub row: u32,
+    pub col: u32,
+    pub value: f64,
+}
+
+/// A formula cell (formula text includes the leading `=`).
+#[derive(Clone, Debug)]
+pub struct FormulaCell {
+    pub sheet: &'static str,
+    pub row: u32,
+    pub col: u32,
+    pub formula: String,
+}
+
+/// A workbook-scoped named range required by a section.
+#[derive(Clone, Copy, Debug)]
+pub struct NamedRangeSpec {
+    pub name: &'static str,
+    pub sheet: &'static str,
+    /// 1-based inclusive bounds.
+    pub start_row: u32,
+    pub start_col: u32,
+    pub end_row: u32,
+    pub end_col: u32,
+}
+
+/// One homogeneous formula family with a known expected verdict.
+#[derive(Clone, Debug)]
+pub struct Section {
+    pub name: &'static str,
+    pub sheet: &'static str,
+    pub verdict: SectionVerdict,
+    /// Expected canonical-template reject kinds (diagnostic labels from
+    /// `formula_plane_diagnostics`), empty for should-span sections.
+    pub expected_canonical_reject_kinds: &'static [&'static str],
+    pub values: Vec<ValueCell>,
+    pub formulas: Vec<FormulaCell>,
+    pub notes: &'static str,
+}
+
+/// Full generated corpus.
+#[derive(Clone, Debug)]
+pub struct CoverageWorkbook {
+    pub sections: Vec<Section>,
+    pub named_ranges: Vec<NamedRangeSpec>,
+    /// Values on the shared `Data` sheet (read by `cross_sheet`).
+    pub data_values: Vec<ValueCell>,
+}
+
+impl CoverageWorkbook {
+    pub fn total_formula_cells(&self) -> u64 {
+        self.sections.iter().map(|s| s.formulas.len() as u64).sum()
+    }
+}
+
+/// Cheap deterministic value mixer so data columns are not trivially uniform.
+/// (splitmix64 finalizer; stable across platforms.)
+fn mix(seed: u64, a: u64, b: u64) -> f64 {
+    let mut z = seed
+        .wrapping_add(a.wrapping_mul(0x9E37_79B9_7F4A_7C15))
+        .wrapping_add(b.wrapping_mul(0xBF58_476D_1CE4_E5B9));
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    // Map to a small positive range with one decimal, keeps SUM/IF behavior tame.
+    ((z % 1000) as f64) / 10.0
+}
+
+/// Generate the coverage corpus.
+///
+/// * `rows_per_section` — formula cells per section (>= 100 required for
+///   `Span` verdicts to hold; see module note on the promotion threshold).
+/// * `seed` — perturbs data values only; the formula structure (and therefore
+///   the expected-support profile) is independent of the seed.
+/// * `include_broken` — include sections that are excluded by default because
+///   they produce wrong values or panics under authoritative mode. Currently
+///   there are none; the flag is the standing escape hatch demanded by the
+///   probe contract.
+pub fn generate(rows_per_section: u32, seed: u64, include_broken: bool) -> CoverageWorkbook {
+    let n = rows_per_section;
+    let first = 2u32; // formula/data rows are 2..=last
+    let last = n + 1;
+    let rows = first..=last;
+
+    let mut sections: Vec<Section> = Vec::new();
+
+    // ------------------------------------------------------------------
+    // (a) row_arith — row-shifted arithmetic column (=B2*C2+A2 style).
+    // Expected: SPAN (relative refs shift uniformly with the row).
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("RowArith", r, 1, r as f64)); // A
+            values.push(val("RowArith", r, 2, mix(seed, r as u64, 1))); // B
+            values.push(val("RowArith", r, 3, ((r % 7) + 1) as f64)); // C
+            formulas.push(formula("RowArith", r, 4, format!("=B{r}*C{r}+A{r}")));
+        }
+        sections.push(Section {
+            name: "row_arith",
+            sheet: "RowArith",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Row-shifted arithmetic =B{r}*C{r}+A{r}; canonical relative offsets, one span.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (b) anchored_agg — fully-anchored aggregate, identical every row
+    // (=SUM($B$2:$B$last)). Expected: SPAN (constant-result span; exempt
+    // from the 100-cell promotion threshold).
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("AnchoredAgg", r, 2, mix(seed, r as u64, 2))); // B
+            formulas.push(formula(
+                "AnchoredAgg",
+                r,
+                3,
+                format!("=SUM($B$2:$B${last})"),
+            ));
+        }
+        sections.push(Section {
+            name: "anchored_agg",
+            sheet: "AnchoredAgg",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Anchored aggregate =SUM($B$2:$B$last), identical per row; constant-result span.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (c) sumifs_fixed — SUMIFS with fixed (absolute) value/criteria ranges
+    // and a row-relative criterion cell. Expected: SPAN.
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("SumifsFixed", r, 1, (r % 5) as f64)); // A: category
+            values.push(val("SumifsFixed", r, 2, mix(seed, r as u64, 3))); // B: amount
+            formulas.push(formula(
+                "SumifsFixed",
+                r,
+                3,
+                format!("=SUMIFS($B$2:$B${last},$A$2:$A${last},A{r})"),
+            ));
+        }
+        sections.push(Section {
+            name: "sumifs_fixed",
+            sheet: "SumifsFixed",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "SUMIFS with fixed criteria/value ranges, row-relative criterion cell.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (d) lookup — VLOOKUP column over an anchored table. Expected: SPAN.
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            // A: lookup keys, a permutation-ish walk over 1..=n.
+            let key = ((u64::from(r - first) * 7) % u64::from(n)) + 1;
+            values.push(val("Lookup", r, 1, key as f64));
+            // H/I: sorted lookup table keyed 1..=n.
+            values.push(val("Lookup", r, 8, (r - 1) as f64));
+            values.push(val("Lookup", r, 9, mix(seed, (r - 1) as u64, 4)));
+            formulas.push(formula(
+                "Lookup",
+                r,
+                3,
+                format!("=VLOOKUP(A{r},$H$2:$I${last},2,FALSE)"),
+            ));
+        }
+        sections.push(Section {
+            name: "lookup",
+            sheet: "Lookup",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "VLOOKUP over anchored $H$2:$I$last table, exact match.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (e) nested_if_literals — nested IF whose literal operands vary per
+    // row. Expected: SPAN via parameterized literal bindings (the
+    // parameterized canonical template is shared; literals become slots).
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("NestedIf", r, 2, mix(seed, r as u64, 5))); // B
+            let t = (r % 50) + 10;
+            let m = (r % 3) + 2;
+            let k = (r % 9) + 1;
+            formulas.push(formula(
+                "NestedIf",
+                r,
+                3,
+                format!("=IF(B{r}>{t},B{r}*{m},IF(B{r}>{k},B{r}+{k},{m}))"),
+            ));
+        }
+        sections.push(Section {
+            name: "nested_if_literals",
+            sheet: "NestedIf",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Nested IF with per-row literal thresholds; spans via literal-slot bindings.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (f) whole_axis — whole-column reference =SUM(A:A).
+    // Expected: SPAN. Whole-axis references gained canonical + placement
+    // support (AxisRef::WholeAxis); pinned empirically on 2026-06-10.
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("WholeAxis", r, 1, mix(seed, r as u64, 6))); // A
+            formulas.push(formula("WholeAxis", r, 3, "=SUM(A:A)".to_string()));
+        }
+        sections.push(Section {
+            name: "whole_axis",
+            sheet: "WholeAxis",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Whole-column =SUM(A:A); whole-axis refs are span-supported (constant family).",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (g) named_range — reference through a workbook-scoped defined name.
+    // Expected: REJECT (canonical NamedReference -> placement
+    // UnsupportedCanonicalTemplate). Flips to SPAN when named-range
+    // fingerprinting lands.
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("NamedRange", r, 2, mix(seed, r as u64, 7))); // B
+            formulas.push(formula(
+                "NamedRange",
+                r,
+                3,
+                format!("=SUM(CovNamedData)+A{r}"),
+            ));
+            values.push(val("NamedRange", r, 1, r as f64)); // A
+        }
+        sections.push(Section {
+            name: "named_range",
+            sheet: "NamedRange",
+            verdict: SectionVerdict::Reject {
+                placement_reason: "UnsupportedCanonicalTemplate",
+            },
+            expected_canonical_reject_kinds: &["named_reference"],
+            values,
+            formulas,
+            notes: "=SUM(CovNamedData)+A{r}; canonical reject NamedReference.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (h) mixed_anchor — range with relative start / absolute end
+    // (=SUM($A{r}:$A$last)): the read region shrinks as the row advances,
+    // so member templates are not row-translation-equivalent.
+    // Expected: REJECT.
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("MixedAnchor", r, 1, mix(seed, r as u64, 8))); // A
+            formulas.push(formula(
+                "MixedAnchor",
+                r,
+                3,
+                format!("=SUM($A{r}:$A${last})"),
+            ));
+        }
+        sections.push(Section {
+            name: "mixed_anchor",
+            sheet: "MixedAnchor",
+            verdict: SectionVerdict::Reject {
+                placement_reason: "UnsupportedDependencySummary",
+            },
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Mixed-anchor =SUM($A{r}:$A$last); canonical OK (MixedAnchors flag) but the \
+                    per-row shrinking-tail read region has no supported dependency summary.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (i) volatile — TODAY()-based column. Expected: REJECT (canonical
+    // VolatileFunction/ParserVolatileFlag -> UnsupportedCanonicalTemplate).
+    // TODAY() (not NOW()) keeps values stable within a calendar day so the
+    // probe's ON-vs-OFF value-equality check stays meaningful.
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("Volatile", r, 2, mix(seed, r as u64, 9))); // B
+            formulas.push(formula("Volatile", r, 3, format!("=B{r}+TODAY()*0")));
+        }
+        sections.push(Section {
+            name: "volatile",
+            sheet: "Volatile",
+            verdict: SectionVerdict::Reject {
+                placement_reason: "UnsupportedCanonicalTemplate",
+            },
+            expected_canonical_reject_kinds: &["volatile_function"],
+            values,
+            formulas,
+            notes: "=B{r}+TODAY()*0; volatile reject. TODAY (not NOW) keeps ON/OFF values equal.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (j) cross_sheet — row-shifted read from the shared Data sheet
+    // (=Data!B{r}*2). Canonical templates support explicit sheet bindings.
+    // Expected: SPAN.
+    // ------------------------------------------------------------------
+    {
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            formulas.push(formula("CrossSheet", r, 3, format!("=Data!B{r}*2")));
+        }
+        sections.push(Section {
+            name: "cross_sheet",
+            sheet: "CrossSheet",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values: Vec::new(),
+            formulas,
+            notes: "Row-shifted cross-sheet =Data!B{r}*2; explicit sheet binding is supported.",
+        });
+    }
+
+    // No sections are currently quarantined as broken under authoritative
+    // mode. If one regresses (wrong values / panic), move it behind this flag
+    // with a loud comment and a minimal repro reference.
+    let _ = include_broken;
+
+    let data_values = rows
+        .clone()
+        .map(|r| val(DATA_SHEET, r, 2, mix(seed, r as u64, 10)))
+        .collect();
+
+    let named_ranges = vec![NamedRangeSpec {
+        name: "CovNamedData",
+        sheet: "NamedRange",
+        start_row: first,
+        start_col: 2,
+        end_row: last,
+        end_col: 2,
+    }];
+
+    debug_assert_eq!(sections.len(), SECTION_COUNT);
+
+    CoverageWorkbook {
+        sections,
+        named_ranges,
+        data_values,
+    }
+}
+
+fn val(sheet: &'static str, row: u32, col: u32, value: f64) -> ValueCell {
+    ValueCell {
+        sheet,
+        row,
+        col,
+        value,
+    }
+}
+
+fn formula(sheet: &'static str, row: u32, col: u32, formula: String) -> FormulaCell {
+    FormulaCell {
+        sheet,
+        row,
+        col,
+        formula,
+    }
+}

--- a/crates/formualizer-testkit/src/lib.rs
+++ b/crates/formualizer-testkit/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod fp_coverage;
+#[cfg(feature = "xlsx")]
 pub mod xlsx;
 
+#[cfg(feature = "xlsx")]
 pub use xlsx::{build_numeric_grid, build_standard_grid, build_workbook, write_workbook};


### PR DESCRIPTION
## Summary

Measurement infrastructure for FormulaPlane span coverage — the prerequisite for the upcoming fingerprint-coverage expansion work. Adds a deterministic 10-section mixed corpus generator, a `probe-fp-coverage` bench bin, and per-section pinning tests that act as the regression net when coverage expands (supporting a new pattern means flipping exactly one pinned verdict).

## What it measures

The generator (`formualizer-testkit/src/fp_coverage.rs`) composes the patterns real models use, each section with a documented expected verdict: row-shifted arithmetic, anchored aggregates, SUMIFS with fixed criteria ranges, VLOOKUP columns, nested IF with per-row literals, whole-axis `SUM(A:A)`, named-range references, mixed-anchor ranges (`$A2:$A$100`), a volatile column, and cross-sheet references. The probe builds the workbook, runs FormulaPlane Off vs AuthoritativeExperimental, and emits coverage %, the placement fallback histogram, the canonicalization reject-kind histogram, load/first/warm timings for both modes, and a cell-by-cell value-equality verdict (process exits nonzero on any mismatch).

## Baseline numbers (20k formula cells, seed 42, release; independently re-run and confirmed)

Coverage 70.0% — 14,000/20,000 cells accepted into 7 spans; 14,000 vertices and edge rows avoided. The 6,000 legacy cells come from exactly three causes: named-range references (2,000, canonicalization reject), volatile functions (2,000, canonicalization reject), mixed-anchor ranges (2,000, dependency-summary reject). Value equality: 20,000/20,000 identical between modes.

Two corrections to the reconnaissance ranking, courtesy of measuring before building: whole-axis `SUM(A:A)` and cross-sheet references ALREADY span — both were ranked as missing patterns. The real expansion shortlist is therefore: named ranges, mixed-anchor ranges, then ROW/COLUMN placement-dependent support.

## Finding: authoritative-mode mixed-workbook blowup (not fixed here)

On the mixed corpus, authoritative mode is dramatically SLOWER than off: first eval 127 -> 996 ms (0.13x), warm recalc 2 -> 105 ms. Every section is faster in isolation; the trigger is legacy-fallback range-reading cells coexisting with accepted spans (~0.25 ms per legacy tail-range cell, linear: 162/244/504/1022 ms at 500/1k/2k/4k legacy cells). Values are correct throughout. Minimal repro: `cargo run -p formualizer-bench-core --features formualizer_runner --release --bin probe-fp-coverage -- --only mixed_anchor,row_arith`. Mode is experimental and off by default, so no user exposure — but this interaction dominates any coverage-expansion gains and is now the top FormulaPlane target. Tracked in a follow-up issue.

## Notes

Placement counters were already publicly reachable (`Engine::formula_ingest_report_total()`), so no engine code changed — this PR is generator + probe + tests only. The testkit's umya/tempfile deps moved behind a default-on `xlsx` feature so the pure generator is dependency-light. Pinning tests use 120 rows/section because non-constant spans under 100 cells are demoted (`SmallDomain`). Repo `.gitignore` had a `*coverage*` glob that silently swallowed the new files; added explicit negations.

## Gates

fmt clean; workspace clippy (-D warnings, CI exclusions) clean; workspace tests pass including the new pinning tests; portable-wasm facade check clean. No hot-path changes, so no standing perf gate.
