### PR TITLE
fix(INDEX): support row_num/column_num = 0 (entire row/column)

### DIFF
--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -229,9 +229,52 @@ impl Function for IndexFn {
             }
         };
 
-        // 1-based indexing per Excel
-        if row <= 0 || col <= 0 {
+        // 1-based indexing per Excel. A 0 means "the entire row" (column_num == 0)
+        // or "the entire column" (row_num == 0); 0 for both yields the whole range.
+        // Negative indices are #REF!.
+        if row < 0 || col < 0 {
             return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
+        }
+        let range_ref = |sheet, sr, sc, er, ec| ReferenceType::Range {
+            sheet,
+            start_row: Some(sr),
+            start_col: Some(sc),
+            end_row: Some(er),
+            end_col: Some(ec),
+            start_row_abs: false,
+            start_col_abs: false,
+            end_row_abs: false,
+            end_col_abs: false,
+        };
+        if col == 0 {
+            if row == 0 {
+                // INDEX(range, 0, 0) -> the entire range.
+                return Some(Ok(range_ref(sheet, sr, sc, er, ec)));
+            }
+            // INDEX(range, r, 0) -> the entire row r (degenerates to a cell for a
+            // single-column range).
+            let r = sr + (row as u32) - 1;
+            if r > er {
+                return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
+            }
+            return Some(Ok(if sc == ec {
+                ReferenceType::cell(sheet, r, sc)
+            } else {
+                range_ref(sheet, r, sc, r, ec)
+            }));
+        }
+        if row == 0 {
+            // INDEX(range, 0, c) -> the entire column c (degenerates to a cell for a
+            // single-row range).
+            let c = sc + (col as u32) - 1;
+            if c > ec {
+                return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
+            }
+            return Some(Ok(if sr == er {
+                ReferenceType::cell(sheet, sr, c)
+            } else {
+                range_ref(sheet, sr, c, er, c)
+            }));
         }
         let r = sr + (row as u32) - 1;
         let c = sc + (col as u32) - 1;
@@ -967,6 +1010,73 @@ mod tests {
             .with_function(std::sync::Arc::new(IndexFn));
 
         let value = evaluate_formula("=INDEX(A1:C1,4)", &wb).unwrap();
+        match value {
+            LiteralValue::Error(err) => assert_eq!(err.kind, ExcelErrorKind::Ref),
+            other => panic!("expected #REF!, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn index_zero_column_degenerates_to_cell_in_single_column_range() {
+        // INDEX(B1:B5, 2, 0) -> entire row 2 of a single-column range = B2.
+        let wb = TestWorkbook::new()
+            .with_cell_a1("Sheet1", "B1", LiteralValue::Int(10))
+            .with_cell_a1("Sheet1", "B2", LiteralValue::Int(20))
+            .with_cell_a1("Sheet1", "B3", LiteralValue::Int(30))
+            .with_function(std::sync::Arc::new(IndexFn));
+
+        let value = evaluate_formula("=INDEX(B1:B5,2,0)", &wb).unwrap();
+        assert_eq!(value, LiteralValue::Number(20.0));
+    }
+
+    #[test]
+    fn index_zero_row_degenerates_to_cell_in_single_row_range() {
+        // INDEX(A1:C1, 0, 2) -> entire column 2 of a single-row range = B1.
+        let wb = TestWorkbook::new()
+            .with_cell_a1("Sheet1", "A1", LiteralValue::Int(10))
+            .with_cell_a1("Sheet1", "B1", LiteralValue::Int(20))
+            .with_cell_a1("Sheet1", "C1", LiteralValue::Int(30))
+            .with_function(std::sync::Arc::new(IndexFn));
+
+        let value = evaluate_formula("=INDEX(A1:C1,0,2)", &wb).unwrap();
+        assert_eq!(value, LiteralValue::Number(20.0));
+    }
+
+    #[test]
+    fn index_zero_column_returns_entire_row_range() {
+        // INDEX(A1:C3, 2, 0) -> entire row 2 (A2:C2); SUM materializes it.
+        let wb = TestWorkbook::new()
+            .with_cell_a1("Sheet1", "A2", LiteralValue::Int(1))
+            .with_cell_a1("Sheet1", "B2", LiteralValue::Int(2))
+            .with_cell_a1("Sheet1", "C2", LiteralValue::Int(3))
+            .with_function(std::sync::Arc::new(IndexFn))
+            .with_function(std::sync::Arc::new(crate::builtins::math::aggregate::SumFn));
+
+        let value = evaluate_formula("=SUM(INDEX(A1:C3,2,0))", &wb).unwrap();
+        assert_eq!(value, LiteralValue::Number(6.0));
+    }
+
+    #[test]
+    fn index_zero_row_returns_entire_column_range() {
+        // INDEX(A1:C3, 0, 2) -> entire column 2 (B1:B3); SUM materializes it.
+        let wb = TestWorkbook::new()
+            .with_cell_a1("Sheet1", "B1", LiteralValue::Int(4))
+            .with_cell_a1("Sheet1", "B2", LiteralValue::Int(5))
+            .with_cell_a1("Sheet1", "B3", LiteralValue::Int(6))
+            .with_function(std::sync::Arc::new(IndexFn))
+            .with_function(std::sync::Arc::new(crate::builtins::math::aggregate::SumFn));
+
+        let value = evaluate_formula("=SUM(INDEX(A1:C3,0,2))", &wb).unwrap();
+        assert_eq!(value, LiteralValue::Number(15.0));
+    }
+
+    #[test]
+    fn index_negative_index_is_ref() {
+        let wb = TestWorkbook::new()
+            .with_cell_a1("Sheet1", "A1", LiteralValue::Int(10))
+            .with_function(std::sync::Arc::new(IndexFn));
+
+        let value = evaluate_formula("=INDEX(A1:C3,-1,2)", &wb).unwrap();
         match value {
             LiteralValue::Error(err) => assert_eq!(err.kind, ExcelErrorKind::Ref),
             other => panic!("expected #REF!, got {other:?}"),

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -336,53 +336,98 @@ impl Function for IndexFn {
                 }
             };
 
-            // Determine if this is a 1D array (single row or single column)
-            let is_single_row = table.len() == 1;
-            let is_single_col = table.iter().all(|r| r.len() == 1);
-
-            // For 1D arrays with 2 args, index is position in the array
-            if args.len() == 2 && (is_single_row || is_single_col) {
-                if index <= 0 {
-                    return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
-                        ExcelError::new(ExcelErrorKind::Ref),
-                    )));
-                }
-                let idx = (index - 1) as usize;
-                let val = if is_single_row {
-                    table[0].get(idx).cloned()
-                } else {
-                    table.get(idx).and_then(|r| r.first()).cloned()
-                };
-                return Ok(crate::traits::CalcValue::Scalar(val.unwrap_or_else(|| {
-                    LiteralValue::Error(ExcelError::new(ExcelErrorKind::Ref))
-                })));
-            }
-
-            // 2D array or 3 arguments: use row and col indexing
-            let row = index as usize;
-            let col = if args.len() >= 3 {
-                match args[2].value()?.into_literal() {
-                    LiteralValue::Number(n) => n as usize,
-                    LiteralValue::Int(i) => i as usize,
+            // Optional explicit column_num (third argument).
+            let explicit_col = if args.len() >= 3 {
+                Some(match args[2].value()?.into_literal() {
+                    LiteralValue::Number(n) => n as i64,
+                    LiteralValue::Int(i) => i,
                     _ => {
                         return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
                             ExcelError::new(ExcelErrorKind::Value),
                         )));
                     }
-                }
+                })
             } else {
-                1
+                None
             };
 
