### PR TITLE
fix: SUMIFS/COUNTIFS/SUMIF <>text criteria should match blank cells (#158)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1326,6 +1326,7 @@ fn compute_criteria_mask(
         _ => return None,
     };
 
+    let ne_matches_blank = text_kind == 1 && !text_pat.is_empty();
     let pat = StringArray::new_scalar(text_pat);
     let mut bool_parts: Vec<BooleanArray> = Vec::new();
 
@@ -1348,7 +1349,7 @@ fn compute_criteria_mask(
             None => {
                 #[cfg(test)]
                 criteria_mask_test_hooks::inc_all_null();
-                if text_kind == 0 && empty_special {
+                if (text_kind == 0 && empty_special) || ne_matches_blank {
                     // Eq("") treats nulls (Empty) as equal.
                     let mut bb = BooleanBuilder::with_capacity(cs.row_len);
                     bb.append_n(cs.row_len, true);
@@ -1369,7 +1370,7 @@ fn compute_criteria_mask(
             _ => return None,
         };
 
-        if text_kind == 0 && empty_special {
+        if (text_kind == 0 && empty_special) || ne_matches_blank {
             // Treat nulls as equal to empty string
             let mut bb = BooleanBuilder::with_capacity(seg_sa.len());
             for i in 0..seg_sa.len() {

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -135,6 +135,7 @@ mod sumif_arrow_used_bounds;
 mod sumifs_arrow_edits;
 mod sumifs_arrow_fastpath;
 mod sumifs_cached_mask_padding;
+mod sumifs_ne_blank_158;
 mod used_bounds_cache;
 mod whole_column_sumifs;
 

--- a/crates/formualizer-eval/src/engine/tests/sumifs_ne_blank_158.rs
+++ b/crates/formualizer-eval/src/engine/tests/sumifs_ne_blank_158.rs
@@ -1,0 +1,107 @@
+use super::common::arrow_eval_config;
+use crate::engine::Engine;
+use crate::test_workbook::TestWorkbook;
+use crate::traits::{ArgumentHandle, DefaultFunctionContext, FunctionProvider};
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
+
+fn range_ref(sheet: &str, sr: u32, sc: u32, er: u32, ec: u32) -> ASTNode {
+    let r = ReferenceType::range(
+        Some(sheet.to_string()),
+        Some(sr),
+        Some(sc),
+        Some(er),
+        Some(ec),
+    );
+    ASTNode::new(
+        ASTNodeType::Reference {
+            original: String::new(),
+            reference: r,
+        },
+        None,
+    )
+}
+
+fn lit_text(s: &str) -> ASTNode {
+    ASTNode::new(ASTNodeType::Literal(LiteralValue::Text(s.into())), None)
+}
+
+fn engine_with_debt_blank_equity() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), arrow_eval_config());
+    let mut ab = engine.begin_bulk_ingest_arrow();
+    ab.add_sheet("Sheet1", 2, 8);
+    ab.append_row(
+        "Sheet1",
+        &[LiteralValue::Text("Debt".into()), LiteralValue::Int(10)],
+    )
+    .unwrap();
+    ab.append_row("Sheet1", &[LiteralValue::Empty, LiteralValue::Int(20)])
+        .unwrap();
+    ab.append_row(
+        "Sheet1",
+        &[LiteralValue::Text("Equity".into()), LiteralValue::Int(30)],
+    )
+    .unwrap();
+    ab.finish().unwrap();
+    engine
+}
+
+#[test]
+fn sumifs_ne_text_includes_blank_criteria_cell() {
+    let engine = engine_with_debt_blank_equity();
+    let sum_rng = range_ref("Sheet1", 1, 2, 3, 2);
+    let crit_rng = range_ref("Sheet1", 1, 1, 3, 1);
+    let crit = lit_text("<>Debt");
+
+    let fun = engine.get_function("", "SUMIFS").expect("SUMIFS available");
+    let interp = crate::interpreter::Interpreter::new(&engine, "Sheet1");
+    let args = vec![
+        ArgumentHandle::new(&sum_rng, &interp),
+        ArgumentHandle::new(&crit_rng, &interp),
+        ArgumentHandle::new(&crit, &interp),
+    ];
+    let fctx = DefaultFunctionContext::new_with_sheet(&engine, None, engine.default_sheet_name());
+    let got = fun.dispatch(&args, &fctx).unwrap().into_literal();
+
+    assert_eq!(got, LiteralValue::Number(50.0));
+}
+
+#[test]
+fn countifs_ne_text_includes_blank_criteria_cell() {
+    let engine = engine_with_debt_blank_equity();
+    let crit_rng = range_ref("Sheet1", 1, 1, 3, 1);
+    let crit = lit_text("<>Debt");
+
+    let fun = engine
+        .get_function("", "COUNTIFS")
+        .expect("COUNTIFS available");
+    let interp = crate::interpreter::Interpreter::new(&engine, "Sheet1");
+    let args = vec![
+        ArgumentHandle::new(&crit_rng, &interp),
+        ArgumentHandle::new(&crit, &interp),
+    ];
+    let fctx = DefaultFunctionContext::new_with_sheet(&engine, None, engine.default_sheet_name());
+    let got = fun.dispatch(&args, &fctx).unwrap().into_literal();
+
+    assert_eq!(got, LiteralValue::Number(2.0));
+}
+
+#[test]
+fn sumif_ne_text_includes_blank_criteria_cell() {
+    let engine = engine_with_debt_blank_equity();
+    let crit_rng = range_ref("Sheet1", 1, 1, 3, 1);
+    let crit = lit_text("<>Debt");
+    let sum_rng = range_ref("Sheet1", 1, 2, 3, 2);
+
+    let fun = engine.get_function("", "SUMIF").expect("SUMIF available");
+    let interp = crate::interpreter::Interpreter::new(&engine, "Sheet1");
+    let args = vec![
+        ArgumentHandle::new(&crit_rng, &interp),
+        ArgumentHandle::new(&crit, &interp),
+        ArgumentHandle::new(&sum_rng, &interp),
+    ];
+    let fctx = DefaultFunctionContext::new_with_sheet(&engine, None, engine.default_sheet_name());
+    let got = fun.dispatch(&args, &fctx).unwrap().into_literal();
+
+    assert_eq!(got, LiteralValue::Number(50.0));
+}


### PR DESCRIPTION
## Summary

Fixes #158. A `<>value` criterion in `SUMIFS` / `SUMIF` / `COUNTIFS` now matches empty/blank cells, aligning with Excel and LibreOffice where a blank cell satisfies `<> "value"` (blank ≠ `"value"` is TRUE).

## Root cause

`compute_criteria_mask` in `crates/formualizer-eval/src/engine/eval.rs` builds not-equal text masks with `nilike`, which returns **null** for blank (null) input cells. Null mask entries are then treated as "no match" when the aggregation sums/counts, so blank-criteria rows were silently dropped from any `<>text` aggregation.

## Fix

For not-equal text predicates with a **non-empty** pattern, blanks are now treated as matching (`true`) - both for all-null segments and for individual null cells within a text segment. `<>""` (the "not blank" case) is deliberately left unchanged, so a blank still does not match `<>""`.

Diff is 3 lines in `eval.rs`.

## Tests

Added `crates/formualizer-eval/src/engine/tests/sumifs_ne_blank_158.rs` reproducing the issue (Debt / blank / Equity rows) through the Arrow evaluation path:

| Case | Before | After (expected, Excel/LibreOffice) |
|---|---|---|
| `SUMIFS(B, A, "<>Debt")` | 30 | 50 |
| `COUNTIFS(A, "<>Debt")` | 1 | 2 |
| `SUMIF(A, "<>Debt", B)` | 30 | 50 |

`cargo fmt --all --check`, `cargo clippy -p formualizer-eval --all-targets -- -D warnings`, and the `formualizer-eval` lib tests all pass (the pre-existing `IMEXP`/`IMSIN`/`IMCOS` ULP test failures are unrelated to this change).

---

Prepared with AI assistance and reviewed by the author.
