### PR TITLE
feat(formula-plane): SpanShiftPlan::Split — spans survive mid-domain row inserts (~13x structural ops)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4523,6 +4523,26 @@ where
             force_binding_residual_axes: bool,
         }
 
+        /// Split a straddled span into an unshifted upper half (which keeps the
+        /// span id via `replace_span_geometry`) and a shifted lower half (a
+        /// fresh span). Domains and origins here are POST-insert for the lower
+        /// half, mirroring `ShiftPlan`.
+        struct SplitPlan {
+            span_ref: FormulaSpanRef,
+            sheet_id: SheetId,
+            template_id: crate::formula_plane::ids::FormulaTemplateId,
+            binding_set_id: Option<crate::formula_plane::runtime::SpanBindingSetId>,
+            is_constant_result: bool,
+            upper_domain: crate::formula_plane::runtime::PlacementDomain,
+            upper_read_summary: Option<SpanReadSummary>,
+            lower_new_origin_row: u32,
+            lower_new_origin_col: u32,
+            lower_new_domain: crate::formula_plane::runtime::PlacementDomain,
+            lower_new_read_summary: Option<SpanReadSummary>,
+            lower_force_binding_residual_axes: bool,
+            lower_overlay_refs: Vec<crate::formula_plane::runtime::FormulaOverlayRef>,
+        }
+
         fn checked_shift_u32(value: u32, delta: i64) -> Option<u32> {
             u32::try_from(i64::from(value).checked_add(delta)?).ok()
         }
@@ -4732,6 +4752,173 @@ where
             })
         }
 
+        /// Re-derive a span read summary for a sub-domain of the original
+        /// result region by replaying each retained projection rule against
+        /// the half's result region — the same derivation ingest performs in
+        /// `SpanReadSummary::from_formula_summary`, minus the dependency
+        /// re-analysis. Returns None (caller demotes) when any rule cannot
+        /// produce explicit read regions.
+        fn rederive_read_summary_for_result(
+            read_summary: &SpanReadSummary,
+            result_region: Region,
+        ) -> Option<SpanReadSummary> {
+            let mut dependencies = Vec::with_capacity(read_summary.dependencies.len());
+            for dependency in &read_summary.dependencies {
+                let sheet_id = dependency.read_region.sheet_id();
+                let read_regions = dependency
+                    .projection
+                    .read_regions_for_result(sheet_id, result_region)
+                    .ok()?;
+                for read_region in read_regions {
+                    let dependency = crate::formula_plane::producer::SpanReadDependency {
+                        read_region,
+                        projection: dependency.projection,
+                    };
+                    if !dependencies.contains(&dependency) {
+                        dependencies.push(dependency);
+                    }
+                }
+            }
+            Some(SpanReadSummary {
+                result_region,
+                dependencies,
+            })
+        }
+
+        /// Plan a conservative span split for a mid-domain insert. Returns
+        /// None whenever the split is not provably clean — missing template,
+        /// masked span, non-trivial literal bindings, an unsplittable domain,
+        /// a half that does not re-classify to NoOp (upper) / Shift (lower),
+        /// or an overlay punch-out that straddles the boundary — in which case
+        /// the caller falls back to demoting the whole span.
+        fn plan_span_split(
+            authority: &crate::formula_plane::authority::FormulaAuthority,
+            span: &crate::formula_plane::runtime::FormulaSpan,
+            span_ref: FormulaSpanRef,
+            read_summary: Option<&SpanReadSummary>,
+            op: StructuralOp,
+        ) -> Option<SplitPlan> {
+            use crate::formula_plane::structural_shift::{AxisShiftCase, split_domain_at};
+
+            if span.intrinsic_mask_id.is_some() {
+                // v1 does not slice intrinsic masks.
+                return None;
+            }
+            let binding_set = span
+                .binding_set_id
+                .and_then(|id| authority.plane.binding_sets.get(id));
+            if binding_set.is_some_and(|binding_set| !binding_set.is_single_literal_binding()) {
+                // Dictionary/affine per-placement literal bindings are keyed by
+                // domain ordinal; splitting re-bases the lower half's ordinals.
+                // Only trivially-uniform bindings are safe to carry across.
+                return None;
+            }
+
+            let (upper_domain, lower_domain) = split_domain_at(&span.domain, op)?;
+            let upper_result_region = Region::from_domain(&upper_domain);
+            let lower_result_region = Region::from_domain(&lower_domain);
+            let (upper_read_summary, lower_read_summary) = match read_summary {
+                Some(summary) => (
+                    Some(rederive_read_summary_for_result(
+                        summary,
+                        upper_result_region,
+                    )?),
+                    Some(rederive_read_summary_for_result(
+                        summary,
+                        lower_result_region,
+                    )?),
+                ),
+                None => (None, None),
+            };
+
+            // Re-classify each half in the pre-insert frame. The upper half
+            // must be a strict no-op (unshifted result, unshifted reads); the
+            // lower half must be a clean whole-span shift.
+            let upper_span = crate::formula_plane::runtime::FormulaSpan {
+                domain: upper_domain.clone(),
+                result_region: ResultRegion::scalar_cells(upper_domain.clone()),
+                ..span.clone()
+            };
+            if classify_span_for_op(&upper_span, upper_read_summary.as_ref(), op)
+                != SpanShiftPlan::NoOp
+            {
+                return None;
+            }
+            let lower_span = crate::formula_plane::runtime::FormulaSpan {
+                domain: lower_domain.clone(),
+                result_region: ResultRegion::scalar_cells(lower_domain.clone()),
+                ..span.clone()
+            };
+            let SpanShiftPlan::Shift {
+                row_delta,
+                col_delta,
+                origin_row_delta,
+                origin_col_delta,
+            } = classify_span_for_op(&lower_span, lower_read_summary.as_ref(), op)
+            else {
+                return None;
+            };
+
+            let template = authority.plane.templates.get(span.template_id)?;
+            let lower_new_origin_row = checked_shift_u32(template.origin_row, origin_row_delta)?;
+            let lower_new_origin_col = checked_shift_u32(template.origin_col, origin_col_delta)?;
+            let lower_new_domain = lower_domain.project_through_axis_shift(row_delta, col_delta)?;
+            let lower_new_result_region = Region::from_domain(&lower_new_domain);
+            let lower_new_read_summary = match lower_read_summary.as_ref() {
+                Some(summary) => Some(shifted_read_summary(
+                    summary,
+                    lower_new_result_region,
+                    op,
+                    row_delta,
+                    col_delta,
+                )?),
+                None => None,
+            };
+
+            // Overlay punch-outs sourced from this span: entries entirely
+            // before the boundary stay with the (id-retaining) upper half;
+            // entries at/after the boundary transfer to the new lower span.
+            // A straddling entry means the split is not clean.
+            let mut lower_overlay_refs = Vec::new();
+            for overlay_ref in authority
+                .plane
+                .formula_overlay
+                .refs_for_source_span(span_ref)
+            {
+                let entry = authority.plane.formula_overlay.get(overlay_ref)?;
+                match op.classify_region(Region::from_domain(&entry.domain)) {
+                    AxisShiftCase::OtherSheet | AxisShiftCase::EntirelyBelow => {}
+                    AxisShiftCase::EntirelyAboveShift { .. } => {
+                        lower_overlay_refs.push(overlay_ref);
+                    }
+                    AxisShiftCase::Straddles | AxisShiftCase::DeleteFullyContains => {
+                        return None;
+                    }
+                }
+            }
+
+            let lower_force_binding_residual_axes = binding_set.is_some_and(|binding_set| {
+                !binding_set.value_ref_slots.is_empty()
+                    && (origin_row_delta != 0 || origin_col_delta != 0)
+            });
+
+            Some(SplitPlan {
+                span_ref,
+                sheet_id: span.sheet_id,
+                template_id: span.template_id,
+                binding_set_id: span.binding_set_id,
+                is_constant_result: span.is_constant_result,
+                upper_domain,
+                upper_read_summary,
+                lower_new_origin_row,
+                lower_new_origin_col,
+                lower_new_domain,
+                lower_new_read_summary,
+                lower_force_binding_residual_axes,
+                lower_overlay_refs,
+            })
+        }
+
         fn domain_origin_1_based(domain: &PlacementDomain) -> (u32, u32) {
             match domain {
                 PlacementDomain::RowRun { row_start, col, .. } => (row_start + 1, col + 1),
@@ -4745,6 +4932,7 @@ where
         }
 
         let mut shift_plans = Vec::new();
+        let mut split_plans = Vec::new();
         let mut remove_refs = Vec::new();
         let mut demote_refs = Vec::new();
         for span_ref in span_refs {
@@ -4832,6 +5020,14 @@ where
                 SpanShiftPlan::Demote { .. } => {
                     demote_refs.push(span_ref);
                 }
+                SpanShiftPlan::Split => {
+                    match plan_span_split(authority, span, span_ref, read_summary, op) {
+                        Some(plan) => split_plans.push(plan),
+                        // Not provably clean: demote the whole span (the
+                        // pre-split conservative path).
+                        None => demote_refs.push(span_ref),
+                    }
+                }
                 SpanShiftPlan::Shift {
                     row_delta,
                     col_delta,
@@ -4903,7 +5099,7 @@ where
                 }
             }
         }
