### PR TITLE
fix(criteria): count blank cells for <> criteria in SUMIFS/COUNTIFS (bounded to used region)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1305,11 +1305,22 @@ fn compute_criteria_mask(
 
     // TEXT PATH: build masks per row-chunk using lowered text slices.
     // This avoids concatenating full-string columns just to compute a boolean mask.
+    //
+    // `ne_null_fill` is the value a blank/Empty cell must take under a `<>` criterion.
+    // Excel treats a blank as equal to the empty string, so:
+    //   - `<>X` (non-empty pattern): blank != "X" is TRUE  -> blank SATISFIES the criterion
+    //   - `<>`  (empty pattern):     blank == ""  is TRUE   -> blank does NOT satisfy `<>`
+    // Arrow's `nilike` returns NULL (not TRUE) for NULL inputs, so without this fill the
+    // vectorized path silently drops blanks for `<>X` (issue #158). This is bounded to the
+    // view's materialized rows because `iter_row_chunks`/`build_criteria_mask` only iterate
+    // the used region — a whole-column `A:A` ref never counts the millions of trailing blanks.
+    let mut ne_null_fill = false;
     let (text_kind, text_pat, empty_special) = match pred {
         crate::args::CriteriaPredicate::Eq(formualizer_common::LiteralValue::Text(t)) => {
             (0u8, t.to_lowercase(), t.is_empty())
         }
         crate::args::CriteriaPredicate::Ne(formualizer_common::LiteralValue::Text(t)) => {
+            ne_null_fill = !t.is_empty();
             (1u8, t.to_lowercase(), false)
         }
         crate::args::CriteriaPredicate::TextLike {
@@ -1353,6 +1364,13 @@ fn compute_criteria_mask(
                     let mut bb = BooleanBuilder::with_capacity(cs.row_len);
                     bb.append_n(cs.row_len, true);
                     bool_parts.push(bb.finish());
+                } else if text_kind == 1 {
+                    // `<>X`: an all-blank column segment is entirely blanks. Fill with the
+                    // Excel `<>`-vs-blank verdict (TRUE for `<>X`, FALSE for `<>`) instead of
+                    // dropping the rows to NULL (issue #158).
+                    let mut bb = BooleanBuilder::with_capacity(cs.row_len);
+                    bb.append_n(cs.row_len, ne_null_fill);
+                    bool_parts.push(bb.finish());
                 } else {
                     // For non-empty patterns, ilike/nilike return null on null inputs.
                     bool_parts.push(BooleanArray::new_null(cs.row_len));
@@ -1377,6 +1395,19 @@ fn compute_criteria_mask(
             }
             let nulls = bb.finish();
             m = boolean::or_kleene(&m, &nulls).ok()?;
+        } else if text_kind == 1 && m.null_count() > 0 {
+            // `<>X`: `nilike` yields NULL for blank/Empty cells (NULL NOT ILIKE 'x' -> NULL).
+            // Excel counts a blank as satisfying `<>X`, so replace those NULLs with the
+            // `<>`-vs-blank verdict (`ne_null_fill`) rather than dropping the rows (issue #158).
+            let mut bb = BooleanBuilder::with_capacity(m.len());
+            for i in 0..m.len() {
+                if m.is_valid(i) {
+                    bb.append_value(m.value(i));
+                } else {
+                    bb.append_value(ne_null_fill);
+                }
+            }
+            m = bb.finish();
         }
 
         bool_parts.push(m);

--- a/crates/formualizer-eval/src/engine/tests/criteria_mask_text_chunked.rs
+++ b/crates/formualizer-eval/src/engine/tests/criteria_mask_text_chunked.rs
@@ -47,13 +47,19 @@ fn criteria_mask_text_is_built_per_chunk_and_handles_empty_string_semantics() {
         assert!(mask_eq.value(i));
     }
 
-    // Ne("") should yield all nulls on an all-empty column (nilike(null, "") == null).
+    // Ne("") i.e. `<>` means "non-blank". A blank cell equals the empty string, so it
+    // does NOT satisfy `<>`. Arrow's nilike(null, "") returns NULL, but the correct
+    // spreadsheet verdict is a definite FALSE (issue #158 fix fills the blank verdict),
+    // so the mask is all-valid / all-false on an all-empty column.
     let pred_ne_empty = crate::args::parse_criteria(&LiteralValue::Text("<>".into())).unwrap();
     let mask_ne = engine
         .build_criteria_mask(&view, 0, &pred_ne_empty)
         .expect("mask");
     assert_eq!(mask_ne.len(), total_rows as usize);
-    assert_eq!(mask_ne.null_count(), total_rows as usize);
+    assert_eq!(mask_ne.null_count(), 0);
+    for i in 0..mask_ne.len() {
+        assert!(!mask_ne.value(i), "blank must not satisfy <>");
+    }
 
     // Ensure we actually walked chunks and hit the all-null segment fast path.
     let (segments_total, segments_all_null) =

--- a/crates/formualizer-eval/src/engine/tests/criteria_notequal_blank.rs
+++ b/crates/formualizer-eval/src/engine/tests/criteria_notequal_blank.rs
@@ -1,0 +1,254 @@
+//! Regression tests for issue #158: `<>X` criteria must count blank/Empty cells.
+//!
+//! In Excel/LibreOffice a blank cell equals the empty string, so a blank
+//! SATISFIES `<>X` (blank != "X" is TRUE) and must be counted by SUMIFS/SUMIF/
+//! COUNTIFS/AVERAGEIFS. The Arrow-vectorized criteria-mask path used Arrow's
+//! `nilike`, which returns NULL (not TRUE) for NULL/blank inputs, so blanks were
+//! silently dropped — under-counting `<>X`.
+//!
+//! The fix is bounded to the criteria range's materialized/used region: a finite
+//! range counts its interior blanks, but a whole-column `A:A` reference must NOT
+//! count the ~1M trailing empty cells (that would be a catastrophic regression).
+
+use super::common::arrow_eval_config;
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn num(engine: &mut Engine<TestWorkbook>, formula: &str) -> LiteralValue {
+    let ast = parse(formula).unwrap();
+    // Put the formula well away from the data columns/rows so whole-column refs
+    // are not self-inclusive (would be circular per #120).
+    engine.set_cell_formula("Sheet1", 1, 20, ast).unwrap();
+    engine.evaluate_cell("Sheet1", 1, 20).unwrap();
+    engine.get_cell_value("Sheet1", 1, 20).unwrap()
+}
+
+/// The exact #158 repro on FINITE explicit ranges with A2 left blank:
+///   A1="Debt" B1=10 ; A2=blank B2=20 ; A3="Equity" B3=30
+fn setup_finite(engine: &mut Engine<TestWorkbook>) {
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Text("Debt".into()))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 2, LiteralValue::Number(10.0))
+        .unwrap();
+    // Row 2 col A intentionally left blank.
+    engine
+        .set_cell_value("Sheet1", 2, 2, LiteralValue::Number(20.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 3, 1, LiteralValue::Text("Equity".into()))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 3, 2, LiteralValue::Number(30.0))
+        .unwrap();
+}
+
+#[test]
+fn issue_158_finite_range_counts_interior_blank_for_ne() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    setup_finite(&mut engine);
+
+    // Excel: 50 (blank row 20 + Equity 30). Bug produced 30.
+    assert_eq!(
+        num(&mut engine, "=SUMIFS(B1:B3, A1:A3, \"<>Debt\")"),
+        LiteralValue::Number(50.0),
+        "SUMIFS <>Debt must include the blank row"
+    );
+
+    // Excel: 2 (blank + Equity). Bug produced 1.
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"<>Debt\")"),
+        LiteralValue::Number(2.0),
+        "COUNTIFS <>Debt must count the blank cell"
+    );
+
+    // Excel: 50. Bug produced 30.
+    assert_eq!(
+        num(&mut engine, "=SUMIF(A1:A3, \"<>Debt\", B1:B3)"),
+        LiteralValue::Number(50.0),
+        "SUMIF <>Debt must include the blank row"
+    );
+
+    // AVERAGEIFS over the two matching rows: (20 + 30) / 2 = 25.
+    assert_eq!(
+        num(&mut engine, "=AVERAGEIFS(B1:B3, A1:A3, \"<>Debt\")"),
+        LiteralValue::Number(25.0),
+        "AVERAGEIFS <>Debt must average blank + Equity rows"
+    );
+}
+
+#[test]
+fn ne_empty_operator_does_not_count_blanks() {
+    // `<>` (empty pattern) means "non-blank": a blank cell must NOT match.
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    setup_finite(&mut engine);
+
+    // Only the two populated rows (Debt=10, Equity=30) match `<>`; blank excluded.
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"<>\")"),
+        LiteralValue::Number(2.0),
+        "<> must count non-blank cells only"
+    );
+    assert_eq!(
+        num(&mut engine, "=SUMIFS(B1:B3, A1:A3, \"<>\")"),
+        LiteralValue::Number(40.0),
+        "<> sums Debt+Equity rows (10+30), not the blank row"
+    );
+}
+
+#[test]
+fn empty_string_and_equality_semantics_on_blanks() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    setup_finite(&mut engine);
+
+    // "" and "=" match blanks (blank == empty string).
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"\")"),
+        LiteralValue::Number(1.0),
+        "empty-string criteria matches the single blank cell"
+    );
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"=\")"),
+        LiteralValue::Number(1.0),
+        "\"=\" matches the single blank cell"
+    );
+
+    // "Debt" / "=Debt" match the populated cell only, never the blank.
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"Debt\")"),
+        LiteralValue::Number(1.0),
+    );
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"=Debt\")"),
+        LiteralValue::Number(1.0),
+    );
+}
+
+#[test]
+fn numeric_predicates_still_exclude_blanks() {
+    // Excel does not count blanks for numeric comparisons like >0; confirm the
+    // #158 fix (scoped to the `<>` text path) leaves this unchanged.
+    //   A1=5 A2=blank A3=-3
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(5.0))
+        .unwrap();
+    // A2 blank.
+    engine
+        .set_cell_value("Sheet1", 3, 1, LiteralValue::Number(-3.0))
+        .unwrap();
+
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \">0\")"),
+        LiteralValue::Number(1.0),
+        ">0 must not count the blank cell"
+    );
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"<5\")"),
+        LiteralValue::Number(1.0),
+        "<5 counts only -3, not the blank"
+    );
+}
+
+#[test]
+fn wildcard_ne_on_blanks_matches_excel() {
+    //   A1="apple" A2=blank A3="apricot"
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Text("apple".into()))
+        .unwrap();
+    // A2 blank.
+    engine
+        .set_cell_value("Sheet1", 3, 1, LiteralValue::Text("apricot".into()))
+        .unwrap();
+
+    // "ap*" matches the two populated cells; blank does not match a wildcard.
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A3, \"ap*\")"),
+        LiteralValue::Number(2.0),
+    );
+}
+
+#[test]
+fn multi_criteria_ne_with_blanks() {
+    // Combine a `<>` criterion (that should include a blank) with a second
+    // numeric criterion. Row 2 has a blank category but a matching amount.
+    //   A (category): "Debt", blank, "Equity", "Debt"
+    //   B (amount):    10,      20,    30,       40
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    let cats = [Some("Debt"), None, Some("Equity"), Some("Debt")];
+    let amts = [10.0, 20.0, 30.0, 40.0];
+    for (i, (cat, amt)) in cats.iter().zip(amts.iter()).enumerate() {
+        let row = (i + 1) as u32;
+        if let Some(c) = cat {
+            engine
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Text((*c).into()))
+                .unwrap();
+        }
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(*amt))
+            .unwrap();
+    }
+
+    // <>Debt AND amount >= 20 : rows 2 (blank, 20) and 3 (Equity, 30) qualify.
+    assert_eq!(
+        num(
+            &mut engine,
+            "=SUMIFS(B1:B4, A1:A4, \"<>Debt\", B1:B4, \">=20\")"
+        ),
+        LiteralValue::Number(50.0),
+        "multi-criteria <> must include the blank-category row"
+    );
+    assert_eq!(
+        num(&mut engine, "=COUNTIFS(A1:A4, \"<>Debt\", B1:B4, \">=20\")"),
+        LiteralValue::Number(2.0),
+    );
+}
+
+#[test]
+fn whole_column_ne_does_not_explode() {
+    // Whole-column `A:A` reference: `<>Debt` must be bounded to the used region,
+    // NOT count the ~1M trailing empty cells. Uses bulk-ingest so the cached
+    // Arrow criteria-mask path (build_criteria_mask/compute_criteria_mask) runs.
+    let mut cfg = arrow_eval_config();
+    cfg.enable_parallel = false;
+    cfg.range_expansion_limit = 2_000_000; // allow whole-column expansion
+    let mut engine = Engine::new(TestWorkbook::new(), cfg);
+
+    // Populate 128 rows across two chunks: category col A, amount col B.
+    // Interior blanks in A at a few rows; last populated row sets the used region.
+    let chunk_rows = 64usize;
+    let total_rows = 128u32;
+    {
+        let mut ab = engine.begin_bulk_ingest_arrow();
+        ab.add_sheet("Sheet1", 2, chunk_rows);
+        for i in 0..total_rows {
+            // "Debt" every 4th row; blank at rows where i%4==1; else "Equity".
+            let a = match i % 4 {
+                0 => LiteralValue::Text("Debt".into()),
+                1 => LiteralValue::Empty, // interior blank
+                _ => LiteralValue::Text("Equity".into()),
+            };
+            let b = LiteralValue::Int((i + 1) as i64);
+            ab.append_row("Sheet1", &[a, b]).unwrap();
+        }
+        ab.finish().unwrap();
+    }
+
+    // Count of rows: i%4 == 0 => Debt (32 rows). Everything else is <>Debt:
+    // 128 - 32 = 96 rows (including the 32 interior blanks). It must NOT explode
+    // to ~1,048,544.
+    let count = num(&mut engine, "=COUNTIFS(A:A, \"<>Debt\")");
+    assert_eq!(
+        count,
+        LiteralValue::Number(96.0),
+        "whole-column <>Debt must count only used-region rows (incl. interior blanks), not 1M blanks"
+    );
+
+    // And the interior blanks ARE included: compare against the same finite range.
+    let finite = num(&mut engine, "=COUNTIFS(A1:A128, \"<>Debt\")");
+    assert_eq!(finite, LiteralValue::Number(96.0));
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -97,6 +97,7 @@ mod countifs_arrow_overlay;
 mod countifs_date_criteria;
 mod criteria_mask_oob_column;
 mod criteria_mask_text_chunked;
+mod criteria_notequal_blank;
 mod criteria_overlay_parity;
 mod custom_function_registry_compat;
 mod dynamic_lookup_arrow;


### PR DESCRIPTION
Fixes #158.

## Problem

A `"<>X"` criterion in SUMIFS/SUMIF/COUNTIFS/AVERAGEIFS silently excluded blank cells. In Excel and LibreOffice a blank equals the empty string, so a blank satisfies `<>X` (blank ≠ "X" is TRUE) and must be counted. Any aggregation that excludes a category via `<>` over a column with blank rows was under-counting.

## Root cause

`compute_criteria_mask` (the Arrow-vectorized cached criteria-mask builder in `crates/formualizer-eval/src/engine/eval.rs`) evaluates `<>X` text criteria with Arrow's `nilike`. Arrow follows SQL null semantics: `NULL NOT ILIKE 'x'` yields NULL, not TRUE. Blank/Empty cells are NULL in the lowered-text column, and the mask consumer counts only valid-and-true, so every blank was dropped. `criteria_match` itself was already correct (`Ne("Debt")` vs `Empty` returns true) — the non-cached fallback path was fine — but these formulas take the cached vectorized path, which is where the bug lived.

## Fix

In the `Ne(Text)` path, replace the `nilike`-produced NULLs (and the all-blank-segment NULL fast path) with the exact `<>`-vs-blank verdict, computed once from the pattern:

- `<>X` (non-empty pattern): a blank does not equal "X" → fill TRUE (blank counts)
- `<>` (empty pattern, i.e. "non-blank"): a blank equals "" → fill FALSE (blank does not count)

The per-cell fill only runs on chunks where `null_count() > 0`; blank-free chunks stay on the fully vectorized `nilike` path untouched, and an all-blank segment fills a constant. Numeric criteria, `Eq`, and wildcard paths are byte-identical to before.

## Finite range vs whole column

The important boundary: a blank satisfying `<>X` is correct for a finite range like `A1:A3`, but a whole-column `A:A` reference must not count the ~1M trailing empty cells. The fill is applied inside `iter_row_chunks`, which clamps iteration to the sheet's used rows, and `build_criteria_mask` returns an empty mask for views starting past the used region. So `<>` blank-inclusion is naturally scoped to the materialized region: `COUNTIFS(A1:A3,"<>Debt")` counts its interior blank, while `COUNTIFS(A:A,"<>Debt")` counts only used-region rows and never explodes. Both are pinned by tests.

## Behavior on a blank cell (pinned)

- `<>X` (non-empty): counts — this was the bug
- `<>` (non-blank): does not count
- `""` / `"="`: counts
- `"X"` / `"=X"`: does not count
- `>0`, `<5` (numeric): does not count (Excel doesn't count blanks for numeric comparisons — left unchanged)
- `ap*` (wildcard): does not count

## Tests

New `criteria_notequal_blank.rs` (7 tests): the exact #158 repro on finite ranges (SUMIFS=50, COUNTIFS=2, SUMIF=50, AVERAGEIFS=25), `<>` excluding blanks, empty-string/equality semantics, numeric predicates still excluding blanks, wildcard, multi-criteria with a blank-category row, and the whole-column non-explosion (bulk Arrow ingest → cached mask path → 96, matching the finite range, not ~1M). One existing test (`criteria_mask_text_chunked`) had a stale assertion that encoded the old all-NULL behavior for `<>` on an all-empty column; corrected to the definite all-false verdict.

fmt / clippy (`-D warnings`) / full workspace test suite all clean.