-            // 1-based indexing
-            if row == 0 || col == 0 {
-                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
-                    ExcelError::new(ExcelErrorKind::Ref),
-                )));
+            let nrows = table.len();
+            let ncols = table.iter().map(|r| r.len()).max().unwrap_or(0);
+            let single_row = nrows == 1;
+
+            // Map (index, optional column) to (row, col) exactly like eval_reference:
+            // for a single-row input the lone index selects the column, otherwise it
+            // selects the row and the column defaults to 1.
+            let (row, col) = match explicit_col {
+                Some(c) => (index, c),
+                None if single_row => (1, index),
+                None => (index, 1),
+            };
+
+            // Negative indices are #REF!. A 0 selects the entire row (column_num == 0)
+            // or entire column (row_num == 0); 0 for both yields the whole array.
+            // This mirrors the reference path so the two don't drift apart.
+            let ref_err = || {
+                crate::traits::CalcValue::Scalar(LiteralValue::Error(ExcelError::new(
+                    ExcelErrorKind::Ref,
+                )))
+            };
+            if row < 0 || col < 0 {
+                return Ok(ref_err());
+            }
+
+            // Wrap a multi-cell array result in a RangeView so aggregations
+            // (SUM, etc.) iterate it, matching how the reference path returns
+            // CalcValue::Range. A literal LiteralValue::Array would otherwise be
+            // strict-coerced as a single scalar by numeric callers.
+            let as_range = |rows: Vec<Vec<LiteralValue>>| {
+                crate::traits::CalcValue::Range(
+                    crate::engine::range_view::RangeView::from_owned_rows(rows, ctx.date_system()),
+                )
+            };
+
+            if col == 0 {
+                if row == 0 {
+                    // INDEX(array, 0, 0) -> the whole array.
+                    return Ok(as_range(table));
+                }
+                // INDEX(array, r, 0) -> the entire row r (scalar for a single-column array).
+                if row as usize > nrows {
+                    return Ok(ref_err());
+                }
+                let r = &table[row as usize - 1];
+                if ncols == 1 {
+                    return Ok(crate::traits::CalcValue::Scalar(
+                        r.first().cloned().unwrap_or(LiteralValue::Empty),
+                    ));
+                }
+                return Ok(as_range(vec![r.clone()]));
+            }
+            if row == 0 {
+                // INDEX(array, 0, c) -> the entire column c (scalar for a single-row array).
+                if col as usize > ncols {
+                    return Ok(ref_err());
+                }
+                let cidx = col as usize - 1;
+                if single_row {
+                    return Ok(crate::traits::CalcValue::Scalar(
+                        table[0].get(cidx).cloned().unwrap_or(LiteralValue::Empty),
+                    ));
+                }
+                let column: Vec<Vec<LiteralValue>> = table
+                    .iter()
+                    .map(|r| vec![r.get(cidx).cloned().unwrap_or(LiteralValue::Empty)])
+                    .collect();
+                return Ok(as_range(column));
+            }
+
+            // 1-based positive indexing.
+            if row as usize > nrows || col as usize > ncols {
+                return Ok(ref_err());
             }
             let val = table
