### PR TITLE
perf(formula-plane): fix mixed-mode legacy interaction — degenerate rect routing + 64x demote spin (mixed corpus 996 to 26 ms, now faster than Off)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -461,6 +461,12 @@ pub struct Engine<R> {
     /// producers become visible) so the cycle members land on the legacy graph
     /// path. Observational only.
     formula_plane_cycle_member_span_demotions: u64,
+    /// Times the FormulaPlane coordinator failed over to the legacy
+    /// primitive because the mixed schedule reported only non-cycle
+    /// fallbacks (capacity caps, unsupported projections, missing result
+    /// regions). One increment per `evaluate_all`-level bailout — the
+    /// cyclic-span demote loop must never spin on these. Observational only.
+    formula_plane_capacity_bailouts: u64,
     /// Transient cancellation flag used during evaluation
     active_cancel_flag: Option<Arc<AtomicBool>>,
 
@@ -1490,6 +1496,7 @@ where
             last_formula_ingest_report: None,
             formula_ingest_report_total: FormulaIngestReport::default(),
             formula_plane_cycle_member_span_demotions: 0,
+            formula_plane_capacity_bailouts: 0,
             active_cancel_flag: None,
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
@@ -1568,6 +1575,7 @@ where
             last_formula_ingest_report: None,
             formula_ingest_report_total: FormulaIngestReport::default(),
             formula_plane_cycle_member_span_demotions: 0,
+            formula_plane_capacity_bailouts: 0,
             active_cancel_flag: None,
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
@@ -3025,6 +3033,11 @@ where
     #[cfg(test)]
     pub(crate) fn formula_plane_indexes_epoch(&self) -> u64 {
         self.graph.formula_authority().indexes_epoch()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn formula_plane_capacity_bailouts(&self) -> u64 {
+        self.formula_plane_capacity_bailouts
     }
 
     fn record_formula_ingest_report(&mut self, report: FormulaIngestReport) {
@@ -8452,6 +8465,23 @@ where
             .formula_authority_mut()
             .take_pending_changed_regions();
 
+        // Steady-state shortcut: in `DirtyClosure` mode span work is derived
+        // exclusively from pending changed regions, so with none pending the
+        // mixed schedule could only ever contain dirty legacy vertices (e.g.
+        // re-dirtied volatiles). Skip the O(all formula vertices)
+        // producer/consumer index rebuild and run them through the legacy
+        // primitive directly — identical evaluation set, with the legacy
+        // path's native cycle/virtual-dep handling.
+        if matches!(span_seed_mode, SpanSeedMode::DirtyClosure)
+            && pending_changed_regions.is_empty()
+        {
+            #[cfg(test)]
+            {
+                self.last_formula_plane_span_eval_report = None;
+            }
+            return self.evaluate_all_legacy_impl();
+        }
+
         let start = crate::instant::FzInstant::now();
         let mut span_seed_mode = span_seed_mode;
         let mut pending_changed_regions = pending_changed_regions;
@@ -8466,6 +8496,30 @@ where
 
             if schedule.is_authoritative_safe() {
                 break (schedule, span_refs_by_id, plane_epoch, legacy_vertices);
+            }
+
+            // The demote loop below can only make progress on cycles: it
+            // demotes cyclic spans and stamps residual legacy-only cycles.
+            // Every other fallback reason (capacity caps, unsupported
+            // projections, missing result regions) is a property of the
+            // inputs — rebuilding the schedule from identical state
+            // reproduces the identical fallback, so iterating would spin
+            // `MAX_CYCLE_DEMOTE_ITERS` times doing O(graph) schedule builds
+            // per iteration before giving up anyway. Fail over to the legacy
+            // primitive immediately instead.
+            let has_cycle_fallback = schedule.stats.cycle_count > 0
+                || schedule
+                    .fallbacks
+                    .iter()
+                    .any(|fb| fb.reason == MixedScheduleFallbackReason::CycleDetected);
+            if !has_cycle_fallback {
+                self.formula_plane_capacity_bailouts =
+                    self.formula_plane_capacity_bailouts.saturating_add(1);
+                #[cfg(test)]
+                {
+                    self.last_formula_plane_span_eval_report = None;
+                }
+                return self.evaluate_all_legacy_impl();
             }
 
             // Gotcha G8 (refs #112): a span whose member cell participates in a
@@ -8605,10 +8659,33 @@ where
                             }
                         }
                     }