-        if !shift_plans.is_empty() || !remove_refs.is_empty() {
+        if !shift_plans.is_empty() || !split_plans.is_empty() || !remove_refs.is_empty() {
             let authority = self.graph.formula_authority_mut();
             for span_ref in remove_refs {
                 authority.plane.remove_overlays_for_source_span(span_ref);
@@ -4961,6 +5157,115 @@ where
                     // to per-placement work rather than broadcasting stale
                     // representative values.
                     authority.plane.force_binding_residual_axes(binding_set_id);
+                }
+            }
+            for plan in split_plans {
+                // Lower half: a fresh span at the POST-insert coordinates,
+                // mirroring the Shift arm's template/binding handling.
+                let Some(lower_template_id) = authority.plane.intern_shifted_template_origin(
+                    plan.template_id,
+                    plan.lower_new_origin_row,
+                    plan.lower_new_origin_col,
+                ) else {
+                    return Err(ExcelError::new(ExcelErrorKind::Ref)
+                        .with_message("FormulaPlane split could not clone template origin")
+                        .into());
+                };
+                let lower_binding_set_id = if let Some(binding_set_id) = plan.binding_set_id {
+                    let Some(source) = authority.plane.binding_sets.get(binding_set_id) else {
+                        return Err(ExcelError::new(ExcelErrorKind::Ref)
+                            .with_message(
+                                "FormulaPlane split found a span with a missing binding set",
+                            )
+                            .into());
+                    };
+                    // Safe to clone wholesale: `plan_span_split` only accepts
+                    // single-literal-binding sets, whose per-placement lookups
+                    // are ordinal-independent.
+                    let clone = source.clone();
+                    let new_binding_set_id = authority.plane.insert_binding_set(clone);
+                    let Some(template) = authority.plane.templates.get(lower_template_id) else {
+                        return Err(ExcelError::new(ExcelErrorKind::Ref)
+                            .with_message("FormulaPlane split could not find shifted template")
+                            .into());
+                    };
+                    let (ast_id, origin_row, origin_col) =
+                        (template.ast_id, template.origin_row, template.origin_col);
+                    authority.plane.set_binding_template_anchor(
+                        new_binding_set_id,
+                        ast_id,
+                        origin_row,
+                        origin_col,
+                    );
+                    Some(new_binding_set_id)
+                } else {
+                    None
+                };
+                let lower_read_summary_id = plan
+                    .lower_new_read_summary
+                    .map(|summary| authority.plane.insert_span_read_summary(summary));
+                let lower_result_region = ResultRegion::scalar_cells(plan.lower_new_domain.clone());
+                let lower_ref =
+                    authority
+                        .plane
+                        .insert_span(crate::formula_plane::runtime::NewFormulaSpan {
+                            sheet_id: plan.sheet_id,
+                            template_id: lower_template_id,
+                            domain: plan.lower_new_domain,
+                            result_region: lower_result_region,
+                            intrinsic_mask_id: None,
+                            read_summary_id: lower_read_summary_id,
+                            binding_set_id: lower_binding_set_id,
+                            is_constant_result: plan.is_constant_result,
+                        });
+                if let Some(binding_set_id) = lower_binding_set_id {
+                    authority
+                        .plane
+                        .set_binding_span_ref(binding_set_id, lower_ref);
+                    if plan.lower_force_binding_residual_axes {
+                        // Same contract as the Shift arm: a moved origin with
+                        // stationary value-ref precedents invalidates
+                        // placement-relative memoization keys.
+                        authority.plane.force_binding_residual_axes(binding_set_id);
+                    }
+                }
+                // The lower half inherits the parent's defined-name
+                // invalidation registrations; the upper half keeps them by
+                // retaining the span id.
+                let name_keys = authority.plane.span_registered_name_keys(plan.span_ref.id);
+                if !name_keys.is_empty() {
+                    authority
+                        .plane
+                        .register_span_name_dependents(lower_ref, &name_keys);
+                }
+                for overlay_ref in plan.lower_overlay_refs {
+                    if !authority
+                        .plane
+                        .set_overlay_source_span(overlay_ref, Some(lower_ref))
+                    {
+                        return Err(ExcelError::new(ExcelErrorKind::Ref)
+                            .with_message(
+                                "FormulaPlane split could not re-point overlay provenance",
+                            )
+                            .into());
+                    }
+                }
+                // Upper half: keep the span id, truncate the domain, and swap
+                // in a summary re-derived for the truncated result region.
+                let upper_read_summary_id = plan
+                    .upper_read_summary
+                    .map(|summary| authority.plane.insert_span_read_summary(summary));
+                let upper_result_region = ResultRegion::scalar_cells(plan.upper_domain.clone());
+                if !authority.plane.replace_span_geometry(
+                    plan.span_ref,
+                    plan.template_id,
+                    plan.upper_domain,
+                    upper_result_region,
+                    upper_read_summary_id,
+                ) {
+                    return Err(ExcelError::new(ExcelErrorKind::Ref)
+                        .with_message("FormulaPlane split could not update span geometry")
+                        .into());
                 }
             }
             authority.rebuild_indexes();

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4919,15 +4919,44 @@ where
             })
         }
 
