### PR TITLE
perf(formula-plane): O(1) candidate mapping on family rejection — 50k-chain ingest penalty 863 to 112 ms; chain corpus section

### DIFF
--- a/crates/formualizer-bench-core/src/bin/probe-fp-reject-chain.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-fp-reject-chain.rs
@@ -1,0 +1,87 @@
+//! Scratch probe: FormulaPlane family-rejection cost on an incremental chain.
+//!
+//! Builds `A1=1`, `A{r}=A{r-1}+1` for r=2..N (one candidate family, rejected
+//! with `InternalDependency`) and times first eval under FormulaPlane Off vs
+//! AuthoritativeExperimental.
+//!
+//! ```bash
+//! cargo run -p formualizer-bench-core --features formualizer_runner \
+//!   --release --bin probe-fp-reject-chain -- --rows 10000,25000,50000,100000
+//! ```
+
+#[cfg(not(feature = "formualizer_runner"))]
+fn main() {
+    eprintln!("requires feature `formualizer_runner`");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "formualizer_runner")]
+mod probe {
+    use std::time::Instant;
+
+    use anyhow::Result;
+    use clap::Parser;
+    use formualizer_eval::engine::FormulaPlaneMode;
+    use formualizer_workbook::{LiteralValue, Workbook, WorkbookConfig};
+
+    #[derive(Debug, Parser)]
+    pub struct Cli {
+        #[arg(long, default_value = "10000,25000,50000,100000")]
+        rows: String,
+        /// Interleaved repetitions per (rows, mode); min is reported.
+        #[arg(long, default_value_t = 3)]
+        reps: u32,
+    }
+
+    fn run_mode(n: u32, mode: FormulaPlaneMode) -> Result<(u128, String)> {
+        let config = WorkbookConfig::interactive().with_formula_plane_mode(mode);
+        let mut wb = Workbook::new_with_config(config);
+        wb.add_sheet("S")?;
+        wb.set_value("S", 1, 1, LiteralValue::Number(1.0))?;
+        let formulas: Vec<Vec<String>> = (2..=n).map(|r| vec![format!("=A{}+1", r - 1)]).collect();
+        wb.set_formulas("S", 2, 1, &formulas)?;
+        let start = Instant::now();
+        wb.evaluate_all()?;
+        let first_eval_ms = start.elapsed().as_millis();
+        let reasons = format!(
+            "{:?}",
+            wb.engine().formula_ingest_report_total().fallback_reasons
+        );
+        // sanity: last cell value
+        let last = wb.get_value("S", n, 1);
+        anyhow::ensure!(
+            matches!(last, Some(LiteralValue::Number(v)) if v == n as f64),
+            "value mismatch at A{n}: {last:?}"
+        );
+        Ok((first_eval_ms, reasons))
+    }
+
+    pub fn main() -> Result<()> {
+        let cli = Cli::parse();
+        println!("rows\toff_ms(min)\tauth_ms(min)\tpenalty_ms");
+        for part in cli.rows.split(',') {
+            let n: u32 = part.trim().parse()?;
+            let mut off_min = u128::MAX;
+            let mut auth_min = u128::MAX;
+            let mut reasons = String::new();
+            for _ in 0..cli.reps.max(1) {
+                let (off_ms, _) = run_mode(n, FormulaPlaneMode::Off)?;
+                let (auth_ms, auth_reasons) =
+                    run_mode(n, FormulaPlaneMode::AuthoritativeExperimental)?;
+                off_min = off_min.min(off_ms);
+                auth_min = auth_min.min(auth_ms);
+                reasons = auth_reasons;
+            }
+            println!(
+                "{n}\t{off_min}\t{auth_min}\t{}\t{reasons}",
+                auth_min as i128 - off_min as i128
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn main() -> anyhow::Result<()> {
+    probe::main()
+}

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -3318,7 +3318,9 @@ where
             let sheet_name = pending_candidates[candidate_indices[0]].0.clone();
             let mut plans_by_coord: BTreeMap<(u32, u32), Vec<DependencyPlanRow>> = BTreeMap::new();
             for idx in &candidate_indices {
-                if let Some(plan) = plans_by_index[*idx].clone() {
+                // Each candidate index belongs to exactly one group, so the
+                // plan row can be moved out instead of deep-cloned.
+                if let Some(plan) = plans_by_index[*idx].take() {
                     let candidate = &pending_candidates[*idx].1;
                     plans_by_coord
                         .entry((candidate.row, candidate.col))
@@ -3387,14 +3389,27 @@ where
                     };
                     Self::accumulate_formula_plane_placement_report(&mut report, &placement_report);
 
+                    // Index candidates by placement once per component. The
+                    // previous per-result linear `find` made this fallback
+                    // mapping O(N²) for rejected families (e.g. an N-cell
+                    // chain rejected with `InternalDependency`), dominating
+                    // first-eval ingest cost on large rejected families.
+                    // First insert wins, matching the old `Iterator::find`
+                    // semantics for duplicate placements.
+                    let mut candidate_by_placement: FxHashMap<
+                        crate::formula_plane::runtime::PlacementCoord,
+                        &FormulaPlacementCandidate,
+                    > = FxHashMap::with_capacity_and_hasher(component.len(), Default::default());
+                    for candidate in &component {
+                        candidate_by_placement
+                            .entry(candidate.placement())
+                            .or_insert(candidate);
+                    }
                     for result in &placement_report.results {
                         let FormulaPlacementResult::Legacy { placement, .. } = result else {
                             continue;
                         };
-                        if let Some(candidate) = component
-                            .iter()
-                            .find(|candidate| candidate.placement() == *placement)
-                        {
+                        if let Some(&candidate) = candidate_by_placement.get(placement) {
                             let plan = plans_by_coord
                                 .get_mut(&(candidate.row, candidate.col))
                                 .and_then(Vec::pop);
@@ -3499,6 +3514,19 @@ where
         candidates: Vec<FormulaPlacementCandidate>,
     ) -> Vec<Vec<FormulaPlacementCandidate>> {
         if candidates.len() <= 1 {
+            return vec![candidates];
+        }
+
+        // Fast path: candidates already ordered as one contiguous
+        // single-column (or single-row) run form exactly one 4-connected
+        // component in their existing (row, col) order; skip the BFS.
+        let is_row_run = candidates.windows(2).all(|w| {
+            w[0].sheet_id == w[1].sheet_id && w[0].col == w[1].col && w[0].row + 1 == w[1].row
+        });
+        let is_col_run = candidates.windows(2).all(|w| {
+            w[0].sheet_id == w[1].sheet_id && w[0].row == w[1].row && w[0].col + 1 == w[1].col
+        });
+        if is_row_run || is_col_run {
             return vec![candidates];
         }
 

--- a/crates/formualizer-eval/src/formula_plane/placement.rs
+++ b/crates/formualizer-eval/src/formula_plane/placement.rs
@@ -915,6 +915,16 @@ pub(crate) fn split_candidate_affine_literal_runs(
     }
     debug_assert_eq!(candidates.len(), analyses.len());
 
+    // Fast path: identical literal bindings across the family mean every
+    // adjacent step is zero, so the family never splits. Skip the per-pair
+    // step computation (which allocates a Vec per window) entirely.
+    if analyses
+        .windows(2)
+        .all(|pair| pair[0].literal_bindings == pair[1].literal_bindings)
+    {
+        return vec![(candidates, analyses)];
+    }
+
     let is_row_run = candidates.windows(2).all(|w| {
         w[0].sheet_id == w[1].sheet_id && w[0].col == w[1].col && w[0].row + 1 == w[1].row
     });

--- a/crates/formualizer-testkit/src/fp_coverage.rs
+++ b/crates/formualizer-testkit/src/fp_coverage.rs
@@ -30,7 +30,7 @@ pub const DATA_SHEET: &str = "Data";
 /// Number of sections emitted with `include_broken = false`.
 ///
 /// Useful for sizing: total formula cells = `SECTION_COUNT * rows_per_section`.
-pub const SECTION_COUNT: usize = 12;
+pub const SECTION_COUNT: usize = 13;
 
 /// Expected FormulaPlane placement verdict for every formula cell of a section.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -466,6 +466,37 @@ pub fn generate(rows_per_section: u32, seed: u64, include_broken: bool) -> Cover
             formulas,
             notes: "Self-cumulative =SUM($C$1:$C{r-1})*0+B{r} reading its own result column; \
                     the InternalDependency guard must reject the span.",
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // (m) chain — incremental chain within the section's own column
+    // (=A{r-1}+1): every cell reads its predecessor, so the family's read
+    // region intersects its own result region. Expected: REJECT with
+    // placement `InternalDependency` (the span runtime cannot express the
+    // cell-by-cell sequencing; legacy graph scheduling handles it). This
+    // section also keeps the reject-path ingest cost visible in the
+    // probe's timing output (the family-rejection path was once O(N²)).
+    // ------------------------------------------------------------------
+    {
+        let mut values = Vec::new();
+        let mut formulas = Vec::new();
+        // Chain base lives in the reserved header/aux row 1.
+        values.push(val("Chain", 1, 1, 1.0));
+        for r in rows.clone() {
+            formulas.push(formula("Chain", r, 1, format!("=A{}+1", r - 1)));
+        }
+        sections.push(Section {
+            name: "chain",
+            sheet: "Chain",
+            verdict: SectionVerdict::Reject {
+                placement_reason: "InternalDependency",
+            },
+            expected_canonical_reject_kinds: &[],
+            values,
+            formulas,
+            notes: "Incremental chain =A{r-1}+1 in its own column; read region intersects the \
+                    family's result region, placement rejects with InternalDependency.",
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes the O(N²) cost of REJECTING a large FormulaPlane candidate family, found while answering "how does the engine handle a 50k-row incremental chain?" The chain (`=A{r-1}+1`) is correctly rejected with `InternalDependency` — but reaching that verdict cost quadratic time: the first-eval penalty of authoritative mode over Off was 35/198/716/2,738 ms at 10k/25k/50k/100k rows (~4x per doubling), all spent on a family the system was always going to send to legacy.

## Root cause (profiled, not guessed)

Not in placement — `place_analyzed_family` computes the InternalDependency verdict before the heavy binding machinery, and its pre-verdict work is ~26 ms at 100k. The quadratic lived in the caller: `analyze_formula_plane_authoritative_ingest` (engine/eval.rs) mapped each of the N `Legacy` placement results back to its candidate with `component.iter().find(...)` — an O(N) scan per result. Instrumentation isolated it at 569 ms @ 50k -> 2,327 ms @ 100k while every other phase scaled linearly.

## Fix

- Per-component `FxHashMap<PlacementCoord, &candidate>` (first-insert-wins, identical semantics to the old find) — O(1) per result.
- `plans_by_index[idx].take()` instead of deep-cloning each `DependencyPlanRow` (each index belongs to exactly one group).
- Two allocation fast-paths in placement: identical literal bindings skip the per-pair run-splitting Vecs; an ordered contiguous single-axis run skips the connected-components BFS.

Verdicts, fallback histograms, and values unchanged; the fix benefits every legacy-fallback family, not just chains.

## Measured (probe-fp-reject-chain, min of 5, auth-minus-off first-eval penalty)

| rows | before | after |
|---|---|---|
| 10k | 24 ms | 10 ms |
| 25k | 237 ms | 46 ms |
| 50k | 863 ms | 112 ms |
| 100k | 3,058 ms | 297 ms |

Now ~linear (~2x per doubling). Steady state was never affected (head-edit recalc and quiescent identical in both modes). Residual linear cost is the per-candidate analysis lifecycle plus a CSR-build ordering difference between planned-fallback and batch ingest — noted as follow-up territory in the commit message.

## Corpus + standing probe

New `chain` section in the #142 coverage corpus (verdict pinned: `InternalDependency`), making 13 sections / 26,000 cells; combined coverage 69.2% (18,000 accepted; the two deliberate always-reject sections contribute 4,000 InternalDependency cells). `probe-fp-reject-chain` lands as a standing probe since it is the only direct measurement of the reject-path penalty curve. Probe value equality: 26,000/26,000, exit 0.

## Gates

fmt clean; workspace clippy (-D warnings, CI exclusions) clean; workspace tests pass post-rebase onto #145 (corpus conflict resolved: both PRs' sections retained); portable-wasm facade check clean. FP-off standing gate vs main: finance-recalc and load-envelope mixed-direction over 4 interleaved rounds — noise, pass (Off mode never executes the changed paths).

Refs #142 (corpus), #145 (mixed-anchor sections it now coexists with).