-                    FormulaProducerId::Legacy(vertex_id) => {
-                        let _ = self.evaluate_vertex_impl(vertex_id, None)?;
-                        computed_vertices = computed_vertices.saturating_add(1);
-                        work_index = work_index.saturating_add(1);
+                    FormulaProducerId::Legacy(_) => {
+                        // Batch the contiguous run of legacy work items into a
+                        // synthetic layer and evaluate it through the same
+                        // coalesced effects pipeline as the legacy scheduler.
+                        // Items in one mixed layer have no edges between them
+                        // (same invariant the legacy Kahn layers rely on), so
+                        // batching preserves ordering semantics while
+                        // amortizing per-write overlay mirroring that makes
+                        // one-vertex-at-a-time evaluation ~30x slower.
+                        let mut vertices = Vec::new();
+                        while work_index < work_items.len() {
+                            let FormulaProducerId::Legacy(vertex_id) =
+                                work_items[work_index].producer
+                            else {
+                                break;
+                            };
+                            vertices.push(vertex_id);
+                            work_index = work_index.saturating_add(1);
+                        }
+                        let legacy_layer = crate::engine::scheduler::Layer { vertices };
+                        let evaluated =
+                            if self.thread_pool.is_some() && legacy_layer.vertices.len() > 1 {
+                                self.evaluate_layer_parallel(&legacy_layer)?
+                            } else {
+                                self.evaluate_layer_sequential(&legacy_layer)?
+                            };
+                        computed_vertices = computed_vertices.saturating_add(evaluated);
                     }
                 }
             }

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -1,0 +1,171 @@
+//! Mixed-mode legacy-interaction regression net (perf):
+//! legacy RANGE-READING cells coexisting with ACTIVE SPANS.
+//!
+//! Measured bug: on a workbook mixing span-accepted formulas with legacy
+//! tail-range readers (`=SUM($A{r}:$A$N)`), authoritative mode was ~50x
+//! slower than `Off`. Chain:
+//!
+//! 1. `shared_range_to_region_pattern` mapped finite single-column reads to
+//!    `Region::rect`, whose degenerate `Span(c, c)` col axis routed them into
+//!    the coarse 64x16 rect buckets of `SheetRegionIndex` instead of the
+//!    per-column interval trees. Every legacy producer's point-result query
+//!    in the same bucket column then collected O(overlapping tail reads)
+//!    candidates (all dropped by the exact filter), tripping the mixed
+//!    scheduler's `max_candidates` fail-closed cap.
+//! 2. The resulting `MaxCandidatesExceeded` fallback made the schedule
+//!    non-authoritative-safe, and the only non-safe handler — the cyclic-span
+//!    demote loop — cannot make progress on capacity fallbacks. It rebuilt
+//!    the identical schedule `MAX_CYCLE_DEMOTE_ITERS` (64) times (each with a
+//!    full legacy Tarjan prepass) before bailing to the legacy primitive,
+//!    which never evaluates span cells, so the *next* recalc re-evaluated
+//!    every span whole.
+//!
+//! These tests assert behavior shape via reports/counters, never wall time:
+//! - the mixed corpus completes in ONE authoritative pass (span eval report
+//!   present, zero capacity bailouts);
+//! - a quiescent recalc does not re-evaluate spans;
+//! - a corpus that legitimately trips the candidate cap bails to legacy
+//!   exactly once per evaluate_all instead of spinning the demote loop.
+
+use std::sync::Arc;
+
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::test_workbook::TestWorkbook;
+
+const SHEET: &str = "Sheet1";
+/// Enough overlapping tail reads that cumulative pre-filter candidates would
+/// exceed the scheduler's `max_candidates = 100_000` cap under the old rect
+/// bucketing (sum 1..=600 of O(r) candidates ≈ 180k), and comfortably above
+/// the 100-cell non-constant span promotion threshold.
+const ROWS: u32 = 600;
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    let ast = parse(formula).unwrap_or_else(|err| panic!("parse {formula}: {err}"));
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn numeric_value(engine: &Engine<TestWorkbook>, row: u32, col: u32) -> f64 {
+    match engine
+        .get_cell_value(SHEET, row, col)
+        .unwrap_or_else(|| panic!("missing {SHEET}!R{row}C{col}"))
+    {
+        LiteralValue::Int(value) => value as f64,
+        LiteralValue::Number(value) => value,
+        value => panic!("expected numeric {SHEET}!R{row}C{col}, got {value:?}"),
+    }
+}
+
+/// `A{r} = r`; span-accepted `B{r} = A{r}+1`; legacy tail readers in the
+/// given column reading the given range template.
+fn build_mixed_engine(tail_formula: impl Fn(u32) -> String) -> Engine<TestWorkbook> {
+    let config =
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    let mut formulas = Vec::with_capacity(2 * ROWS as usize);
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}+1")));
+        formulas.push(record(&mut engine, row, 4, &tail_formula(row)));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .expect("ingest formulas");
+    engine
+}
+
+fn tail_sum(row: u32) -> f64 {
+    // SUM of r..=ROWS with A{r} = r.
+    ((ROWS as u64 + row as u64) * (ROWS as u64 - row as u64 + 1) / 2) as f64
+}
+
+#[test]
+fn mixed_tail_reads_complete_in_one_authoritative_pass() {
+    // Single-column tail reads: with degenerate-span normalization these
+    // index as per-column intervals, so legacy point-result queries on other
+    // columns see zero candidates and the schedule stays authoritative-safe.
+    let mut engine = build_mixed_engine(|row| format!("=SUM($A{row}:$A${ROWS})"));
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.formula_plane_capacity_bailouts(),
+        0,
+        "single-column tail reads must not trip the candidate cap"
+    );
+    assert!(
+        engine.last_formula_plane_span_eval_report().is_some(),
+        "first evaluate_all must run the authoritative mixed pass \
+         (a None report means it bailed to the legacy primitive)"
+    );
+
+    for row in [1, 2, ROWS / 2, ROWS] {
+        assert_eq!(numeric_value(&engine, row, 2), row as f64 + 1.0);
+        assert_eq!(numeric_value(&engine, row, 4), tail_sum(row));
+    }
+
+    // Quiescent recalc: nothing dirty, no pending changed regions — spans
+    // must NOT be re-evaluated whole (the failed first pass used to leave
+    // `formula_plane_indexes_epoch_seen` stale, forcing WholeAll re-eval).
+    engine.evaluate_all().unwrap();
+    assert!(
+        engine.last_formula_plane_span_eval_report().is_none(),
+        "quiescent recalc must not re-evaluate spans"
+    );
+    assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
+}
+
+#[test]
+fn capacity_fallback_bails_to_legacy_once_per_eval_not_demote_spin() {
+    // Two-column tail reads stay rect-bucketed (a real rect has no precise
+    // interval-tree form), so the cumulative candidate cap legitimately
+    // trips. The coordinator must fail over to the legacy primitive exactly
+    // once per evaluate_all — the cyclic-span demote loop cannot make
+    // progress on capacity fallbacks and used to spin its full 64-iteration
+    // budget (each iteration an O(graph) schedule build + Tarjan prepass).
+    let mut engine = build_mixed_engine(|row| format!("=SUM($A{row}:$B${ROWS})"));
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.formula_plane_capacity_bailouts(),
+        1,
+        "capacity fallback must bail exactly once, not iterate the demote loop"
+    );
+
+    // The legacy bail cannot evaluate span cells; the follow-up recalc
+    // (WholeAll seeding, no dirty legacy producers) picks them up.
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.formula_plane_capacity_bailouts(),
+        1,
+        "span-only follow-up schedule must be authoritative-safe"
+    );
+    assert!(
+        engine.last_formula_plane_span_eval_report().is_some(),
+        "follow-up recalc must evaluate the spans the bail pass skipped"
+    );
+
+    for row in [1, 2, ROWS / 2, ROWS] {
+        assert_eq!(numeric_value(&engine, row, 2), row as f64 + 1.0);
+    }
+    // KNOWN PRE-EXISTING GAP (not pinned here): the legacy tail readers in
+    // column D evaluated during the bail pass while the span cells in column
+    // B were still empty, and computed-overlay flushes do not re-dirty
+    // dependent legacy vertices, so their values remain stale
+    // (`tail_sum(A)` only) on every subsequent quiescent recalc. The old
+    // demote-spin path reached the identical state after its 64 iterations;
+    // fixing it requires the capacity-bail path to either demote affected
+    // spans or re-dirty legacy readers of span result regions.
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -114,6 +114,7 @@ mod formula_plane_ingest_shadow;
 mod formula_plane_literal_param_memo;
 mod formula_plane_lookup_family_promotion;
 mod formula_plane_lookup_semantics;