-        fn domain_origin_1_based(domain: &PlacementDomain) -> (u32, u32) {
-            match domain {
-                PlacementDomain::RowRun { row_start, col, .. } => (row_start + 1, col + 1),
-                PlacementDomain::ColRun { row, col_start, .. } => (row + 1, col_start + 1),
-                PlacementDomain::Rect {
-                    row_start,
-                    col_start,
-                    ..
-                } => (row_start + 1, col_start + 1),
+        /// Carry a 1-based template origin coordinate through a delete of
+        /// `count` rows/columns starting at 0-based `start`. Returns None when
+        /// the delete removes the origin coordinate itself: the template's
+        /// relative reference deltas are anchored there, so the caller must
+        /// demote rather than guess a new anchor.
+        fn origin_coord_through_delete(origin: u32, start: u32, count: u32) -> Option<u32> {
+            let origin0 = origin.checked_sub(1)?;
+            let end = start.saturating_add(count);
+            if origin0 < start {
+                Some(origin)
+            } else if origin0 >= end {
+                Some(origin - count)
+            } else {
+                None
+            }
+        }
+
+        /// Carry the template origin through a delete instead of rebasing it
+        /// to the compacted domain's start. Rebasing is only correct when the
+        /// origin coincides with the domain start; split/shifted spans keep
+        /// their original origin (Shift{origin_delta: 0} convention), and a
+        /// head-overlapping delete moves the domain start away from the
+        /// origin, so rebasing silently re-anchors every relative read.
+        fn origin_through_delete(
+            origin_row: u32,
+            origin_col: u32,
+            op: StructuralOp,
+        ) -> Option<(u32, u32)> {
+            match op {
+                StructuralOp::DeleteRows { start, count, .. } => Some((
+                    origin_coord_through_delete(origin_row, start, count)?,
+                    origin_col,
+                )),
+                StructuralOp::DeleteColumns { start, count, .. } => Some((
+                    origin_row,
+                    origin_coord_through_delete(origin_col, start, count)?,
+                )),
+                StructuralOp::InsertRows { .. } | StructuralOp::InsertColumns { .. } => None,
             }
         }
 
@@ -4982,16 +5011,18 @@ where
                         } else {
                             None
                         };
-                        if read_summary.is_none() || new_read_summary.is_some() {
-                            let (new_origin_row, new_origin_col) = domain_origin_1_based(&new_domain);
-                            let Some(template) = authority.plane.templates.get(span.template_id)
-                            else {
-                                return Err(ExcelError::new(ExcelErrorKind::Ref)
-                                    .with_message(
-                                        "FormulaPlane delete compaction found a span with a missing template",
-                                    )
-                                    .into());
-                            };
+                        let Some(template) = authority.plane.templates.get(span.template_id) else {
+                            return Err(ExcelError::new(ExcelErrorKind::Ref)
+                                .with_message(
+                                    "FormulaPlane delete compaction found a span with a missing template",
+                                )
+                                .into());
+                        };
+                        let carried_origin =
+                            origin_through_delete(template.origin_row, template.origin_col, op);
+                        if (read_summary.is_none() || new_read_summary.is_some())
+                            && let Some((new_origin_row, new_origin_col)) = carried_origin
+                        {
                             let force_binding_residual_axes = span
                                 .binding_set_id
                                 .and_then(|id| authority.plane.binding_sets.get(id))

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -1232,3 +1232,137 @@ fn formula_plane_repeated_mid_span_row_inserts_stay_split_and_linear() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Delete compaction must carry the template origin (not rebase to the new
+// domain start), which the split path makes load-bearing: split lower halves
+// keep their original origin while their domain starts elsewhere.
+// ---------------------------------------------------------------------------
+
+fn span_off_engine() -> Engine<TestWorkbook> {
+    let cfg = EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::Off);
+    Engine::new(TestWorkbook::default(), cfg)
+}
+
+fn assert_value_parity(
+    span_on: &Engine<TestWorkbook>,
+    span_off: &Engine<TestWorkbook>,
+    rows: u32,
+    cols: u32,
+) {
+    for row in 1..=rows {
+        for col in 1..=cols {
+            assert_eq!(
+                span_on.get_cell_value("Sheet1", row, col),
+                span_off.get_cell_value("Sheet1", row, col),
+                "span-on/off divergence at row={row} col={col}"
+            );
+        }
+    }
+}
+
+#[test]
+fn formula_plane_split_then_inner_delete_matches_span_off_engine() {
+    // Split lower halves keep the original template origin (row 1) while
+    // their domain starts at the split boundary. A later delete strictly
+    // inside the lower half must carry that origin through compaction;
+    // rebasing it to the compacted domain start silently re-anchors every
+    // relative read (=A{p-41}*2 instead of =A{p}*2).
+    let mut span_on = build_single_formula_column_family(100);
+    let mut span_off = span_off_engine();
+    add_single_formula_column_family(&mut span_off, "Sheet1", 100);
+    span_off.evaluate_all().unwrap();
+
+    for engine in [&mut span_on, &mut span_off] {
+        engine.insert_rows("Sheet1", 40, 2).unwrap();
+        engine.delete_rows("Sheet1", 60, 2).unwrap();
+        engine.evaluate_all().unwrap();
+    }
+
+    // The upper half stays put and the lower half compacts in place: the
+    // sequence never materializes legacy vertices on the span-on engine.
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(span_on.baseline_stats().graph_formula_vertex_count, 0);
+    assert_span_read_summaries_exact(&span_on);
+    assert_value_parity(&span_on, &span_off, 104, 2);
+}
+
+#[test]
+fn formula_plane_delete_overlapping_span_head_matches_span_off_engine() {
+    // A delete that starts above the span and cuts into its head moves the
+    // compacted domain start away from the template origin; the origin must
+    // not be rebased to the new start. The delete removes the origin row
+    // itself here, so the fixed path demotes rather than guessing an anchor.
+    let mut span_on = authoritative_engine();
+    let mut span_off = span_off_engine();
+    for engine in [&mut span_on, &mut span_off] {
+        let mut formulas = Vec::new();
+        for row in 1..=120 {
+            engine
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+        }
+        // Promotion requires at least 100 non-constant cells; anchor the span
+        // at row 5 so a delete starting at row 3 cuts into its head.
+        for row in 5..=120 {
+            formulas.push(record(engine, row, 2, &format!("=A{row}*2")));
+        }
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 1);
+
+    for engine in [&mut span_on, &mut span_off] {
+        engine.delete_rows("Sheet1", 3, 4).unwrap();
+        engine.evaluate_all().unwrap();
+    }
+
+    assert_value_parity(&span_on, &span_off, 120, 2);
+}
+
+#[test]
+fn formula_plane_mixed_read_row_insert_still_demotes() {
+    // v1 scope pin: a template with mixed reads (relative A{r}/B{r} shift with
+    // the block, absolute $F$1 stays put) does NOT split — the lower half
+    // classifies Demote(MixedReadRegionShift), so the whole span demotes
+    // exactly as before the split feature. Mixed-read splitting is a
+    // follow-up phase.
+    let mut engine = authoritative_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(3.0))
+        .unwrap();
+    let mut formulas = Vec::new();
+    for row in 1..=100 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(row as f64 + 1.0))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 3, &format!("=A{row}*B{row}*$F$1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+
+    engine.insert_rows("Sheet1", 40, 1).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 10, 3),
+        Some(LiteralValue::Number(10.0 * 11.0 * 3.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 41, 3),
+        Some(LiteralValue::Number(40.0 * 41.0 * 3.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 101, 3),
+        Some(LiteralValue::Number(100.0 * 101.0 * 3.0))
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -521,7 +521,11 @@ fn formula_plane_authoritative_row_insert_shifts_span_outputs_correctly() {
     let mut engine = build_single_formula_column_family(100);
 
     engine.insert_rows("Sheet1", 3, 1).unwrap();
-    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    // A mid-domain row insert splits the span at the boundary: the upper half
+    // keeps its rows in place, the lower half shifts down. No placement is
+    // materialized as a legacy graph formula.
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
     engine.evaluate_all().unwrap();
 
     assert_eq!(
@@ -859,4 +863,372 @@ fn formula_plane_origin_shift_with_stationary_value_ref_does_not_memo_broadcast_
         engine.get_cell_value("Sheet1", 50, 3),
         Some(LiteralValue::Number(51.0))
     );
+}
+
+// ---------------------------------------------------------------------------
+// Mid-domain insert span splitting (SpanShiftPlan::Split, conservative v1)
+// ---------------------------------------------------------------------------
+
+/// Seed a span with an absolute `$A$1` read directly into the authority
+/// plane. Engine batch ingest groups families per column (so it only ever
+/// produces RowRun spans); this helper lets structural tests exercise ColRun
+/// and Rect domains through the real engine insert path.
+fn seed_absolute_read_span(
+    engine: &mut Engine<TestWorkbook>,
+    formula: &str,
+    domain: crate::formula_plane::runtime::PlacementDomain,
+) {
+    use crate::formula_plane::producer::{
+        AxisProjection, DirtyProjectionRule, SpanReadDependency, SpanReadSummary,
+    };
+    use crate::formula_plane::region_index::Region;
+    use crate::formula_plane::runtime::{NewFormulaSpan, PlacementDomain, ResultRegion};
+
+    let ast = parse(formula).unwrap();
+    let ast_id = engine.intern_formula_ast(&ast);
+    let (origin_row, origin_col) = match &domain {
+        PlacementDomain::RowRun { row_start, col, .. } => (*row_start + 1, *col + 1),
+        PlacementDomain::ColRun { row, col_start, .. } => (*row + 1, *col_start + 1),
+        PlacementDomain::Rect {
+            row_start,
+            col_start,
+            ..
+        } => (*row_start + 1, *col_start + 1),
+    };
+    let authority = engine.graph.formula_authority_mut();
+    let template_id = authority.plane.intern_template(
+        Arc::<str>::from(format!("seeded:{formula}:{domain:?}")),
+        ast_id,
+        origin_row,
+        origin_col,
+        Some(Arc::<str>::from(formula)),
+    );
+    let result_region = Region::from_domain(&domain);
+    let summary = SpanReadSummary {
+        result_region,
+        dependencies: vec![SpanReadDependency {
+            read_region: Region::point(domain.sheet_id(), 0, 0),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Absolute { index: 0 },
+                col: AxisProjection::Absolute { index: 0 },
+            },
+        }],
+    };
+    let read_summary_id = authority.plane.insert_span_read_summary(summary);
+    authority.plane.insert_span(NewFormulaSpan {
+        sheet_id: domain.sheet_id(),
+        template_id,
+        result_region: ResultRegion::scalar_cells(domain.clone()),
+        domain,
+        intrinsic_mask_id: None,
+        read_summary_id: Some(read_summary_id),
+        binding_set_id: None,
+        is_constant_result: false,
+    });
+    authority.rebuild_indexes();
+}
+
+/// Every active span must retain a read summary whose `result_region` exactly
+/// equals the span's result region: `FormulaAuthority::rebuild_indexes` drops
+/// mismatched spans from the consumer read index silently, and the mixed
+/// scheduler treats the mismatch as a hard error.
+fn assert_span_read_summaries_exact(engine: &Engine<TestWorkbook>) {
+    use crate::formula_plane::region_index::Region;
+    let plane = &engine.graph.formula_authority().plane;
+    for span in plane.spans.active_spans() {
+        let result_region = Region::from_domain(span.result_region.domain());
+        let summary_id = span
+            .read_summary_id
+            .expect("split halves must retain read summaries");
+        let summary = plane
+            .span_read_summaries
+            .get(summary_id)
+            .expect("read summary id must resolve");
+        assert_eq!(
+            summary.result_region, result_region,
+            "span {:?} read summary result region must match span geometry",
+            span.id
+        );
+    }
+}
+
+#[test]
+fn formula_plane_row_insert_split_halves_have_exact_read_summaries() {
+    let mut engine = build_single_formula_column_family(100);
+
+    engine.insert_rows("Sheet1", 40, 2).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    assert_span_read_summaries_exact(&engine);
+
+    {
+        use crate::formula_plane::runtime::PlacementDomain;
+        let plane = &engine.graph.formula_authority().plane;
+        let mut domains: Vec<PlacementDomain> = plane
+            .spans
+            .active_spans()
+            .map(|span| span.domain.clone())
+            .collect();
+        domains.sort_by_key(|domain| match domain {
+            PlacementDomain::RowRun { row_start, .. } => *row_start,
+            _ => u32::MAX,
+        });
+        // 0-based: upper rows 0..=38 stay; lower rows 39..=99 shift by +2.
+        assert_eq!(domains[0], PlacementDomain::row_run(0, 0, 38, 1));
+        assert_eq!(domains[1], PlacementDomain::row_run(0, 41, 101, 1));
+    }
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 39, 2),
+        Some(LiteralValue::Number(78.0))
+    );
+    assert_eq!(engine.get_cell_value("Sheet1", 40, 2), None);
+    assert_eq!(engine.get_cell_value("Sheet1", 41, 2), None);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 42, 2),
+        Some(LiteralValue::Number(80.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 102, 2),
+        Some(LiteralValue::Number(200.0))
+    );
+
+    // The rederived summaries must keep driving precedent dirty propagation
+    // for both halves after the split.
+    engine
+        .set_cell_value("Sheet1", 10, 1, LiteralValue::Number(1000.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 50, 1, LiteralValue::Number(2000.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 10, 2),
+        Some(LiteralValue::Number(2000.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 50, 2),
+        Some(LiteralValue::Number(4000.0))
+    );
+}
+
+#[test]
+fn formula_plane_column_insert_splits_col_run_span_with_stationary_reads() {
+    use crate::formula_plane::runtime::PlacementDomain;
+    let mut engine = authoritative_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(21.0))
+        .unwrap();
+    // Engine batch ingest groups families per column, so ColRun spans never
+    // form through the public path; seed one directly through the authority
+    // plane to exercise the engine's structural split on the column axis.
+    seed_absolute_read_span(
+        &mut engine,
+        "=$A$1*2",
+        PlacementDomain::col_run(0, 0, 1, 100),
+    );
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 51),
+        Some(LiteralValue::Number(42.0))
+    );
+
+    // Insert before column 50 (1-based): straddles the col run. The read
+    // ($A$1) stays put, so the lower half shifts with a moving origin.
+    engine.insert_columns("Sheet1", 50, 1).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    assert_span_read_summaries_exact(&engine);
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 49),
+        Some(LiteralValue::Number(42.0))
+    );
+    assert_eq!(engine.get_cell_value("Sheet1", 1, 50), None);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 51),
+        Some(LiteralValue::Number(42.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 102),
+        Some(LiteralValue::Number(42.0))
+    );
+
+    // Both halves must still track the shared precedent.
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(20.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 102),
+        Some(LiteralValue::Number(20.0))
+    );
+}
+
+#[test]
+fn formula_plane_rect_span_row_insert_splits_into_two_rects() {
+    use crate::formula_plane::runtime::PlacementDomain;
+    let mut engine = authoritative_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(7.0))
+        .unwrap();
+    // Engine batch ingest groups families per column, so Rect spans never
+    // form through the public path; seed one directly through the authority
+    // plane to exercise the engine's structural split on a rect domain.
+    seed_absolute_read_span(
+        &mut engine,
+        "=$A$1+1",
+        PlacementDomain::rect(0, 0, 99, 1, 3),
+    );
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 50, 3),
+        Some(LiteralValue::Number(8.0))
+    );
+
+    engine.insert_rows("Sheet1", 50, 3).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    assert_span_read_summaries_exact(&engine);
+    {
+        let plane = &engine.graph.formula_authority().plane;
+        let mut domains: Vec<PlacementDomain> = plane
+            .spans
+            .active_spans()
+            .map(|span| span.domain.clone())
+            .collect();
+        domains.sort_by_key(|domain| match domain {
+            PlacementDomain::Rect { row_start, .. } => *row_start,
+            _ => u32::MAX,
+        });
+        assert_eq!(domains[0], PlacementDomain::rect(0, 0, 48, 1, 3));
+        assert_eq!(domains[1], PlacementDomain::rect(0, 52, 102, 1, 3));
+    }
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 49, 3),
+        Some(LiteralValue::Number(8.0))
+    );
+    assert_eq!(engine.get_cell_value("Sheet1", 50, 3), None);
+    assert_eq!(engine.get_cell_value("Sheet1", 52, 3), None);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 53, 3),
+        Some(LiteralValue::Number(8.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 103, 4),
+        Some(LiteralValue::Number(8.0))
+    );
+}
+
+#[test]
+fn formula_plane_row_insert_split_demotes_unique_literal_bindings() {
+    let mut engine = authoritative_engine();
+    let mut formulas = Vec::new();
+    for row in 1..=100 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        // Per-placement literal parameters produce a multi-binding dictionary,
+        // which is not safe to re-base across a split: the whole span must
+        // fall back to demotion.
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}+{}", row * 7)));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    let promoted = engine.baseline_stats().formula_plane_active_span_count;
+
+    engine.insert_rows("Sheet1", 40, 1).unwrap();
+    if promoted == 1 {
+        assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    }
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 10, 2),
+        Some(LiteralValue::Number(10.0 + 70.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 41, 2),
+        Some(LiteralValue::Number(40.0 + 280.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 101, 2),
+        Some(LiteralValue::Number(100.0 + 700.0))
+    );
+}
+
+#[test]
+fn formula_plane_repeated_mid_span_row_inserts_stay_split_and_linear() {
+    let rows = 5_000;
+    let mut engine = authoritative_engine();
+    let mut formulas = Vec::with_capacity(rows as usize);
+    for row in 1..=rows {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}*2")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+
+    // Each mid-span insert splits exactly one span; nothing demotes to legacy
+    // vertices and the structural edit itself stays fast.
+    let insert_sequence = [2_500u32, 1_200, 3_800, 600, 4_600];
+    for (edit_idx, before) in insert_sequence.into_iter().enumerate() {
+        let started = std::time::Instant::now();
+        engine.insert_rows("Sheet1", before, 1).unwrap();
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            engine.baseline_stats().formula_plane_active_span_count,
+            edit_idx + 2,
+            "each mid-span insert must split one span into two"
+        );
+        assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+
+        if !cfg!(debug_assertions) {
+            let limit = std::time::Duration::from_secs(1);
+            assert!(
+                elapsed < limit,
+                "split edit_{edit_idx} took {elapsed:?}, expected below {limit:?}"
+            );
+        }
+
+        engine.evaluate_all().unwrap();
+    }
+
+    // Rows 1..=rows carried their values through five splices; spot-check the
+    // moved tail against column A, which shifted congruently.
+    for row in [1u32, 1_000, 2_400, 3_200, rows + 5] {
+        let a = engine.get_cell_value("Sheet1", row, 1);
+        let b = engine.get_cell_value("Sheet1", row, 2);
+        match a {
+            Some(LiteralValue::Number(a)) => {
+                assert_eq!(
+                    b,
+                    Some(LiteralValue::Number(a * 2.0)),
+                    "row {row} must track its shifted precedent"
+                );
+            }
+            _ => assert_eq!(b, None, "row {row} must be empty after the splice"),
+        }
+    }
 }

