### PR TITLE
feat(formula-plane): span mixed-anchor ranges — tail reads and running totals (corpus coverage 70% to 80%)

### DIFF
--- a/crates/formualizer-bench-core/src/bin/probe-fp-coverage.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-fp-coverage.rs
@@ -50,7 +50,7 @@ mod probe {
     #[derive(Debug, Parser)]
     #[command(about = "FormulaPlane span-coverage probe over the shared fp_coverage mixed corpus")]
     pub struct Cli {
-        /// Formula cells per section (10 sections; default ~20k cells total).
+        /// Formula cells per section (12 sections; default ~24k cells total).
         #[arg(long, default_value_t = 2_000)]
         rows_per_section: u32,
         /// Seed perturbing data values (formula structure is seed-independent).

--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -951,9 +951,12 @@ fn compute_read_projections(
                         else {
                             return Err(ProjectionFallbackReason::UnsupportedDependencySummary);
                         };
-                        if start_row_abs != end_row_abs || start_col_abs != end_col_abs {
-                            return Err(ProjectionFallbackReason::UnsupportedDependencySummary);
-                        }
+                        // Mixed-anchor bounds (one absolute, one placement-
+                        // relative per axis, e.g. `$A$2:$A2` running totals or
+                        // `$A2:$A$100` tail reads) are supported: the read
+                        // region is the per-bound extent union and the dirty
+                        // projection inverts them as half-open placement
+                        // intervals.
                         push_projection(
                             projections,
                             ReadProjection {
@@ -1559,22 +1562,18 @@ mod tests {
     }
 
     #[test]
-    fn formula_plane_ingest_read_projections_reject_top_level_and_mixed_ranges() {
+    fn formula_plane_ingest_read_projections_reject_top_level_and_open_ranges() {
         let mut sheet_registry = SheetRegistry::new();
         let sheet = sheet_registry.id_for("Sheet1");
         let placement = CellRef::new(sheet, Coord::from_excel(1, 2, true, true));
         let top_level = parse("=A1:A10").unwrap();
-        let mixed = parse("=SUM($A$1:$A1)").unwrap();
         let top_level_whole_column = parse("=$A:$A").unwrap();
         let open_whole_column = parse("=SUM($A$1:$A)").unwrap();
         let whole_row = parse("=SUM($1:$1)").unwrap();
+        let mixed_whole_column = parse("=SUM(A:$A)").unwrap();
 
         assert_eq!(
             compute_read_projections(&top_level, placement, &sheet_registry),
-            Err(ProjectionFallbackReason::UnsupportedDependencySummary)
-        );
-        assert_eq!(
-            compute_read_projections(&mixed, placement, &sheet_registry),
             Err(ProjectionFallbackReason::UnsupportedDependencySummary)
         );
         assert_eq!(
@@ -1588,6 +1587,48 @@ mod tests {
         assert_eq!(
             compute_read_projections(&whole_row, placement, &sheet_registry),
             Err(ProjectionFallbackReason::UnsupportedDependencySummary)
+        );
+        // Whole-column ranges with mixed column anchors stay rejected to match
+        // the dependency-summary analyzer.
+        assert_eq!(
+            compute_read_projections(&mixed_whole_column, placement, &sheet_registry),
+            Err(ProjectionFallbackReason::UnsupportedDependencySummary)
+        );
+    }
+
+    #[test]
+    fn formula_plane_ingest_read_projections_accept_mixed_anchor_ranges() {
+        let mut sheet_registry = SheetRegistry::new();
+        let sheet = sheet_registry.id_for("Sheet1");
+        let placement = CellRef::new(sheet, Coord::from_excel(1, 2, true, true));
+
+        // Running total `=SUM($A$1:$A1)`: absolute start row, relative end row.
+        let running_total = parse("=SUM($A$1:$A1)").unwrap();
+        let projections =
+            compute_read_projections(&running_total, placement, &sheet_registry).unwrap();
+        assert_eq!(projections.len(), 1);
+        assert_eq!(
+            projections[0].rule,
+            DirtyProjectionRule::AffineRange {
+                row_start: AxisProjection::Absolute { index: 0 },
+                row_end: AxisProjection::Relative { offset: 0 },
+                col_start: AxisProjection::Absolute { index: 0 },
+                col_end: AxisProjection::Absolute { index: 0 },
+            }
+        );
+
+        // Tail read `=SUM($A1:$A$100)`: relative start row, absolute end row.
+        let tail_read = parse("=SUM($A1:$A$100)").unwrap();
+        let projections = compute_read_projections(&tail_read, placement, &sheet_registry).unwrap();
+        assert_eq!(projections.len(), 1);
+        assert_eq!(
+            projections[0].rule,
+            DirtyProjectionRule::AffineRange {
+                row_start: AxisProjection::Relative { offset: 0 },
+                row_end: AxisProjection::Absolute { index: 99 },
+                col_start: AxisProjection::Absolute { index: 0 },
+                col_end: AxisProjection::Absolute { index: 0 },
+            }
         );
     }
 

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_anchor_spans.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_anchor_spans.rs
@@ -1,0 +1,314 @@
+//! Mixed-anchor range span support: promotion, read-region geometry, dirty
+//! precision, and the InternalDependency guard.
+//!
+//! Mixed-anchor ranges have one bound of an axis relative to the placement and
+//! the other absolute. The two everyday idioms are:
+//!
+//! - tail reads `=SUM($A{r}:$A$N)` — per-placement read region [r..N]
+//!   (shrinking), and
+//! - running totals `=SUM($B$2:$B{r})` — per-placement read region [2..r]
+//!   (expanding).
+//!
+//! Both are affine in the placement index, so the dirty inversion ("changed
+//! rows [a, b] -> which placements read it?") is a half-open placement
+//! interval. These tests pin (counter-style, never wall time):
+//!
+//! - both idioms promote to spans and evaluate to legacy-identical values;
+//! - the span's union read region is the full single-column bounding interval
+//!   (a `col_interval`, which `SheetRegionIndex` routes into the per-column
+//!   interval trees — the #143 degenerate-rect regression surface);
+//! - after the first eval, a single-cell edit re-evaluates only the affected
+//!   placement interval, not the whole span;
+//! - an expanding range that covers the family's own result region still
+//!   rejects with `InternalDependency` (the union read region keeps the
+//!   intersect check conservative).
+
+use std::sync::Arc;
+
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::formula_plane::region_index::Region;
+use crate::test_workbook::TestWorkbook;
+
+const SHEET: &str = "Sheet1";
+const ROWS: u32 = 400;
+
+fn authoritative_engine() -> Engine<TestWorkbook> {
+    let cfg =
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    Engine::new(TestWorkbook::default(), cfg)
+}
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    let ast = parse(formula).unwrap_or_else(|err| panic!("parse {formula}: {err}"));
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn numeric_value(engine: &Engine<TestWorkbook>, row: u32, col: u32) -> f64 {
+    match engine
+        .get_cell_value(SHEET, row, col)
+        .unwrap_or_else(|| panic!("missing {SHEET}!R{row}C{col}"))
+    {
+        LiteralValue::Int(value) => value as f64,
+        LiteralValue::Number(value) => value,
+        value => panic!("expected numeric {SHEET}!R{row}C{col}, got {value:?}"),
+    }
+}
+
+/// `A{r} = r` for rows 1..=ROWS; tail readers `C{r} = SUM($A{r}:$A$ROWS)`.
+fn build_tail_read_engine() -> Engine<TestWorkbook> {
+    let mut engine = authoritative_engine();
+    let mut formulas = Vec::with_capacity(ROWS as usize);
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(
+            &mut engine,
+            row,
+            3,
+            &format!("=SUM($A{row}:$A${ROWS})"),
+        ));
+    }
+    let report = engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .expect("ingest formulas");
+    assert_eq!(
+        report.shadow_accepted_span_cells,
+        u64::from(ROWS),
+        "tail-read family must span; histogram: {:?}",
+        report.fallback_reasons
+    );
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine
+}
+
+/// `B{r} = r` for rows 2..=ROWS+1; running totals `C{r} = SUM($B$2:$B{r})`.
+fn build_running_total_engine() -> Engine<TestWorkbook> {
+    let mut engine = authoritative_engine();
+    let mut formulas = Vec::with_capacity(ROWS as usize);
+    for row in 2..=ROWS + 1 {
+        engine
+            .set_cell_value(SHEET, row, 2, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 3, &format!("=SUM($B$2:$B{row})")));
+    }
+    let report = engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .expect("ingest formulas");
+    assert_eq!(
+        report.shadow_accepted_span_cells,
+        u64::from(ROWS),
+        "running-total family must span; histogram: {:?}",
+        report.fallback_reasons
+    );
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine
+}
+
+/// SUM of a..=b.
+fn interval_sum(a: u64, b: u64) -> f64 {
+    ((a + b) * (b - a + 1) / 2) as f64
+}
+
+fn single_span_read_regions(engine: &Engine<TestWorkbook>) -> Vec<Region> {
+    let authority = engine.graph.formula_authority();
+    let spans: Vec<_> = authority.plane.spans.active_spans().collect();
+    assert_eq!(spans.len(), 1);
+    let read_summary = authority
+        .plane
+        .span_read_summaries
+        .get(spans[0].read_summary_id.expect("read summary id"))
+        .expect("read summary");
+    read_summary
+        .dependencies
+        .iter()
+        .map(|dependency| dependency.read_region)
+        .collect()
+}
+
+#[test]
+fn tail_read_span_union_read_region_is_single_column_interval() {
+    let engine = build_tail_read_engine();
+    let sheet_id = engine.graph.sheet_id(SHEET).expect("sheet id for Sheet1");
+
+    // Union read region must be the full bounding interval [1..=ROWS] x col A
+    // as a degenerate single-column region (Point col axis), so that
+    // SheetRegionIndex routes it into the per-column interval trees rather
+    // than the coarse rect buckets (#143).
+    assert_eq!(
+        single_span_read_regions(&engine),
+        vec![Region::col_interval(sheet_id, 0, 0, ROWS - 1)]
+    );
+}
+
+#[test]
+fn running_total_span_union_read_region_is_single_column_interval() {
+    let engine = build_running_total_engine();
+    let sheet_id = engine.graph.sheet_id(SHEET).expect("sheet id for Sheet1");
+
+    // Rows 2..=ROWS+1 are 1..=ROWS 0-based; column B is 1.
+    assert_eq!(
+        single_span_read_regions(&engine),
+        vec![Region::col_interval(sheet_id, 1, 1, ROWS)]
+    );
+}
+
+#[test]
+fn tail_read_edit_recalc_is_bounded_by_affected_placement_interval() {
+    let mut engine = build_tail_read_engine();
+
+    engine.evaluate_all().unwrap();
+    let first = engine
+        .last_formula_plane_span_eval_report()
+        .expect("first eval must run the authoritative span pass");
+    assert_eq!(first.span_eval_placement_count, u64::from(ROWS));
+    for row in [1, 2, ROWS / 2, ROWS] {
+        assert_eq!(
+            numeric_value(&engine, row, 3),
+            interval_sum(u64::from(row), u64::from(ROWS))
+        );
+    }
+
+    // Edit one cell inside the read region. A change at A10 is read only by
+    // the placements whose shrinking tail still covers row 10: rows 1..=10.
+    const EDIT_ROW: u32 = 10;
+    engine
+        .action_atomic_journal("edit A10".to_string(), |tx| {
+            tx.set_cell_value(SHEET, EDIT_ROW, 1, LiteralValue::Number(1_000.0))?;
+            Ok(())
+        })
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    let report = engine
+        .last_formula_plane_span_eval_report()
+        .expect("edit recalc must evaluate span work");
+    assert_eq!(
+        report.span_eval_placement_count,
+        u64::from(EDIT_ROW),
+        "tail-read dirty work must be the affected placement interval, not \
+         the whole span: {report:?}"
+    );
+
+    let delta = 1_000.0 - EDIT_ROW as f64;
+    assert_eq!(
+        numeric_value(&engine, 1, 3),
+        interval_sum(1, u64::from(ROWS)) + delta
+    );
+    assert_eq!(
+        numeric_value(&engine, EDIT_ROW, 3),
+        interval_sum(u64::from(EDIT_ROW), u64::from(ROWS)) + delta
+    );
+    // Placements past the edit row never read it and keep their values.
+    assert_eq!(
+        numeric_value(&engine, EDIT_ROW + 1, 3),
+        interval_sum(u64::from(EDIT_ROW) + 1, u64::from(ROWS))
+    );
+}
+
+#[test]
+fn running_total_edit_recalc_is_bounded_by_affected_placement_interval() {
+    let mut engine = build_running_total_engine();
+
+    engine.evaluate_all().unwrap();
+    let first = engine
+        .last_formula_plane_span_eval_report()
+        .expect("first eval must run the authoritative span pass");
+    assert_eq!(first.span_eval_placement_count, u64::from(ROWS));
+    for row in [2, ROWS / 2, ROWS + 1] {
+        assert_eq!(
+            numeric_value(&engine, row, 3),
+            interval_sum(2, u64::from(row))
+        );
+    }
+
+    // A change at B395 is read only by the placements whose expanding range
+    // has reached it: rows 395..=ROWS+1.
+    const EDIT_ROW: u32 = ROWS - 5; // 395
+    engine
+        .action_atomic_journal("edit B395".to_string(), |tx| {
+            tx.set_cell_value(SHEET, EDIT_ROW, 2, LiteralValue::Number(5_000.0))?;
+            Ok(())
+        })
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    let report = engine
+        .last_formula_plane_span_eval_report()
+        .expect("edit recalc must evaluate span work");
+    assert_eq!(
+        report.span_eval_placement_count,
+        u64::from(ROWS + 1 - EDIT_ROW + 1), // rows 395..=401 inclusive
+        "running-total dirty work must be the affected placement interval, \
+         not the whole span: {report:?}"
+    );
+
+    let delta = 5_000.0 - EDIT_ROW as f64;
+    // Placements before the edit row never read it and keep their values.
+    assert_eq!(
+        numeric_value(&engine, EDIT_ROW - 1, 3),
+        interval_sum(2, u64::from(EDIT_ROW) - 1)
+    );
+    assert_eq!(
+        numeric_value(&engine, EDIT_ROW, 3),
+        interval_sum(2, u64::from(EDIT_ROW)) + delta
+    );
+    assert_eq!(
+        numeric_value(&engine, ROWS + 1, 3),
+        interval_sum(2, u64::from(ROWS) + 1) + delta
+    );
+}
+
+#[test]
+fn self_reading_expanding_range_family_rejects_with_internal_dependency() {
+    // `=SUM($C$1:$C{r-1})*0+B{r}` placed in column C: the expanding range
+    // reads the family's own result column. The union read region
+    // [1..=ROWS] x C intersects the result region [2..=ROWS+1] x C, so the
+    // InternalDependency guard must keep the whole family legacy.
+    let mut engine = authoritative_engine();
+    let mut formulas = Vec::with_capacity(ROWS as usize);
+    for row in 2..=ROWS + 1 {
+        engine
+            .set_cell_value(SHEET, row, 2, LiteralValue::Number(row as f64))
+            .unwrap();
+        let prev = row - 1;
+        formulas.push(record(
+            &mut engine,
+            row,
+            3,
+            &format!("=SUM($C$1:$C{prev})*0+B{row}"),
+        ));
+    }
+    let report = engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .expect("ingest formulas");
+
+    assert_eq!(report.shadow_accepted_span_cells, 0);
+    assert_eq!(
+        report
+            .fallback_reasons
+            .get("InternalDependency")
+            .copied()
+            .unwrap_or(0),
+        u64::from(ROWS),
+        "histogram: {:?}",
+        report.fallback_reasons
+    );
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+
+    engine.evaluate_all().unwrap();
+    for row in [2, ROWS / 2, ROWS + 1] {
+        assert_eq!(numeric_value(&engine, row, 3), row as f64);
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -68,6 +68,13 @@ fn numeric_value(engine: &Engine<TestWorkbook>, row: u32, col: u32) -> f64 {
 
 /// `A{r} = r`; span-accepted `B{r} = A{r}+1`; legacy tail readers in the
 /// given column reading the given range template.
+///
+/// Mixed-anchor tail-read families are span-supported now, so a uniform
+/// `=SUM($A{r}:$A$N)` column would be promoted and stop exercising the
+/// legacy-interaction path this net pins. Alternate odd rows to a structurally
+/// different but value-identical template (`...+0`): each resulting family has
+/// row gaps (`UnsupportedShapeOrGaps`), keeping all tail readers legacy while
+/// preserving the original read-region geometry and candidate counts.
 fn build_mixed_engine(tail_formula: impl Fn(u32) -> String) -> Engine<TestWorkbook> {
     let config =
         EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
@@ -78,11 +85,23 @@ fn build_mixed_engine(tail_formula: impl Fn(u32) -> String) -> Engine<TestWorkbo
             .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
             .unwrap();
         formulas.push(record(&mut engine, row, 2, &format!("=A{row}+1")));
-        formulas.push(record(&mut engine, row, 4, &tail_formula(row)));
+        let tail = if row % 2 == 0 {
+            format!("{}+0", tail_formula(row))
+        } else {
+            tail_formula(row)
+        };
+        formulas.push(record(&mut engine, row, 4, &tail));
     }
-    engine
+    let report = engine
         .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
         .expect("ingest formulas");
+    assert_eq!(
+        report.shadow_accepted_span_cells,
+        u64::from(ROWS),
+        "only the B column family may span; tail readers must stay legacy \
+         (histogram: {:?})",
+        report.fallback_reasons
+    );
     engine
 }
 

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -114,6 +114,7 @@ mod formula_plane_ingest_shadow;
 mod formula_plane_literal_param_memo;
 mod formula_plane_lookup_family_promotion;
 mod formula_plane_lookup_semantics;
+mod formula_plane_mixed_anchor_spans;
 mod formula_plane_mixed_legacy_tail_reads;
 mod formula_plane_parallel_span_eval;
 mod formula_plane_per_placement_literal_bindings;

--- a/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
+++ b/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
@@ -809,7 +809,7 @@ impl SummaryAnalyzer {
                 {
                     return false;
                 }
-                if !axis_kinds_match(start_row, end_row) || !axis_kinds_match(start_col, end_col) {
+                if !range_axis_kinds_supported(start_row, end_row, start_col, end_col) {
                     self.reasons
                         .insert(DependencyRejectReason::MixedAxisRangeUnsupported { context });
                     return false;
@@ -990,6 +990,37 @@ fn axis_is_finite_cell(axis: &AxisRef) -> bool {
 
 fn axis_is_placement_invariant(axis: &AxisRef) -> bool {
     matches!(axis, AxisRef::AbsoluteVc { .. } | AxisRef::WholeAxis)
+}
+
+/// Range bound combinations a precedent pattern can carry.
+///
+/// All-finite ranges may mix placement-relative and absolute bounds freely
+/// within an axis: mixed-anchor ranges like `$A$2:$A{r}` (running total) and
+/// `$A{r}:$A$N` (tail read) are affine in the placement index per bound, so
+/// every downstream consumer (region instantiation, forward read-region
+/// projection, inverse dirty projection) handles them per bound.
+///
+/// Ranges involving `WholeAxis` keep the stricter per-axis kind uniformity:
+/// `A:A` is fine, but `A:$A` (whole-column with mixed column anchors) stays
+/// rejected — the ingest read-projection path does not model it either, and
+/// accepting it here only would make the two analyses disagree.
+fn range_axis_kinds_supported(
+    start_row: &AxisRef,
+    end_row: &AxisRef,
+    start_col: &AxisRef,
+    end_col: &AxisRef,
+) -> bool {
+    let any_whole = [start_row, end_row, start_col, end_col]
+        .iter()
+        .any(|axis| matches!(axis, AxisRef::WholeAxis));
+    if any_whole {
+        axis_kinds_match(start_row, end_row) && axis_kinds_match(start_col, end_col)
+    } else {
+        // Open/unsupported bounds were rejected by `reject_non_finite_range`;
+        // every remaining bound is RelativeToPlacement or AbsoluteVc and any
+        // mixture is supported.
+        true
+    }
 }
 
 fn axis_kinds_match(left: &AxisRef, right: &AxisRef) -> bool {
@@ -1953,7 +1984,52 @@ fn inverse_range_axis_changed_range(
                 && ranges_intersect(changed_start, changed_end, range_start, range_end))
             .then_some((1, u32::MAX))
         }
+        // Mixed-anchor axis: placement p reads
+        // [min(p + offset, index), max(p + offset, index)], so the inverse of
+        // a changed interval is a half-open placement interval (clamped to the
+        // valid 1-based coordinate space; out-of-range bounds saturate
+        // conservatively rather than dropping placements).
+        (AxisRef::RelativeToPlacement { offset }, AxisRef::AbsoluteVc { index })
+        | (AxisRef::AbsoluteVc { index }, AxisRef::RelativeToPlacement { offset }) => {
+            if *index == 0 {
+                return None;
+            }
+            if changed_start <= *index && *index <= changed_end {
+                // Every placement's read interval contains the pinned bound.
+                Some((1, u32::MAX))
+            } else if *index < changed_start {
+                // Affected iff p + offset >= changed_start.
+                let start = clamped_inverse_offset_floor(changed_start, *offset)?;
+                Some((start, u32::MAX))
+            } else {
+                // index > changed_end: affected iff p + offset <= changed_end.
+                let end = clamped_inverse_offset_ceil(changed_end, *offset)?;
+                Some((1, end))
+            }
+        }
         _ => None,
+    }
+}
+
+/// `coordinate - offset` clamped low to 1; `None` when the bound exceeds
+/// `u32::MAX` (no placement can satisfy `p >= bound`).
+fn clamped_inverse_offset_floor(coordinate: u32, offset: i64) -> Option<u32> {
+    let value = i128::from(coordinate) - i128::from(offset);
+    if value > i128::from(u32::MAX) {
+        None
+    } else {
+        Some(value.max(1) as u32)
+    }
+}
+
+/// `coordinate - offset` clamped high to `u32::MAX`; `None` when the bound is
+/// below 1 (no placement can satisfy `p <= bound`).
+fn clamped_inverse_offset_ceil(coordinate: u32, offset: i64) -> Option<u32> {
+    let value = i128::from(coordinate) - i128::from(offset);
+    if value < 1 {
+        None
+    } else {
+        Some(value.min(i128::from(u32::MAX)) as u32)
     }
 }
 
@@ -2796,16 +2872,45 @@ mod tests {
     }
 
     #[test]
-    fn formula_plane_dependency_summary_rejects_mixed_axis_range() {
+    fn formula_plane_dependency_summary_accepts_mixed_axis_running_total_range() {
+        // `=SUM($A$1:$A1)` at row 1: absolute start row, placement-relative
+        // end row (offset 0) — the expanding running-total idiom.
         let summary = summary("=SUM($A$1:$A1)", 1, 2);
 
-        assert_eq!(summary.formula_class, FormulaClass::Rejected);
-        assert!(has_reason(
-            &summary,
-            &DependencyRejectReason::MixedAxisRangeUnsupported {
-                context: AnalyzerContext::Value
-            }
-        ));
+        assert_eq!(summary.formula_class, FormulaClass::StaticPointwise);
+        assert!(summary.reject_reasons.is_empty());
+        assert_eq!(
+            summary.precedent_patterns,
+            vec![range(
+                SheetBinding::CurrentSheet,
+                AxisRef::AbsoluteVc { index: 1 },
+                AxisRef::AbsoluteVc { index: 1 },
+                AxisRef::RelativeToPlacement { offset: 0 },
+                AxisRef::AbsoluteVc { index: 1 },
+            )]
+        );
+        assert!(!summary.is_constant_result());
+    }
+
+    #[test]
+    fn formula_plane_dependency_summary_accepts_mixed_axis_tail_read_range() {
+        // `=SUM($A1:$A$100)` at row 1: placement-relative start row, absolute
+        // end row — the shrinking tail-read idiom.
+        let summary = summary("=SUM($A1:$A$100)", 1, 2);
+
+        assert_eq!(summary.formula_class, FormulaClass::StaticPointwise);
+        assert!(summary.reject_reasons.is_empty());
+        assert_eq!(
+            summary.precedent_patterns,
+            vec![range(
+                SheetBinding::CurrentSheet,
+                AxisRef::RelativeToPlacement { offset: 0 },
+                AxisRef::AbsoluteVc { index: 1 },
+                AxisRef::AbsoluteVc { index: 100 },
+                AxisRef::AbsoluteVc { index: 1 },
+            )]
+        );
+        assert!(!summary.is_constant_result());
     }
 
     #[test]
@@ -3120,6 +3225,86 @@ mod tests {
         assert_eq!(arena.reverse_counters.reverse_max_overage, 24);
         assert_eq!(arena.reverse_counters.reverse_median_overage, 24);
         assert_eq!(arena.reverse_counters.global_dirty_fallback_count, 0);
+    }
+
+    #[test]
+    fn formula_plane_reverse_query_inverts_mixed_anchor_running_total_to_half_open_interval() {
+        // `=SUM($A$1:$A1)` over C1..C100: placement row r reads A1..A{r}.
+        let cells = (1..=100)
+            .map(|row| candidate_cell(row, 3, "tpl_running_total"))
+            .collect::<Vec<_>>();
+        let store = run_store(cells, 25);
+        let summaries =
+            template_summary_map(vec![("tpl_running_total", summary("=SUM($A$1:$A1)", 1, 3))]);
+        let mut arena = instantiate_run_dependency_summaries(&store, &summaries);
+
+        assert_eq!(arena.counters.supported_run_summary_count, 1);
+        // Union read region is the full bounding rect over the run.
+        assert_eq!(
+            arena.run_summaries[0].precedent_regions[0].region.region,
+            FiniteRegion::new("Sheet1", 1, 1, 100, 1)
+        );
+
+        // A change at A50 affects exactly the placements with r >= 50.
+        let query = arena.query_changed_cell("Sheet1", 50, 1);
+        assert!(!query.global_dirty_fallback);
+        assert_eq!(query.dependent_partitions.len(), 3);
+        let matched: Vec<_> = query
+            .dependent_partitions
+            .iter()
+            .flat_map(|partition| partition.matched_result_regions.iter().cloned())
+            .collect();
+        assert_eq!(
+            matched,
+            vec![
+                FiniteRegion::cell("Sheet1", 50, 3),
+                FiniteRegion::new("Sheet1", 51, 3, 75, 3),
+                FiniteRegion::new("Sheet1", 76, 3, 100, 3),
+            ]
+        );
+        // A change above the run's read region maps to no placements.
+        let above = arena.query_changed_cell("Sheet1", 101, 1);
+        assert!(above.dependent_partitions.is_empty());
+    }
+
+    #[test]
+    fn formula_plane_reverse_query_inverts_mixed_anchor_tail_read_to_half_open_interval() {
+        // `=SUM($A1:$A$100)` over C1..C100: placement row r reads A{r}..A100.
+        let cells = (1..=100)
+            .map(|row| candidate_cell(row, 3, "tpl_tail_read"))
+            .collect::<Vec<_>>();
+        let store = run_store(cells, 25);
+        let summaries =
+            template_summary_map(vec![("tpl_tail_read", summary("=SUM($A1:$A$100)", 1, 3))]);
+        let mut arena = instantiate_run_dependency_summaries(&store, &summaries);
+
+        assert_eq!(arena.counters.supported_run_summary_count, 1);
+
+        // A change at A50 affects exactly the placements with r <= 50.
+        let query = arena.query_changed_cell("Sheet1", 50, 1);
+        assert!(!query.global_dirty_fallback);
+        assert_eq!(query.dependent_partitions.len(), 2);
+        let matched: Vec<_> = query
+            .dependent_partitions
+            .iter()
+            .flat_map(|partition| partition.matched_result_regions.iter().cloned())
+            .collect();
+        assert_eq!(
+            matched,
+            vec![
+                FiniteRegion::new("Sheet1", 1, 3, 25, 3),
+                FiniteRegion::new("Sheet1", 26, 3, 50, 3),
+            ]
+        );
+        assert!(
+            query
+                .dependent_partitions
+                .iter()
+                .all(|partition| partition.is_exact)
+        );
+        // A change at the pinned end row affects every placement.
+        let pinned = arena.query_changed_cell("Sheet1", 100, 1);
+        assert_eq!(pinned.dependent_partitions.len(), 4);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/formula_plane/producer.rs
+++ b/crates/formualizer-eval/src/formula_plane/producer.rs
@@ -535,11 +535,6 @@ impl DirtyProjectionRule {
                 col_start,
                 col_end,
             } => {
-                if !row_start.same_kind(row_end) || !col_start.same_kind(col_end) {
-                    return ProjectionResult::Unsupported(
-                        ProjectionFallbackReason::UnsupportedAxis,
-                    );
-                }
                 let dirty_rows =
                     match project_changed_range_axis(row_start, row_end, changed_rows, result_rows)
                     {
@@ -601,14 +596,6 @@ impl AxisProjection {
         }
     }
 
-    fn same_kind(self, other: Self) -> bool {
-        matches!(
-            (self, other),
-            (Self::Relative { .. }, Self::Relative { .. })
-                | (Self::Absolute { .. }, Self::Absolute { .. })
-        )
-    }
-
     fn project_changed_axis(
         self,
         changed: AxisRange,
@@ -642,9 +629,12 @@ fn range_source_extent_for_result(
     end: AxisProjection,
     result: BoundedRange,
 ) -> Result<BoundedRange, ProjectionFallbackReason> {
-    if !start.same_kind(end) {
-        return Err(ProjectionFallbackReason::UnsupportedAxis);
-    }
+    // Per placement the read interval on this axis is
+    // [min(start(p), end(p)), max(start(p), end(p))]; both bounds are affine
+    // in the placement index (Relative tracks p, Absolute is constant), so the
+    // union over the bounded result extent is exactly the union of each
+    // bound's own extent. This holds for uniform AND mixed-anchor bounds
+    // (e.g. `$A$2:$A{r}` running totals or `$A{r}:$A$N` tail reads).
     let start_extent = start.source_extent_for_result(result)?;
     let end_extent = end.source_extent_for_result(result)?;
     Ok(start_extent.union(end_extent))
@@ -695,7 +685,31 @@ fn project_changed_range_axis(
             let source = AxisRange::Span(start_index.min(end_index), start_index.max(end_index));
             Ok(source.intersects(changed).then_some(result))
         }
-        _ => Ok(None),
+        // Mixed-anchor axis: one bound pinned (Absolute), one moving with the
+        // placement (Relative). Placement p reads
+        // [min(p + offset, index), max(p + offset, index)] on this axis, so the
+        // inverse of a changed interval [a, b] is a half-open placement
+        // interval:
+        // - index in [a, b]: every placement reads the pinned bound -> all;
+        // - index < a: intersects iff max(p + offset, index) >= a, i.e.
+        //   p + offset >= a (running totals `$2:{p}` with the change below);
+        // - index > b: intersects iff min(p + offset, index) <= b, i.e.
+        //   p + offset <= b (tail reads `{p}:$N` with the change above).
+        (AxisProjection::Relative { offset }, AxisProjection::Absolute { index })
+        | (AxisProjection::Absolute { index }, AxisProjection::Relative { offset }) => {
+            let (changed_low, changed_high) = changed.query_bounds();
+            let projection_offset = offset
+                .checked_neg()
+                .ok_or(ProjectionFallbackReason::CoordinateOverflow)?;
+            let dirty = if changed_low <= index && index <= changed_high {
+                Some(AxisRange::All)
+            } else if index < changed_low {
+                project_axis_range_through_offset(AxisRange::From(changed_low), projection_offset)
+            } else {
+                project_axis_range_through_offset(AxisRange::To(changed_high), projection_offset)
+            };
+            Ok(dirty.and_then(|dirty| intersect_axis_ranges(dirty, result)))
+        }
     }
 }
 
@@ -1418,18 +1432,92 @@ mod tests {
     }
 
     #[test]
-    fn mixed_axis_range_projection_rejects() {
+    fn mixed_axis_running_total_range_projects_half_open_placement_interval() {
+        // `=SUM($A$2:$A{r})` style: absolute start row, placement-relative end
+        // row, fixed column. Result placements rows 1..=120 (0-based) in col 2.
         let projection = DirtyProjectionRule::AffineRange {
-            row_start: AxisProjection::Absolute { index: 0 },
+            row_start: AxisProjection::Absolute { index: 1 },
             row_end: AxisProjection::Relative { offset: 0 },
             col_start: AxisProjection::Absolute { index: 0 },
             col_end: AxisProjection::Absolute { index: 0 },
         };
-        let result = Region::col_interval(0, 2, 0, 9);
+        let result = Region::col_interval(0, 2, 1, 120);
 
+        // Union read region is the full bounding rect [2..=r_max] x col A.
+        let read = projection.read_region_for_result(0, result).unwrap();
+        assert_eq!(read, Region::col_interval(0, 0, 1, 120));
+
+        // A change at row 50 dirties exactly the placements whose expanding
+        // range reaches it: rows 50..=120.
         assert_eq!(
-            projection.read_region_for_result(0, result),
-            Err(ProjectionFallbackReason::UnsupportedAxis)
+            projection.project_changed_region(Region::point(0, 50, 0), read, result),
+            ProjectionResult::Exact(ProducerDirtyDomain::Regions(vec![Region::col_interval(
+                0, 2, 50, 120
+            )]))
+        );
+        // A change at the pinned start row dirties every placement.
+        assert_eq!(
+            projection.project_changed_region(Region::point(0, 1, 0), read, result),
+            ProjectionResult::Exact(ProducerDirtyDomain::Regions(vec![result]))
+        );
+        // A change outside the union read region is not an intersection.
+        assert_eq!(
+            projection.project_changed_region(Region::point(0, 200, 0), read, result),
+            ProjectionResult::NoIntersection
+        );
+    }
+
+    #[test]
+    fn mixed_axis_tail_read_range_projects_half_open_placement_interval() {
+        // `=SUM($A{r}:$A$N)` style: placement-relative start row, absolute end
+        // row. Result placements rows 1..=100 in col 2; pinned end row 120.
+        let projection = DirtyProjectionRule::AffineRange {
+            row_start: AxisProjection::Relative { offset: 0 },
+            row_end: AxisProjection::Absolute { index: 120 },
+            col_start: AxisProjection::Absolute { index: 0 },
+            col_end: AxisProjection::Absolute { index: 0 },
+        };
+        let result = Region::col_interval(0, 2, 1, 100);
+
+        let read = projection.read_region_for_result(0, result).unwrap();
+        assert_eq!(read, Region::col_interval(0, 0, 1, 120));
+
+        // A change at row 50 dirties exactly the placements whose shrinking
+        // tail still covers it: rows 1..=50.
+        assert_eq!(
+            projection.project_changed_region(Region::point(0, 50, 0), read, result),
+            ProjectionResult::Exact(ProducerDirtyDomain::Regions(vec![Region::col_interval(
+                0, 2, 1, 50
+            )]))
+        );
+        // A change at the pinned end row dirties every placement.
+        assert_eq!(
+            projection.project_changed_region(Region::point(0, 120, 0), read, result),
+            ProjectionResult::Exact(ProducerDirtyDomain::Regions(vec![result]))
+        );
+    }
+
+    #[test]
+    fn mixed_axis_range_with_negative_relative_offset_projects_and_clips() {
+        // `=SUM($C$1:$C{r-1})` style self-cumulative shape (here pointed at a
+        // different column so it is a plain consumer): end row offset -1.
+        let projection = DirtyProjectionRule::AffineRange {
+            row_start: AxisProjection::Absolute { index: 0 },
+            row_end: AxisProjection::Relative { offset: -1 },
+            col_start: AxisProjection::Absolute { index: 0 },
+            col_end: AxisProjection::Absolute { index: 0 },
+        };
+        let result = Region::col_interval(0, 2, 1, 100);
+
+        let read = projection.read_region_for_result(0, result).unwrap();
+        assert_eq!(read, Region::col_interval(0, 0, 0, 99));
+
+        // A change at row 40 affects placements with r - 1 >= 40 -> rows 41..
+        assert_eq!(
+            projection.project_changed_region(Region::point(0, 40, 0), read, result),
+            ProjectionResult::Exact(ProducerDirtyDomain::Regions(vec![Region::col_interval(
+                0, 2, 41, 100
+            )]))
         );
     }
 

--- a/crates/formualizer-testkit/src/fp_coverage.rs
+++ b/crates/formualizer-testkit/src/fp_coverage.rs
@@ -30,7 +30,7 @@ pub const DATA_SHEET: &str = "Data";
 /// Number of sections emitted with `include_broken = false`.
 ///
 /// Useful for sizing: total formula cells = `SECTION_COUNT * rows_per_section`.
-pub const SECTION_COUNT: usize = 10;
+pub const SECTION_COUNT: usize = 12;
 
 /// Expected FormulaPlane placement verdict for every formula cell of a section.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -332,9 +332,10 @@ pub fn generate(rows_per_section: u32, seed: u64, include_broken: bool) -> Cover
 
     // ------------------------------------------------------------------
     // (h) mixed_anchor — range with relative start / absolute end
-    // (=SUM($A{r}:$A$last)): the read region shrinks as the row advances,
-    // so member templates are not row-translation-equivalent.
-    // Expected: REJECT.
+    // (=SUM($A{r}:$A$last)): the per-row read region is a shrinking tail,
+    // affine in the placement index. Expected: SPAN. Mixed-anchor ranges
+    // gained dependency-summary + half-open dirty-projection support;
+    // pinned empirically on 2026-06-11.
     // ------------------------------------------------------------------
     {
         let mut values = Vec::new();
@@ -351,14 +352,12 @@ pub fn generate(rows_per_section: u32, seed: u64, include_broken: bool) -> Cover
         sections.push(Section {
             name: "mixed_anchor",
             sheet: "MixedAnchor",
-            verdict: SectionVerdict::Reject {
-                placement_reason: "UnsupportedDependencySummary",
-            },
+            verdict: SectionVerdict::Span,
             expected_canonical_reject_kinds: &[],
             values,
             formulas,
-            notes: "Mixed-anchor =SUM($A{r}:$A$last); canonical OK (MixedAnchors flag) but the \
-                    per-row shrinking-tail read region has no supported dependency summary.",
+            notes: "Mixed-anchor tail read =SUM($A{r}:$A$last); shrinking read region, span via \
+                    half-open placement-interval dirty projection.",
         });
     }
 
@@ -406,6 +405,67 @@ pub fn generate(rows_per_section: u32, seed: u64, include_broken: bool) -> Cover
             values: Vec::new(),
             formulas,
             notes: "Row-shifted cross-sheet =Data!B{r}*2; explicit sheet binding is supported.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (k) running_total — expanding mixed-anchor range reading a DIFFERENT
+    // column (=SUM($B$2:$B{r})): absolute start, relative end. Expected:
+    // SPAN — the opposite polarity of mixed_anchor's shrinking tail.
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("RunningTotal", r, 2, mix(seed, r as u64, 11))); // B
+            formulas.push(formula("RunningTotal", r, 3, format!("=SUM($B$2:$B{r})")));
+        }
+        sections.push(Section {
+            name: "running_total",
+            sheet: "RunningTotal",
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Running total =SUM($B$2:$B{r}) over a data column; expanding read region, \
+                    span via half-open placement-interval dirty projection.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (l) self_cumulative — expanding mixed-anchor range reading the
+    // family's OWN result column (=SUM($C$1:$C{r-1})*0+B{r} in column C).
+    // The union read region intersects the result region, so the
+    // InternalDependency placement guard must keep the family legacy.
+    // (`*0+B{r}` keeps the evaluated values bounded and per-row distinct —
+    // a raw cumulative self-sum doubles every row and overflows to +inf,
+    // which defeats the ON-vs-OFF value-equality check.)
+    // Expected: REJECT (InternalDependency).
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        for r in rows.clone() {
+            values.push(val("SelfCumulative", r, 2, mix(seed, r as u64, 12))); // B
+            let rm1 = r - 1;
+            formulas.push(formula(
+                "SelfCumulative",
+                r,
+                3,
+                format!("=SUM($C$1:$C{rm1})*0+B{r}"),
+            ));
+        }
+        sections.push(Section {
+            name: "self_cumulative",
+            sheet: "SelfCumulative",
+            verdict: SectionVerdict::Reject {
+                placement_reason: "InternalDependency",
+            },
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Self-cumulative =SUM($C$1:$C{r-1})*0+B{r} reading its own result column; \
+                    the InternalDependency guard must reject the span.",
         });
     }
 


### PR DESCRIPTION
## Summary

FormulaPlane now spans mixed-anchor ranges — one bound relative-to-placement, the other absolute — covering two of the most common formula idioms: tail reads (`=SUM($A2:$A$100)`) and running totals (`=SUM($A$2:$A2)`). Canonicalization already accepted these shapes; the gate was the dependency analyzer's `axis_kinds_match` check, and the work is dependency bookkeeping: the per-placement read region is an expanding/shrinking rectangle, still affine in placement index.

On the #142 coverage corpus this flips the mixed_anchor section from legacy to span: 70.0% -> 80.0% coverage on the original sections. The corpus also gains running_total (expected span) and self_cumulative (expected reject) sections, making the new 12-section denominator 75.0%.

## Design

- Kept `AffineRectPattern` (no new variant) — it already carries per-bound `AxisRef`s; the rejection was the only analyzer gate. Consumer mapping found five places assuming axis-kind uniformity (forward extent, changed-range projection, the `AffineRange` same-kind gate, the passive reverse arena, and a duplicate abs-flag gate in ingest), all updated. Whole-axis ranges keep strict uniformity.
- Dirty-projection inversion for the mixed case is a half-open interval of placements: for a change at rows [a,b], the expanding side affects placements with p+off >= a, the shrinking side p+off <= b, with conservative clamping; the constant-bound row inside [a,b] means all placements.
- Union read region is the exact per-bound extent union (bounding rect), which keeps the placement-time `InternalDependency` intersect conservative — self-reading cumulatives still reject (pinned).
- Single-column mixed reads route into #143's per-column interval trees (pinned by counter test), not rect buckets.

## Evidence

Dirty precision (counter-pinned in `formula_plane_mixed_anchor_spans.rs`): on a 400-placement tail-read span, editing A10 evaluates exactly 10 placements; on a running-total span, editing B395 evaluates exactly 7. Graph compression: the mixed_anchor section is now 1 span instead of 2,000 legacy vertices.

Timings (probe-fp-coverage, release): every new-span section evaluates at-or-better than Off (`--only mixed_anchor` 6-8 -> 2-3 ms first eval; running_total 7-15 -> 3 ms); full-corpus auth first eval keeps the #143 win. Value equality perfect on the full corpus and every `--only` slice. One flag for the record: the new self_cumulative section (a 2,000-deep legacy SUM chain) adds ~25-30 ms auth-warm overhead by ablation — a pre-existing mixed-mode pattern unrelated to the span path, kept in the corpus precisely so it stays visible.

## Gates

fmt clean; workspace clippy (-D warnings, CI exclusions) clean; workspace tests pass (formualizer-eval 1977 incl. 5 new); portable-wasm facade check clean. FP-off standing gate vs main: finance-recalc medians identical (213.7/213.7 ms, checksums equal), load-envelope mixed-direction — noise, pass.

Note for the #143 regression net: uniform tail-read families now span (that is the feature), so `formula_plane_mixed_legacy_tail_reads.rs` keeps its legacy-interaction surface via row-gapped templates, with an added assertion that exactly the intended family spans.

Refs #142 (coverage baseline), #143 (mixed-mode fix), #144 (tracked staleness gap).