+mod formula_plane_mixed_legacy_tail_reads;
 mod formula_plane_parallel_span_eval;
 mod formula_plane_per_placement_literal_bindings;
 mod formula_plane_per_span_overhead;

--- a/crates/formualizer-eval/src/formula_plane/region_index.rs
+++ b/crates/formualizer-eval/src/formula_plane/region_index.rs
@@ -213,6 +213,22 @@ impl Region {
         }
     }
 
+    /// Canonical axis-kind form: degenerate one-cell spans (`Span(x, x)`)
+    /// become `Point(x)` on each axis. Semantically a no-op
+    /// (`intersects`/`contains` already treat them identically), but the
+    /// index's routing is kind-driven: a single-column finite range left as
+    /// `(Span, Span)` lands in the coarse 64x16 rect buckets where it
+    /// over-candidates every point query in the same bucket column, instead
+    /// of the precise per-column interval tree.
+    #[inline]
+    pub(crate) fn normalized(self) -> Self {
+        Self {
+            sheet_id: self.sheet_id,
+            rows: self.rows.normalized(),
+            cols: self.cols.normalized(),
+        }
+    }
+
     #[inline]
     pub(crate) fn as_point(self) -> Option<RegionKey> {
         if let (AxisRange::Point(row), AxisRange::Point(col)) = (self.rows, self.cols) {
@@ -360,6 +376,16 @@ impl AxisRange {
         }
     }
 
+    /// Degenerate one-coordinate spans become points; see
+    /// [`Region::normalized`].
+    #[inline]
+    pub(crate) fn normalized(self) -> Self {
+        match self {
+            Self::Span(start, end) if start == end => Self::Point(start),
+            other => other,
+        }
+    }
+
     #[inline]
     pub(crate) fn kind(self) -> AxisKind {
         match self {
@@ -481,7 +507,12 @@ impl<T: Clone> SheetRegionIndex<T> {
     pub(crate) fn insert(&mut self, region: Region, value: T) -> usize {
         let id = self.entries.len();
         self.entries.push(RegionEntry { value, region });
-        self.index_entry(id, region);
+        // Index routing is axis-kind-driven; normalize degenerate one-cell
+        // spans to points so single-column/row finite ranges use the precise
+        // interval trees instead of the coarse rect buckets. The stored
+        // entry (and therefore `indexed_region` in matches) keeps the
+        // caller's original region.
+        self.index_entry(id, region.normalized());
         self.epoch = self.epoch.saturating_add(1);
         id
     }
@@ -515,7 +546,9 @@ impl<T: Clone> SheetRegionIndex<T> {
 
     pub(crate) fn query(&self, query: Region) -> RegionQueryResult<T> {
         let mut candidate_ids = FxHashSet::default();
-        self.collect_candidates(query, &mut candidate_ids);
+        // Match the normalization applied at insert so degenerate-span
+        // queries route through the same precise structures.
+        self.collect_candidates(query.normalized(), &mut candidate_ids);
 
         let candidate_count = candidate_ids.len();
         let mut matches = Vec::new();
@@ -1765,6 +1798,49 @@ mod tests {
     }
 
     #[test]
+    fn degenerate_single_col_rects_index_as_intervals_not_rect_buckets() {
+        // Regression: mixed-mode legacy interaction (perf). Finite
+        // single-column ranges built via `Region::rect` (e.g. legacy
+        // `=SUM($A{r}:$A$N)` reads routed through
+        // `shared_range_to_region_pattern`) used to keep their degenerate
+        // `Span(c, c)` col axis and land in the 64x16 rect buckets. With N
+        // overlapping tail reads, every point query in the same bucket
+        // column (e.g. the formula result column) collected O(N) candidates
+        // that the exact filter then dropped — O(N^2) cumulative candidates
+        // across a scheduling pass, tripping the mixed scheduler's
+        // `max_candidates` fail-closed cap. Normalization must route these
+        // entries through the per-column interval trees so unrelated point
+        // queries see zero candidates, not O(N) dropped ones.
+        let mut index = SheetRegionIndex::new();
+        let n = 2_000;
+        for r in 1..=n {
+            index.insert(Region::rect(1, r, n, 1, 1), r);
+        }
+
+        // Point queries on a *different* column inside the same 16-col rect
+        // bucket column must not even see the tail reads as candidates.
+        for r in [1, 64, 1_000, n] {
+            let result = index.query(Region::point(1, r, 3));
+            assert_eq!(
+                result.stats.candidate_count, 0,
+                "row {r}: point query on col 3 must be O(1), got {} candidates \
+                 ({} dropped by the exact filter)",
+                result.stats.candidate_count, result.stats.exact_filter_drop_count
+            );
+        }
+
+        // Queries on the indexed column still see exactly the true
+        // intersections (every read whose row range covers the point).
+        let hit = index.query(Region::point(1, 5, 1));
+        assert_eq!(hit.matches.len(), 5);
+        assert_eq!(hit.stats.exact_filter_drop_count, 0);
+
+        // Degenerate-span queries are normalized symmetrically.
+        let span_query = index.query(Region::rect(1, 5, 5, 3, 3));
+        assert_eq!(span_query.stats.candidate_count, 0);
+    }
+
+    #[test]
     fn sheet_region_index_does_not_return_other_sheet_entries() {
         let mut index = SheetRegionIndex::with_rect_bucket_size(10, 10);
         index.insert(Region::point(1, 0, 0), "sheet_1_point");
@@ -1933,9 +2009,11 @@ mod tests {
 
     #[test]
     fn sheet_region_index_may_overreturn_rect_bucket_but_never_misses_intersection() {
+        // True (multi-cell) rects: degenerate 1xN/Nx1 rects normalize to
+        // points/intervals and never reach the rect buckets.
         let mut index = SheetRegionIndex::with_rect_bucket_size(10, 10);
-        index.insert(Region::rect(1, 0, 0, 0, 0), "hit");
-        index.insert(Region::rect(1, 9, 9, 9, 9), "same_bucket_drop");
+        index.insert(Region::rect(1, 0, 1, 0, 1), "hit");
+        index.insert(Region::rect(1, 8, 9, 8, 9), "same_bucket_drop");
 
         let result = index.query(Region::point(1, 0, 0));
 
@@ -2070,14 +2148,16 @@ mod tests {
         let mut index = SpanDependencyIndex::default();
         let hit = span_ref(8);
         let drop = span_ref(9);
+        // True (multi-cell) rects: degenerate 1xN/Nx1 rects normalize to
+        // points/intervals and never reach the rect buckets.
         index.insert_dependency(
             hit,
-            Region::rect(4, 0, 0, 0, 0),
+            Region::rect(4, 0, 1, 0, 1),
             DirtyProjection::WholeTarget,
         );
         index.insert_dependency(
             drop,
-            Region::rect(4, 63, 63, 15, 15),
+            Region::rect(4, 62, 63, 14, 15),
             DirtyProjection::WholeTarget,
         );
 


### PR DESCRIPTION
## Summary

Fixes the FormulaPlane authoritative-mode mixed-workbook blowup found by #142's coverage probe: legacy range-reading cells coexisting with accepted spans cost ~0.25 ms each, making the mixed corpus 8x slower on first eval (127 -> 996 ms) and ~50x slower warm (2 -> 105 ms) than plain mode. After this PR the same corpus runs first eval in 26 ms under authoritative mode — faster than Off — and warm recalc returns to single digits.

## Root cause (profiled, not guessed)

Three stacked defects in the authoritative coordinator path:

1. `shared_range_to_region_pattern` mapped finite single-column tail reads (`$A{r}:$A$N`) to rects whose degenerate column axis stayed `Span(c,c)`, so `SheetRegionIndex` routed all of them into the coarse 64x16 rect buckets instead of the per-column interval trees. Point queries against those buckets returned O(rows) candidates, all dropped by the exact filter — O(N²/2) cumulative pre-filter work, tripping `max_candidates` at ~row 416.
2. The resulting `MaxCandidatesExceeded` fallback made the schedule non-authoritative-safe, and the only non-safe handler was the G8 cyclic-span demote loop — which filters for `CycleDetected` fallbacks only, demoted nothing, and retried with identical inputs the full `MAX_CYCLE_DEMOTE_ITERS = 64` times, rebuilding the mixed schedule plus a legacy Tarjan prepass each spin (~7.3 us/cell x 64 = the 0.25 ms/cell constant) before bailing to legacy eval.
3. The failed pass never recorded the index epoch, so warm recalcs picked `SpanSeedMode::WholeAll` (re-evaluating all spans with nothing dirty) and evaluated re-dirtied volatile cells one `evaluate_vertex_impl` at a time (~43 us/cell vs ~1.5 us in the batched layer path).

## Fix

- **region_index**: normalize degenerate `Span(x,x)` axes to `Point(x)` at insert/query routing — single-col/row finite reads use the interval trees; stored regions and exact-filter semantics untouched.
- **coordinator**: bail to the legacy primitive immediately (new `formula_plane_capacity_bailouts` counter) when a non-safe schedule contains no `CycleDetected` fallbacks — the demote loop cannot converge on capacity fallbacks; batch contiguous legacy runs in mixed layers through the standard layer evaluators; quiescent shortcut skips the O(all formulas) index rebuild when the dirty closure has no pending changed regions.
- **tests**: pin one-pass authoritative eval on the mixed corpus (0 capacity bailouts), no span re-eval on quiescent recalc, exactly-once bailout for true multi-column cap-tripping corpora, and 0 point-query candidates against 2000 single-col tail reads.

## Measured (probe-fp-coverage; independently re-verified)

| Scenario | Before (off -> auth) | After (off -> auth) |
|---|---|---|
| Full corpus first eval | 127 -> 996 ms | 130 -> 26 ms |
| Full corpus warm recalc | 2 -> 105 ms | 2 -> 3 ms |
| mixed_anchor+row_arith first eval | 13 -> 558 ms | 10 -> 8 ms |
| Legacy-cell sweep 500/1k/2k/4k | 162/244/504/1022 ms | 7/9/11/18 ms (flat) |

Value equality 20,000/20,000 in every configuration; #142 pinning tests green.

## Gates

fmt clean; workspace clippy (-D warnings, CI exclusions) clean; workspace tests pass; portable-wasm facade check clean. FP-off standing gate vs main: 4+ interleaved A/B rounds of finance-recalc and linear-rollup 200k — mixed directions, checksums identical, noise, pass.

## Pre-existing gap surfaced (not introduced or fixed here)

When any capacity bail runs the legacy primitive (including the old 64-spin path), legacy readers of span result regions evaluate against still-empty span cells and stay stale until those spans next evaluate, because computed-overlay flushes do not re-dirty dependents. Documented in the new test file; needs its own issue — the bail path should demote affected spans or re-dirty legacy readers of span result regions. Authoritative mode remains experimental and off by default.

Refs #142 (coverage probe), #121 (CycleMember demotion).
