### PR TITLE
feat(formula-plane): named-range fingerprint support — canonicalize by identity, resolve at projection time (corpus coverage 69% to 77%)

### DIFF
--- a/crates/formualizer-eval/src/engine/arena/ast.rs
+++ b/crates/formualizer-eval/src/engine/arena/ast.rs
@@ -195,7 +195,8 @@ impl CanonicalLabels {
     pub(crate) const REJECT_SPILL_RESULT_REGION_OPERATOR: u64 = 1 << 10;
     pub(crate) const REJECT_IMPLICIT_INTERSECTION_OPERATOR: u64 = 1 << 11;
     pub(crate) const REJECT_CALL_EXPRESSION: u64 = 1 << 12;
-    pub(crate) const REJECT_NAMED_REFERENCE: u64 = 1 << 13;
+    // Bit 13 (REJECT_NAMED_REFERENCE) retired: named references canonicalize
+    // by identity and are accepted/rejected at read-projection time instead.
     pub(crate) const REJECT_STRUCTURED_REFERENCE: u64 = 1 << 14;
     pub(crate) const REJECT_STRUCTURED_REFERENCE_CURRENT_ROW: u64 = 1 << 15;
     pub(crate) const REJECT_THREE_D_REFERENCE: u64 = 1 << 16;

--- a/crates/formualizer-eval/src/engine/arena/canonical.rs
+++ b/crates/formualizer-eval/src/engine/arena/canonical.rs
@@ -204,8 +204,11 @@ fn mix_reference(
         }
         CompactRefType::NamedRange(name_id) => {
             hasher.mix_u8(REF_NAMED);
+            // Named references no longer reject at the canonical-label layer:
+            // they canonicalize by identity and the accept decision is made by
+            // the per-cell read projections (which resolve the name against
+            // the live registry at ingest time).
             labels.flags |= CanonicalLabels::FLAG_CONTAINS_NAME;
-            labels.rejects |= CanonicalLabels::REJECT_NAMED_REFERENCE;
             let normalized = strings
                 .get(name_id)
                 .map(|name| name.to_ascii_uppercase())

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -2203,6 +2203,12 @@ where
         definition: NamedDefinition,
         scope: NameScope,
     ) -> Result<(), ExcelError> {
+        // A new define can flip resolution for spans that previously resolved
+        // the same name through another scope (e.g. a sheet-scoped name
+        // shadowing a workbook-scoped one). Demote those spans BEFORE the
+        // registry changes so their cells re-ingest and re-resolve through
+        // the normal legacy path.
+        self.invalidate_formula_plane_spans_for_name(name)?;
         self.graph.define_name(name, definition, scope)?;
         self.record_formula_plane_structural_change(StructuralScope::AllSheets);
         self.mark_topology_edited();
@@ -2215,6 +2221,12 @@ where
         definition: NamedDefinition,
         scope: NameScope,
     ) -> Result<(), ExcelError> {
+        // Demote name-dependent spans BEFORE the registry update: the demoted
+        // cells re-materialize as legacy vertices attached to the name vertex
+        // (via their resolved-name dep plans), so the registry update's
+        // dependent dirtying reaches them exactly like long-lived legacy
+        // formulas.
+        self.invalidate_formula_plane_spans_for_name(name)?;
         self.graph.update_name(name, definition, scope)?;
         self.record_formula_plane_structural_change(StructuralScope::AllSheets);
         self.mark_topology_edited();
@@ -2222,9 +2234,40 @@ where
     }
 
     pub fn delete_name(&mut self, name: &str, scope: NameScope) -> Result<(), ExcelError> {
+        // Demote first (see update_name): the demoted legacy vertices become
+        // dependents of the name vertex, so delete_name dirties them and they
+        // re-evaluate to #NAME? exactly as legacy formulas do.
+        self.invalidate_formula_plane_spans_for_name(name)?;
         self.graph.delete_name(name, scope)?;
         self.record_formula_plane_structural_change(StructuralScope::AllSheets);
         self.mark_topology_edited();
+        Ok(())
+    }
+
+    /// Demote every FormulaPlane span whose ingest-time read projections
+    /// resolved `name` (any scope; see the FormulaPlane name-dependents map
+    /// for the conservative keying contract). Demotion materializes the span
+    /// placements as legacy graph formulas through the existing demotion
+    /// machinery, preserving computed values; the subsequent registry change
+    /// then dirties them through the legacy name-dependents path.
+    fn invalidate_formula_plane_spans_for_name(&mut self, name: &str) -> Result<(), ExcelError> {
+        if self.config.formula_plane_mode == FormulaPlaneMode::Off {
+            return Ok(());
+        }
+        let regions: Vec<Region> = {
+            let authority = self.graph.formula_authority();
+            authority
+                .plane
+                .name_dependent_span_refs(name)
+                .into_iter()
+                .filter_map(|span_ref| authority.plane.spans.get(span_ref))
+                .map(|span| Region::from_domain(span.result_region.domain()))
+                .collect()
+        };
+        for region in regions {
+            self.demote_spans_preserving_computed_overlays(region.sheet_id(), region)
+                .map_err(Self::editor_error_to_excel)?;
+        }
         Ok(())
     }
 

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1224,7 +1224,7 @@ impl DependencyGraph {
         policy: formualizer_parse::parser::CollectPolicy,
     ) -> crate::engine::ingest_pipeline::IngestPipeline<'a> {
         use crate::engine::ingest_pipeline::{
-            NameRegistryView, NamedEntryRef, SourceEntryRef, SourceRegistryView,
+            NameRegistryView, NamedEntryRef, NamedTarget, SourceEntryRef, SourceRegistryView,
             TableEntrySnapshot, TableRegistryView,
         };
 
@@ -1262,6 +1262,18 @@ impl DependencyGraph {
             };
             found.map(|entry| NamedEntryRef {
                 vertex: entry.vertex,
+                target: match &entry.definition {
+                    crate::engine::named_range::NamedDefinition::Cell(cell) => {
+                        NamedTarget::Cell(*cell)
+                    }
+                    crate::engine::named_range::NamedDefinition::Range(range) => {
+                        NamedTarget::Range(*range)
+                    }
+                    crate::engine::named_range::NamedDefinition::Literal(_)
+                    | crate::engine::named_range::NamedDefinition::Formula { .. } => {
+                        NamedTarget::Other
+                    }
+                },
             })
         });
 

--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -42,6 +42,19 @@ use std::sync::Arc;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct NamedEntryRef {
     pub(crate) vertex: VertexId,
+    /// Concrete resolution target snapshot for FormulaPlane read projections.
+    pub(crate) target: NamedTarget,
+}
+
+/// Snapshot of what a defined name resolves to, taken at ingest time.
+///
+/// Only `Cell` and `Range` definitions are FormulaPlane-supported; `Other`
+/// covers Literal/Formula definitions, which fall back to legacy evaluation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NamedTarget {
+    Cell(CellRef),
+    Range(RangeRef),
+    Other,
 }
 
 #[derive(Clone, Debug)]
