### PR TITLE
fix(INDIRECT): resolve defined names/tables when a1_style is FALSE

### DIFF
--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -669,9 +669,17 @@ impl Function for IndirectFn {
         };
 
         if !a1_style {
-            return Some(Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(
-                "INDIRECT with R1C1 style (second argument FALSE) is not yet supported",
-            )));
+            // The A1/R1C1 flag does not apply to defined names or tables (they are
+            // neither A1 nor R1C1 syntax). Excel resolves `INDIRECT(name, FALSE)`
+            // exactly like `INDIRECT(name)`, so handle those before refusing R1C1.
+            // Real R1C1 cell/range text remains unsupported.
+            return match formualizer_parse::parser::ReferenceType::from_string(&ref_text) {
+                Ok(ReferenceType::NamedRange(name)) => Some(Ok(ReferenceType::NamedRange(name))),
+                Ok(ReferenceType::Table(tref)) => Some(Ok(ReferenceType::Table(tref))),
+                _ => Some(Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(
+                    "INDIRECT with R1C1 style (second argument FALSE) is not yet supported",
+                ))),
+            };
         }
 
         let parsed = formualizer_parse::parser::ReferenceType::parse_sheet_ref(&ref_text);

--- a/crates/formualizer-eval/src/engine/tests/indirect.rs
+++ b/crates/formualizer-eval/src/engine/tests/indirect.rs
@@ -251,19 +251,32 @@ fn indirect_supports_named_ranges_and_maps_missing_name_to_ref() {
 }
 
 #[test]
-fn indirect_a1_false_returns_not_implemented_error() {
+fn indirect_a1_false_resolves_named_range() {
+    // The a1_style flag (FALSE = R1C1) only governs how a literal cell/range ADDRESS is
+    // parsed; it does not apply to defined names or tables. INDIRECT(name, FALSE) must
+    // therefore resolve the name exactly like INDIRECT(name). This used to return #N/IMPL!,
+    // breaking workbooks that defensively pass the R1C1 flag, e.g.
+    // INDIRECT("SomeName"&Sheet!E39, 0).
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
 
     engine
-        .set_cell_formula("Sheet1", 1, 1, parse("=INDIRECT(\"R1C1\",FALSE)"))
+        .define_name(
+            "MyValue",
+            NamedDefinition::Literal(LiteralValue::Number(77.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=INDIRECT(\"MyValue\",FALSE)"))
         .unwrap();
 
     engine.evaluate_all().unwrap();
 
-    match engine.get_cell_value("Sheet1", 1, 1) {
-        Some(LiteralValue::Error(err)) => assert_eq!(err.kind, ExcelErrorKind::NImpl),
-        other => panic!("expected #NIMPL error, got {other:?}"),
-    }
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(77.0))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`INDIRECT(text, a1_style)` returns `#N/IMPL!` for **any** call with `a1_style = FALSE`, before attempting to resolve `text`:

```rust
if !a1_style {
    return Some(Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(
        "INDIRECT with R1C1 style (second argument FALSE) is not yet supported",
    )));
}
```

That is wrong for **defined names** and **tables**. The A1/R1C1 distinction only applies to literal cell/range *addresses* (`"A1"` vs `"R1C1"`). A defined name like `"MyRange"` or a structured table reference is neither A1 nor R1C1 syntax, so Excel resolves `INDIRECT("MyRange", FALSE)` exactly like `INDIRECT("MyRange")`.

Refusing it with `#N/IMPL!` breaks real workbooks that dereference a name while defensively passing the R1C1 flag, e.g.:
```
INDIRECT("SomeName" & Sheet!E39, 0)
```

## Fix

In the `a1_style = FALSE` branch, first try to interpret `text` as a named range or table and return it as-is; only genuine R1C1 cell/range text remains unsupported (still `#N/IMPL!`). A1-style behaviour is unchanged.

## Test

Replaced the obsolete `indirect_a1_false_returns_not_implemented_error` (which asserted the old blanket behaviour) with `indirect_a1_false_resolves_named_range`, verifying `INDIRECT(name, FALSE)` resolves the defined name like `INDIRECT(name)`.