--- a/crates/formualizer-eval/src/formula_plane/producer.rs
+++ b/crates/formualizer-eval/src/formula_plane/producer.rs
@@ -378,24 +378,40 @@ pub(crate) struct SpanReadSummaryId(pub(crate) u32);
 
 #[derive(Debug, Default)]
 pub(crate) struct SpanReadSummaryStore {
-    records: Vec<SpanReadSummary>,
+    records: Vec<Option<SpanReadSummary>>,
+    live: usize,
     epoch: u64,
 }
 
 impl SpanReadSummaryStore {
     pub(crate) fn insert(&mut self, summary: SpanReadSummary) -> SpanReadSummaryId {
         let id = SpanReadSummaryId(self.records.len() as u32);
-        self.records.push(summary);
+        self.records.push(Some(summary));
+        self.live = self.live.saturating_add(1);
         self.epoch = self.epoch.saturating_add(1);
         id
     }
 
     pub(crate) fn get(&self, id: SpanReadSummaryId) -> Option<&SpanReadSummary> {
-        self.records.get(id.0 as usize)
+        self.records.get(id.0 as usize)?.as_ref()
+    }
+
+    /// Release a summary that is no longer referenced by any span. Ids are
+    /// never reused; the slot becomes a tombstone.
+    pub(crate) fn remove(&mut self, id: SpanReadSummaryId) -> bool {
+        let Some(slot) = self.records.get_mut(id.0 as usize) else {
+            return false;
+        };
+        let removed = slot.take().is_some();
+        if removed {
+            self.live = self.live.saturating_sub(1);
+            self.epoch = self.epoch.saturating_add(1);
+        }
+        removed
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.records.len()
+        self.live
     }
 
     pub(crate) fn epoch(&self) -> u64 {

--- a/crates/formualizer-eval/src/formula_plane/runtime.rs
+++ b/crates/formualizer-eval/src/formula_plane/runtime.rs
@@ -1090,6 +1090,31 @@ impl FormulaOverlay {
         })
     }
 