@@ -227,11 +240,15 @@ impl<'a> IngestPipeline<'a> {
         dep_plan.dynamic = metadata.labels.has_flag(CanonicalLabels::FLAG_DYNAMIC);
         dep_plan.dedup_and_sort();
 
-        let (read_projections, read_projection_fallback) =
-            match compute_read_projections(&ast_for_oracles, placement, self.sheet_registry) {
-                Ok(projections) => (Some(projections), None),
-                Err(reason) => (None, Some(reason)),
-            };
+        let (read_projections, read_projection_fallback) = match compute_read_projections(
+            &ast_for_oracles,
+            placement,
+            self.sheet_registry,
+            &self.names,
+        ) {
+            Ok(projections) => (Some(projections), None),
+            Err(reason) => (None, Some(reason)),
+        };
         let read_summary = read_projections.as_ref().and_then(|projections| {
             span_read_summary_from_projections(placement, projections).ok()
         });
@@ -816,6 +833,7 @@ fn compute_read_projections(
     ast: &ASTNode,
     placement: CellRef,
     sheet_registry: &SheetRegistry,
+    names: &NameRegistryView<'_>,
 ) -> Result<Vec<ReadProjection>, ProjectionFallbackReason> {
     fn axis_projection(index: u32, is_abs: bool, anchor: i64) -> AxisProjection {
         if is_abs {
@@ -839,6 +857,7 @@ fn compute_read_projections(
         ast: &ASTNode,
         placement: CellRef,
         sheet_registry: &SheetRegistry,
+        names: &NameRegistryView<'_>,
         projections: &mut Vec<ReadProjection>,
         context: AnalyzerContext,
         in_function_arg: bool,
@@ -852,6 +871,79 @@ fn compute_read_projections(
                     Ok(())
                 } else {
                     Err(ProjectionFallbackReason::UnsupportedDependencySummary)
+                }
+            }
+            ASTNodeType::Reference {
+                reference: ReferenceType::NamedRange(name),
+                ..
+            } => {
+                // Resolve the name with the placement's sheet scope (the same
+                // resolution legacy dependency planning uses, so sheet-scoped
+                // names shadow workbook-scoped names identically). A resolved
+                // Cell/Range definition is an all-absolute read region; the
+                // resolved target's sheet need not be the placement sheet.
+                let entry = names
+                    .resolve(name, placement.sheet_id)
+                    .ok_or(ProjectionFallbackReason::NamedReferenceUnsupported)?;
+                match entry.target {
+                    NamedTarget::Cell(cell) => {
+                        // A named CELL behaves like a concrete cell reference:
+                        // no extra context gating beyond what cells get.
+                        push_projection(
+                            projections,
+                            ReadProjection {
+                                target_sheet_id: cell.sheet_id,
+                                rule: DirtyProjectionRule::AffineCell {
+                                    row: AxisProjection::Absolute {
+                                        index: cell.coord.row(),
+                                    },
+                                    col: AxisProjection::Absolute {
+                                        index: cell.coord.col(),
+                                    },
+                                },
+                            },
+                        );
+                        Ok(())
+                    }
+                    NamedTarget::Range(range) => {
+                        // A named RANGE behaves like its underlying range
+                        // reference: only valid as a function argument in a
+                        // range-accepting position (same gating as concrete
+                        // ranges below).
+                        if !in_function_arg
+                            || !matches!(
+                                context,
+                                AnalyzerContext::Value | AnalyzerContext::CriteriaRangeArg
+                            )
+                        {
+                            return Err(ProjectionFallbackReason::UnsupportedDependencySummary);
+                        }
+                        if range.start.sheet_id != range.end.sheet_id {
+                            return Err(ProjectionFallbackReason::NamedReferenceUnsupported);
+                        }
+                        let (row_min, row_max) = (
+                            range.start.coord.row().min(range.end.coord.row()),
+                            range.start.coord.row().max(range.end.coord.row()),
+                        );
+                        let (col_min, col_max) = (
+                            range.start.coord.col().min(range.end.coord.col()),
+                            range.start.coord.col().max(range.end.coord.col()),
+                        );
+                        push_projection(
+                            projections,
+                            ReadProjection {
+                                target_sheet_id: range.start.sheet_id,
+                                rule: DirtyProjectionRule::AffineRange {
+                                    row_start: AxisProjection::Absolute { index: row_min },
+                                    row_end: AxisProjection::Absolute { index: row_max },
+                                    col_start: AxisProjection::Absolute { index: col_min },
+                                    col_end: AxisProjection::Absolute { index: col_max },
+                                },
+                            },
+                        );
+                        Ok(())
+                    }
+                    NamedTarget::Other => Err(ProjectionFallbackReason::NamedReferenceUnsupported),
                 }
             }
             ASTNodeType::Reference { reference, .. } => {
@@ -987,6 +1079,7 @@ fn compute_read_projections(
                     expr,
                     placement,
                     sheet_registry,
+                    names,
                     projections,
                     context,
                     in_function_arg,
@@ -1004,6 +1097,7 @@ fn compute_read_projections(
                     left,
                     placement,
                     sheet_registry,
+                    names,
                     projections,
                     context,
                     in_function_arg,
@@ -1012,6 +1106,7 @@ fn compute_read_projections(
                     right,
                     placement,
                     sheet_registry,
+                    names,
                     projections,
                     context,
                     in_function_arg,
@@ -1028,6 +1123,7 @@ fn compute_read_projections(
                         arg,
                         placement,
                         sheet_registry,
+                        names,
                         projections,
                         arg_context,
                         function_accepts_range_at(&canonical_name, arg_index),
@@ -1050,6 +1146,7 @@ fn compute_read_projections(
         ast,
         placement,
         sheet_registry,
+        names,
         &mut projections,
         AnalyzerContext::Value,
         false,
@@ -1515,6 +1612,10 @@ mod tests {
     use crate::test_workbook::TestWorkbook;
     use formualizer_parse::parser::parse;
 
+    fn empty_names() -> NameRegistryView<'static> {
+        NameRegistryView::new(|_, _| None)
+    }
+
     fn read_projections_for(formula: &str, row: u32, col: u32) -> Vec<ReadProjection> {
         let mut sheet_registry = SheetRegistry::new();
         let sheet = sheet_registry.id_for("Sheet1");
@@ -1523,6 +1624,7 @@ mod tests {
             &ast,
             CellRef::new(sheet, Coord::from_excel(row, col, true, true)),
             &sheet_registry,
+            &empty_names(),
         )
         .unwrap()
     }
@@ -1573,25 +1675,40 @@ mod tests {
         let mixed_whole_column = parse("=SUM(A:$A)").unwrap();
 
         assert_eq!(
-            compute_read_projections(&top_level, placement, &sheet_registry),
+            compute_read_projections(&top_level, placement, &sheet_registry, &empty_names()),
             Err(ProjectionFallbackReason::UnsupportedDependencySummary)
         );
         assert_eq!(
-            compute_read_projections(&top_level_whole_column, placement, &sheet_registry),
+            compute_read_projections(
+                &top_level_whole_column,
+                placement,
+                &sheet_registry,
+                &empty_names()
+            ),
             Err(ProjectionFallbackReason::UnsupportedDependencySummary)
         );
         assert_eq!(
-            compute_read_projections(&open_whole_column, placement, &sheet_registry),
+            compute_read_projections(
+                &open_whole_column,
+                placement,
+                &sheet_registry,
+                &empty_names()
+            ),
             Err(ProjectionFallbackReason::UnsupportedDependencySummary)
         );
         assert_eq!(
-            compute_read_projections(&whole_row, placement, &sheet_registry),
+            compute_read_projections(&whole_row, placement, &sheet_registry, &empty_names()),
             Err(ProjectionFallbackReason::UnsupportedDependencySummary)
         );
         // Whole-column ranges with mixed column anchors stay rejected to match
         // the dependency-summary analyzer.
         assert_eq!(
-            compute_read_projections(&mixed_whole_column, placement, &sheet_registry),
+            compute_read_projections(
+                &mixed_whole_column,
+                placement,
+                &sheet_registry,
+                &empty_names()
+            ),
             Err(ProjectionFallbackReason::UnsupportedDependencySummary)
         );
     }
@@ -1605,7 +1722,8 @@ mod tests {
         // Running total `=SUM($A$1:$A1)`: absolute start row, relative end row.
         let running_total = parse("=SUM($A$1:$A1)").unwrap();
         let projections =
-            compute_read_projections(&running_total, placement, &sheet_registry).unwrap();
+            compute_read_projections(&running_total, placement, &sheet_registry, &empty_names())
+                .unwrap();
         assert_eq!(projections.len(), 1);
         assert_eq!(
             projections[0].rule,
@@ -1619,7 +1737,9 @@ mod tests {
 
         // Tail read `=SUM($A1:$A$100)`: relative start row, absolute end row.
         let tail_read = parse("=SUM($A1:$A$100)").unwrap();
-        let projections = compute_read_projections(&tail_read, placement, &sheet_registry).unwrap();
+        let projections =
+            compute_read_projections(&tail_read, placement, &sheet_registry, &empty_names())
+                .unwrap();
         assert_eq!(projections.len(), 1);
         assert_eq!(
             projections[0].rule,

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -173,11 +173,20 @@ pub mod fp8_parity_test_support {
                     "canonical label rejects differ for {formula} at {placement:?}\nold={:?}\nnew={:#x}",
                     old.labels.reject_reasons, new.labels.rejects
                 );
-                assert_eq!(
-                    old.read_summary_debug,
-                    new.read_summary.as_ref().map(|s| format!("{s:?}")),
-                    "read summary differs for {formula} at {placement:?}"
-                );
+                // The passive summary oracle cannot resolve defined names, so
+                // a named formula that the ingest pipeline resolved to a
+                // concrete region is an intentional superset: old None / new
+                // Some is allowed exactly when the only blocking reason was a
+                // named reference.
+                let named_resolution_superset = old.summary_rejected_only_for_named_reference
+                    && old.read_summary_debug.is_none();
+                if !named_resolution_superset {
+                    assert_eq!(
+                        old.read_summary_debug,
+                        new.read_summary.as_ref().map(|s| format!("{s:?}")),
+                        "read summary differs for {formula} at {placement:?}"
+                    );
+                }
                 assert_eq!(new.formula_text.as_deref(), Some(formula));
                 assert_eq!(new.placement, placement);
                 Fp8ParityObservation {
@@ -219,6 +228,7 @@ pub mod fp8_parity_test_support {
         volatile: bool,
         dynamic: bool,
         read_summary_debug: Option<String>,
+        summary_rejected_only_for_named_reference: bool,
     }
 
     fn old_path<R: EvaluationContext>(
@@ -248,6 +258,14 @@ pub mod fp8_parity_test_support {
             engine.graph.sheet_reg(),
         )
         .ok();
+        let summary_rejected_only_for_named_reference = !summary.reject_reasons.is_empty()
+            && summary.reject_reasons.iter().all(|reason| {
+                matches!(
+                    reason,
+                    crate::formula_plane::dependency_summary::DependencyRejectReason
+                        ::NamedRangeUnsupported { .. }
+                )
+            });
         Ok(OldOutput {
             payload: template.key.payload().to_string(),
             labels: template.labels,
@@ -257,6 +275,7 @@ pub mod fp8_parity_test_support {
             volatile,
             dynamic,
             read_summary_debug: read_summary.as_ref().map(|s| format!("{s:?}")),
+            summary_rejected_only_for_named_reference,
         })
     }
 
@@ -280,6 +299,7 @@ pub mod fp8_parity_test_support {
                 CanonicalTemplateFlag::AbsoluteReferenceAxis => CanonicalLabels::FLAG_ABSOLUTE_ONLY,
                 CanonicalTemplateFlag::MixedAnchors => CanonicalLabels::FLAG_MIXED_ANCHORS,
                 CanonicalTemplateFlag::FiniteRangeReference => CanonicalLabels::FLAG_CONTAINS_RANGE,
+                CanonicalTemplateFlag::NamedReference => CanonicalLabels::FLAG_CONTAINS_NAME,
             };
         }
         for reason in &old.reject_reasons {
@@ -294,7 +314,6 @@ pub mod fp8_parity_test_support {
                 }
                 CanonicalRejectReason::ArrayOrSpillFunction { .. }
                 | CanonicalRejectReason::ArrayLiteral => CanonicalLabels::FLAG_CONTAINS_ARRAY,
-                CanonicalRejectReason::NamedReference { .. } => CanonicalLabels::FLAG_CONTAINS_NAME,
                 CanonicalRejectReason::StructuredReference { .. }
                 | CanonicalRejectReason::StructuredReferenceCurrentRow { .. } => {
                     CanonicalLabels::FLAG_CONTAINS_TABLE
@@ -342,9 +361,6 @@ pub mod fp8_parity_test_support {
                     CanonicalLabels::REJECT_IMPLICIT_INTERSECTION_OPERATOR
                 }
                 CanonicalRejectReason::CallExpression => CanonicalLabels::REJECT_CALL_EXPRESSION,
-                CanonicalRejectReason::NamedReference { .. } => {
-                    CanonicalLabels::REJECT_NAMED_REFERENCE
-                }
                 CanonicalRejectReason::StructuredReference { .. } => {
                     CanonicalLabels::REJECT_STRUCTURED_REFERENCE
                 }

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_coverage_pinning.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_coverage_pinning.rs
@@ -72,23 +72,36 @@ fn build_engine(
             continue;
         }
         let sheet_id = engine.graph.sheet_id_mut(named.sheet);
-        let start = CellRef::new(
-            sheet_id,
-            Coord::new(named.start_row - 1, named.start_col - 1, true, true),
-        );
-        let end = CellRef::new(
-            sheet_id,
-            Coord::new(named.end_row - 1, named.end_col - 1, true, true),
-        );
         engine
             .define_name(
                 named.name,
-                NamedDefinition::Range(RangeRef::new(start, end)),
+                named_definition_for_spec(sheet_id, named),
                 NameScope::Workbook,
             )
             .unwrap();
     }
     engine
+}
+
+/// 1x1 specs define a named CELL, larger specs a named RANGE, so the corpus
+/// exercises both FormulaPlane-supported definition shapes.
+fn named_definition_for_spec(
+    sheet_id: crate::SheetId,
+    named: &fp_coverage::NamedRangeSpec,
+) -> NamedDefinition {
+    let start = CellRef::new(
+        sheet_id,
+        Coord::new(named.start_row - 1, named.start_col - 1, true, true),
+    );
+    let end = CellRef::new(
+        sheet_id,
+        Coord::new(named.end_row - 1, named.end_col - 1, true, true),
+    );
+    if start == end {
+        NamedDefinition::Cell(start)
+    } else {
+        NamedDefinition::Range(RangeRef::new(start, end))
+    }
 }
 
 fn ingest_section(
@@ -250,18 +263,10 @@ fn fp_coverage_corpus_combined_totals() {
     }
     for named in &corpus.named_ranges {
         let sheet_id = engine.graph.sheet_id_mut(named.sheet);
-        let start = CellRef::new(
-            sheet_id,
-            Coord::new(named.start_row - 1, named.start_col - 1, true, true),
-        );
-        let end = CellRef::new(
-            sheet_id,
-            Coord::new(named.end_row - 1, named.end_col - 1, true, true),
-        );
         engine
             .define_name(
                 named.name,
-                NamedDefinition::Range(RangeRef::new(start, end)),
+                named_definition_for_spec(sheet_id, named),
                 NameScope::Workbook,
             )
             .unwrap();

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
@@ -1,0 +1,598 @@
+//! Named-reference span support: acceptance, dirty precision, name lifecycle
+//! invalidation (define/update/delete), cross-sheet and shadowed resolution,
+//! the InternalDependency guard, and precise fallback reasons.
+//!
+//! Defined names canonicalize by identity (raw text participates in the
+//! template fingerprint) and resolve to all-absolute read regions per cell at
+//! ingest. These tests pin (counter-style, never wall time):
+//!
+//! - workbook-scoped named-range/named-cell families promote to spans and
+//!   evaluate to legacy-identical values, before and after edits;
+//! - edits inside the resolved named region re-evaluate the span, edits
+//!   outside do not;
+//! - define/update/delete of a name demotes name-dependent spans so their
+//!   cells re-ingest and re-resolve exactly like legacy formulas (the
+//!   load-bearing invalidation hook: without it, a span keeps a stale
+//!   resolved read region and misses edits inside the new region);
+//! - sheet-scope shadowing resolves per placement sheet without
+//!   cross-contaminating span families on other sheets;
+//! - a name covering the family's own result column falls back
+//!   (InternalDependency), and Literal-definition/undefined names fall back
+//!   with `UnsupportedNamedReference`.
+
+use std::sync::Arc;
+
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::reference::{CellRef, Coord, RangeRef};
+use crate::test_workbook::TestWorkbook;
+
+const SHEET: &str = "Sheet1";
+/// Must be >= 100 (`MIN_PROMOTED_NON_CONSTANT_SPAN_CELLS`).
+const ROWS: u32 = 120;
+const FIRST_ROW: u32 = 2;
+const LAST_ROW: u32 = ROWS + 1;
+
+fn engine_with_mode(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    let cfg = EvalConfig::default().with_formula_plane_mode(mode);
+    Engine::new(TestWorkbook::default(), cfg)
+}
+
+fn cell_ref(engine: &mut Engine<TestWorkbook>, sheet: &str, row1: u32, col1: u32) -> CellRef {
+    let sheet_id = engine.graph.sheet_id_mut(sheet);
+    CellRef::new(sheet_id, Coord::new(row1 - 1, col1 - 1, true, true))
+}
+
+fn range_def(
+    engine: &mut Engine<TestWorkbook>,
+    sheet: &str,
+    start_row1: u32,
+    start_col1: u32,
+    end_row1: u32,
+    end_col1: u32,
+) -> NamedDefinition {
+    let start = cell_ref(engine, sheet, start_row1, start_col1);
+    let end = cell_ref(engine, sheet, end_row1, end_col1);
+    NamedDefinition::Range(RangeRef::new(start, end))
+}
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    let ast = parse(formula).unwrap_or_else(|err| panic!("parse {formula}: {err}"));
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn ingest_column(
+    engine: &mut Engine<TestWorkbook>,
+    sheet: &str,
+    col: u32,
+    formula_for_row: impl Fn(u32) -> String,
+) -> crate::engine::FormulaIngestReport {
+    let mut records = Vec::with_capacity(ROWS as usize);
+    for row in FIRST_ROW..=LAST_ROW {
+        let formula = formula_for_row(row);
+        records.push(record(engine, row, col, &formula));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(sheet, records)])
+        .expect("ingest formulas")
+}
+
+fn literal_eq(a: &LiteralValue, b: &LiteralValue) -> bool {
+    fn as_num(v: &LiteralValue) -> Option<f64> {
+        match v {
+            LiteralValue::Number(n) => Some(*n),
+            LiteralValue::Int(i) => Some(*i as f64),
+            LiteralValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+            _ => None,
+        }
+    }
+    match (as_num(a), as_num(b)) {
+        (Some(x), Some(y)) => {
+            let scale = x.abs().max(y.abs()).max(1.0);
+            (x - y).abs() <= scale * 1e-9
+        }
+        _ => a == b,
+    }
+}
+
+fn assert_column_parity(
+    label: &str,
+    sheet: &str,
+    col: u32,
+    auth: &Engine<TestWorkbook>,
+    off: &Engine<TestWorkbook>,
+) {
+    for row in FIRST_ROW..=LAST_ROW {
+        let got = auth.get_cell_value(sheet, row, col);
+        let expected = off.get_cell_value(sheet, row, col);
+        let equal = match (&got, &expected) {
+            (Some(a), Some(b)) => literal_eq(a, b),
+            (a, b) => a == b,
+        };
+        assert!(
+            equal,
+            "{label}: value mismatch at {sheet}!R{row}C{col}: auth={got:?} off={expected:?}"
+        );
+    }
+}
+
+fn set_value(engine: &mut Engine<TestWorkbook>, sheet: &str, row: u32, col: u32, value: f64) {
+    engine
+        .action_atomic_journal(format!("edit {sheet}!R{row}C{col}"), |tx| {
+            tx.set_cell_value(sheet, row, col, LiteralValue::Number(value))?;
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// Data column B carries `row` as value; A carries `10*row`.
+fn seed_named_workbook(engine: &mut Engine<TestWorkbook>) {
+    for row in FIRST_ROW..=LAST_ROW {
+        engine
+            .set_cell_value(SHEET, row, 2, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(10.0 * row as f64))
+            .unwrap();
+    }
+    let def = range_def(engine, SHEET, FIRST_ROW, 2, LAST_ROW, 2);
+    engine
+        .define_name("Data", def, NameScope::Workbook)
+        .unwrap();
+}
+
+/// (a) Acceptance + first-eval/after-edit value parity, counter-pinned.
+#[test]
+fn named_range_family_promotes_to_span_with_value_parity() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        seed_named_workbook(engine);
+    }
+    let report = ingest_column(&mut auth, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    let _ = ingest_column(&mut off, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+
+    assert_eq!(
+        report.shadow_accepted_span_cells,
+        u64::from(ROWS),
+        "named-range family must span; histogram: {:?}",
+        report.fallback_reasons
+    );
+    assert_eq!(report.shadow_fallback_cells, 0);
+    assert!(report.shadow_spans_created >= 1);
+    assert_eq!(auth.baseline_stats().formula_plane_active_span_count, 1);
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("first eval", SHEET, 3, &auth, &off);
+
+    // Edit inside the named region and a relative precedent; values must stay
+    // legacy-identical.
+    for engine in [&mut auth, &mut off] {
+        set_value(engine, SHEET, 10, 2, 5_000.0);
+        set_value(engine, SHEET, 11, 1, 7_000.0);
+    }
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("after edits", SHEET, 3, &auth, &off);
+}
+
+/// (b) Dirty precision: edits inside the resolved named region re-evaluate
+/// the span; edits outside do not.
+#[test]
+fn named_range_edit_dirty_precision_is_region_bounded() {
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    let report = ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(ROWS));
+
+    engine.evaluate_all().unwrap();
+    let first = engine
+        .last_formula_plane_span_eval_report()
+        .expect("first eval must run the authoritative span pass");
+    assert_eq!(first.span_eval_placement_count, u64::from(ROWS));
+
+    // Inside the named region: every placement reads it.
+    set_value(&mut engine, SHEET, 10, 2, 5_000.0);
+    engine.evaluate_all().unwrap();
+    let inside = engine
+        .last_formula_plane_span_eval_report()
+        .expect("edit inside named region must produce span work");
+    assert_eq!(inside.span_eval_placement_count, u64::from(ROWS));
+
+    // Relative precedent A11: exactly one placement reads it.
+    set_value(&mut engine, SHEET, 11, 1, 7_000.0);
+    engine.evaluate_all().unwrap();
+    let relative = engine
+        .last_formula_plane_span_eval_report()
+        .expect("edit of a relative precedent must produce span work");
+    assert_eq!(relative.span_eval_placement_count, 1);
+
+    // Outside every read region (column F): no span recompute.
+    set_value(&mut engine, SHEET, 10, 6, 9_999.0);
+    engine.evaluate_all().unwrap();
+    let outside_placements = engine
+        .last_formula_plane_span_eval_report()
+        .map(|report| report.span_eval_placement_count)
+        .unwrap_or(0);
+    assert_eq!(
+        outside_placements, 0,
+        "edit outside all read regions must not re-evaluate the span"
+    );
+}
+
+/// (c) THE load-bearing invalidation test: update_name to a different region
+/// must demote the span so cells re-resolve. Without the hook the span keeps
+/// the stale resolved region and misses edits inside the new region.
+#[test]
+fn update_name_to_new_region_invalidates_spans_and_tracks_new_region() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        seed_named_workbook(engine);
+        // Alternate data column D for the re-pointed name.
+        for row in FIRST_ROW..=LAST_ROW {
+            engine
+                .set_cell_value(SHEET, row, 4, LiteralValue::Number(1_000.0 + row as f64))
+                .unwrap();
+        }
+    }
+    let report = ingest_column(&mut auth, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    let _ = ingest_column(&mut off, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(ROWS));
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("before update_name", SHEET, 3, &auth, &off);
+
+    for engine in [&mut auth, &mut off] {
+        let def = range_def(engine, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+        engine
+            .update_name("Data", def, NameScope::Workbook)
+            .unwrap();
+    }
+    // The span resolved the old region; the invalidation hook must demote it.
+    assert_eq!(
+        auth.baseline_stats().formula_plane_active_span_count,
+        0,
+        "update_name must demote the name-dependent span"
+    );
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("after update_name", SHEET, 3, &auth, &off);
+
+    // Edit inside the NEW region (column D): values must track it.
+    for engine in [&mut auth, &mut off] {
+        set_value(engine, SHEET, 20, 4, 50_000.0);
+    }
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("edit inside re-pointed region", SHEET, 3, &auth, &off);
+}
+
+/// (d) define_name of a sheet-scoped name AFTER ingest that shadows a
+/// workbook-scoped name already resolved by spans on that sheet.
+#[test]
+fn sheet_scoped_define_after_ingest_invalidates_workbook_resolved_spans() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        seed_named_workbook(engine);
+        for row in FIRST_ROW..=LAST_ROW {
+            engine
+                .set_cell_value(SHEET, row, 4, LiteralValue::Number(2_000.0 + row as f64))
+                .unwrap();
+        }
+    }
+    let report = ingest_column(&mut auth, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    let _ = ingest_column(&mut off, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(ROWS));
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("before shadowing define", SHEET, 3, &auth, &off);
+
+    for engine in [&mut auth, &mut off] {
+        let sheet_id = engine.graph.sheet_id_mut(SHEET);
+        let def = range_def(engine, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+        engine
+            .define_name("Data", def, NameScope::Sheet(sheet_id))
+            .unwrap();
+    }
+    assert_eq!(
+        auth.baseline_stats().formula_plane_active_span_count,
+        0,
+        "shadowing define must demote spans that resolved through workbook scope"
+    );
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("after shadowing define", SHEET, 3, &auth, &off);
+
+    // Edits inside the shadowed (sheet-scoped) region must flow identically.
+    for engine in [&mut auth, &mut off] {
+        set_value(engine, SHEET, 30, 4, 77_000.0);
+    }
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("edit inside shadowed region", SHEET, 3, &auth, &off);
+}
+
+/// (e) delete_name: cells fall back to legacy and evaluate to #NAME? exactly
+/// like the Off-mode ground truth.
+#[test]
+fn delete_name_falls_back_to_name_error_parity() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        seed_named_workbook(engine);
+    }
+    let report = ingest_column(&mut auth, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    let _ = ingest_column(&mut off, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(ROWS));
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+
+    for engine in [&mut auth, &mut off] {
+        engine.delete_name("Data", NameScope::Workbook).unwrap();
+    }
+    assert_eq!(auth.baseline_stats().formula_plane_active_span_count, 0);
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("after delete_name", SHEET, 3, &auth, &off);
+
+    // And the parity target itself must be #NAME?, not a stale number.
+    match off.get_cell_value(SHEET, FIRST_ROW, 3) {
+        Some(LiteralValue::Error(err)) => {
+            assert_eq!(err.kind, formualizer_common::ExcelErrorKind::Name)
+        }
+        other => panic!("expected #NAME? ground truth after delete_name, got {other:?}"),
+    }
+}
+
+/// (f) Named CELL definition and a named range defined on ANOTHER sheet than
+/// the formulas (cross-sheet resolution), counter-pinned with dirty checks.
+#[test]
+fn named_cell_and_cross_sheet_named_range_span_and_track_edits() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        engine.add_sheet("Sheet2").unwrap();
+        for row in FIRST_ROW..=LAST_ROW {
+            engine
+                .set_cell_value("Sheet2", row, 2, LiteralValue::Number(row as f64))
+                .unwrap();
+            engine
+                .set_cell_value(SHEET, row, 1, LiteralValue::Number(3.0 * row as f64))
+                .unwrap();
+        }
+        engine
+            .set_cell_value("Sheet2", 1, 5, LiteralValue::Number(41.5))
+            .unwrap();
+        let remote = range_def(engine, "Sheet2", FIRST_ROW, 2, LAST_ROW, 2);
+        engine
+            .define_name("RemoteData", remote, NameScope::Workbook)
+            .unwrap();
+        let cell = cell_ref(engine, "Sheet2", 1, 5);
+        engine
+            .define_name(
+                "RemoteCell",
+                NamedDefinition::Cell(cell),
+                NameScope::Workbook,
+            )
+            .unwrap();
+    }
+    let report = ingest_column(&mut auth, SHEET, 3, |r| {
+        format!("=SUM(RemoteData)+RemoteCell*2+A{r}")
+    });
+    let _ = ingest_column(&mut off, SHEET, 3, |r| {
+        format!("=SUM(RemoteData)+RemoteCell*2+A{r}")
+    });
+    assert_eq!(
+        report.shadow_accepted_span_cells,
+        u64::from(ROWS),
+        "cross-sheet named range + named cell must span; histogram: {:?}",
+        report.fallback_reasons
+    );
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("cross-sheet first eval", SHEET, 3, &auth, &off);
+
+    // Edit inside the remote named region and the named cell.
+    for engine in [&mut auth, &mut off] {
+        set_value(engine, "Sheet2", 15, 2, 12_345.0);
+        set_value(engine, "Sheet2", 1, 5, 100.25);
+    }
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("cross-sheet after edits", SHEET, 3, &auth, &off);
+}
+
+/// Section-2 subtlety: the same name string resolving differently per sheet
+/// (sheet-scope shadowing) must not cross-contaminate span families.
+#[test]
+fn shadowed_names_on_two_sheets_resolve_per_sheet_without_cross_contamination() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        engine.add_sheet("Sheet2").unwrap();
+        for row in FIRST_ROW..=LAST_ROW {
+            engine
+                .set_cell_value(SHEET, row, 2, LiteralValue::Number(row as f64))
+                .unwrap();
+            engine
+                .set_cell_value("Sheet2", row, 2, LiteralValue::Number(1_000.0 + row as f64))
+                .unwrap();
+            engine
+                .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+            engine
+                .set_cell_value("Sheet2", row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+        }
+        // Workbook-scoped X -> Sheet1!B; sheet-scoped X on Sheet2 -> Sheet2!B.
+        let workbook = range_def(engine, SHEET, FIRST_ROW, 2, LAST_ROW, 2);
+        engine
+            .define_name("X", workbook, NameScope::Workbook)
+            .unwrap();
+        let sheet2_id = engine.graph.sheet_id_mut("Sheet2");
+        let shadowed = range_def(engine, "Sheet2", FIRST_ROW, 2, LAST_ROW, 2);
+        engine
+            .define_name("X", shadowed, NameScope::Sheet(sheet2_id))
+            .unwrap();
+    }
+    for sheet in [SHEET, "Sheet2"] {
+        let report_auth = ingest_column(&mut auth, sheet, 3, |r| format!("=SUM(X)+A{r}"));
+        let _ = ingest_column(&mut off, sheet, 3, |r| format!("=SUM(X)+A{r}"));
+        assert_eq!(
+            report_auth.shadow_accepted_span_cells,
+            u64::from(ROWS),
+            "{sheet}: shadowed-name family must span; histogram: {:?}",
+            report_auth.fallback_reasons
+        );
+    }
+    assert_eq!(auth.baseline_stats().formula_plane_active_span_count, 2);
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("shadowed Sheet1", SHEET, 3, &auth, &off);
+    assert_column_parity("shadowed Sheet2", "Sheet2", 3, &auth, &off);
+
+    // The two sheets must see different sums (proof the resolutions differ).
+    let s1 = auth.get_cell_value(SHEET, FIRST_ROW, 3);
+    let s2 = auth.get_cell_value("Sheet2", FIRST_ROW, 3);
+    assert_ne!(s1, s2, "shadowed name resolutions must differ per sheet");
+
+    // An edit inside Sheet2's shadowed region must not touch Sheet1 values.
+    for engine in [&mut auth, &mut off] {
+        set_value(engine, "Sheet2", 40, 2, 99_000.0);
+    }
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("shadowed Sheet1 after Sheet2 edit", SHEET, 3, &auth, &off);
+    assert_column_parity("shadowed Sheet2 after edit", "Sheet2", 3, &auth, &off);
+}
+
+/// (g) Self-overlap: a name whose region covers the family's own result
+/// column must reject with InternalDependency and stay value-identical to
+/// the Off-mode ground truth.
+#[test]
+fn name_covering_own_result_column_rejects_with_internal_dependency() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        for row in FIRST_ROW..=LAST_ROW {
+            engine
+                .set_cell_value(SHEET, row, 2, LiteralValue::Number(row as f64))
+                .unwrap();
+        }
+        // Covers column C rows 2..=LAST_ROW: the formulas' own result region.
+        let def = range_def(engine, SHEET, FIRST_ROW, 3, LAST_ROW, 3);
+        engine
+            .define_name("SelfRegion", def, NameScope::Workbook)
+            .unwrap();
+    }
+    let report = ingest_column(&mut auth, SHEET, 3, |r| format!("=SUM(SelfRegion)*0+B{r}"));
+    let _ = ingest_column(&mut off, SHEET, 3, |r| format!("=SUM(SelfRegion)*0+B{r}"));
+
+    assert_eq!(report.shadow_accepted_span_cells, 0);
+    assert_eq!(
+        report
+            .fallback_reasons
+            .get("InternalDependency")
+            .copied()
+            .unwrap_or(0),
+        u64::from(ROWS),
+        "histogram: {:?}",
+        report.fallback_reasons
+    );
+    assert_eq!(auth.baseline_stats().formula_plane_active_span_count, 0);
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("self-overlap", SHEET, 3, &auth, &off);
+}
+
+/// (h) Literal-definition and undefined names fall back with the precise
+/// `UnsupportedNamedReference` reason, values legacy-identical.
+#[test]
+fn literal_and_undefined_names_fall_back_with_precise_reason() {
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        for row in FIRST_ROW..=LAST_ROW {
+            engine
+                .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+        }
+        engine
+            .define_name(
+                "LitName",
+                NamedDefinition::Literal(LiteralValue::Number(2.5)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+    }
+
+    // Literal-definition name -> column C.
+    let literal_report = ingest_column(&mut auth, SHEET, 3, |r| format!("=LitName+A{r}"));
+    let _ = ingest_column(&mut off, SHEET, 3, |r| format!("=LitName+A{r}"));
+    assert_eq!(literal_report.shadow_accepted_span_cells, 0);
+    assert_eq!(
+        literal_report
+            .fallback_reasons
+            .get("UnsupportedNamedReference")
+            .copied()
+            .unwrap_or(0),
+        u64::from(ROWS),
+        "histogram: {:?}",
+        literal_report.fallback_reasons
+    );
+
+    // Undefined name -> column D.
+    let undefined_report = ingest_column(&mut auth, SHEET, 4, |r| format!("=NoSuchName+A{r}"));
+    let _ = ingest_column(&mut off, SHEET, 4, |r| format!("=NoSuchName+A{r}"));
+    assert_eq!(undefined_report.shadow_accepted_span_cells, 0);
+    assert_eq!(
+        undefined_report
+            .fallback_reasons
+            .get("UnsupportedNamedReference")
+            .copied()
+            .unwrap_or(0),
+        u64::from(ROWS),
+        "histogram: {:?}",
+        undefined_report.fallback_reasons
+    );
+
+    assert_eq!(auth.baseline_stats().formula_plane_active_span_count, 0);
+
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("literal-name column", SHEET, 3, &auth, &off);
+    assert_column_parity("undefined-name column", SHEET, 4, &auth, &off);
+
+    // Ground-truth sanity: literal-name cells are numeric, undefined-name
+    // cells are #NAME?.
+    match off.get_cell_value(SHEET, FIRST_ROW, 3) {
+        Some(LiteralValue::Number(n)) => assert!((n - (2.5 + FIRST_ROW as f64)).abs() < 1e-9),
+        other => panic!("expected numeric literal-name ground truth, got {other:?}"),
+    }
+    match off.get_cell_value(SHEET, FIRST_ROW, 4) {
+        Some(LiteralValue::Error(err)) => {
+            assert_eq!(err.kind, formualizer_common::ExcelErrorKind::Name)
+        }
+        other => panic!("expected #NAME? ground truth for undefined name, got {other:?}"),
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -116,6 +116,7 @@ mod formula_plane_lookup_family_promotion;
 mod formula_plane_lookup_semantics;
 mod formula_plane_mixed_anchor_spans;
 mod formula_plane_mixed_legacy_tail_reads;
+mod formula_plane_named_ranges;
 mod formula_plane_parallel_span_eval;
 mod formula_plane_per_placement_literal_bindings;
 mod formula_plane_per_span_overhead;

--- a/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
+++ b/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
@@ -623,8 +623,7 @@ impl SummaryAnalyzer {
             CanonicalRejectReason::CallExpression => DependencyRejectReason::UnsupportedAstNode {
                 node: "call_expression".to_string(),
             },
-            CanonicalRejectReason::NamedReference { .. }
-            | CanonicalRejectReason::StructuredReference { .. }
+            CanonicalRejectReason::StructuredReference { .. }
             | CanonicalRejectReason::StructuredReferenceCurrentRow { .. }
             | CanonicalRejectReason::ThreeDReference { .. }
             | CanonicalRejectReason::ExternalReference { .. }
@@ -834,6 +833,21 @@ impl SummaryAnalyzer {
                     false
                 }
             }
+            CanonicalReference::Named { .. } => {
+                // The summary layer is passive classification: it has no
+                // registry access and cannot resolve a defined name to a
+                // concrete region, so it conservatively rejects here. The
+                // authoritative accept decision for named formulas is driven
+                // by the per-cell read projections computed at ingest, which
+                // resolve names against the live registry.
+                let reason = if matches!(context, AnalyzerContext::LocalBinding) {
+                    DependencyRejectReason::LocalEnvUnsupported { function: None }
+                } else {
+                    DependencyRejectReason::NamedRangeUnsupported { context }
+                };
+                self.reasons.insert(reason);
+                false
+            }
             CanonicalReference::Unsupported { kind, diagnostic } => {
                 self.reject_unsupported_reference(kind, diagnostic, context);
                 false
@@ -878,14 +892,6 @@ impl SummaryAnalyzer {
         context: AnalyzerContext,
     ) {
         let reason = match kind {
-            UnsupportedReferenceKind::NamedRange
-                if matches!(context, AnalyzerContext::LocalBinding) =>
-            {
-                DependencyRejectReason::LocalEnvUnsupported { function: None }
-            }
-            UnsupportedReferenceKind::NamedRange => {
-                DependencyRejectReason::NamedRangeUnsupported { context }
-            }
             UnsupportedReferenceKind::StructuredReference => {
                 DependencyRejectReason::StructuredReferenceUnsupported { context }
             }

--- a/crates/formualizer-eval/src/formula_plane/diagnostics.rs
+++ b/crates/formualizer-eval/src/formula_plane/diagnostics.rs
@@ -337,6 +337,7 @@ fn template_flag_label(flag: &CanonicalTemplateFlag) -> &'static str {
         CanonicalTemplateFlag::AbsoluteReferenceAxis => "absolute_reference_axis",
         CanonicalTemplateFlag::MixedAnchors => "mixed_anchors",
         CanonicalTemplateFlag::FiniteRangeReference => "finite_range_reference",
+        CanonicalTemplateFlag::NamedReference => "named_reference",
     }
 }
 
@@ -353,7 +354,6 @@ fn reject_kind_label(kind: CanonicalRejectKind) -> &'static str {
         CanonicalRejectKind::SpillReference => "spill_reference",
         CanonicalRejectKind::ImplicitIntersection => "implicit_intersection",
         CanonicalRejectKind::CallExpression => "call_expression",
-        CanonicalRejectKind::NamedReference => "named_reference",
         CanonicalRejectKind::StructuredReference => "structured_reference",
         CanonicalRejectKind::StructuredReferenceCurrentRow => "structured_reference_current_row",
         CanonicalRejectKind::ThreeDReference => "three_d_reference",
@@ -395,7 +395,6 @@ fn reject_reason_label(reason: &CanonicalRejectReason) -> String {
             "implicit_intersection_operator".to_string()
         }
         CanonicalRejectReason::CallExpression => "call_expression".to_string(),
-        CanonicalRejectReason::NamedReference { name } => format!("named_reference:{name}"),
         CanonicalRejectReason::StructuredReference { diagnostic } => {
             format!("structured_reference:{diagnostic}")
         }

--- a/crates/formualizer-eval/src/formula_plane/placement.rs
+++ b/crates/formualizer-eval/src/formula_plane/placement.rs
@@ -104,6 +104,11 @@ pub(crate) enum PlacementFallbackReason {
     /// in the current sheet registry. Keep it legacy so the graph evaluator
     /// preserves existing #REF!/missing-sheet diagnostics.
     UnknownSheetBinding,
+    /// A formula references a defined name that is undefined in the
+    /// placement's scope or whose definition is not a concrete Cell/Range
+    /// (Literal/Formula definitions). Legacy evaluation preserves #NAME? and
+    /// named-formula semantics.
+    UnsupportedNamedReference,
     /// At least one read region intersects the family's own result region.
     /// These families have an internal/self dependency that the current span
     /// runtime cannot evaluate as bounded dirty work and demotes to whole-span
@@ -187,6 +192,11 @@ pub(crate) struct CandidateAnalysis {
     template_slot_map: TemplateSlotMap,
     read_projections: Vec<ReadProjection>,
     read_projections_constant: bool,
+    /// Defined names this formula resolved at ingest (raw text). Used to
+    /// register accepted spans in the FormulaPlane name-dependents map so
+    /// define/update/delete of a name can invalidate them. Empty for
+    /// formulas without names (no allocation on the hot path).
+    resolved_named_refs: Vec<String>,
 }
 
 impl CandidateAnalysis {
@@ -201,15 +211,19 @@ impl CandidateAnalysis {
         if ingested.labels.rejects != 0 {
             return Err(PlacementFallbackReason::UnsupportedCanonicalTemplate);
         }
-        let read_projections = ingested.read_projections.clone().ok_or_else(|| {
-            if ingested.read_projection_fallback
-                == Some(ProjectionFallbackReason::UnsupportedSheetBinding)
-            {
-                PlacementFallbackReason::UnknownSheetBinding
-            } else {
-                PlacementFallbackReason::UnsupportedDependencySummary
-            }
-        })?;
+        let read_projections =
+            ingested
+                .read_projections
+                .clone()
+                .ok_or(match ingested.read_projection_fallback {
+                    Some(ProjectionFallbackReason::UnsupportedSheetBinding) => {
+                        PlacementFallbackReason::UnknownSheetBinding
+                    }
+                    Some(ProjectionFallbackReason::NamedReferenceUnsupported) => {
+                        PlacementFallbackReason::UnsupportedNamedReference
+                    }
+                    _ => PlacementFallbackReason::UnsupportedDependencySummary,
+                })?;
         let is_constant_result = read_projections
             .iter()
             .all(|read_projection| is_constant_projection(&read_projection.rule));
@@ -227,6 +241,7 @@ impl CandidateAnalysis {
             template_slot_map: ingested.template_slot_map.clone(),
             read_projections,
             read_projections_constant: is_constant_result,
+            resolved_named_refs: ingested.dep_plan.resolved_named_refs.clone(),
         })
     }
 }
@@ -333,6 +348,9 @@ pub(crate) fn analyze_candidate(
         template_slot_map: build_template_slot_map(candidate.ast_id, data_store, &template.expr),
         read_projections,
         read_projections_constant: summary.is_constant_result(),
+        // This registry-less analysis path rejects named references at the
+        // dependency-summary gate above, so there are never names to record.
+        resolved_named_refs: Vec::new(),
     })
 }
 
@@ -519,6 +537,12 @@ fn place_analyzed_family(
         is_constant_result,
     });
     plane.set_binding_span_ref(binding_set_id, span);
+    if !origin_analysis.resolved_named_refs.is_empty() {
+        // All family members share the parameterized template (asserted
+        // above) and live on one sheet, so the origin's resolved name set is
+        // the family's name set.
+        plane.register_span_name_dependents(span, &origin_analysis.resolved_named_refs);
+    }
 
     report.counters.spans_created = 1;
     report.counters.accepted_span_cells = candidates.len() as u64;
@@ -1106,6 +1130,9 @@ fn residual_relative_axes(expr: &CanonicalExpr) -> (bool, bool) {
                 matches!(start_col, AxisRef::RelativeToPlacement { .. })
                     || matches!(end_col, AxisRef::RelativeToPlacement { .. }),
             ),
+            // Named references are placement-invariant (all-absolute after
+            // resolution), so they contribute no residual relative axes.
+            CanonicalReference::Named { .. } => (false, false),
             CanonicalReference::Unsupported { .. } => (false, false),
         }
     }

--- a/crates/formualizer-eval/src/formula_plane/producer.rs
+++ b/crates/formualizer-eval/src/formula_plane/producer.rs
@@ -728,6 +728,10 @@ pub(crate) enum ProjectionResult {
 pub(crate) enum ProjectionFallbackReason {
     UnsupportedDependencySummary,
     UnsupportedSheetBinding,
+    /// A defined-name reference whose definition is not a concrete Cell or
+    /// Range (Literal/Formula definitions), or which does not resolve at all
+    /// in the placement's scope. Such formulas stay on the legacy graph.
+    NamedReferenceUnsupported,
     UnsupportedAxis,
     UnboundedResultRegion,
     UnsupportedChangedRegion,

--- a/crates/formualizer-eval/src/formula_plane/runtime.rs
+++ b/crates/formualizer-eval/src/formula_plane/runtime.rs
@@ -1152,6 +1152,16 @@ pub(crate) struct FormulaPlane {
     pub(crate) formula_overlay: FormulaOverlay,
     pub(crate) projection_cache: SpanProjectionCache,
     pub(crate) dirty: SpanDirtyStore,
+    /// Defined-name dependents: lowercased name key -> spans whose read
+    /// projections resolved that name at ingest. Keys are always lowercased
+    /// regardless of the engine's case-sensitive-names config: under a
+    /// case-sensitive config two distinct names can share a bucket, which
+    /// only over-invalidates (conservative, never incorrect). The map is also
+    /// deliberately scope-blind: any define/update/delete of a name in ANY
+    /// scope invalidates every span under that key, so a sheet-scoped define
+    /// finds spans that previously resolved through workbook scope.
+    name_dependent_spans: FxHashMap<String, Vec<FormulaSpanRef>>,
+    span_name_keys: FxHashMap<FormulaSpanId, Vec<String>>,
     epoch: FormulaPlaneEpoch,
 }
 
@@ -1290,9 +1300,57 @@ impl FormulaPlane {
             if let Some(binding_set_id) = binding_set_id {
                 self.binding_sets.remove(binding_set_id);
             }
+            self.unregister_span_name_dependents(span_ref);
             self.bump_epoch();
         }
         removed
+    }
+
+    /// Record that `span` resolved `names` (raw text) at ingest. See
+    /// `name_dependent_spans` for the keying contract.
+    pub(crate) fn register_span_name_dependents(&mut self, span: FormulaSpanRef, names: &[String]) {
+        let mut keys = Vec::with_capacity(names.len());
+        for name in names {
+            let key = name.to_lowercase();
+            let entry = self.name_dependent_spans.entry(key.clone()).or_default();
+            if !entry.contains(&span) {
+                entry.push(span);
+            }
+            if !keys.contains(&key) {
+                keys.push(key);
+            }
+        }
+        if !keys.is_empty() {
+            self.span_name_keys.insert(span.id, keys);
+        }
+    }
+
+    fn unregister_span_name_dependents(&mut self, span_ref: FormulaSpanRef) {
+        let Some(keys) = self.span_name_keys.remove(&span_ref.id) else {
+            return;
+        };
+        for key in keys {
+            if let Some(entry) = self.name_dependent_spans.get_mut(&key) {
+                entry.retain(|candidate| candidate.id != span_ref.id);
+                if entry.is_empty() {
+                    self.name_dependent_spans.remove(&key);
+                }
+            }
+        }
+    }
+
+    /// Spans whose ingest-time read projections resolved `name` (any scope).
+    pub(crate) fn name_dependent_span_refs(&self, name: &str) -> Vec<FormulaSpanRef> {
+        self.name_dependent_spans
+            .get(&name.to_lowercase())
+            .map(|spans| {
+                spans
+                    .iter()
+                    .copied()
+                    .filter(|span_ref| self.spans.get(*span_ref).is_some())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     pub(crate) fn insert_overlay(

--- a/crates/formualizer-eval/src/formula_plane/span_eval.rs
+++ b/crates/formualizer-eval/src/formula_plane/span_eval.rs
@@ -1032,9 +1032,13 @@ fn validate_relocatable_arena_ast(
 
 fn validate_relocatable_compact_reference(reference: &CompactRefType) -> Result<(), SpanEvalError> {
     match reference {
-        CompactRefType::Cell { .. } | CompactRefType::Range { .. } => Ok(()),
-        CompactRefType::NamedRange(_)
-        | CompactRefType::Table { .. }
+        // Named references are placement-invariant: relocation passes them
+        // through unchanged and the interpreter resolves the name at
+        // evaluation time with the span's sheet as the current sheet.
+        CompactRefType::Cell { .. }
+        | CompactRefType::Range { .. }
+        | CompactRefType::NamedRange(_) => Ok(()),
+        CompactRefType::Table { .. }
         | CompactRefType::Cell3D { .. }
         | CompactRefType::Range3D { .. }
         | CompactRefType::External { .. } => Err(SpanEvalError::UnsupportedReferenceRelocation),

--- a/crates/formualizer-eval/src/formula_plane/structural.rs
+++ b/crates/formualizer-eval/src/formula_plane/structural.rs
@@ -121,8 +121,10 @@ fn relocate_reference_for_offset(
             end_row_abs: *end_row_abs,
             end_col_abs: *end_col_abs,
         }),
-        ReferenceType::NamedRange(_)
-        | ReferenceType::Table(_)
+        // Defined names are placement-invariant: the demoted per-placement
+        // AST references the same name, resolved at evaluation time.
+        ReferenceType::NamedRange(name) => Ok(ReferenceType::NamedRange(name.clone())),
+        ReferenceType::Table(_)
         | ReferenceType::Cell3D { .. }
         | ReferenceType::Range3D { .. }
         | ReferenceType::External(_) => Err(unsupported_reference_relocation_error()),

--- a/crates/formualizer-eval/src/formula_plane/template_canonical.rs
+++ b/crates/formualizer-eval/src/formula_plane/template_canonical.rs
@@ -197,6 +197,14 @@ pub(crate) enum CanonicalReference {
         end_row: AxisRef,
         end_col: AxisRef,
     },
+    /// A defined-name reference, canonicalized by identity. The raw name
+    /// string is preserved exactly as parsed (no case normalization): the
+    /// engine supports a case-sensitive-names config, and folding two
+    /// distinct case-sensitive names would merge fingerprints and wrongly
+    /// group cells into one span family. Preserving raw text means the worst
+    /// case is reduced sharing, never wrong sharing. Resolution to a concrete
+    /// region happens later, at per-cell read-projection time.
+    Named { name: String },
     Unsupported {
         kind: UnsupportedReferenceKind,
         diagnostic: String,
@@ -228,7 +236,6 @@ pub(crate) enum AxisRef {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum UnsupportedReferenceKind {
-    NamedRange,
     StructuredReference,
     ThreeDReference,
     ExternalReference,
@@ -275,7 +282,6 @@ pub(crate) enum CanonicalRejectKind {
     SpillReference,
     ImplicitIntersection,
     CallExpression,
-    NamedReference,
     StructuredReference,
     StructuredReferenceCurrentRow,
     ThreeDReference,
@@ -300,7 +306,6 @@ pub(crate) enum CanonicalRejectReason {
     SpillResultRegionOperator,
     ImplicitIntersectionOperator,
     CallExpression,
-    NamedReference { name: String },
     StructuredReference { diagnostic: String },
     StructuredReferenceCurrentRow { diagnostic: String },
     ThreeDReference { diagnostic: String },
@@ -342,7 +347,6 @@ impl CanonicalRejectReason {
                 CanonicalRejectKind::ImplicitIntersection
             }
             CanonicalRejectReason::CallExpression => CanonicalRejectKind::CallExpression,
-            CanonicalRejectReason::NamedReference { .. } => CanonicalRejectKind::NamedReference,
             CanonicalRejectReason::StructuredReference { .. } => {
                 CanonicalRejectKind::StructuredReference
             }
@@ -376,6 +380,10 @@ pub(crate) enum CanonicalTemplateFlag {
     AbsoluteReferenceAxis,
     MixedAnchors,
     FiniteRangeReference,
+    /// The template contains at least one defined-name reference. Names
+    /// canonicalize by identity (raw text); whether they resolve to a
+    /// supported concrete region is decided per cell at projection time.
+    NamedReference,
 }
 
 /// Canonicalize a parsed formula AST at a one-based formula placement anchor.
@@ -736,13 +744,11 @@ impl Canonicalizer {
                 }
             }
             ReferenceType::NamedRange(name) => {
-                self.labels.reject(CanonicalRejectReason::NamedReference {
-                    name: name.to_ascii_uppercase(),
-                });
-                CanonicalReference::Unsupported {
-                    kind: UnsupportedReferenceKind::NamedRange,
-                    diagnostic: name.to_ascii_uppercase(),
-                }
+                // Names are canonicalized by identity with the RAW parsed
+                // text (no case folding; see `CanonicalReference::Named`).
+                // Resolution happens at per-cell read-projection time.
+                self.labels.flag(CanonicalTemplateFlag::NamedReference);
+                CanonicalReference::Named { name: name.clone() }
             }
         }
     }
@@ -1348,6 +1354,11 @@ fn write_reference_key(reference: &CanonicalReference, out: &mut String) {
             write_axis_key(end_col, out);
             out.push(')');
         }
+        CanonicalReference::Named { name } => {
+            out.push_str("named(");
+            write_string_key(name, out);
+            out.push(')');
+        }
         CanonicalReference::Unsupported { kind, diagnostic } => {
             out.push_str("unsupported_ref(");
             write_unsupported_reference_kind_key(kind, out);
@@ -1387,7 +1398,6 @@ fn write_axis_key(axis: &AxisRef, out: &mut String) {
 
 fn write_unsupported_reference_kind_key(kind: &UnsupportedReferenceKind, out: &mut String) {
     out.push_str(match kind {
-        UnsupportedReferenceKind::NamedRange => "named_range",
         UnsupportedReferenceKind::StructuredReference => "structured_reference",
         UnsupportedReferenceKind::ThreeDReference => "three_d_reference",
         UnsupportedReferenceKind::ExternalReference => "external_reference",
@@ -1459,10 +1469,6 @@ fn write_reject_reason_key(reason: &CanonicalRejectReason, out: &mut String) {
             out.push_str("implicit_intersection_operator")
         }
         CanonicalRejectReason::CallExpression => out.push_str("call_expression"),
-        CanonicalRejectReason::NamedReference { name } => {
-            out.push_str("name_ref:");
-            write_string_key(name, out);
-        }
         CanonicalRejectReason::StructuredReference { diagnostic } => {
             out.push_str("structured_ref:");
             write_string_key(diagnostic, out);
@@ -1504,6 +1510,7 @@ fn write_template_flag_key(flag: &CanonicalTemplateFlag, out: &mut String) {
         CanonicalTemplateFlag::AbsoluteReferenceAxis => "absolute_axis",
         CanonicalTemplateFlag::MixedAnchors => "mixed_anchors",
         CanonicalTemplateFlag::FiniteRangeReference => "finite_range",
+        CanonicalTemplateFlag::NamedReference => "named_reference",
     });
 }
 
@@ -1873,6 +1880,34 @@ mod tests {
             template
                 .labels
                 .contains_reject_kind(CanonicalRejectKind::OpenRangeReference)
+        );
+    }
+
+    #[test]
+    fn formula_plane_named_references_canonicalize_by_identity() {
+        let one = canonical("=SUM(MyData)+A2", 2, 3);
+        let two = canonical("=SUM(MyData)+A3", 3, 3);
+
+        assert_eq!(one.key, two.key);
+        assert!(one.labels.is_authority_supported());
+        assert!(
+            one.labels
+                .flags
+                .contains(&CanonicalTemplateFlag::NamedReference)
+        );
+    }
+
+    #[test]
+    fn formula_plane_named_reference_raw_case_is_preserved_in_keys() {
+        let lower = canonical("=myname", 1, 1);
+        let upper = canonical("=MYNAME", 1, 1);
+
+        assert_ne!(lower.key, upper.key);
+        assert_eq!(
+            only_reference(&lower),
+            &CanonicalReference::Named {
+                name: "myname".to_string(),
+            }
         );
     }
 }

--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -1604,8 +1604,10 @@ fn relocate_reference_for_offset(
             end_row_abs: *end_row_abs,
             end_col_abs: *end_col_abs,
         }),
-        ReferenceType::NamedRange(_)
-        | ReferenceType::Table(_)
+        // Defined names are placement-invariant: a relocated copy of the
+        // formula references the same name, resolved at evaluation time.
+        ReferenceType::NamedRange(name) => Ok(ReferenceType::NamedRange(name.clone())),
+        ReferenceType::Table(_)
         | ReferenceType::Cell3D { .. }
         | ReferenceType::Range3D { .. }
         | ReferenceType::External(_) => Err(unsupported_reference_relocation_error()),

--- a/crates/formualizer-testkit/src/fp_coverage.rs
+++ b/crates/formualizer-testkit/src/fp_coverage.rs
@@ -299,34 +299,36 @@ pub fn generate(rows_per_section: u32, seed: u64, include_broken: bool) -> Cover
     }
 
     // ------------------------------------------------------------------
-    // (g) named_range — reference through a workbook-scoped defined name.
-    // Expected: REJECT (canonical NamedReference -> placement
-    // UnsupportedCanonicalTemplate). Flips to SPAN when named-range
-    // fingerprinting lands.
+    // (g) named_range — references through workbook-scoped defined names:
+    // a named RANGE (CovNamedData = column B) and a named CELL
+    // (CovNamedCell = $E$1). Expected: SPAN. Names canonicalize by identity
+    // and resolve to all-absolute read regions at projection time (named
+    // -range fingerprinting, pinned empirically on 2026-06-11).
     // ------------------------------------------------------------------
     {
         let mut values = Vec::new();
         let mut formulas = Vec::new();
+        // Named-cell target lives in the reserved header/aux row 1.
+        values.push(val("NamedRange", 1, 5, 2.5)); // E1 = CovNamedCell
         for r in rows.clone() {
             values.push(val("NamedRange", r, 2, mix(seed, r as u64, 7))); // B
             formulas.push(formula(
                 "NamedRange",
                 r,
                 3,
-                format!("=SUM(CovNamedData)+A{r}"),
+                format!("=SUM(CovNamedData)+CovNamedCell*2+A{r}"),
             ));
             values.push(val("NamedRange", r, 1, r as f64)); // A
         }
         sections.push(Section {
             name: "named_range",
             sheet: "NamedRange",
-            verdict: SectionVerdict::Reject {
-                placement_reason: "UnsupportedCanonicalTemplate",
-            },
-            expected_canonical_reject_kinds: &["named_reference"],
+            verdict: SectionVerdict::Span,
+            expected_canonical_reject_kinds: &[],
             values,
             formulas,
-            notes: "=SUM(CovNamedData)+A{r}; canonical reject NamedReference.",
+            notes: "=SUM(CovNamedData)+CovNamedCell*2+A{r}; named range + named cell resolve to \
+                    all-absolute read regions, span family.",
         });
     }
 
@@ -510,14 +512,27 @@ pub fn generate(rows_per_section: u32, seed: u64, include_broken: bool) -> Cover
         .map(|r| val(DATA_SHEET, r, 2, mix(seed, r as u64, 10)))
         .collect();
 
-    let named_ranges = vec![NamedRangeSpec {
-        name: "CovNamedData",
-        sheet: "NamedRange",
-        start_row: first,
-        start_col: 2,
-        end_row: last,
-        end_col: 2,
-    }];
+    let named_ranges = vec![
+        NamedRangeSpec {
+            name: "CovNamedData",
+            sheet: "NamedRange",
+            start_row: first,
+            start_col: 2,
+            end_row: last,
+            end_col: 2,
+        },
+        // Single-cell name (1x1 bounds): loaders/engines may define this as a
+        // Cell definition; both Cell and 1x1 Range resolve to the same
+        // absolute read region.
+        NamedRangeSpec {
+            name: "CovNamedCell",
+            sheet: "NamedRange",
+            start_row: 1,
+            start_col: 5,
+            end_row: 1,
+            end_col: 5,
+        },
+    ];
 
     debug_assert_eq!(sections.len(), SECTION_COUNT);
 

--- a/crates/formualizer-workbook/src/backends/umya.rs
+++ b/crates/formualizer-workbook/src/backends/umya.rs
@@ -1469,19 +1469,6 @@ where
             }
         }
 
-        if !engine.config.defer_graph_building && !eager_formula_batches.is_empty() {
-            let t_bulk = Instant::now();
-            engine
-                .ingest_formula_batches(eager_formula_batches)
-                .map_err(IoError::Engine)?;
-            if debug {
-                eprintln!(
-                    "[fz][load] umya: bulk formula ingest finished in {:.1} ms",
-                    t_bulk.elapsed().as_secs_f64() * 1000.0,
-                );
-            }
-        }
-
         let t_defined = Instant::now();
         {
             use rustc_hash::FxHashSet;
@@ -1554,6 +1541,22 @@ where
                 "[fz][load] umya: defined names registered in {:.1} ms",
                 t_defined.elapsed().as_secs_f64() * 1000.0,
             );
+        }
+
+        // Defined names are registered BEFORE the eager formula ingest so
+        // ingest-time name resolution (legacy resolved-name dep plans and
+        // FormulaPlane named read projections) sees the loaded registry.
+        if !engine.config.defer_graph_building && !eager_formula_batches.is_empty() {
+            let t_bulk = Instant::now();
+            engine
+                .ingest_formula_batches(eager_formula_batches)
+                .map_err(IoError::Engine)?;
+            if debug {
+                eprintln!(
+                    "[fz][load] umya: bulk formula ingest finished in {:.1} ms",
+                    t_bulk.elapsed().as_secs_f64() * 1000.0,
+                );
+            }
         }
 
         let t_finalize = Instant::now();


### PR DESCRIPTION
## What

Formulas referencing defined names (e.g. `=SUM(MyData)+A5`) were rejected at template canonicalization (`CanonicalRejectReason::NamedReference`) and always fell back to legacy per-cell evaluation. This PR makes names whose definition is a concrete Cell or Range first-class FormulaPlane citizens: they canonicalize, fingerprint, and span like anchored-absolute-range formulas, with correct dirty propagation for edits inside the named region and correct invalidation across the name lifecycle (define/update/delete). Names defined as Literal or Formula, and undefined names, keep falling back with a precise new counter key (`UnsupportedNamedReference`) and unchanged `#NAME?` semantics.

## Design: canonicalize by identity, resolve at projection time

**Canonical layer stays pure.** `canonicalize_template` has no registry access and keeps none. A named reference becomes `CanonicalReference::Named { name }` carrying the raw parsed text — no case folding, because the engine supports a case-sensitive-names config and folding two distinct case-sensitive names would merge fingerprints and wrongly coalesce cells into one span family. Raw text means the worst case is reduced sharing, never wrong sharing. This is the same precedent `SheetBinding::ExplicitName` set for sheet names.

**Resolution happens per cell at read-projection time.** `compute_read_projections` now takes the ingest pipeline's `NameRegistryView` — the same resolver legacy dependency planning uses, so FormulaPlane and legacy can never disagree on what a name means (including sheet-scoped names shadowing workbook-scoped ones). A resolved Cell/Range definition is an all-absolute read region on the definition's sheet (which need not be the placement sheet), so placement, the region index, producer dirty inversion, and the InternalDependency self-overlap guard all work with zero new math. Per-cell resolution also makes shadowing safe across placements that share a template: families are keyed per sheet, and resolution is a function of (name, sheet) only.

**Name lifecycle invalidation is the genuinely new machinery.** In authoritative mode span cells have no graph vertices, so the legacy `NamedRange.dependents` dirty path cannot reach them. The runtime now keeps a name-dependents map (lowercased name key → spans whose ingest-time projections resolved that name; deliberately scope-blind so a sheet-scoped define finds spans that resolved through workbook scope — conservative over-invalidation only). `define_name` / `update_name` / `delete_name` demote affected spans through the existing demotion machinery BEFORE mutating the registry, so the demoted cells re-materialize as legacy vertices attached to the name vertex and the registry change dirties them exactly like long-lived legacy formulas. `define` is hooked, not just update/delete: a new sheet-scoped name can flip resolution for spans that previously resolved through workbook scope.

**Bundled fix:** the umya XLSX backend ingested formulas before registering defined names, so named formulas in loaded workbooks could never resolve at ingest time. Names are now registered first. (calamine/json backends share the same latent ordering; harmless for correctness today — named formulas just fall back — noted as a follow-up.)

## Numbers (all independently reproduced against an origin/main baseline build)

- probe-fp-coverage: coverage 69.2% → 76.9% (20,000 of 26,000 corpus cells span; the named_range section flipped Reject → Span), value equality 26,000 cells / 0 mismatches, auth first-eval 364 → 332 ms, auth warm 28 → 25 ms.
- Standing perf A/B vs origin/main (4 interleaved rounds, medians): probe-finance-recalc total_recalc −1.2%, p95 −4.2%, initial_eval +11.3% (single-digit-ms noise); probe-load-envelope (200k×8 linear-rollup) load +0.7%, evaluate −3.3%. Mixed directions = noise; no names appear in either workload and the no-name hot path adds only a match arm.

## Tests

- New `formula_plane_named_ranges.rs` (9 tests): span acceptance with counter pinning, dirty precision (edit inside vs outside the named region), `update_name` re-resolution in authoritative mode (verified load-bearing: neutering the invalidation hook makes it fail), sheet-scoped define-after-ingest shadowing flip, `delete_name` → `#NAME?` parity with Off mode, named cell + cross-sheet definitions, self-overlap fallback, Literal-definition and undefined-name fallback reason pinning.
- Corpus named_range section flipped to Span and extended with a named-cell flavor (`=SUM(CovNamedData)+CovNamedCell*2+A{r}`); coverage pinning tests updated.
- Full gates green: fmt, clippy `-D warnings`, workspace tests (2,681 passed), wasm32 portable check.

## Follow-up candidates (pre-existing, deliberately not fixed here)

- `VertexEditor::define/update/delete_name` (journal replay/undo paths) mutate the registry directly and bypass the engine-level span invalidation hook — same pattern as other editor-vs-engine FormulaPlane interactions.
- calamine/json backend name-registration ordering (see above).
- The FP8 parity oracle gets a narrow documented carve-out: the passive summary layer cannot resolve names, so old-None/new-Some read summaries are allowed exactly when the only blocking reason was a named reference.