-                .get(row - 1)
-                .and_then(|r| r.get(col - 1))
+                .get(row as usize - 1)
+                .and_then(|r| r.get(col as usize - 1))
                 .cloned()
                 .unwrap_or_else(|| LiteralValue::Error(ExcelError::new(ExcelErrorKind::Ref)));
             Ok(crate::traits::CalcValue::Scalar(val))
@@ -1079,6 +1124,73 @@ mod tests {
             .with_function(std::sync::Arc::new(IndexFn));
 
         let value = evaluate_formula("=INDEX(A1:C3,-1,2)", &wb).unwrap();
+        match value {
+            LiteralValue::Error(err) => assert_eq!(err.kind, ExcelErrorKind::Ref),
+            other => panic!("expected #REF!, got {other:?}"),
+        }
+    }
+
+    fn as_number(v: &LiteralValue) -> f64 {
+        match v {
+            LiteralValue::Number(n) => *n,
+            LiteralValue::Int(i) => *i as f64,
+            other => panic!("expected number, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn index_array_constant_zero_column_returns_entire_row() {
+        // INDEX({1,2,3},0) over an array constant -> the whole row {1,2,3}.
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(IndexFn));
+
+        let raw = evaluate_formula("=INDEX({1,2,3},0)", &wb).unwrap();
+        let LiteralValue::Array(rows) = raw else {
+            panic!("expected a 1x3 array, got {raw:?}");
+        };
+        assert_eq!(rows.len(), 1);
+        let flat: Vec<f64> = rows[0].iter().map(as_number).collect();
+        assert_eq!(flat, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn index_array_constant_zero_row_returns_entire_column() {
+        // INDEX({1,2;3,4},0,2) over an array constant -> the whole column {2;4}.
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(IndexFn));
+
+        let raw = evaluate_formula("=INDEX({1,2;3,4},0,2)", &wb).unwrap();
+        let LiteralValue::Array(rows) = raw else {
+            panic!("expected a 2x1 array, got {raw:?}");
+        };
+        let flat: Vec<f64> = rows.iter().map(|r| as_number(&r[0])).collect();
+        assert_eq!(flat, vec![2.0, 4.0]);
+    }
+
+    #[test]
+    fn index_array_constant_zero_zero_returns_whole_array() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(IndexFn));
+
+        let raw = evaluate_formula("=INDEX({1,2;3,4},0,0)", &wb).unwrap();
+        let LiteralValue::Array(rows) = raw else {
+            panic!("expected the whole 2x2 array, got {raw:?}");
+        };
+        let flat: Vec<f64> = rows.iter().flatten().map(as_number).collect();
+        assert_eq!(flat, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn index_array_constant_row_zero_for_single_row_degenerates_to_scalar() {
+        // INDEX({1,2,3},0,2): single-row array, entire column 2 -> scalar 2.
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(IndexFn));
+
+        let value = evaluate_formula("=INDEX({1,2,3},0,2)", &wb).unwrap();
+        assert_eq!(as_number(&value), 2.0);
+    }
+
+    #[test]
+    fn index_array_constant_negative_is_ref() {
+        let wb = TestWorkbook::new().with_function(std::sync::Arc::new(IndexFn));
+
+        let value = evaluate_formula("=INDEX({1,2,3},-1)", &wb).unwrap();
         match value {
             LiteralValue::Error(err) => assert_eq!(err.kind, ExcelErrorKind::Ref),
             other => panic!("expected #REF!, got {other:?}"),

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -98,7 +98,9 @@ pub struct IndexFn;
 /// - If `column_num` is omitted for a single-row or single-column input, `row_num` selects the
 ///   position along that 1D vector.
 /// - For rectangular 2D inputs, omitted `column_num` defaults to the first column.
-/// - `row_num <= 0`, `column_num <= 0`, or out-of-bounds indexes return `#REF!`.
+/// - A `row_num` or `column_num` of `0` selects the entire column or row respectively
+///   (both `0` selects the whole range), matching Excel.
+/// - Negative or out-of-bounds indexes return `#REF!`.
 /// - Non-numeric index arguments return `#VALUE!`.
 ///
 /// # Examples
@@ -134,7 +136,7 @@ pub struct IndexFn;
 ///   - q: "How does INDEX behave when column_num is omitted?"
 ///     a: "For single-row or single-column inputs, row_num selects the position along that vector; for 2D inputs, omitted column_num defaults to the first column."
 ///   - q: "Which errors indicate bad indexes?"
-///     a: "Non-numeric index arguments return #VALUE!, while 0/negative or out-of-bounds indexes return #REF!."
+///     a: "Non-numeric index arguments return #VALUE!. A 0 row_num/column_num selects an entire column/row (Excel behavior); negative or out-of-bounds indexes return #REF!."
 /// ```
 /// [formualizer-docgen:schema:start]
 /// Name: INDEX

--- a/tests/formula_tests/lookup.json
+++ b/tests/formula_tests/lookup.json
@@ -168,6 +168,18 @@
       "description": "INDEX 1D array second element"
     },
     {
+      "formula": "=INDEX({2,3,4}, 0, 2)",
+      "result": 3,
+      "result_type": "int",
+      "description": "INDEX array row_num=0 on single-row array selects entire column 2 -> scalar"
+    },
+    {
+      "formula": "=INDEX({2;3;4}, 2, 0)",
+      "result": 3,
+      "result_type": "int",
+      "description": "INDEX array column_num=0 on single-column array selects entire row 2 -> scalar"
+    },
+    {
       "formula": "=CHOOSE(1, \"Wide\", 115, \"world\", 8)",
       "result": "Wide",
       "result_type": "str",


### PR DESCRIPTION
## Summary

In Excel, passing `0` as `row_num` or `column_num` to `INDEX` selects a whole line of the array:

- `INDEX(range, r, 0)` → the **entire row** `r`
- `INDEX(range, 0, c)` → the **entire column** `c`
- `INDEX(range, 0, 0)` → the **entire range**

This is a common idiom inside aggregates (`=SUM(INDEX(a, r, 0))`) and when feeding a whole row/column to another function.

formualizer rejected a `0` index with `#REF!` because of the guard `if row <= 0 || col <= 0`.

## Reproduction

| Formula (B1:B5 = 10,20,30,40,50; A1:C3 rows) | Excel | formualizer (before) |
|---|---|---|
| `=INDEX(B1:B5,2,0)` | `20` | `#REF!` |
| `=INDEX(A1:C1,0,2)` | `20` | `#REF!` |
| `=SUM(INDEX(A1:C3,2,0))` | sum of row 2 | `#REF!` |
| `=SUM(INDEX(A1:C3,0,2))` | sum of column 2 | `#REF!` |
| `=INDEX(A1:C3,-1,2)` | `#REF!` | `#REF!` (unchanged) |

## Fix

In `IndexFn::eval_reference`, treat a `0` index as "entire row/column":

- `column_num == 0` → return the row range `(r, sc)..(r, ec)` (or the single cell if the source is one column),
- `row_num == 0` → return the column range `(sr, c)..(er, c)` (or the single cell if the source is one row),
- both `0` → the entire range,
- negative indices remain `#REF!`.

Adds regression tests for the degenerate single-cell cases, full row/column materialization via `SUM`, and the negative-index `#REF!` case.