+    /// Re-point an overlay entry's provenance at a different span, e.g. when a
+    /// span split transfers ownership of punch-outs to the new half. Returns
+    /// false for stale refs.
+    pub(crate) fn set_source_span(
+        &mut self,
+        overlay_ref: FormulaOverlayRef,
+        source_span: Option<FormulaSpanRef>,
+    ) -> bool {
+        let Some(slot) = self.slots.get_mut(overlay_ref.id.0 as usize) else {
+            return false;
+        };
+        if slot.generation != overlay_ref.generation {
+            return false;
+        }
+        let Some(entry) = slot.entry.as_mut() else {
+            return false;
+        };
+        if entry.source_span == source_span {
+            return true;
+        }
+        entry.source_span = source_span;
+        self.epoch = self.epoch.saturating_add(1);
+        true
+    }
+
     pub(crate) fn refs_for_source_span(&self, span_ref: FormulaSpanRef) -> Vec<FormulaOverlayRef> {
         self.slots
             .iter()
@@ -1388,6 +1413,30 @@ impl FormulaPlane {
             self.bump_epoch();
         }
         removed
+    }
+
+    pub(crate) fn set_overlay_source_span(
+        &mut self,
+        overlay_ref: FormulaOverlayRef,
+        source_span: Option<FormulaSpanRef>,
+    ) -> bool {
+        let updated = self
+            .formula_overlay
+            .set_source_span(overlay_ref, source_span);
+        if updated {
+            self.bump_epoch();
+        }
+        updated
+    }
+
+    /// Lowercased defined-name keys the span registered at ingest (see
+    /// `name_dependent_spans`). Used to carry name-dependent invalidation over
+    /// to spans that inherit part of an existing span's domain.
+    pub(crate) fn span_registered_name_keys(&self, span_id: FormulaSpanId) -> Vec<String> {
+        self.span_name_keys
+            .get(&span_id)
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub(crate) fn remove_overlays_for_source_span(&mut self, span_ref: FormulaSpanRef) -> usize {

--- a/crates/formualizer-eval/src/formula_plane/runtime.rs
+++ b/crates/formualizer-eval/src/formula_plane/runtime.rs
@@ -1243,6 +1243,10 @@ impl FormulaPlane {
         result_region: ResultRegion,
         read_summary_id: Option<SpanReadSummaryId>,
     ) -> bool {
+        let old_read_summary_id = self
+            .spans
+            .get(span_ref)
+            .and_then(|span| span.read_summary_id);
         let replaced = self.spans.replace_geometry(
             span_ref,
             template_id,
@@ -1251,6 +1255,13 @@ impl FormulaPlane {
             read_summary_id,
         );
         if replaced {
+            // Summaries are per-span (never interned/shared); release the one
+            // the replaced geometry no longer references.
+            if let Some(old_id) = old_read_summary_id
+                && read_summary_id != Some(old_id)
+            {
+                self.span_read_summaries.remove(old_id);
+            }
             self.bump_epoch();
         }
         replaced
@@ -1291,14 +1302,18 @@ impl FormulaPlane {
     }
 
     pub(crate) fn remove_span(&mut self, span_ref: FormulaSpanRef) -> bool {
-        let binding_set_id = self
+        let (binding_set_id, read_summary_id) = self
             .spans
             .get(span_ref)
-            .and_then(|span| span.binding_set_id);
+            .map(|span| (span.binding_set_id, span.read_summary_id))
+            .unwrap_or((None, None));
         let removed = self.spans.remove(span_ref);
         if removed {
             if let Some(binding_set_id) = binding_set_id {
                 self.binding_sets.remove(binding_set_id);
+            }
+            if let Some(read_summary_id) = read_summary_id {
+                self.span_read_summaries.remove(read_summary_id);
             }
             self.unregister_span_name_dependents(span_ref);
             self.bump_epoch();

--- a/crates/formualizer-eval/src/formula_plane/structural_shift.rs
+++ b/crates/formualizer-eval/src/formula_plane/structural_shift.rs
@@ -1,6 +1,6 @@
 use super::producer::SpanReadSummary;
 use super::region_index::{AxisRange, Region};
-use super::runtime::FormulaSpan;
+use super::runtime::{FormulaSpan, PlacementDomain};
 use crate::SheetId;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -45,6 +45,12 @@ pub(crate) enum SpanShiftPlan {
         origin_row_delta: i64,
         origin_col_delta: i64,
     },
+    /// A mid-domain insert straddles the span's result domain. The apply site
+    /// may split the domain at the insert boundary into an unshifted upper
+    /// half and a shifted lower half, re-derive each half's read summary, and
+    /// re-classify each half; it must fall back to demoting the whole span
+    /// when either half does not classify cleanly.
+    Split,
     Demote {
         reason: SpanDemoteReason,
     },
@@ -53,7 +59,6 @@ pub(crate) enum SpanShiftPlan {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SpanDemoteReason {
-    ResultDomainStraddles,
     ReadRegionStraddles,
     OriginNotShiftedButReadRegionShifts,
     DeletePartiallyOverlaps,
@@ -165,12 +170,12 @@ pub(crate) fn classify_span_for_op(
         AxisShiftCase::EntirelyAboveShift { .. } => op.axis_shift_delta(),
         AxisShiftCase::DeleteFullyContains => return SpanShiftPlan::Remove,
         AxisShiftCase::Straddles => {
-            return SpanShiftPlan::Demote {
-                reason: if op.is_delete() {
-                    SpanDemoteReason::DeletePartiallyOverlaps
-                } else {
-                    SpanDemoteReason::ResultDomainStraddles
-                },
+            return if op.is_delete() {
+                SpanShiftPlan::Demote {
+                    reason: SpanDemoteReason::DeletePartiallyOverlaps,
+                }
+            } else {
+                SpanShiftPlan::Split
             };
         }
     };
@@ -216,6 +221,100 @@ pub(crate) fn classify_span_for_op(
         (true, true, true) => SpanShiftPlan::Demote {
             reason: SpanDemoteReason::MixedReadRegionShift,
         },
+    }
+}
+
+fn split_axis_at(min: u32, max: u32, before: u32) -> Option<((u32, u32), (u32, u32))> {
+    if min < before && before <= max {
+        Some(((min, before - 1), (before, max)))
+    } else {
+        None
+    }
+}
+
+/// Split `domain` at an insert boundary into (upper, lower) halves in the
+/// PRE-insert coordinate frame: the upper half is untouched by the insert,
+/// the lower half starts at the insert boundary and shifts by the insert
+/// count. Sibling of the delete-compaction domain surgery in
+/// `demote_spans_for_structural_op_impl` (deliberately not merged: compaction
+/// yields one domain, splitting yields two). Returns None whenever the domain
+/// cannot be split cleanly along the insert axis; callers fall back to
+/// demoting the whole span.
+pub(crate) fn split_domain_at(
+    domain: &PlacementDomain,
+    op: StructuralOp,
+) -> Option<(PlacementDomain, PlacementDomain)> {
+    if domain.sheet_id() != op.sheet_id() {
+        return None;
+    }
+    match (domain, op) {
+        (
+            PlacementDomain::RowRun {
+                sheet_id,
+                row_start,
+                row_end,
+                col,
+            },
+            StructuralOp::InsertRows { before, .. },
+        ) => {
+            let ((upper_start, upper_end), (lower_start, lower_end)) =
+                split_axis_at(*row_start, *row_end, before)?;
+            Some((
+                PlacementDomain::row_run(*sheet_id, upper_start, upper_end, *col),
+                PlacementDomain::row_run(*sheet_id, lower_start, lower_end, *col),
+            ))
+        }
+        (
+            PlacementDomain::Rect {
+                sheet_id,
+                row_start,
+                row_end,
+                col_start,
+                col_end,
+            },
+            StructuralOp::InsertRows { before, .. },
+        ) => {
+            let ((upper_start, upper_end), (lower_start, lower_end)) =
+                split_axis_at(*row_start, *row_end, before)?;
+            Some((
+                PlacementDomain::rect(*sheet_id, upper_start, upper_end, *col_start, *col_end),
+                PlacementDomain::rect(*sheet_id, lower_start, lower_end, *col_start, *col_end),
+            ))
+        }
+        (
+            PlacementDomain::ColRun {
+                sheet_id,
+                row,
+                col_start,
+                col_end,
+            },
+            StructuralOp::InsertColumns { before, .. },
+        ) => {
+            let ((upper_start, upper_end), (lower_start, lower_end)) =
+                split_axis_at(*col_start, *col_end, before)?;
+            Some((
+                PlacementDomain::col_run(*sheet_id, *row, upper_start, upper_end),
+                PlacementDomain::col_run(*sheet_id, *row, lower_start, lower_end),
+            ))
+        }
+        (
+            PlacementDomain::Rect {
+                sheet_id,
+                row_start,
+                row_end,
+                col_start,
+                col_end,
+            },
+            StructuralOp::InsertColumns { before, .. },
+        ) => {
+            let ((upper_start, upper_end), (lower_start, lower_end)) =
+                split_axis_at(*col_start, *col_end, before)?;
+            Some((
+                PlacementDomain::rect(*sheet_id, *row_start, *row_end, upper_start, upper_end),
+                PlacementDomain::rect(*sheet_id, *row_start, *row_end, lower_start, lower_end),
+            ))
+        }
+        _ => None,
     }
 }
 
@@ -414,9 +513,7 @@ mod tests {
         let result_straddle = span(PlacementDomain::col_run(0, 0, 2, 4));
         assert_eq!(
             classify_span_for_op(&result_straddle, None, insert),
-            SpanShiftPlan::Demote {
-                reason: SpanDemoteReason::ResultDomainStraddles
-            }
+            SpanShiftPlan::Split
         );
 
         let result_above = span(PlacementDomain::col_run(0, 0, 5, 7));
@@ -438,6 +535,25 @@ mod tests {
             SpanShiftPlan::Demote {
                 reason: SpanDemoteReason::DeletePartiallyOverlaps
             }
+        );
+    }
+
+    #[test]
+    fn classify_span_returns_split_for_mid_domain_row_insert() {
+        let s = span(PlacementDomain::row_run(0, 0, 99, 1));
+        let op = StructuralOp::InsertRows {
+            sheet_id: 0,
+            before: 50,
+            count: 2,
+        };
+        // Result-domain straddle on an insert is now a split candidate even
+        // when reads would straddle: the apply site re-classifies each half
+        // and falls back to demoting the whole span.
+        assert_eq!(classify_span_for_op(&s, None, op), SpanShiftPlan::Split);
+        let read_straddle = summary(vec![Region::col_interval(0, 0, 0, 99)]);
+        assert_eq!(
+            classify_span_for_op(&s, Some(&read_straddle), op),
+            SpanShiftPlan::Split
         );
     }
 
@@ -477,6 +593,136 @@ mod tests {
             SpanShiftPlan::Demote {
                 reason: SpanDemoteReason::DeletePartiallyOverlaps
             }
+        );
+    }
+
+    #[test]
+    fn split_domain_at_covers_row_and_column_axes() {
+        // RowRun / row insert: rows [10, 99] split before row 40.
+        assert_eq!(
+            split_domain_at(
+                &PlacementDomain::row_run(0, 10, 99, 2),
+                StructuralOp::InsertRows {
+                    sheet_id: 0,
+                    before: 40,
+                    count: 3,
+                },
+            ),
+            Some((
+                PlacementDomain::row_run(0, 10, 39, 2),
+                PlacementDomain::row_run(0, 40, 99, 2),
+            ))
+        );
+        // Rect / row insert keeps the column extent on both halves.
+        assert_eq!(
+            split_domain_at(
+                &PlacementDomain::rect(0, 0, 99, 1, 3),
+                StructuralOp::InsertRows {
+                    sheet_id: 0,
+                    before: 50,
+                    count: 1,
+                },
+            ),
+            Some((
+                PlacementDomain::rect(0, 0, 49, 1, 3),
+                PlacementDomain::rect(0, 50, 99, 1, 3),
+            ))
+        );
+        // ColRun / column insert.
+        assert_eq!(
+            split_domain_at(
+                &PlacementDomain::col_run(0, 5, 1, 100),
+                StructuralOp::InsertColumns {
+                    sheet_id: 0,
+                    before: 49,
+                    count: 2,
+                },
+            ),
+            Some((
+                PlacementDomain::col_run(0, 5, 1, 48),
+                PlacementDomain::col_run(0, 5, 49, 100),
+            ))
+        );
+        // Rect / column insert keeps the row extent on both halves.
+        assert_eq!(
+            split_domain_at(
+                &PlacementDomain::rect(0, 0, 9, 2, 8),
+                StructuralOp::InsertColumns {
+                    sheet_id: 0,
+                    before: 4,
+                    count: 1,
+                },
+            ),
+            Some((
+                PlacementDomain::rect(0, 0, 9, 2, 3),
+                PlacementDomain::rect(0, 0, 9, 4, 8),
+            ))
+        );
+    }
+
+    #[test]
+    fn split_domain_at_rejects_non_straddling_and_cross_axis_cases() {
+        let row_run = PlacementDomain::row_run(0, 10, 99, 2);
+        // Boundary at/above the start or beyond the end is not a straddle.
+        for before in [5, 10, 100, 200] {
+            assert_eq!(
+                split_domain_at(
+                    &row_run,
+                    StructuralOp::InsertRows {
+                        sheet_id: 0,
+                        before,
+                        count: 1,
+                    },
+                ),
+                None
+            );
+        }
+        // A row insert cannot split a single-row ColRun; a column insert
+        // cannot split a single-column RowRun; deletes never split.
+        assert_eq!(
+            split_domain_at(
+                &PlacementDomain::col_run(0, 5, 1, 100),
+                StructuralOp::InsertRows {
+                    sheet_id: 0,
+                    before: 5,
+                    count: 1,
+                },
+            ),
+            None
+        );
+        assert_eq!(
+            split_domain_at(
+                &row_run,
+                StructuralOp::InsertColumns {
+                    sheet_id: 0,
+                    before: 2,
+                    count: 1,
+                },
+            ),
+            None
+        );
+        assert_eq!(
+            split_domain_at(
+                &row_run,
+                StructuralOp::DeleteRows {
+                    sheet_id: 0,
+                    start: 40,
+                    count: 1,
+                },
+            ),
+            None
+        );
+        // Other-sheet ops never split.
+        assert_eq!(
+            split_domain_at(
+                &row_run,
+                StructuralOp::InsertRows {
+                    sheet_id: 1,
+                    before: 40,
+                    count: 1,
+                },
+            ),
+            None
         );
     }
 


### PR DESCRIPTION
## What

Adds `SpanShiftPlan::Split`: when a row insert lands strictly inside a span's placement domain, the span now splits into two live spans (upper keeps its id/geometry via `replace_span_geometry`; lower is a fresh span with a shifted read summary, re-origined template, re-anchored binding set, inherited name registrations, and re-pointed overlay) instead of demoting the whole span back to per-cell graph vertices.

Stacked on #164. Scope is deliberately conservative (v1):

- Splits apply to templates whose reads all shift with the span (pure-relative) or are fully stationary. Mixed templates (shifting relative reads + stationary absolutes, e.g. `=A2*B2*$F$1`) still demote via `MixedReadRegionShift` — pinned by test, addressed next in the mixed-read follow-up.
- Delete-side compaction now carries the template origin through the delete (`origin_coord_through_delete`) instead of rebasing it to the new domain start.

## Why

Demote-on-straddle meant one mid-column insert threw away span compilation for the whole column, forcing per-cell re-materialization: ~13x slower structural ops for pure-relative templates, plus permanent loss of span evaluation for that column.

The origin carry-through also fixes a wrong-values bug that exists on released 0.7.1 independent of splitting: a delete overlapping a span head rebases surviving placements against the wrong origin, silently corrupting values (regression test included; verified to fail before the fix).

## Testing

- New split tests: mid-domain insert splits into two spans producing identical values to span-OFF mode; split-then-inner-delete composition; delete-overlapping-span-head regression.
- `formula_plane_mixed_read_row_insert_still_demotes` pins the v1 limitation.
- The 8 parity tests from #164 now exercise the live split path.
- Full formualizer-eval suite green on the combined stack.

Closes #166. Closes #167. Related (not fixed here): #168.
