### PR TITLE
feat(formula-plane): mixed-read span splitting + Excel-correct absolute refs under structural ops (#168)

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4512,6 +4512,26 @@ where
             self.compute_current_formula_plane_dirty_result_coords()?
         };
 
+        /// A template AST rewrite accompanying a span shift: the op displaced
+        /// the target of an absolute read, which origin relocation cannot
+        /// repoint (issue #168). The adjusted AST is re-interned as a fresh
+        /// arena AST + template record at the apply site; keys are re-derived
+        /// from the rewritten AST so the new record can never collide with
+        /// the (immutable, possibly shared) pre-rewrite template.
+        struct SpanTemplateRewrite {
+            adjusted_ast: ASTNode,
+            exact_canonical_key: Arc<str>,
+            parameterized_canonical_key: Arc<str>,
+            formula_text: Option<Arc<str>>,
+            /// Canonical form of the rewritten AST at the new origin, used to
+            /// rebuild the binding set's template-derived slot data (the
+            /// literal slot map is keyed by arena node ids of the template
+            /// AST; value-ref slot patterns carry canonical reference
+            /// coordinates — both go stale across a rewrite).
+            canonical_expr: crate::formula_plane::template_canonical::CanonicalExpr,
+            value_ref_slots: Arc<[crate::formula_plane::runtime::ValueRefSlotDescriptor]>,
+        }
+
         struct ShiftPlan {
             span_ref: FormulaSpanRef,
             template_id: crate::formula_plane::ids::FormulaTemplateId,
@@ -4521,6 +4541,53 @@ where
             new_read_summary: Option<SpanReadSummary>,
             binding_set_id: Option<crate::formula_plane::runtime::SpanBindingSetId>,
             force_binding_residual_axes: bool,
+            rewrite: Option<SpanTemplateRewrite>,
+        }
+
+        /// StructuralOp and ShiftOperation are field-for-field identical
+        /// (both 0-based); the adjuster type is the legacy shared one.
+        fn shift_operation_for(
+            op: StructuralOp,
+        ) -> crate::engine::graph::editor::reference_adjuster::ShiftOperation {
+            use crate::engine::graph::editor::reference_adjuster::ShiftOperation;
+            match op {
+                StructuralOp::InsertRows {
+                    sheet_id,
+                    before,
+                    count,
+                } => ShiftOperation::InsertRows {
+                    sheet_id,
+                    before,
+                    count,
+                },
+                StructuralOp::DeleteRows {
+                    sheet_id,
+                    start,
+                    count,
+                } => ShiftOperation::DeleteRows {
+                    sheet_id,
+                    start,
+                    count,
+                },
+                StructuralOp::InsertColumns {
+                    sheet_id,
+                    before,
+                    count,
+                } => ShiftOperation::InsertColumns {
+                    sheet_id,
+                    before,
+                    count,
+                },
+                StructuralOp::DeleteColumns {
+                    sheet_id,
+                    start,
+                    count,
+                } => ShiftOperation::DeleteColumns {
+                    sheet_id,
+                    start,
+                    count,
+                },
+            }
         }
 
         /// Split a straddled span into an unshifted upper half (which keeps the
@@ -5011,7 +5078,17 @@ where
                         .binding_set_id
                         .and_then(|id| authority.plane.binding_sets.get(id))
                         .is_none_or(|binding_set| binding_set.is_single_literal_binding());
+                    // Compaction projects read regions through the delete but
+                    // keeps the template AST: an absolute read whose target
+                    // the delete displaces would keep its stale coordinate
+                    // (issue #168), so demote to the per-cell path instead.
+                    let absolute_reads_compaction_safe = read_summary.is_none_or(|summary| {
+                        !crate::formula_plane::structural_shift::summary_has_displaced_absolute_read(
+                            summary, op,
+                        )
+                    });
                     if binding_compaction_safe
+                        && absolute_reads_compaction_safe
                         && let Some(new_domain) = compact_domain_through_delete(&span.domain, op)
                     {
                         let new_result_region = Region::from_domain(&new_domain);
@@ -5049,6 +5126,7 @@ where
                                 new_read_summary,
                                 binding_set_id: span.binding_set_id,
                                 force_binding_residual_axes,
+                                rewrite: None,
                             });
                         } else {
                             demote_refs.push(span_ref);
@@ -5075,15 +5153,6 @@ where
                     origin_col_delta,
                     rewrite_absolute_reads,
                 } => {
-                    if rewrite_absolute_reads {
-                        // The op displaces an absolute read's target; the
-                        // span-preserving template AST rewrite lands in a
-                        // follow-up commit. Until then demote so the
-                        // per-cell adjuster repoints the reference
-                        // (issue #168 correctness over speed).
-                        demote_refs.push(span_ref);
-                        continue;
-                    }
                     let Some(template) = authority.plane.templates.get(span.template_id) else {
                         return Err(ExcelError::new(ExcelErrorKind::Ref)
                             .with_message("FormulaPlane shift found a span with a missing template")
@@ -5136,6 +5205,88 @@ where
                             !binding_set.value_ref_slots.is_empty()
                                 && (origin_row_delta != 0 || origin_col_delta != 0)
                         });
+                    let rewrite = if rewrite_absolute_reads {
+                        // Reify the (immutable, possibly shared) template
+                        // AST and repoint its displaced references through
+                        // the shared adjuster — the same relocation the
+                        // per-cell path applies, so span-ON stays equal to
+                        // span-OFF (issue #168). Canonical keys are
+                        // re-derived from the rewritten AST at the new
+                        // origin, so the fresh record cannot collide with
+                        // the pre-rewrite template.
+                        let Some(ast) = self
+                            .graph
+                            .data_store()
+                            .retrieve_ast(template.ast_id, self.graph.sheet_reg())
+                        else {
+                            demote_refs.push(span_ref);
+                            continue;
+                        };
+                        let shift_op = shift_operation_for(op);
+                        let adjuster =
+                            crate::engine::graph::editor::reference_adjuster::ReferenceAdjuster::new();
+                        let Some(adjusted_ast) = adjuster.adjust_ast_if_changed(&ast, &shift_op)
+                        else {
+                            // The classifier saw a displaced absolute read,
+                            // so an unchanged AST is a contract violation;
+                            // demote conservatively rather than shift with a
+                            // stale template.
+                            demote_refs.push(span_ref);
+                            continue;
+                        };
+                        let canonical = crate::formula_plane::template_canonical::canonicalize_template(
+                            &adjusted_ast,
+                            new_origin_row,
+                            new_origin_col,
+                        );
+                        if !canonical.labels.is_authority_supported() {
+                            demote_refs.push(span_ref);
+                            continue;
+                        }
+                        // The rewrite touches only references; the literal
+                        // slot layout must survive unchanged or the binding
+                        // set's per-placement literal bindings no longer
+                        // line up. Demote defensively if it differs.
+                        let literal_slots_compatible = span
+                            .binding_set_id
+                            .and_then(|id| authority.plane.binding_sets.get(id))
+                            .is_none_or(|binding_set| {
+                                binding_set.literal_slots.as_ref()
+                                    == canonical.literal_slot_descriptors.as_ref()
+                            });
+                        if !literal_slots_compatible {
+                            demote_refs.push(span_ref);
+                            continue;
+                        }
+                        // Value-ref slot patterns are re-derived from the
+                        // rewritten canonical template so memoized reads
+                        // resolve the repointed coordinates (issue #168).
+                        // Placement-relative memo KEYS are additionally
+                        // protected by force_binding_residual_axes below
+                        // (the rewrite always moves the origin, so the
+                        // existing origin-delta condition fires).
+                        let value_ref_slots = Arc::from(
+                            crate::formula_plane::placement::value_ref_slot_descriptors(
+                                &canonical.expr,
+                            )
+                            .into_boxed_slice(),
+                        );
+                        let formula_text = Some(Arc::<str>::from(
+                            formualizer_parse::pretty::canonical_formula(&adjusted_ast),
+                        ));
+                        Some(SpanTemplateRewrite {
+                            exact_canonical_key: Arc::<str>::from(canonical.key.payload()),
+                            parameterized_canonical_key: Arc::<str>::from(
+                                canonical.parameterized_key.payload(),
+                            ),
+                            formula_text,
+                            canonical_expr: canonical.expr,
+                            value_ref_slots,
+                            adjusted_ast,
+                        })
+                    } else {
+                        None
+                    };
                     shift_plans.push(ShiftPlan {
                         span_ref,
                         template_id: span.template_id,
@@ -5145,26 +5296,78 @@ where
                         new_read_summary,
                         binding_set_id: span.binding_set_id,
                         force_binding_residual_axes,
+                        rewrite,
                     });
                 }
             }
         }
         if !shift_plans.is_empty() || !split_plans.is_empty() || !remove_refs.is_empty() {
+            // Rewritten template ASTs must be interned into the graph's AST
+            // arena before the authority is borrowed mutably; the literal
+            // slot map is keyed by the freshly interned arena node ids.
+            let mut prepared_shift_plans = Vec::with_capacity(shift_plans.len());
+            for plan in shift_plans {
+                let rewrite_prepared = plan.rewrite.as_ref().map(|rewrite| {
+                    let ast_id = self.graph.store_ast(&rewrite.adjusted_ast);
+                    let template_slot_map = crate::formula_plane::placement::build_template_slot_map(
+                        ast_id,
+                        self.graph.data_store(),
+                        &rewrite.canonical_expr,
+                    );
+                    (ast_id, template_slot_map)
+                });
+                prepared_shift_plans.push((plan, rewrite_prepared));
+            }
             let authority = self.graph.formula_authority_mut();
             for span_ref in remove_refs {
                 authority.plane.remove_overlays_for_source_span(span_ref);
                 authority.plane.remove_span(span_ref);
             }
-            for plan in shift_plans {
-                let Some(template_id) = authority.plane.intern_shifted_template_origin(
-                    plan.template_id,
-                    plan.new_origin_row,
-                    plan.new_origin_col,
-                ) else {
-                    return Err(ExcelError::new(ExcelErrorKind::Ref)
-                        .with_message("FormulaPlane shift could not clone template origin")
-                        .into());
+            for (plan, rewrite_prepared) in prepared_shift_plans {
+                let (template_id, rewrite_slots) = if let Some(rewrite) = plan.rewrite {
+                    let Some((ast_id, template_slot_map)) = rewrite_prepared else {
+                        return Err(ExcelError::new(ExcelErrorKind::Ref)
+                            .with_message("FormulaPlane shift lost a rewritten template AST")
+                            .into());
+                    };
+                    let Some(template_id) = authority.plane.intern_rewritten_template(
+                        plan.template_id,
+                        ast_id,
+                        rewrite.exact_canonical_key,
+                        rewrite.parameterized_canonical_key,
+                        rewrite.formula_text,
+                        plan.new_origin_row,
+                        plan.new_origin_col,
+                    ) else {
+                        return Err(ExcelError::new(ExcelErrorKind::Ref)
+                            .with_message("FormulaPlane shift could not intern rewritten template")
+                            .into());
+                    };
+                    (
+                        template_id,
+                        Some((template_slot_map, rewrite.value_ref_slots)),
+                    )
+                } else {
+                    let Some(template_id) = authority.plane.intern_shifted_template_origin(
+                        plan.template_id,
+                        plan.new_origin_row,
+                        plan.new_origin_col,
+                    ) else {
+                        return Err(ExcelError::new(ExcelErrorKind::Ref)
+                            .with_message("FormulaPlane shift could not clone template origin")
+                            .into());
+                    };
+                    (template_id, None)
                 };
+                if let Some((template_slot_map, value_ref_slots)) = rewrite_slots
+                    && let Some(binding_set_id) = plan.binding_set_id
+                {
+                    authority.plane.set_binding_template_slots(
+                        binding_set_id,
+                        template_slot_map,
+                        value_ref_slots,
+                    );
+                }
                 if let Some(binding_set_id) = plan.binding_set_id {
                     let Some(template) = authority.plane.templates.get(template_id) else {
                         return Err(ExcelError::new(ExcelErrorKind::Ref)

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4614,12 +4614,24 @@ where
             u32::try_from(i64::from(value).checked_add(delta)?).ok()
         }
 
+        /// Structural transform of a read summary for a NO-REWRITE shift.
+        /// Regions move with the op; projection rules keep their absolute
+        /// bounds (the AST is untouched) but must shift their RELATIVE
+        /// bounds by `-origin_delta`: rules store placement-relative
+        /// offsets, which equal `authored_coordinate - template_origin`,
+        /// and a moved origin over an unchanged AST changes that difference
+        /// (otherwise incremental dirty projection silently goes stale —
+        /// issue #168 family). Rewrite plans do NOT use this transform;
+        /// their summaries are re-derived from the rewritten canonical
+        /// template instead.
         fn shifted_read_summary(
             read_summary: &SpanReadSummary,
             new_result_region: Region,
             op: StructuralOp,
             row_delta: i64,
             col_delta: i64,
+            origin_row_delta: i64,
+            origin_col_delta: i64,
         ) -> Option<SpanReadSummary> {
             let mut dependencies = Vec::with_capacity(read_summary.dependencies.len());
             for dependency in &read_summary.dependencies {
@@ -4640,7 +4652,9 @@ where
                 };
                 dependencies.push(crate::formula_plane::producer::SpanReadDependency {
                     read_region,
-                    projection: dependency.projection,
+                    projection: dependency
+                        .projection
+                        .with_relative_offsets_shifted(-origin_row_delta, -origin_col_delta),
                 });
             }
             Some(SpanReadSummary {
@@ -4947,6 +4961,8 @@ where
                     op,
                     row_delta,
                     col_delta,
+                    origin_row_delta,
+                    origin_col_delta,
                 )?),
                 None => None,
             };
@@ -5180,24 +5196,6 @@ where
                             .into());
                     };
                     let new_result_region = Region::from_domain(&new_domain);
-                    let new_read_summary = if let Some(summary) = read_summary {
-                        Some(
-                            shifted_read_summary(
-                                summary,
-                                new_result_region,
-                                op,
-                                row_delta,
-                                col_delta,
-                            )
-                            .ok_or_else(|| {
-                                ExcelError::new(ExcelErrorKind::Ref).with_message(
-                                    "FormulaPlane shift could not project read summary",
-                                )
-                            })?,
-                        )
-                    } else {
-                        None
-                    };
                     let force_binding_residual_axes = span
                         .binding_set_id
                         .and_then(|id| authority.plane.binding_sets.get(id))
@@ -5205,7 +5203,7 @@ where
                             !binding_set.value_ref_slots.is_empty()
                                 && (origin_row_delta != 0 || origin_col_delta != 0)
                         });
-                    let rewrite = if rewrite_absolute_reads {
+                    let rewrite_and_summary = if rewrite_absolute_reads {
                         // Reify the (immutable, possibly shared) template
                         // AST and repoint its displaced references through
                         // the shared adjuster — the same relocation the
@@ -5214,6 +5212,30 @@ where
                         // re-derived from the rewritten AST at the new
                         // origin, so the fresh record cannot collide with
                         // the pre-rewrite template.
+                        //
+                        // FRAME GUARD: the adjuster relocates by AUTHORED
+                        // coordinate, but a template's authoring frame may
+                        // diverge from its domain (split lower halves keep
+                        // the original anchor; pinned-origin shifts move the
+                        // domain without the origin). The rewrite is only
+                        // equivalent to per-cell adjustment when every
+                        // relative read's authored coordinate classifies
+                        // against the op boundary the same way its read
+                        // region does — otherwise the rewrite shears
+                        // relative reads by the op count. Demote instead;
+                        // see rewrite_frame_is_sound for the full invariant.
+                        let frame_sound = read_summary.is_some_and(|summary| {
+                            crate::formula_plane::structural_shift::rewrite_frame_is_sound(
+                                summary,
+                                template.origin_row,
+                                template.origin_col,
+                                op,
+                            )
+                        });
+                        if !frame_sound {
+                            demote_refs.push(span_ref);
+                            continue;
+                        }
                         let Some(ast) = self
                             .graph
                             .data_store()
@@ -5271,21 +5293,75 @@ where
                             )
                             .into_boxed_slice(),
                         );
+                        // The read summary is RE-DERIVED from the rewritten
+                        // canonical template rather than structurally
+                        // transformed: a structural transform would keep the
+                        // old projection rules, whose absolute indices (and
+                        // relative offsets, via the moved origin) no longer
+                        // match the rewritten AST — incremental writes to
+                        // the repointed targets would then silently fail to
+                        // dirty the span. Re-derivation rebuilds rules in
+                        // the (rewritten AST, new origin) frame, keeping
+                        // `result_region == domain region` by construction.
+                        let dependency_summary =
+                            crate::formula_plane::dependency_summary::summarize_canonical_template(
+                                &canonical,
+                            );
+                        let rewritten_result_region =
+                            ResultRegion::scalar_cells(new_domain.clone());
+                        let Ok(rederived_summary) = SpanReadSummary::from_formula_summary(
+                            span.sheet_id,
+                            &rewritten_result_region,
+                            &dependency_summary,
+                            self.graph.sheet_reg(),
+                        ) else {
+                            demote_refs.push(span_ref);
+                            continue;
+                        };
                         let formula_text = Some(Arc::<str>::from(
                             formualizer_parse::pretty::canonical_formula(&adjusted_ast),
                         ));
-                        Some(SpanTemplateRewrite {
-                            exact_canonical_key: Arc::<str>::from(canonical.key.payload()),
-                            parameterized_canonical_key: Arc::<str>::from(
-                                canonical.parameterized_key.payload(),
-                            ),
-                            formula_text,
-                            canonical_expr: canonical.expr,
-                            value_ref_slots,
-                            adjusted_ast,
-                        })
+                        Some((
+                            SpanTemplateRewrite {
+                                exact_canonical_key: Arc::<str>::from(canonical.key.payload()),
+                                parameterized_canonical_key: Arc::<str>::from(
+                                    canonical.parameterized_key.payload(),
+                                ),
+                                formula_text,
+                                canonical_expr: canonical.expr,
+                                value_ref_slots,
+                                adjusted_ast,
+                            },
+                            rederived_summary,
+                        ))
                     } else {
                         None
+                    };
+                    let (rewrite, new_read_summary) = match rewrite_and_summary {
+                        Some((rewrite, summary)) => (Some(rewrite), Some(summary)),
+                        None => {
+                            let new_read_summary = if let Some(summary) = read_summary {
+                                Some(
+                                    shifted_read_summary(
+                                        summary,
+                                        new_result_region,
+                                        op,
+                                        row_delta,
+                                        col_delta,
+                                        origin_row_delta,
+                                        origin_col_delta,
+                                    )
+                                    .ok_or_else(|| {
+                                        ExcelError::new(ExcelErrorKind::Ref).with_message(
+                                            "FormulaPlane shift could not project read summary",
+                                        )
+                                    })?,
+                                )
+                            } else {
+                                None
+                            };
+                            (None, new_read_summary)
+                        }
                     };
                     shift_plans.push(ShiftPlan {
                         span_ref,

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4854,10 +4854,19 @@ where
                 col_delta,
                 origin_row_delta,
                 origin_col_delta,
+                rewrite_absolute_reads,
             } = classify_span_for_op(&lower_span, lower_read_summary.as_ref(), op)
             else {
                 return None;
             };
+            if rewrite_absolute_reads {
+                // A displaced absolute read in the lower half implies the
+                // upper half reads it too and cannot be a NoOp, so this is
+                // unreachable when the upper check above passed; keep the
+                // guard so a future classifier change cannot silently skip
+                // the template rewrite.
+                return None;
+            }
 
             let template = authority.plane.templates.get(span.template_id)?;
             let lower_new_origin_row = checked_shift_u32(template.origin_row, origin_row_delta)?;
@@ -5064,7 +5073,17 @@ where
                     col_delta,
                     origin_row_delta,
                     origin_col_delta,
+                    rewrite_absolute_reads,
                 } => {
+                    if rewrite_absolute_reads {
+                        // The op displaces an absolute read's target; the
+                        // span-preserving template AST rewrite lands in a
+                        // follow-up commit. Until then demote so the
+                        // per-cell adjuster repoints the reference
+                        // (issue #168 correctness over speed).
+                        demote_refs.push(span_ref);
+                        continue;
+                    }
                     let Some(template) = authority.plane.templates.get(span.template_id) else {
                         return Err(ExcelError::new(ExcelErrorKind::Ref)
                             .with_message("FormulaPlane shift found a span with a missing template")

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -5309,11 +5309,12 @@ where
             for plan in shift_plans {
                 let rewrite_prepared = plan.rewrite.as_ref().map(|rewrite| {
                     let ast_id = self.graph.store_ast(&rewrite.adjusted_ast);
-                    let template_slot_map = crate::formula_plane::placement::build_template_slot_map(
-                        ast_id,
-                        self.graph.data_store(),
-                        &rewrite.canonical_expr,
-                    );
+                    let template_slot_map =
+                        crate::formula_plane::placement::build_template_slot_map(
+                            ast_id,
+                            self.graph.data_store(),
+                            &rewrite.canonical_expr,
+                        );
                     (ast_id, template_slot_map)
                 });
                 prepared_shift_plans.push((plan, rewrite_prepared));

--- a/crates/formualizer-eval/src/engine/graph/editor/reference_adjuster.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/reference_adjuster.rs
@@ -194,7 +194,9 @@ impl ReferenceAdjuster {
                 let adjusted_args = args
                     .iter()
                     .map(|arg| {
-                        if let Some(adjusted) = self.adjust_ast_if_changed_with_policy(arg, op, policy) {
+                        if let Some(adjusted) =
+                            self.adjust_ast_if_changed_with_policy(arg, op, policy)
+                        {
                             changed = true;
                             adjusted
                         } else {

--- a/crates/formualizer-eval/src/engine/graph/editor/reference_adjuster.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/reference_adjuster.rs
@@ -1,6 +1,34 @@
 use crate::reference::{CellRef, Coord};
 use formualizer_parse::parser::{ASTNode, ASTNodeType};
 
+/// How absolute (`$`-anchored) references respond to structural shifts.
+///
+/// Policy decision pinned on issue #168: absolute references TRACK structural
+/// inserts/deletes — the `$` pins copy/fill relocation only, it does not pin
+/// the reference against rows/columns physically moving. A delete that
+/// removes the referenced row/column yields `#REF!` exactly like a relative
+/// reference.
+///
+/// `Pin` preserves the legacy behavior (absolute refs never move under
+/// structural ops) and exists solely for named-range definition adjustment,
+/// which historically pinned absolute anchors; flipping named ranges to
+/// `Track` is a separate policy decision (see the #168 discussion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbsShiftPolicy {
+    /// Absolute references shift with structural inserts/deletes
+    /// (Excel-correct; the default for formula reference adjustment).
+    Track,
+    /// Legacy behavior: absolute references never move under structural ops.
+    Pin,
+}
+
+impl AbsShiftPolicy {
+    #[inline]
+    fn pins(self) -> bool {
+        matches!(self, Self::Pin)
+    }
+}
+
 /// Centralized reference adjustment logic for structural changes
 pub struct ReferenceAdjuster;
 
@@ -33,14 +61,26 @@ impl ReferenceAdjuster {
         Self
     }
 
-    /// Adjust an AST for a shift operation, preserving source tokens
+    /// Adjust an AST for a shift operation, preserving source tokens.
+    /// Absolute references track the shift (see [`AbsShiftPolicy::Track`]).
     pub fn adjust_ast(&self, ast: &ASTNode, op: &ShiftOperation) -> ASTNode {
+        self.adjust_ast_with_policy(ast, op, AbsShiftPolicy::Track)
+    }
+
+    /// Adjust an AST for a shift operation under an explicit absolute-ref
+    /// policy, preserving source tokens.
+    pub fn adjust_ast_with_policy(
+        &self,
+        ast: &ASTNode,
+        op: &ShiftOperation,
+        policy: AbsShiftPolicy,
+    ) -> ASTNode {
         match &ast.node_type {
             ASTNodeType::Reference {
                 original,
                 reference,
             } => {
-                let adjusted = self.adjust_reference(reference, op);
+                let adjusted = self.adjust_reference(reference, op, policy);
                 ASTNode {
                     node_type: ASTNodeType::Reference {
                         original: original.clone(),
@@ -57,8 +97,8 @@ impl ReferenceAdjuster {
             } => ASTNode {
                 node_type: ASTNodeType::BinaryOp {
                     op: bin_op.clone(),
-                    left: Box::new(self.adjust_ast(left, op)),
-                    right: Box::new(self.adjust_ast(right, op)),
+                    left: Box::new(self.adjust_ast_with_policy(left, op, policy)),
+                    right: Box::new(self.adjust_ast_with_policy(right, op, policy)),
                 },
                 source_token: ast.source_token.clone(),
                 contains_volatile: ast.contains_volatile,
@@ -66,7 +106,7 @@ impl ReferenceAdjuster {
             ASTNodeType::UnaryOp { op: un_op, expr } => ASTNode {
                 node_type: ASTNodeType::UnaryOp {
                     op: un_op.clone(),
-                    expr: Box::new(self.adjust_ast(expr, op)),
+                    expr: Box::new(self.adjust_ast_with_policy(expr, op, policy)),
                 },
                 source_token: ast.source_token.clone(),
                 contains_volatile: ast.contains_volatile,
@@ -74,7 +114,10 @@ impl ReferenceAdjuster {
             ASTNodeType::Function { name, args } => ASTNode {
                 node_type: ASTNodeType::Function {
                     name: name.clone(),
-                    args: args.iter().map(|arg| self.adjust_ast(arg, op)).collect(),
+                    args: args
+                        .iter()
+                        .map(|arg| self.adjust_ast_with_policy(arg, op, policy))
+                        .collect(),
                 },
                 source_token: ast.source_token.clone(),
                 contains_volatile: ast.contains_volatile,
@@ -87,12 +130,22 @@ impl ReferenceAdjuster {
     /// if at least one reference actually changed. Avoids cloning when no work
     /// is needed.
     pub fn adjust_ast_if_changed(&self, ast: &ASTNode, op: &ShiftOperation) -> Option<ASTNode> {
+        self.adjust_ast_if_changed_with_policy(ast, op, AbsShiftPolicy::Track)
+    }
+
+    /// [`Self::adjust_ast_if_changed`] under an explicit absolute-ref policy.
+    pub fn adjust_ast_if_changed_with_policy(
+        &self,
+        ast: &ASTNode,
+        op: &ShiftOperation,
+        policy: AbsShiftPolicy,
+    ) -> Option<ASTNode> {
         match &ast.node_type {
             ASTNodeType::Reference {
                 original,
                 reference,
             } => {
-                let adjusted = self.adjust_reference(reference, op);
+                let adjusted = self.adjust_reference(reference, op, policy);
                 if adjusted == *reference {
                     return None;
                 }
@@ -110,8 +163,8 @@ impl ReferenceAdjuster {
                 left,
                 right,
             } => {
-                let adjusted_left = self.adjust_ast_if_changed(left, op);
-                let adjusted_right = self.adjust_ast_if_changed(right, op);
+                let adjusted_left = self.adjust_ast_if_changed_with_policy(left, op, policy);
+                let adjusted_right = self.adjust_ast_if_changed_with_policy(right, op, policy);
                 if adjusted_left.is_none() && adjusted_right.is_none() {
                     return None;
                 }
@@ -126,7 +179,7 @@ impl ReferenceAdjuster {
                 })
             }
             ASTNodeType::UnaryOp { op: un_op, expr } => {
-                let adjusted_expr = self.adjust_ast_if_changed(expr, op)?;
+                let adjusted_expr = self.adjust_ast_if_changed_with_policy(expr, op, policy)?;
                 Some(ASTNode {
                     node_type: ASTNodeType::UnaryOp {
                         op: un_op.clone(),
@@ -141,7 +194,7 @@ impl ReferenceAdjuster {
                 let adjusted_args = args
                     .iter()
                     .map(|arg| {
-                        if let Some(adjusted) = self.adjust_ast_if_changed(arg, op) {
+                        if let Some(adjusted) = self.adjust_ast_if_changed_with_policy(arg, op, policy) {
                             changed = true;
                             adjusted
                         } else {
@@ -165,9 +218,20 @@ impl ReferenceAdjuster {
         }
     }
 
-    /// Adjust a cell reference for a shift operation
-    /// Returns None if the cell is deleted
+    /// Adjust a cell reference for a shift operation.
+    /// Returns None if the cell is deleted.
+    /// Absolute references track the shift (see [`AbsShiftPolicy::Track`]).
     pub fn adjust_cell_ref(&self, cell_ref: &CellRef, op: &ShiftOperation) -> Option<CellRef> {
+        self.adjust_cell_ref_with_policy(cell_ref, op, AbsShiftPolicy::Track)
+    }
+
+    /// [`Self::adjust_cell_ref`] under an explicit absolute-ref policy.
+    pub fn adjust_cell_ref_with_policy(
+        &self,
+        cell_ref: &CellRef,
+        op: &ShiftOperation,
+        policy: AbsShiftPolicy,
+    ) -> Option<CellRef> {
         let coord = cell_ref.coord;
         let adjusted_coord = match op {
             ShiftOperation::InsertRows {
@@ -175,8 +239,9 @@ impl ReferenceAdjuster {
                 before,
                 count,
             } if cell_ref.sheet_id == *sheet_id => {
-                if coord.row_abs() || coord.row() < *before {
-                    // Absolute references or cells before insert point don't move
+                if (policy.pins() && coord.row_abs()) || coord.row() < *before {
+                    // Cells before the insert point don't move (nor do
+                    // absolute references under the legacy Pin policy).
                     coord
                 } else {
                     // Shift down
@@ -193,8 +258,8 @@ impl ReferenceAdjuster {
                 start,
                 count,
             } if cell_ref.sheet_id == *sheet_id => {
-                if coord.row_abs() {
-                    // Absolute references don't adjust
+                if policy.pins() && coord.row_abs() {
+                    // Legacy Pin policy: absolute references don't adjust
                     coord
                 } else if coord.row() >= *start && coord.row() < start + count {
                     // Cell deleted
@@ -217,8 +282,9 @@ impl ReferenceAdjuster {
                 before,
                 count,
             } if cell_ref.sheet_id == *sheet_id => {
-                if coord.col_abs() || coord.col() < *before {
-                    // Absolute references or cells before insert point don't move
+                if (policy.pins() && coord.col_abs()) || coord.col() < *before {
+                    // Cells before the insert point don't move (nor do
+                    // absolute references under the legacy Pin policy).
                     coord
                 } else {
                     // Shift right
@@ -235,8 +301,8 @@ impl ReferenceAdjuster {
                 start,
                 count,
             } if cell_ref.sheet_id == *sheet_id => {
-                if coord.col_abs() {
-                    // Absolute references don't adjust
+                if policy.pins() && coord.col_abs() {
+                    // Legacy Pin policy: absolute references don't adjust
                     coord
                 } else if coord.col() >= *start && coord.col() < start + count {
                     // Cell deleted
@@ -265,6 +331,7 @@ impl ReferenceAdjuster {
         &self,
         reference: &formualizer_parse::parser::ReferenceType,
         op: &ShiftOperation,
+        policy: AbsShiftPolicy,
     ) -> formualizer_parse::parser::ReferenceType {
         use formualizer_parse::parser::ReferenceType;
 
@@ -291,7 +358,7 @@ impl ReferenceAdjuster {
                     Coord::new(cell.coord.row(), cell.coord.col(), *row_abs, *col_abs),
                 );
 
-                match self.adjust_cell_ref(&temp_ref, op) {
+                match self.adjust_cell_ref_with_policy(&temp_ref, op, policy) {
                     None => ReferenceType::Cell {
                         sheet: Some("#REF".to_string()),
                         row: 0,
@@ -331,7 +398,7 @@ impl ReferenceAdjuster {
                 let ec = range.end_col;
 
                 let adjust_insert = |b: formualizer_common::AxisBound, before: u32, count: u32| {
-                    if b.abs {
+                    if policy.pins() && b.abs {
                         b.index
                     } else if b.index >= before {
                         b.index + count
@@ -341,7 +408,7 @@ impl ReferenceAdjuster {
                 };
 
                 let adjust_delete = |idx: u32, abs: bool, start: u32, count: u32| {
-                    if abs {
+                    if policy.pins() && abs {
                         idx
                     } else if idx >= start + count {
                         idx - count
@@ -359,7 +426,7 @@ impl ReferenceAdjuster {
                     ),
                     ShiftOperation::DeleteRows { start, count, .. } => match (sr, er) {
                         (Some(range_start), Some(range_end))
-                            if !range_start.abs && !range_end.abs =>
+                            if !policy.pins() || (!range_start.abs && !range_end.abs) =>
                         {
                             let range_start = range_start.index;
                             let range_end = range_end.index;
@@ -423,7 +490,7 @@ impl ReferenceAdjuster {
                     ),
                     ShiftOperation::DeleteColumns { start, count, .. } => match (sc, ec) {
                         (Some(range_start), Some(range_end))
-                            if !range_start.abs && !range_end.abs =>
+                            if !policy.pins() || (!range_start.abs && !range_end.abs) =>
                         {
                             let range_start = range_start.index;
                             let range_end = range_end.index;
@@ -1125,7 +1192,7 @@ mod tests {
     }
 
     #[test]
-    fn test_absolute_reference_preservation() {
+    fn test_absolute_row_tracks_row_insert() {
         let adjuster = ReferenceAdjuster::new();
 
         // Test with absolute row references ($5)
@@ -1134,27 +1201,32 @@ mod tests {
             Coord::new(5, 2, true, false), // Row 5 absolute, col 2 relative
         );
 
-        // Insert rows before the absolute reference
-        let result = adjuster.adjust_cell_ref(
-            &cell_abs_row,
-            &ShiftOperation::InsertRows {
-                sheet_id: 0,
-                before: 3,
-                count: 2,
-            },
-        );
+        let op = ShiftOperation::InsertRows {
+            sheet_id: 0,
+            before: 3,
+            count: 2,
+        };
 
-        // Absolute row should not change
+        // Issue #168 policy: absolute references TRACK structural shifts —
+        // the `$` pins copy/fill relocation only.
+        let result = adjuster.adjust_cell_ref(&cell_abs_row, &op);
         assert!(result.is_some());
         let adjusted = result.unwrap();
-        assert_eq!(adjusted.coord.row(), 5); // Row stays at 5
+        assert_eq!(adjusted.coord.row(), 7); // Row 5 -> 7 (shifted)
         assert_eq!(adjusted.coord.col(), 2); // Column unchanged
-        assert!(adjusted.coord.row_abs());
+        assert!(adjusted.coord.row_abs()); // Anchor flag preserved
         assert!(!adjusted.coord.col_abs());
+
+        // Legacy Pin policy (named-range definitions) keeps the old behavior.
+        let pinned = adjuster
+            .adjust_cell_ref_with_policy(&cell_abs_row, &op, AbsShiftPolicy::Pin)
+            .unwrap();
+        assert_eq!(pinned.coord.row(), 5);
+        assert!(pinned.coord.row_abs());
     }
 
     #[test]
-    fn test_absolute_column_preservation() {
+    fn test_absolute_column_tracks_column_delete() {
         let adjuster = ReferenceAdjuster::new();
 
         // Test with absolute column references ($B)
@@ -1163,23 +1235,45 @@ mod tests {
             Coord::new(5, 2, false, true), // Row 5 relative, col 2 absolute
         );
 
-        // Delete columns before the absolute reference
-        let result = adjuster.adjust_cell_ref(
-            &cell_abs_col,
-            &ShiftOperation::DeleteColumns {
-                sheet_id: 0,
-                start: 1,
-                count: 1,
-            },
-        );
+        let op = ShiftOperation::DeleteColumns {
+            sheet_id: 0,
+            start: 1,
+            count: 1,
+        };
 
-        // Absolute column should not change
+        // Issue #168 policy: the absolute column shifts left with the delete.
+        let result = adjuster.adjust_cell_ref(&cell_abs_col, &op);
         assert!(result.is_some());
         let adjusted = result.unwrap();
         assert_eq!(adjusted.coord.row(), 5); // Row unchanged
-        assert_eq!(adjusted.coord.col(), 2); // Column stays at 2 despite deletion
+        assert_eq!(adjusted.coord.col(), 1); // Column 2 -> 1 (shifted left)
         assert!(!adjusted.coord.row_abs());
-        assert!(adjusted.coord.col_abs());
+        assert!(adjusted.coord.col_abs()); // Anchor flag preserved
+
+        // Legacy Pin policy keeps the old behavior.
+        let pinned = adjuster
+            .adjust_cell_ref_with_policy(&cell_abs_col, &op, AbsShiftPolicy::Pin)
+            .unwrap();
+        assert_eq!(pinned.coord.col(), 2);
+        assert!(pinned.coord.col_abs());
+    }
+
+    #[test]
+    fn test_absolute_reference_deleted_becomes_ref_error() {
+        let adjuster = ReferenceAdjuster::new();
+
+        // $F$1 with the delete removing row 0 (the target row): the
+        // reference is gone, exactly like a relative reference (issue #168).
+        let fully_abs = CellRef::new(0, Coord::new(0, 5, true, true));
+        let result = adjuster.adjust_cell_ref(
+            &fully_abs,
+            &ShiftOperation::DeleteRows {
+                sheet_id: 0,
+                start: 0,
+                count: 1,
+            },
+        );
+        assert!(result.is_none(), "deleted absolute target must be #REF!");
     }
 
     #[test]
@@ -1228,42 +1322,52 @@ mod tests {
     }
 
     #[test]
-    fn test_fully_absolute_reference() {
+    fn test_fully_absolute_reference_tracks_structural_ops() {
         let adjuster = ReferenceAdjuster::new();
 
-        // Test $A$1 - fully absolute
+        // Test $B$2 - fully absolute (0-based row 1, col 1)
         let fully_abs = CellRef::new(
             0,
             Coord::new(1, 1, true, true), // Both row and col absolute
         );
 
-        // Try various operations - nothing should change
+        // Issue #168 policy: absolute references track structural shifts.
 
-        // Insert rows
-        let result1 = adjuster.adjust_cell_ref(
-            &fully_abs,
-            &ShiftOperation::InsertRows {
-                sheet_id: 0,
-                before: 1,
-                count: 5,
-            },
-        );
-        assert!(result1.is_some());
-        assert_eq!(result1.unwrap().coord.row(), 1);
-        assert_eq!(result1.unwrap().coord.col(), 1);
+        // Insert rows at/above the target: the target row moves down.
+        let insert = ShiftOperation::InsertRows {
+            sheet_id: 0,
+            before: 1,
+            count: 5,
+        };
+        let result1 = adjuster.adjust_cell_ref(&fully_abs, &insert).unwrap();
+        assert_eq!(result1.coord.row(), 6); // Row 1 -> 6 (shifted)
+        assert_eq!(result1.coord.col(), 1);
+        assert!(result1.coord.row_abs());
+        assert!(result1.coord.col_abs());
 
-        // Delete columns
-        let result2 = adjuster.adjust_cell_ref(
-            &fully_abs,
-            &ShiftOperation::DeleteColumns {
-                sheet_id: 0,
-                start: 0,
-                count: 1,
-            },
-        );
-        assert!(result2.is_some());
-        assert_eq!(result2.unwrap().coord.row(), 1);
-        assert_eq!(result2.unwrap().coord.col(), 1);
+        // Delete a column before the target: the target column moves left.
+        let delete = ShiftOperation::DeleteColumns {
+            sheet_id: 0,
+            start: 0,
+            count: 1,
+        };
+        let result2 = adjuster.adjust_cell_ref(&fully_abs, &delete).unwrap();
+        assert_eq!(result2.coord.row(), 1);
+        assert_eq!(result2.coord.col(), 0); // Col 1 -> 0 (shifted left)
+        assert!(result2.coord.row_abs());
+        assert!(result2.coord.col_abs());
+
+        // Legacy Pin policy (named ranges): nothing moves.
+        let pinned1 = adjuster
+            .adjust_cell_ref_with_policy(&fully_abs, &insert, AbsShiftPolicy::Pin)
+            .unwrap();
+        assert_eq!(pinned1.coord.row(), 1);
+        assert_eq!(pinned1.coord.col(), 1);
+        let pinned2 = adjuster
+            .adjust_cell_ref_with_policy(&fully_abs, &delete, AbsShiftPolicy::Pin)
+            .unwrap();
+        assert_eq!(pinned2.coord.row(), 1);
+        assert_eq!(pinned2.coord.col(), 1);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -45,22 +45,33 @@ fn is_valid_excel_name(name: &str) -> bool {
 }
 
 /// Helper function to adjust a named definition during structural operations.
+///
+/// Named definitions deliberately keep the legacy `Pin` policy for absolute
+/// anchors: formula reference adjustment now tracks absolute refs through
+/// structural shifts (issue #168), but flipping named-range definitions to
+/// the same semantics is a separate policy decision that has not been made —
+/// see `AbsShiftPolicy` and the #168 discussion.
 fn adjust_named_definition(
     definition: &mut NamedDefinition,
     adjuster: &crate::engine::graph::editor::reference_adjuster::ReferenceAdjuster,
     operation: &crate::engine::graph::editor::reference_adjuster::ShiftOperation,
 ) -> Result<(), ExcelError> {
+    use crate::engine::graph::editor::reference_adjuster::AbsShiftPolicy;
     match definition {
         NamedDefinition::Cell(cell_ref) => {
-            if let Some(adjusted) = adjuster.adjust_cell_ref(cell_ref, operation) {
+            if let Some(adjusted) =
+                adjuster.adjust_cell_ref_with_policy(cell_ref, operation, AbsShiftPolicy::Pin)
+            {
                 *cell_ref = adjusted;
             } else {
                 return Err(ExcelError::new(ExcelErrorKind::Ref));
             }
         }
         NamedDefinition::Range(range_ref) => {
-            let adjusted_start = adjuster.adjust_cell_ref(&range_ref.start, operation);
-            let adjusted_end = adjuster.adjust_cell_ref(&range_ref.end, operation);
+            let adjusted_start =
+                adjuster.adjust_cell_ref_with_policy(&range_ref.start, operation, AbsShiftPolicy::Pin);
+            let adjusted_end =
+                adjuster.adjust_cell_ref_with_policy(&range_ref.end, operation, AbsShiftPolicy::Pin);
 
             if let (Some(start), Some(end)) = (adjusted_start, adjusted_end) {
                 range_ref.start = start;
@@ -77,7 +88,8 @@ fn adjust_named_definition(
             dependencies,
             range_deps,
         } => {
-            let adjusted_ast = adjuster.adjust_ast(ast, operation);
+            let adjusted_ast =
+                adjuster.adjust_ast_with_policy(ast, operation, AbsShiftPolicy::Pin);
             *ast = adjusted_ast;
 
             dependencies.clear();

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -68,10 +68,16 @@ fn adjust_named_definition(
             }
         }
         NamedDefinition::Range(range_ref) => {
-            let adjusted_start =
-                adjuster.adjust_cell_ref_with_policy(&range_ref.start, operation, AbsShiftPolicy::Pin);
-            let adjusted_end =
-                adjuster.adjust_cell_ref_with_policy(&range_ref.end, operation, AbsShiftPolicy::Pin);
+            let adjusted_start = adjuster.adjust_cell_ref_with_policy(
+                &range_ref.start,
+                operation,
+                AbsShiftPolicy::Pin,
+            );
+            let adjusted_end = adjuster.adjust_cell_ref_with_policy(
+                &range_ref.end,
+                operation,
+                AbsShiftPolicy::Pin,
+            );
 
             if let (Some(start), Some(end)) = (adjusted_start, adjusted_end) {
                 range_ref.start = start;
@@ -88,8 +94,7 @@ fn adjust_named_definition(
             dependencies,
             range_deps,
         } => {
-            let adjusted_ast =
-                adjuster.adjust_ast_with_policy(ast, operation, AbsShiftPolicy::Pin);
+            let adjusted_ast = adjuster.adjust_ast_with_policy(ast, operation, AbsShiftPolicy::Pin);
             *ast = adjusted_ast;
 
             dependencies.clear();

--- a/crates/formualizer-eval/src/engine/tests/arrow_canonical_611.rs
+++ b/crates/formualizer-eval/src/engine/tests/arrow_canonical_611.rs
@@ -264,12 +264,15 @@ fn canonical_insert_rows_shifts_values_and_formulas_and_rewrites_references() {
 }
 
 #[test]
-fn canonical_insert_rows_does_not_move_fully_absolute_reference_address() {
+fn canonical_insert_rows_moves_fully_absolute_reference_with_its_target() {
     let cfg = arrow_eval_config();
     let mut engine = Engine::new(TestWorkbook::default(), cfg);
 
-    // A2 = $A$1. After inserting a row before row 1, the formula cell shifts to A3,
-    // but $A$1 should remain $A$1 (so it now points at an empty cell).
+    // A2 = $A$1. After inserting a row before row 1, the referenced value
+    // physically moves to A2 and the formula cell shifts to A3. Policy
+    // pinned on issue #168: absolute references TRACK structural
+    // inserts/deletes (the `$` pins copy/fill relocation only), so the
+    // formula must now reference $A$2 and keep computing 99.
     engine
         .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(99.0))
         .unwrap();
@@ -292,15 +295,18 @@ fn canonical_insert_rows_does_not_move_fully_absolute_reference_address() {
         Some(LiteralValue::Number(99.0))
     );
 
-    // Formula moved to A3 and still references $A$1, which is now empty.
+    // Formula moved to A3 and its absolute reference tracked the target.
     let (ast_opt, _) = engine.get_cell("Sheet1", 3, 1).expect("A3 exists");
     let ast = ast_opt.expect("A3 has formula");
     let f = canonical_formula(&ast);
     assert!(
-        f.contains("$A$1"),
-        "expected absolute ref to remain, got: {f}"
+        f.contains("$A$2"),
+        "expected absolute ref to track its moved target, got: {f}"
     );
-    assert_eq!(engine.get_cell_value("Sheet1", 3, 1), None);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 3, 1),
+        Some(LiteralValue::Number(99.0))
+    );
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -1326,6 +1326,118 @@ fn formula_plane_delete_overlapping_span_head_matches_span_off_engine() {
 }
 
 #[test]
+fn formula_plane_absolute_read_insert_above_rewrites_template_and_keeps_span() {
+    // Issue #168, span-preserving fix: inserting rows above the whole span
+    // displaces both the span and its absolute read target ($F$1 -> $F$3).
+    // The span must SHIFT with a template AST rewrite — not demote — and
+    // keep computing the same values against the physically moved scalar.
+    let mut engine = authoritative_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(3.0))
+        .unwrap();
+    let mut formulas = Vec::new();
+    // 120 rows: comfortably above the 100-cell span promotion threshold.
+    for row in 2..=121 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(row as f64 + 1.0))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 3, &format!("=A{row}*B{row}*$F$1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+
+    engine.insert_rows("Sheet1", 1, 2).unwrap();
+    // The span survives as a single shifted span with a rewritten template.
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    engine.evaluate_all().unwrap();
+
+    // The scalar physically moved to F3; every formula (now rows 4..=102)
+    // must keep reading it through the rewritten $F$3.
+    for row in [2u32, 50, 121] {
+        assert_eq!(
+            engine.get_cell_value("Sheet1", row + 2, 3),
+            Some(LiteralValue::Number(row as f64 * (row as f64 + 1.0) * 3.0)),
+            "original row {row} (now {})",
+            row + 2
+        );
+    }
+
+    // A follow-up structural op on the rewritten span keeps working: a
+    // mid-domain insert must split it (stationary $F$3 read, shifting
+    // relative reads).
+    engine.insert_rows("Sheet1", 50, 1).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    engine.evaluate_all().unwrap();
+    // Original row 50 sat at row 52 and shifted once more to row 53.
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 53, 3),
+        Some(LiteralValue::Number(50.0 * 51.0 * 3.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 124, 3),
+        Some(LiteralValue::Number(121.0 * 122.0 * 3.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 4, 3),
+        Some(LiteralValue::Number(2.0 * 3.0 * 3.0))
+    );
+}
+
+#[test]
+fn formula_plane_absolute_read_column_insert_rewrites_template_and_keeps_span() {
+    // Column-axis mirror of the #168 fix, on a vertical (RowRun) span:
+    // engine ingest only forms column families, so the column-axis rewrite
+    // is exercised by inserting columns before a RowRun span whose template
+    // reads relative columns (A{r}, B{r}) plus an absolute column ($F$1).
+    // Everything shifts right by 2: inputs to C/D, formulas to E, the
+    // scalar to H — the template must be rewritten to read $H$1.
+    let mut engine = authoritative_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(3.0))
+        .unwrap();
+    let mut formulas = Vec::new();
+    for row in 2..=121 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(row as f64 + 1.0))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 3, &format!("=A{row}*B{row}*$F$1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+
+    engine.insert_columns("Sheet1", 1, 2).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    engine.evaluate_all().unwrap();
+
+    // Scalar physically moved to H1.
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 8),
+        Some(LiteralValue::Number(3.0))
+    );
+    for row in [2u32, 60, 121] {
+        assert_eq!(
+            engine.get_cell_value("Sheet1", row, 5),
+            Some(LiteralValue::Number(row as f64 * (row as f64 + 1.0) * 3.0)),
+            "row {row} at shifted column E"
+        );
+    }
+}
+#[test]
 fn formula_plane_mixed_read_row_insert_splits_span() {
     // P2.5: this INVERTS the v1 scope pin (previously
     // `formula_plane_mixed_read_row_insert_still_demotes`). A template with

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -1438,6 +1438,57 @@ fn formula_plane_absolute_read_column_insert_rewrites_template_and_keeps_span() 
     }
 }
 #[test]
+fn formula_plane_partial_absolute_displacement_rewrites_selectively() {
+    // Two absolute reads, only one displaced: $F$1 sits above the insert
+    // (stationary), $F$5 below it (displaced), and the span shifts. The
+    // template rewrite must repoint ONLY $F$5 (per-reference selectivity of
+    // the shared adjuster) while $F$1 keeps its coordinate.
+    let mut engine = authoritative_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(3.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 5, 6, LiteralValue::Number(7.0))
+        .unwrap();
+    let mut formulas = Vec::new();
+    for row in 10..=150 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 3, &format!("=A{row}*$F$1*$F$5")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+
+    // Insert two rows between the scalars (1-based row 3): $F$1 stays,
+    // $F$5's value physically moves to F7, the span shifts to rows 12..=152.
+    engine.insert_rows("Sheet1", 3, 2).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 6),
+        Some(LiteralValue::Number(3.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 7, 6),
+        Some(LiteralValue::Number(7.0))
+    );
+    for row in [10u32, 80, 150] {
+        assert_eq!(
+            engine.get_cell_value("Sheet1", row + 2, 3),
+            Some(LiteralValue::Number(row as f64 * 3.0 * 7.0)),
+            "original row {row} (now {})",
+            row + 2
+        );
+    }
+}
+
+#[test]
 fn formula_plane_mixed_read_row_insert_splits_span() {
     // P2.5: this INVERTS the v1 scope pin (previously
     // `formula_plane_mixed_read_row_insert_still_demotes`). A template with

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -1545,3 +1545,198 @@ fn formula_plane_mixed_read_row_insert_splits_span() {
         Some(LiteralValue::Number(100.0 * 101.0 * 3.0))
     );
 }
+
+#[test]
+fn formula_plane_split_then_insert_displacing_absolute_matches_span_off_engine() {
+    // Frame-divergence composition regression (issue #168 review): op1
+    // splits the span, leaving the lower half with its template origin at
+    // row 1 while its domain starts at row 51. Op2 inserts rows BETWEEN
+    // the stale origin and the domain start while displacing the absolute
+    // target $F$30, routing the lower half into the
+    // Shift{rewrite_absolute_reads} arm. The shared adjuster relocates by
+    // AUTHORED coordinate (A1 sits below the insert point), so an
+    // unguarded rewrite shears every relative read by the insert count.
+    // rewrite_frame_is_sound must refuse the rewrite (demote instead) and
+    // keep span-ON byte-identical to span-OFF.
+    let mut span_on = authoritative_engine();
+    let mut span_off = span_off_engine();
+    for engine in [&mut span_on, &mut span_off] {
+        let mut formulas = Vec::new();
+        for row in 1..=120 {
+            engine
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+        }
+        engine
+            .set_cell_value("Sheet1", 30, 6, LiteralValue::Number(1000.0))
+            .unwrap();
+        for row in 1..=120 {
+            formulas.push(record(engine, row, 3, &format!("=A{row}+$F$30")));
+        }
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 1);
+
+    for engine in [&mut span_on, &mut span_off] {
+        engine.insert_rows("Sheet1", 50, 1).unwrap();
+        engine.insert_rows("Sheet1", 10, 3).unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_value_parity(&span_on, &span_off, 124, 6);
+}
+
+#[test]
+fn formula_plane_origin_follows_shift_keeps_incremental_dirty_projection() {
+    // Second frame bug pinned during the #168 review: projection rules
+    // store PLACEMENT-relative offsets (= authored - origin). An
+    // origin-follows shift (stationary relative reads, shifted span) moves
+    // the origin over an unchanged AST, so the stored offsets must shift
+    // by -origin_delta or incremental dirty projection maps changed
+    // regions to the wrong result rows and the span silently keeps stale
+    // values. Span rows 150..=270 read A10..A130 (stationary under the
+    // insert at 140); after the shift, a write to A10 must still re-dirty
+    // the span.
+    let mut span_on = authoritative_engine();
+    let mut span_off = span_off_engine();
+    for engine in [&mut span_on, &mut span_off] {
+        let mut formulas = Vec::new();
+        for row in 10..=130 {
+            engine
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+        }
+        for row in 150..=270 {
+            formulas.push(record(engine, row, 3, &format!("=A{}", row - 140)));
+        }
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 1);
+    for engine in [&mut span_on, &mut span_off] {
+        engine.insert_rows("Sheet1", 140, 1).unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    // The span survives the shift (origin follows the block).
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 1);
+    // Incremental dirty: change a read target, re-evaluate.
+    for engine in [&mut span_on, &mut span_off] {
+        engine
+            .set_cell_value("Sheet1", 10, 1, LiteralValue::Number(999.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(
+        span_on.get_cell_value("Sheet1", 151, 3),
+        Some(LiteralValue::Number(999.0)),
+        "the shifted span must observe the incremental write"
+    );
+    assert_value_parity(&span_on, &span_off, 275, 6);
+}
+
+#[test]
+fn formula_plane_rewrite_keeps_incremental_dirty_on_moved_absolute() {
+    // Companion to the frame-invariant fix: after a template rewrite the
+    // span's read summary must be RE-DERIVED from the rewritten canonical
+    // template — a structural transform would keep the old Absolute rule
+    // indices, and an incremental write to the MOVED scalar would silently
+    // fail to dirty the span.
+    let mut span_on = authoritative_engine();
+    let mut span_off = span_off_engine();
+    for engine in [&mut span_on, &mut span_off] {
+        engine
+            .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(3.0))
+            .unwrap();
+        let mut formulas = Vec::new();
+        for row in 2..=121 {
+            engine
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+            formulas.push(record(engine, row, 3, &format!("=A{row}*$F$1")));
+        }
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        engine.insert_rows("Sheet1", 1, 2).unwrap();
+        engine.evaluate_all().unwrap();
+        // Incremental write to the MOVED absolute target (now F3).
+        engine
+            .set_cell_value("Sheet1", 3, 6, LiteralValue::Number(5.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(
+        span_on.get_cell_value("Sheet1", 4, 3),
+        Some(LiteralValue::Number(2.0 * 5.0)),
+        "the rewritten span must observe the incremental write to $F$3"
+    );
+    assert_value_parity(&span_on, &span_off, 125, 6);
+}
+
+#[test]
+fn formula_plane_column_pinned_origin_shifts_compose_and_match_span_off_engine() {
+    // Column-axis mirror of the frame-divergence composition. Engine ingest
+    // only forms vertical families, and every column-op sequence that could
+    // displace an absolute target through a diverged column origin first
+    // routes the span through the rewrite arm (which re-aligns the origin),
+    // so the row repro's shear is not reachable on this axis — pinned at
+    // unit level in rewrite_frame_soundness_matrix. What IS reachable is
+    // composing pinned-origin column shifts: op1 diverges origin_col from
+    // the domain column, op2 shifts again through the diverged frame. Both
+    // must stay on the span fast path and match span-OFF.
+    let mut span_on = authoritative_engine();
+    let mut span_off = span_off_engine();
+    for engine in [&mut span_on, &mut span_off] {
+        engine
+            .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(1000.0))
+            .unwrap();
+        let mut formulas = Vec::new();
+        for row in 1..=120 {
+            engine
+                .set_cell_value("Sheet1", row, 3, LiteralValue::Number(row as f64))
+                .unwrap();
+            formulas.push(record(engine, row, 4, &format!("=C{row}+$A$1")));
+        }
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 1);
+
+    for engine in [&mut span_on, &mut span_off] {
+        // op1: insert between $A$1 and the inputs — inputs and formulas
+        // shift right, the scalar stays: pinned-origin column shift
+        // (origin_col keeps the authored anchor while the domain moves).
+        engine.insert_columns("Sheet1", 2, 1).unwrap();
+        // op2: insert at the (shifted) input column — shifts inputs and
+        // formulas again through the diverged column frame.
+        engine.insert_columns("Sheet1", 4, 1).unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    // Both ops are mixed-read fast-path shifts: the span survives.
+    assert_eq!(span_on.baseline_stats().formula_plane_active_span_count, 1);
+    // Incremental writes through the diverged frame must still re-dirty
+    // the span (rule offsets track the pinned origin).
+    for engine in [&mut span_on, &mut span_off] {
+        engine
+            .set_cell_value("Sheet1", 5, 5, LiteralValue::Number(500.0))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(2000.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(
+        span_on.get_cell_value("Sheet1", 5, 6),
+        Some(LiteralValue::Number(500.0 + 2000.0)),
+        "shifted formula must track both incremental writes"
+    );
+    assert_value_parity(&span_on, &span_off, 125, 8);
+}

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -720,9 +720,12 @@ fn formula_plane_delete_on_read_range_sheet_straddles_and_demotes() {
     assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
     engine.evaluate_all().unwrap();
 
+    // Issue #168 policy: absolute bounds track structural deletes, so
+    // `$A$1:$A$10` contracts to `$A$1:$A$9` when row 5 is deleted. The
+    // surviving values in rows 1..=9 are 1,2,3,4,6,7,8,9,10 → 50.
     assert_eq!(
         engine.get_cell_value("Sheet1", 1, 1),
-        Some(LiteralValue::Number(61.0))
+        Some(LiteralValue::Number(50.0))
     );
 }
 

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -1326,12 +1326,14 @@ fn formula_plane_delete_overlapping_span_head_matches_span_off_engine() {
 }
 
 #[test]
-fn formula_plane_mixed_read_row_insert_still_demotes() {
-    // v1 scope pin: a template with mixed reads (relative A{r}/B{r} shift with
-    // the block, absolute $F$1 stays put) does NOT split — the lower half
-    // classifies Demote(MixedReadRegionShift), so the whole span demotes
-    // exactly as before the split feature. Mixed-read splitting is a
-    // follow-up phase.
+fn formula_plane_mixed_read_row_insert_splits_span() {
+    // P2.5: this INVERTS the v1 scope pin (previously
+    // `formula_plane_mixed_read_row_insert_still_demotes`). A template with
+    // mixed reads — relative A{r}/B{r} shift with the block, absolute $F$1
+    // stays put — now SPLITS on a mid-domain insert: the stationary
+    // absolute read imposes no constraint (its AST coordinate still points
+    // at the unmoved target), so the lower half classifies as a clean
+    // shift with a stationary origin and the span stays on the fast path.
     let mut engine = authoritative_engine();
     engine
         .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(3.0))
@@ -1353,13 +1355,24 @@ fn formula_plane_mixed_read_row_insert_still_demotes() {
     engine.evaluate_all().unwrap();
 
     engine.insert_rows("Sheet1", 40, 1).unwrap();
-    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    // Split, not demote: upper half rows 1..=39 keeps the span id, lower
+    // half rows 41..=101 is a fresh span.
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
     engine.evaluate_all().unwrap();
 
+    // Upper half (unmoved).
     assert_eq!(
         engine.get_cell_value("Sheet1", 10, 3),
         Some(LiteralValue::Number(10.0 * 11.0 * 3.0))
     );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 39, 3),
+        Some(LiteralValue::Number(39.0 * 40.0 * 3.0))
+    );
+    // The inserted row has no formula.
+    assert_eq!(engine.get_cell_value("Sheet1", 40, 3), None);
+    // Lower half (shifted down one row, still reading $F$1).
     assert_eq!(
         engine.get_cell_value("Sheet1", 41, 3),
         Some(LiteralValue::Number(40.0 * 41.0 * 3.0))

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural_split_acceptance.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural_split_acceptance.rs
@@ -319,3 +319,214 @@ fn oracle_insert_columns_before_absolute_target_span_on() {
         FormulaPlaneMode::AuthoritativeExperimental,
     );
 }
+
+// ---------------------------------------------------------------------------
+// Mixed-read / absolute-target edge matrix (P2.5, issue #168): every case is
+// pinned as span-ON == span-OFF parity over a full-sheet snapshot, plus a
+// hardcoded value oracle on the span-ON engine (parity alone cannot detect
+// shared corruption — see the oracle block above).
+// ---------------------------------------------------------------------------
+
+/// A vertical span rows 2..=201 in column C reading `=A{r}*$F$<scalar_row>`
+/// with `A{r} = r` and the scalar `3.0` at `F<scalar_row>`.
+fn build_abs_target_engine(mode: FormulaPlaneMode, scalar_row: u32) -> Engine<TestWorkbook> {
+    let cfg = EvalConfig::default().with_formula_plane_mode(mode);
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+    engine.add_sheet(SHEET).ok();
+    engine
+        .set_cell_value(SHEET, scalar_row, 6, LiteralValue::Number(3.0))
+        .unwrap();
+    let mut formulas = Vec::with_capacity(N as usize);
+    for r in SPAN_START..=span_end() {
+        engine
+            .set_cell_value(SHEET, r, 1, LiteralValue::Number(r as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, r, 3, &format!("=A{r}*$F${scalar_row}")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .expect("ingest abs-target span");
+    engine.evaluate_all().expect("baseline evaluate_all");
+    engine
+}
+
+fn snapshot_rect(
+    engine: &Engine<TestWorkbook>,
+    rows_hi: u32,
+    cols_hi: u32,
+) -> Vec<Option<LiteralValue>> {
+    let mut out = Vec::new();
+    for r in 1..=rows_hi {
+        for c in 1..=cols_hi {
+            out.push(engine.get_cell_value(SHEET, r, c));
+        }
+    }
+    out
+}
+
+/// Apply `op` to both modes of the abs-target fixture, assert full-sheet
+/// parity, and hand the span-ON engine back for hardcoded value oracles.
+fn assert_abs_target_op_parity(
+    scalar_row: u32,
+    rows_hi: u32,
+    op: impl Fn(&mut Engine<TestWorkbook>),
+) -> Engine<TestWorkbook> {
+    let mut off = build_abs_target_engine(FormulaPlaneMode::Off, scalar_row);
+    let mut on = build_abs_target_engine(FormulaPlaneMode::AuthoritativeExperimental, scalar_row);
+    op(&mut off);
+    op(&mut on);
+    off.evaluate_all().expect("post-op evaluate_all (off)");
+    on.evaluate_all().expect("post-op evaluate_all (on)");
+    assert_eq!(
+        snapshot_rect(&off, rows_hi, 6),
+        snapshot_rect(&on, rows_hi, 6),
+        "span-ON vs span-OFF diverged after structural op"
+    );
+    on
+}
+
+#[test]
+fn edge_insert_exactly_at_absolute_target_row_below_span() {
+    // `before == abs_target_row`: the scalar sits BELOW the span (row 250)
+    // and the insert lands exactly on its row — the target shifts, the span
+    // does not. (Stationary span + displaced absolute read: demote path.)
+    let on = assert_abs_target_op_parity(250, 260, |engine| {
+        engine.insert_rows(SHEET, 250, 1).unwrap();
+    });
+    // Scalar value physically moved to F251; formulas must follow it.
+    assert_eq!(
+        on.get_cell_value(SHEET, 251, 6),
+        Some(LiteralValue::Number(3.0))
+    );
+    for r in [SPAN_START, span_end()] {
+        assert_eq!(
+            on.get_cell_value(SHEET, r, 3),
+            Some(LiteralValue::Number(r as f64 * 3.0)),
+            "row {r} must keep tracking the moved scalar"
+        );
+    }
+}
+
+#[test]
+fn edge_absolute_target_in_inserted_gap_mid_span() {
+    // The absolute target (row 100) sits INSIDE the span's row range and the
+    // insert lands exactly on it: the span straddles (split candidate), but
+    // the upper half would keep reading the now-displaced target, so the
+    // whole span must fall back to demotion — with values still tracking
+    // the moved scalar (now F101).
+    let on = assert_abs_target_op_parity(100, 210, |engine| {
+        engine.insert_rows(SHEET, 100, 1).unwrap();
+    });
+    assert_eq!(
+        on.get_cell_value(SHEET, 101, 6),
+        Some(LiteralValue::Number(3.0))
+    );
+    // Upper region (unmoved rows) and lower region (shifted rows).
+    assert_eq!(
+        on.get_cell_value(SHEET, 2, 3),
+        Some(LiteralValue::Number(2.0 * 3.0))
+    );
+    assert_eq!(
+        on.get_cell_value(SHEET, span_end() + 1, 3),
+        Some(LiteralValue::Number(span_end() as f64 * 3.0))
+    );
+}
+
+#[test]
+fn edge_delete_absolute_target_yields_ref_error() {
+    // Policy pinned on issue #168: a delete removing the absolute target
+    // yields #REF!, exactly like a relative reference.
+    use formualizer_common::ExcelErrorKind;
+    let on = assert_abs_target_op_parity(1, 205, |engine| {
+        engine.delete_rows(SHEET, 1, 1).unwrap();
+    });
+    for r in [SPAN_START - 1, span_end() - 1] {
+        let value = on.get_cell_value(SHEET, r, 3);
+        assert!(
+            matches!(
+                &value,
+                Some(LiteralValue::Error(err)) if err.kind == ExcelErrorKind::Ref
+            ),
+            "row {r} must be #REF! after the absolute target row was deleted, got {value:?}"
+        );
+    }
+}
+
+#[test]
+fn edge_delete_inside_span_with_displaced_absolute_target() {
+    // Delete strictly inside the span, above an absolute target that also
+    // sits inside the span's row range: compaction would keep the template
+    // AST while the target moves up, so the span must demote and the
+    // per-cell adjuster repoints $F$150 -> $F$149.
+    let on = assert_abs_target_op_parity(150, 205, |engine| {
+        engine.delete_rows(SHEET, 50, 1).unwrap();
+    });
+    assert_eq!(
+        on.get_cell_value(SHEET, 149, 6),
+        Some(LiteralValue::Number(3.0))
+    );
+    // Row above the delete: unmoved. Rows below: shifted up, values follow
+    // their (moved) relative inputs and the (moved) scalar.
+    assert_eq!(
+        on.get_cell_value(SHEET, 2, 3),
+        Some(LiteralValue::Number(2.0 * 3.0))
+    );
+    assert_eq!(
+        on.get_cell_value(SHEET, span_end() - 1, 3),
+        Some(LiteralValue::Number(span_end() as f64 * 3.0))
+    );
+}
+
+#[test]
+fn edge_column_insert_before_flagship_span_parity() {
+    // Column-axis mirror on the flagship fixture: inserting columns before
+    // everything displaces the absolute COLUMN target ($F$1 -> $H$1) while
+    // the whole span shifts right (rewrite path on a RowRun span).
+    let rows_hi = span_end() + 2;
+    let mut off = build_engine(FormulaPlaneMode::Off);
+    let mut on = build_engine(FormulaPlaneMode::AuthoritativeExperimental);
+    for engine in [&mut off, &mut on] {
+        engine.insert_columns(SHEET, 1, 2).unwrap();
+        engine.evaluate_all().expect("post-op evaluate_all");
+    }
+    assert_eq!(
+        snapshot_rect(&off, rows_hi, 9),
+        snapshot_rect(&on, rows_hi, 9),
+        "span-ON vs span-OFF diverged after insert_columns"
+    );
+    // Oracle: original C{r} moved to column E, still r * 2r * 3.
+    for r in [SPAN_START, span_end()] {
+        assert_eq!(
+            on.get_cell_value(SHEET, r, 5),
+            Some(expected_c_value(r)),
+            "row {r} at shifted column E"
+        );
+    }
+}
+
+#[test]
+fn edge_column_delete_of_absolute_target_column_parity() {
+    // Deleting column F removes the absolute target's column: #REF! in both
+    // modes (issue #168 policy).
+    use formualizer_common::ExcelErrorKind;
+    let rows_hi = span_end() + 2;
+    let mut off = build_engine(FormulaPlaneMode::Off);
+    let mut on = build_engine(FormulaPlaneMode::AuthoritativeExperimental);
+    for engine in [&mut off, &mut on] {
+        engine.delete_columns(SHEET, 6, 1).unwrap();
+        engine.evaluate_all().expect("post-op evaluate_all");
+    }
+    assert_eq!(
+        snapshot_rect(&off, rows_hi, 6),
+        snapshot_rect(&on, rows_hi, 6),
+        "span-ON vs span-OFF diverged after delete_columns"
+    );
+    let value = on.get_cell_value(SHEET, SPAN_START, 3);
+    assert!(
+        matches!(
+            &value,
+            Some(LiteralValue::Error(err)) if err.kind == ExcelErrorKind::Ref
+        ),
+        "expected #REF! after deleting the absolute target column, got {value:?}"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural_split_acceptance.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural_split_acceptance.rs
@@ -182,3 +182,138 @@ fn split_acceptance_delete_strictly_inside_span() {
         engine.delete_rows(SHEET, mid, 1).unwrap();
     });
 }
+
+// ---------------------------------------------------------------------------
+// Absolute-reference tracking oracles (issue #168).
+//
+// Policy (pinned on the issue): absolute references TRACK structural
+// inserts/deletes — inserting rows above `$F$1`'s target moves both the value
+// and the reference, so formulas keep reading the same logical cell. The `$`
+// pins copy/fill relocation only. A delete that removes the target yields
+// `#REF!`.
+//
+// These are value oracles with HARDCODED expected numbers, deliberately not
+// parity assertions: the parity harness above compares span-ON to span-OFF
+// and would stay green if both modes shared the same wrong answer (which is
+// exactly how the pre-fix behavior slipped through).
+// ---------------------------------------------------------------------------
+
+fn expected_c_value(r: u32) -> LiteralValue {
+    // C{r} = A{r} * B{r} * $F$1 = r * 2r * 3.
+    LiteralValue::Number((r as f64) * (2 * r) as f64 * 3.0)
+}
+
+fn expected_tail_sum() -> LiteralValue {
+    let mut sum = 0.0;
+    for r in SPAN_START..=span_end() {
+        sum += (r as f64) * (2 * r) as f64 * 3.0;
+    }
+    LiteralValue::Number(sum)
+}
+
+fn assert_insert_above_header_oracle(mode: FormulaPlaneMode) {
+    let mut engine = build_engine(mode);
+    // Insert 2 rows above everything: the header row holding `$F$1`'s target
+    // moves to row 3, the span moves to rows 4..=203. Every formula must
+    // keep reading the (moved) scalar and the (moved) inputs.
+    engine.insert_rows(SHEET, 1, 2).unwrap();
+    engine.evaluate_all().expect("post-insert evaluate_all");
+
+    // The scalar value physically moved to F3.
+    assert_eq!(
+        engine.get_cell_value(SHEET, 3, 6),
+        Some(LiteralValue::Number(3.0)),
+        "scalar value should have physically moved to F3 ({mode:?})"
+    );
+    for r in [SPAN_START, SPAN_START + N / 2, span_end()] {
+        assert_eq!(
+            engine.get_cell_value(SHEET, r + 2, 3),
+            Some(expected_c_value(r)),
+            "C for original row {r} (now row {}) must track $F$1 ({mode:?})",
+            r + 2
+        );
+    }
+    assert_eq!(
+        engine.get_cell_value(SHEET, 3, 5),
+        Some(expected_tail_sum()),
+        "tail SUM must track the moved span ({mode:?})"
+    );
+}
+
+#[test]
+fn oracle_insert_rows_above_absolute_target_span_off() {
+    assert_insert_above_header_oracle(FormulaPlaneMode::Off);
+}
+
+#[test]
+fn oracle_insert_rows_above_absolute_target_span_on() {
+    assert_insert_above_header_oracle(FormulaPlaneMode::AuthoritativeExperimental);
+}
+
+/// Column-axis mirror: a horizontal formula family in row 3 reading a
+/// relative input above (`{col}1`) times an absolute scalar (`$A$1`), then
+/// `insert_columns` before column A displaces the scalar's target.
+fn assert_insert_columns_before_absolute_target_oracle(mode: FormulaPlaneMode) {
+    const COL_START: u32 = 2;
+    const COLS: u32 = 40;
+    let col_end = COL_START + COLS - 1;
+
+    let cfg = EvalConfig::default().with_formula_plane_mode(mode);
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+    engine.add_sheet(SHEET).ok();
+
+    // Scalar multiplier in A1, inputs along row 1, formulas along row 3.
+    engine
+        .set_cell_value(SHEET, 1, 1, LiteralValue::Number(3.0))
+        .unwrap();
+    let mut formulas = Vec::with_capacity(COLS as usize);
+    for c in COL_START..=col_end {
+        engine
+            .set_cell_value(SHEET, 1, c, LiteralValue::Number(c as f64))
+            .unwrap();
+        let col_name = crate::reference::Coord::col_to_letters(c - 1);
+        formulas.push(record(&mut engine, 3, c, &format!("={col_name}1*$A$1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .expect("ingest column family");
+    engine.evaluate_all().expect("baseline evaluate_all");
+    for c in [COL_START, COL_START + COLS / 2, col_end] {
+        assert_eq!(
+            engine.get_cell_value(SHEET, 3, c),
+            Some(LiteralValue::Number(c as f64 * 3.0)),
+            "baseline value at row 3 col {c} ({mode:?})"
+        );
+    }
+
+    // Insert 2 columns before column A: scalar target moves to C1, inputs
+    // and formulas shift right by 2.
+    engine.insert_columns(SHEET, 1, 2).unwrap();
+    engine.evaluate_all().expect("post-insert evaluate_all");
+
+    assert_eq!(
+        engine.get_cell_value(SHEET, 1, 3),
+        Some(LiteralValue::Number(3.0)),
+        "scalar value should have physically moved to C1 ({mode:?})"
+    );
+    for c in [COL_START, COL_START + COLS / 2, col_end] {
+        assert_eq!(
+            engine.get_cell_value(SHEET, 3, c + 2),
+            Some(LiteralValue::Number(c as f64 * 3.0)),
+            "formula for original col {c} (now col {}) must track $A$1 ({mode:?})",
+            c + 2
+        );
+    }
+}
+
+#[test]
+fn oracle_insert_columns_before_absolute_target_span_off() {
+    assert_insert_columns_before_absolute_target_oracle(FormulaPlaneMode::Off);
+}
+
+#[test]
+fn oracle_insert_columns_before_absolute_target_span_on() {
+    assert_insert_columns_before_absolute_target_oracle(
+        FormulaPlaneMode::AuthoritativeExperimental,
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural_split_acceptance.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural_split_acceptance.rs
@@ -255,7 +255,9 @@ fn oracle_insert_rows_above_absolute_target_span_on() {
 /// `insert_columns` before column A displaces the scalar's target.
 fn assert_insert_columns_before_absolute_target_oracle(mode: FormulaPlaneMode) {
     const COL_START: u32 = 2;
-    const COLS: u32 = 40;
+    // Above the 100-cell span promotion threshold so span-ON exercises the
+    // span path rather than falling back to legacy vertices.
+    const COLS: u32 = 120;
     let col_end = COL_START + COLS - 1;
 
     let cfg = EvalConfig::default().with_formula_plane_mode(mode);

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural_w0_oracle.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural_w0_oracle.rs
@@ -1,0 +1,483 @@
+//! W0 oracle harness (P3 recon follow-up): pins the two behaviors that the
+//! WholeAll-after-structural-op crutch currently masks, for every
+//! structural-op outcome class:
+//!
+//! (a) `*_post_op_values_without_eval` — structural op, then read values
+//!     WITHOUT an intervening `evaluate_all`: pins what the op itself must
+//!     leave behind (relocated inputs, retained above-boundary results,
+//!     span-ON == span-OFF for everything else).
+//! (b) `*_incremental_write_after_relocation` — structural op, evaluate,
+//!     targeted incremental write to a precedent (including moved absolute
+//!     targets), evaluate: pins incremental dirty routing through relocated
+//!     geometry — the class that produced the origin-follows and
+//!     rewrite-summary staleness bugs (issue #168 review).
+//!
+//! Outcome classes covered (row axis; the column-axis classes are pinned by
+//! the edge matrix in `formula_plane_structural_split_acceptance.rs`):
+//! NoOp, Shift with origin following (stationary relative reads), Shift with
+//! pinned origin (mixed reads), Shift with template rewrite (displaced
+//! absolute), Split, delete-compaction, and whole-span demote.
+//!
+//! Every probe asserts full-rect span-ON == span-OFF parity PLUS hardcoded
+//! oracle values: parity alone is blind to corruption shared by both modes
+//! (see the oracle block in `formula_plane_structural_split_acceptance.rs`).
+//!
+//! Formula-overlay punch-outs (`FormulaOverlayEntryKind`) have no public
+//! construction path today (only unit tests build them via
+//! `FormulaPlane::insert_overlay`), so the punch-out domain-relocation gap
+//! flagged in the P3 recon is not reachable through this harness and has no
+//! repro test here.
+
+use std::sync::Arc;
+
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+const SHEET: &str = "Sheet1";
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    let ast = parse(formula).unwrap();
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn engine_pair() -> (Engine<TestWorkbook>, Engine<TestWorkbook>) {
+    let on = Engine::new(
+        TestWorkbook::default(),
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental),
+    );
+    let off = Engine::new(
+        TestWorkbook::default(),
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::Off),
+    );
+    (on, off)
+}
+
+fn assert_rect_parity(
+    span_on: &Engine<TestWorkbook>,
+    span_off: &Engine<TestWorkbook>,
+    rows: u32,
+    cols: u32,
+) {
+    for row in 1..=rows {
+        for col in 1..=cols {
+            assert_eq!(
+                span_on.get_cell_value(SHEET, row, col),
+                span_off.get_cell_value(SHEET, row, col),
+                "span-on/off divergence at row={row} col={col}"
+            );
+        }
+    }
+}
+
+fn num(value: f64) -> Option<LiteralValue> {
+    Some(LiteralValue::Number(value))
+}
+
+// ---------------------------------------------------------------------------
+// Class fixtures. Each builder ingests the same workload into both engines
+// and runs the baseline evaluate_all.
+// ---------------------------------------------------------------------------
+
+/// Flagship mixed-read family: `C{r} = A{r}*B{r}*$F$1` over `rows`, with
+/// `A{r} = r`, `B{r} = 2r`, `F1 = 3`, and a tail `SUM` over the whole span
+/// output in E1 (a legacy consumer of span results).
+fn build_flagship(engine: &mut Engine<TestWorkbook>, span_start: u32, span_end: u32) {
+    engine.add_sheet(SHEET).ok();
+    engine
+        .set_cell_value(SHEET, 1, 6, LiteralValue::Number(3.0))
+        .unwrap();
+    let mut formulas = Vec::new();
+    for r in span_start..=span_end {
+        engine
+            .set_cell_value(SHEET, r, 1, LiteralValue::Number(r as f64))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, r, 2, LiteralValue::Number((2 * r) as f64))
+            .unwrap();
+        formulas.push(record(engine, r, 3, &format!("=A{r}*B{r}*$F$1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .unwrap();
+    engine
+        .set_cell_formula(
+            SHEET,
+            1,
+            5,
+            parse(&format!("=SUM(C{span_start}:C{span_end})")).unwrap(),
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+}
+
+fn flagship_c(r: u32, scalar: f64) -> Option<LiteralValue> {
+    num(r as f64 * (2 * r) as f64 * scalar)
+}
+
+fn flagship_pair(span_start: u32, span_end: u32) -> (Engine<TestWorkbook>, Engine<TestWorkbook>) {
+    let (mut on, mut off) = engine_pair();
+    build_flagship(&mut on, span_start, span_end);
+    build_flagship(&mut off, span_start, span_end);
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    (on, off)
+}
+
+// ---------------------------------------------------------------------------
+// Class 1: NoOp — insert below the span; nothing about the span changes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w0_noop_post_op_values_without_eval() {
+    let (mut on, mut off) = flagship_pair(2, 121);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 130, 2).unwrap();
+    }
+    // The op boundary (row 130) is below everything: the whole span's
+    // computed values must survive the op itself, readable with NO eval.
+    for r in [2u32, 60, 121] {
+        assert_eq!(on.get_cell_value(SHEET, r, 3), flagship_c(r, 3.0));
+    }
+    assert_rect_parity(&on, &off, 135, 6);
+}
+
+#[test]
+fn w0_noop_incremental_write_after_relocation() {
+    let (mut on, mut off) = flagship_pair(2, 121);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 130, 2).unwrap();
+        engine.evaluate_all().unwrap();
+        engine
+            .set_cell_value(SHEET, 51, 1, LiteralValue::Number(1000.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(on.get_cell_value(SHEET, 51, 3), num(1000.0 * 102.0 * 3.0));
+    assert_rect_parity(&on, &off, 135, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Class 2: Shift with the origin FOLLOWING the block (all relative reads
+// stationary): span rows 150..=270 read A10..A130 via `=A{r-140}`; the
+// insert at 140 sits between the reads and the span.
+// ---------------------------------------------------------------------------
+
+fn build_origin_follows(engine: &mut Engine<TestWorkbook>) {
+    engine.add_sheet(SHEET).ok();
+    let mut formulas = Vec::new();
+    for row in 10..=130 {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+    }
+    for row in 150..=270 {
+        formulas.push(record(engine, row, 3, &format!("=A{}", row - 140)));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .unwrap();
+    engine.evaluate_all().unwrap();
+}
+
+#[test]
+fn w0_shift_origin_follows_post_op_values_without_eval() {
+    let (mut on, mut off) = engine_pair();
+    build_origin_follows(&mut on);
+    build_origin_follows(&mut off);
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 140, 1).unwrap();
+    }
+    // Inputs sit entirely above the boundary: values must survive in place.
+    assert_eq!(on.get_cell_value(SHEET, 10, 1), num(10.0));
+    assert_eq!(on.get_cell_value(SHEET, 130, 1), num(130.0));
+    assert_rect_parity(&on, &off, 275, 6);
+}
+
+#[test]
+fn w0_shift_origin_follows_incremental_write_after_relocation() {
+    let (mut on, mut off) = engine_pair();
+    build_origin_follows(&mut on);
+    build_origin_follows(&mut off);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 140, 1).unwrap();
+        engine.evaluate_all().unwrap();
+        engine
+            .set_cell_value(SHEET, 10, 1, LiteralValue::Number(999.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    // Original C150 (reading A10) moved to row 151 and must observe the write.
+    assert_eq!(on.get_cell_value(SHEET, 151, 3), num(999.0));
+    assert_rect_parity(&on, &off, 275, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Class 3: Shift with the origin PINNED (mixed reads: relative inputs shift
+// with the block, absolute $F$1 stays): insert between the scalar and the
+// span.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w0_shift_origin_pinned_post_op_values_without_eval() {
+    let (mut on, mut off) = flagship_pair(3, 122);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 2, 1).unwrap();
+    }
+    // The scalar sits above the boundary and must survive in place; the
+    // relocated inputs carry their values without an eval.
+    assert_eq!(on.get_cell_value(SHEET, 1, 6), num(3.0));
+    assert_eq!(on.get_cell_value(SHEET, 4, 1), num(3.0)); // original A3
+    assert_eq!(on.get_cell_value(SHEET, 123, 2), num(244.0)); // original B122
+    assert_rect_parity(&on, &off, 128, 6);
+}
+
+#[test]
+fn w0_shift_origin_pinned_incremental_write_after_relocation() {
+    let (mut on, mut off) = flagship_pair(3, 122);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 2, 1).unwrap();
+        engine.evaluate_all().unwrap();
+        // Write BOTH kinds of precedent: the stationary absolute target and
+        // a relocated relative input.
+        engine
+            .set_cell_value(SHEET, 1, 6, LiteralValue::Number(5.0))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, 61, 1, LiteralValue::Number(1000.0))
+            .unwrap(); // original A60
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    // Original row 60 now sits at 61: A was overwritten, B kept 2*60.
+    assert_eq!(on.get_cell_value(SHEET, 61, 3), num(1000.0 * 120.0 * 5.0));
+    // An untouched row must track only the scalar change.
+    assert_eq!(on.get_cell_value(SHEET, 11, 3), flagship_c(10, 5.0));
+    assert_rect_parity(&on, &off, 128, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Class 4: Shift with template rewrite (displaced absolute): insert above
+// everything; $F$1's target physically moves to F3.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w0_shift_rewrite_post_op_values_without_eval() {
+    let (mut on, mut off) = flagship_pair(2, 121);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 1, 2).unwrap();
+    }
+    // Everything is at/after the boundary: computed results are flushed in
+    // both modes, but the raw inputs and the scalar must arrive relocated
+    // with their values, with NO eval.
+    assert_eq!(on.get_cell_value(SHEET, 3, 6), num(3.0)); // scalar at F3
+    assert_eq!(on.get_cell_value(SHEET, 4, 1), num(2.0)); // original A2
+    assert_eq!(on.get_cell_value(SHEET, 123, 2), num(242.0)); // original B121
+    assert_rect_parity(&on, &off, 128, 6);
+}
+
+#[test]
+fn w0_shift_rewrite_incremental_write_after_relocation() {
+    let (mut on, mut off) = flagship_pair(2, 121);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 1, 2).unwrap();
+        engine.evaluate_all().unwrap();
+        // Write the MOVED absolute target (now F3) and a relocated input.
+        engine
+            .set_cell_value(SHEET, 3, 6, LiteralValue::Number(5.0))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, 54, 1, LiteralValue::Number(1000.0))
+            .unwrap(); // original A52
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(on.get_cell_value(SHEET, 54, 3), num(1000.0 * 104.0 * 5.0));
+    assert_eq!(on.get_cell_value(SHEET, 4, 3), flagship_c(2, 5.0));
+    assert_rect_parity(&on, &off, 128, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Class 5: Split — mid-span insert; upper half keeps the span id, lower half
+// is a fresh shifted span.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w0_split_post_op_values_without_eval() {
+    let (mut on, mut off) = flagship_pair(2, 121);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 60, 1).unwrap();
+    }
+    // Above the boundary the computed results must survive the op itself.
+    for r in [2u32, 30, 59] {
+        assert_eq!(on.get_cell_value(SHEET, r, 3), flagship_c(r, 3.0));
+    }
+    // Relocated inputs below the boundary carry values without an eval.
+    assert_eq!(on.get_cell_value(SHEET, 61, 1), num(60.0)); // original A60
+    assert_rect_parity(&on, &off, 128, 6);
+}
+
+#[test]
+fn w0_split_incremental_write_after_relocation() {
+    let (mut on, mut off) = flagship_pair(2, 121);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 60, 1).unwrap();
+        engine.evaluate_all().unwrap();
+        // One precedent in each half, plus the shared absolute scalar.
+        engine
+            .set_cell_value(SHEET, 10, 1, LiteralValue::Number(100.0))
+            .unwrap(); // upper half input
+        engine
+            .set_cell_value(SHEET, 101, 1, LiteralValue::Number(200.0))
+            .unwrap(); // lower half input (original A100)
+        engine
+            .set_cell_value(SHEET, 1, 6, LiteralValue::Number(5.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(on.get_cell_value(SHEET, 10, 3), num(100.0 * 20.0 * 5.0));
+    assert_eq!(on.get_cell_value(SHEET, 101, 3), num(200.0 * 200.0 * 5.0));
+    // Untouched rows in each half track only the scalar change.
+    assert_eq!(on.get_cell_value(SHEET, 30, 3), flagship_c(30, 5.0));
+    assert_eq!(on.get_cell_value(SHEET, 122, 3), flagship_c(121, 5.0));
+    assert_rect_parity(&on, &off, 128, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Class 6: delete-compaction — delete strictly inside a pure-relative span;
+// the span survives with a compacted domain.
+// ---------------------------------------------------------------------------
+
+fn build_relative_double(engine: &mut Engine<TestWorkbook>) {
+    engine.add_sheet(SHEET).ok();
+    let mut formulas = Vec::new();
+    for r in 2..=121 {
+        engine
+            .set_cell_value(SHEET, r, 1, LiteralValue::Number(r as f64))
+            .unwrap();
+        formulas.push(record(engine, r, 3, &format!("=A{r}*2")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .unwrap();
+    engine.evaluate_all().unwrap();
+}
+
+#[test]
+fn w0_delete_compaction_post_op_values_without_eval() {
+    let (mut on, mut off) = engine_pair();
+    build_relative_double(&mut on);
+    build_relative_double(&mut off);
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    for engine in [&mut on, &mut off] {
+        engine.delete_rows(SHEET, 60, 1).unwrap();
+    }
+    // Above the boundary the computed results must survive the op itself,
+    // and relocated inputs below carry their values.
+    assert_eq!(on.get_cell_value(SHEET, 10, 3), num(20.0));
+    assert_eq!(on.get_cell_value(SHEET, 59, 3), num(118.0));
+    assert_eq!(on.get_cell_value(SHEET, 60, 1), num(61.0)); // original A61
+    assert_rect_parity(&on, &off, 125, 6);
+}
+
+#[test]
+fn w0_delete_compaction_incremental_write_after_relocation() {
+    let (mut on, mut off) = engine_pair();
+    build_relative_double(&mut on);
+    build_relative_double(&mut off);
+    for engine in [&mut on, &mut off] {
+        engine.delete_rows(SHEET, 60, 1).unwrap();
+        engine.evaluate_all().unwrap();
+        engine
+            .set_cell_value(SHEET, 10, 1, LiteralValue::Number(100.0))
+            .unwrap(); // above the deleted band
+        engine
+            .set_cell_value(SHEET, 100, 1, LiteralValue::Number(500.0))
+            .unwrap(); // below (original row 101)
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(on.get_cell_value(SHEET, 10, 3), num(200.0));
+    assert_eq!(on.get_cell_value(SHEET, 100, 3), num(1000.0));
+    // An untouched compacted row: original row 80 now sits at 79.
+    assert_eq!(on.get_cell_value(SHEET, 79, 3), num(160.0));
+    assert_rect_parity(&on, &off, 125, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Class 7: whole-span demote — the absolute target sits inside the span's
+// row range and the insert lands exactly on it (target-in-inserted-gap).
+// ---------------------------------------------------------------------------
+
+fn build_in_span_absolute(engine: &mut Engine<TestWorkbook>) {
+    engine.add_sheet(SHEET).ok();
+    engine
+        .set_cell_value(SHEET, 100, 6, LiteralValue::Number(3.0))
+        .unwrap();
+    let mut formulas = Vec::new();
+    for r in 2..=201 {
+        engine
+            .set_cell_value(SHEET, r, 1, LiteralValue::Number(r as f64))
+            .unwrap();
+        formulas.push(record(engine, r, 3, &format!("=A{r}*$F$100")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .unwrap();
+    engine.evaluate_all().unwrap();
+}
+
+#[test]
+fn w0_demote_post_op_values_without_eval() {
+    let (mut on, mut off) = engine_pair();
+    build_in_span_absolute(&mut on);
+    build_in_span_absolute(&mut off);
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 1);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 100, 1).unwrap();
+    }
+    // Above the boundary the computed results must survive the op itself.
+    assert_eq!(on.get_cell_value(SHEET, 10, 3), num(30.0));
+    assert_eq!(on.get_cell_value(SHEET, 99, 3), num(297.0));
+    // The scalar's value physically moved to F101.
+    assert_eq!(on.get_cell_value(SHEET, 101, 6), num(3.0));
+    assert_rect_parity(&on, &off, 208, 6);
+}
+
+#[test]
+fn w0_demote_incremental_write_after_relocation() {
+    let (mut on, mut off) = engine_pair();
+    build_in_span_absolute(&mut on);
+    build_in_span_absolute(&mut off);
+    for engine in [&mut on, &mut off] {
+        engine.insert_rows(SHEET, 100, 1).unwrap();
+        engine.evaluate_all().unwrap();
+        // Write the MOVED absolute target (now F101) and one input.
+        engine
+            .set_cell_value(SHEET, 101, 6, LiteralValue::Number(7.0))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, 10, 1, LiteralValue::Number(100.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    // Demoted: no active spans, values on the per-cell path.
+    assert_eq!(on.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(on.get_cell_value(SHEET, 10, 3), num(700.0));
+    assert_eq!(on.get_cell_value(SHEET, 99, 3), num(99.0 * 7.0));
+    // Original row 150 (shifted to 151) tracks the new scalar.
+    assert_eq!(on.get_cell_value(SHEET, 151, 3), num(150.0 * 7.0));
+    assert_rect_parity(&on, &off, 208, 6);
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -126,6 +126,7 @@ mod formula_plane_structural;
 mod formula_plane_structural_affected_region;
 mod formula_plane_structural_split_acceptance;
 mod formula_plane_structural_tail_precision;
+mod formula_plane_structural_w0_oracle;
 mod indirect;
 mod info_reference_context;
 mod let_lambda;

--- a/crates/formualizer-eval/src/formula_plane/producer.rs
+++ b/crates/formualizer-eval/src/formula_plane/producer.rs
@@ -445,6 +445,52 @@ pub(crate) enum DirtyProjectionRule {
 }
 
 impl DirtyProjectionRule {
+    /// Shift every `Relative` bound by the given per-axis deltas, leaving
+    /// `Absolute` bounds untouched.
+    ///
+    /// Rules store PLACEMENT-relative offsets, which equal
+    /// `authored_coordinate - template_origin`. A structural shift that
+    /// moves the template origin without rewriting the AST (the
+    /// origin-follows arm) changes that difference by `-origin_delta`;
+    /// without this transform the rule silently diverges from the template
+    /// frame, and incremental dirty projection maps changed regions to the
+    /// wrong result rows (stale span values — issue #168 family).
+    pub(crate) fn with_relative_offsets_shifted(self, row_delta: i64, col_delta: i64) -> Self {
+        fn shift(projection: AxisProjection, delta: i64) -> AxisProjection {
+            match projection {
+                AxisProjection::Relative { offset } => AxisProjection::Relative {
+                    offset: offset.saturating_add(delta),
+                },
+                AxisProjection::Absolute { .. } => projection,
+            }
+        }
+        if row_delta == 0 && col_delta == 0 {
+            return self;
+        }
+        match self {
+            Self::AffineCell { row, col } => Self::AffineCell {
+                row: shift(row, row_delta),
+                col: shift(col, col_delta),
+            },
+            Self::AffineRange {
+                row_start,
+                row_end,
+                col_start,
+                col_end,
+            } => Self::AffineRange {
+                row_start: shift(row_start, row_delta),
+                row_end: shift(row_end, row_delta),
+                col_start: shift(col_start, col_delta),
+                col_end: shift(col_end, col_delta),
+            },
+            Self::WholeColumnRange { col_start, col_end } => Self::WholeColumnRange {
+                col_start: shift(col_start, col_delta),
+                col_end: shift(col_end, col_delta),
+            },
+            Self::WholeResult => Self::WholeResult,
+        }
+    }
+
     pub(crate) fn read_region_for_result(
         self,
         sheet_id: SheetId,

--- a/crates/formualizer-eval/src/formula_plane/runtime.rs
+++ b/crates/formualizer-eval/src/formula_plane/runtime.rs
@@ -667,6 +667,24 @@ impl BindingStore {
         }
     }
 
+    /// Swap in template-derived slot data rebuilt for a structurally
+    /// rewritten template AST (issue #168): the literal slot map is keyed by
+    /// arena node ids of the template AST, and value-ref slot patterns carry
+    /// canonical reference coordinates — both go stale when the template is
+    /// rewritten and re-interned.
+    pub(crate) fn set_template_slots(
+        &mut self,
+        id: SpanBindingSetId,
+        template_slot_map: TemplateSlotMap,
+        value_ref_slots: Arc<[ValueRefSlotDescriptor]>,
+    ) {
+        if let Some(Some(set)) = self.records.get_mut(id.0 as usize) {
+            set.template_slot_map = template_slot_map;
+            set.value_ref_slots = value_ref_slots;
+            self.epoch = self.epoch.saturating_add(1);
+        }
+    }
+
     pub(crate) fn force_residual_axes(&mut self, id: SpanBindingSetId) {
         if let Some(Some(set)) = self.records.get_mut(id.0 as usize)
             && (!set.template_slot_map.residual_relative_row
@@ -793,6 +811,58 @@ impl TemplateStore {
         let parameterized_canonical_key = Arc::clone(&source.parameterized_canonical_key);
         let formula_text = source.formula_text.clone();
         let ast_id = source.ast_id;
+        self.records.push(TemplateRecord {
+            id: new_id,
+            generation: 0,
+            version: 0,
+            ast_id,
+            origin_row,
+            origin_col,
+            exact_canonical_key,
+            parameterized_canonical_key,
+            formula_text,
+            relocatable_ast_validated: OnceLock::new(),
+        });
+        self.epoch = self.epoch.saturating_add(1);
+        Some((new_id, true))
+    }
+
+    /// Intern a structurally rewritten clone of `id`: a NEW arena AST (the
+    /// source template adjusted through the shared `ReferenceAdjuster` for a
+    /// structural op that displaced an absolute read's target, issue #168)
+    /// with canonical keys re-derived from the rewritten AST at the new
+    /// origin. Source records are immutable and may be shared across spans,
+    /// so this never mutates `id`.
+    ///
+    /// Like `intern_shifted_origin_clone`, the clone is deliberately NOT
+    /// added to the intern map: the map's parameterized-key lookup returns a
+    /// single record regardless of origin, and hijacking the key could hand
+    /// future ingests a template anchored at the wrong origin. Duplicate
+    /// records for the same rewritten shape are deduped by linear scan.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn intern_rewritten_clone(
+        &mut self,
+        id: FormulaTemplateId,
+        ast_id: AstNodeId,
+        exact_canonical_key: Arc<str>,
+        parameterized_canonical_key: Arc<str>,
+        formula_text: Option<Arc<str>>,
+        origin_row: u32,
+        origin_col: u32,
+    ) -> Option<(FormulaTemplateId, bool)> {
+        // Validate the source still exists (mirrors intern_shifted_origin_clone).
+        self.get(id)?;
+        if let Some(existing) = self.records.iter().find(|record| {
+            record.ast_id == ast_id
+                && record.exact_canonical_key == exact_canonical_key
+                && record.parameterized_canonical_key == parameterized_canonical_key
+                && record.origin_row == origin_row
+                && record.origin_col == origin_col
+        }) {
+            return Some((existing.id, false));
+        }
+
+        let new_id = FormulaTemplateId(self.records.len() as u32);
         self.records.push(TemplateRecord {
             id: new_id,
             generation: 0,
@@ -1260,6 +1330,33 @@ impl FormulaPlane {
         Some(id)
     }
 
+    /// See [`TemplateStore::intern_rewritten_clone`].
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn intern_rewritten_template(
+        &mut self,
+        template_id: FormulaTemplateId,
+        ast_id: AstNodeId,
+        exact_canonical_key: Arc<str>,
+        parameterized_canonical_key: Arc<str>,
+        formula_text: Option<Arc<str>>,
+        origin_row: u32,
+        origin_col: u32,
+    ) -> Option<FormulaTemplateId> {
+        let (id, inserted) = self.templates.intern_rewritten_clone(
+            template_id,
+            ast_id,
+            exact_canonical_key,
+            parameterized_canonical_key,
+            formula_text,
+            origin_row,
+            origin_col,
+        )?;
+        if inserted {
+            self.bump_epoch();
+        }
+        Some(id)
+    }
+
     pub(crate) fn replace_span_geometry(
         &mut self,
         span_ref: FormulaSpanRef,
@@ -1317,6 +1414,18 @@ impl FormulaPlane {
     ) {
         self.binding_sets
             .set_template_anchor(id, ast_id, origin_row, origin_col);
+        self.bump_epoch();
+    }
+
+    /// See [`SpanBindingSetStore::set_template_slots`].
+    pub(crate) fn set_binding_template_slots(
+        &mut self,
+        id: SpanBindingSetId,
+        template_slot_map: TemplateSlotMap,
+        value_ref_slots: Arc<[ValueRefSlotDescriptor]>,
+    ) {
+        self.binding_sets
+            .set_template_slots(id, template_slot_map, value_ref_slots);
         self.bump_epoch();
     }
 

--- a/crates/formualizer-eval/src/formula_plane/structural_shift.rs
+++ b/crates/formualizer-eval/src/formula_plane/structural_shift.rs
@@ -208,6 +208,25 @@ fn rule_axis_bound_kinds(rule: DirtyProjectionRule, axis: AxisKindForOp) -> (boo
     }
 }
 
+/// Whether the op displaces the target of any absolute-anchored read in the
+/// summary. Used by the delete-compaction path (which never reaches
+/// `classify_span_for_op`'s read partition because the result-region
+/// straddle is classified first): compaction projects read REGIONS through
+/// the delete but keeps the template AST, so a displaced absolute read must
+/// force a demote to the per-cell path where the shared adjuster repoints
+/// the reference (issue #168).
+pub(crate) fn summary_has_displaced_absolute_read(
+    read_summary: &SpanReadSummary,
+    op: StructuralOp,
+) -> bool {
+    read_summary.dependencies.iter().any(|dependency| {
+        matches!(
+            op.classify_region(dependency.read_region),
+            AxisShiftCase::EntirelyAboveShift { .. }
+        ) && rule_axis_bound_kinds(dependency.projection, op.axis_kind()).1
+    })
+}
+
 pub(crate) fn classify_span_for_op(
     span: &FormulaSpan,
     read_summary: Option<&SpanReadSummary>,

--- a/crates/formualizer-eval/src/formula_plane/structural_shift.rs
+++ b/crates/formualizer-eval/src/formula_plane/structural_shift.rs
@@ -1,4 +1,4 @@
-use super::producer::SpanReadSummary;
+use super::producer::{AxisProjection, DirtyProjectionRule, SpanReadSummary};
 use super::region_index::{AxisRange, Region};
 use super::runtime::{FormulaSpan, PlacementDomain};
 use crate::SheetId;
@@ -63,6 +63,12 @@ pub(crate) enum SpanDemoteReason {
     OriginNotShiftedButReadRegionShifts,
     DeletePartiallyOverlaps,
     MixedReadRegionShift,
+    /// The op displaces the target of an absolute (`$`-anchored) read.
+    /// Origin-based relocation can never repoint an absolute reference —
+    /// only a template AST rewrite can (issue #168) — so until the rewrite
+    /// path exists the span must demote to the per-cell path, where the
+    /// shared `ReferenceAdjuster` repoints the reference correctly.
+    AbsoluteReadDisplaced,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -153,6 +159,42 @@ impl StructuralOp {
     }
 }
 
+/// Whether a dirty-projection rule anchors the op's axis with an absolute
+/// (`$`-style) bound. Only such reads need a template AST rewrite when the
+/// op displaces their target: relative bounds are relocated by the origin
+/// choice, and bounds on the other axis are unaffected by the op.
+///
+/// `WholeResult` is a test-only rule with no axis information; it is treated
+/// as relative to preserve the legacy region-level classification.
+fn rule_has_absolute_bound_on_op_axis(rule: DirtyProjectionRule, axis: AxisKindForOp) -> bool {
+    fn is_abs(projection: AxisProjection) -> bool {
+        matches!(projection, AxisProjection::Absolute { .. })
+    }
+    match (rule, axis) {
+        (DirtyProjectionRule::AffineCell { row, .. }, AxisKindForOp::Row) => is_abs(row),
+        (DirtyProjectionRule::AffineCell { col, .. }, AxisKindForOp::Col) => is_abs(col),
+        (
+            DirtyProjectionRule::AffineRange {
+                row_start, row_end, ..
+            },
+            AxisKindForOp::Row,
+        ) => is_abs(row_start) || is_abs(row_end),
+        (
+            DirtyProjectionRule::AffineRange {
+                col_start, col_end, ..
+            },
+            AxisKindForOp::Col,
+        ) => is_abs(col_start) || is_abs(col_end),
+        (DirtyProjectionRule::WholeColumnRange { col_start, col_end }, AxisKindForOp::Col) => {
+            is_abs(col_start) || is_abs(col_end)
+        }
+        // A whole-column read has no row bounds to displace; row-op regions
+        // for it are whole-axis and classify as straddles before this check.
+        (DirtyProjectionRule::WholeColumnRange { .. }, AxisKindForOp::Row) => false,
+        (DirtyProjectionRule::WholeResult, _) => false,
+    }
+}
+
 pub(crate) fn classify_span_for_op(
     span: &FormulaSpan,
     read_summary: Option<&SpanReadSummary>,
@@ -183,6 +225,7 @@ pub(crate) fn classify_span_for_op(
 
     let mut saw_read_shift = false;
     let mut saw_read_no_shift = false;
+    let mut saw_displaced_absolute = false;
     if let Some(read_summary) = read_summary {
         for dependency in &read_summary.dependencies {
             match op.classify_region(dependency.read_region) {
@@ -191,6 +234,9 @@ pub(crate) fn classify_span_for_op(
                 }
                 AxisShiftCase::EntirelyAboveShift { .. } => {
                     saw_read_shift = true;
+                    if rule_has_absolute_bound_on_op_axis(dependency.projection, op.axis_kind()) {
+                        saw_displaced_absolute = true;
+                    }
                 }
                 AxisShiftCase::Straddles | AxisShiftCase::DeleteFullyContains => {
                     return SpanShiftPlan::Demote {
@@ -199,6 +245,17 @@ pub(crate) fn classify_span_for_op(
                 }
             }
         }
+    }
+
+    // An absolute read whose target the op displaces cannot be relocated by
+    // any origin choice; it needs a template AST rewrite. Until that path
+    // lands, demote conservatively so the per-cell adjuster repoints it
+    // (issue #168: previously this fell into the `Shift { origin_delta: 0 }`
+    // arm and silently kept reading the stale coordinate).
+    if result_shifts && saw_displaced_absolute {
+        return SpanShiftPlan::Demote {
+            reason: SpanDemoteReason::AbsoluteReadDisplaced,
+        };
     }
 
     match (result_shifts, saw_read_shift, saw_read_no_shift) {
@@ -723,6 +780,101 @@ mod tests {
                 },
             ),
             None
+        );
+    }
+
+    #[test]
+    fn classify_span_demotes_when_absolute_read_target_is_displaced() {
+        // Flagship shape (issue #168): a vertical run reading relative
+        // inputs plus an absolute scalar `$F$1`. An insert above everything
+        // displaces the scalar's target; origin relocation cannot repoint
+        // the absolute read, so the span must demote (until the template
+        // rewrite path exists).
+        let s = span(PlacementDomain::row_run(0, 10, 99, 2));
+        let relative_dep = SpanReadDependency {
+            read_region: Region::col_interval(0, 0, 10, 99),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Relative { offset: 0 },
+                col: AxisProjection::Relative { offset: -2 },
+            },
+        };
+        let absolute_dep = SpanReadDependency {
+            read_region: Region::point(0, 0, 5),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Absolute { index: 0 },
+                col: AxisProjection::Absolute { index: 5 },
+            },
+        };
+        let rs = SpanReadSummary {
+            result_region: Region::col_interval(0, 2, 10, 99),
+            dependencies: vec![relative_dep, absolute_dep],
+        };
+
+        // Insert above the absolute target: everything (span, relative
+        // inputs, scalar target) shifts, but the absolute read requires a
+        // template rewrite.
+        let insert_above_all = StructuralOp::InsertRows {
+            sheet_id: 0,
+            before: 0,
+            count: 2,
+        };
+        assert_eq!(
+            classify_span_for_op(&s, Some(&rs), insert_above_all),
+            SpanShiftPlan::Demote {
+                reason: SpanDemoteReason::AbsoluteReadDisplaced
+            }
+        );
+
+        // Insert between the absolute target and the span: the scalar's
+        // target is stationary, so no rewrite is needed — but the relative
+        // reads shift while the absolute read does not, which is the mixed
+        // case that still demotes (upgraded by the read-kind split in P2.5).
+        let insert_between = StructuralOp::InsertRows {
+            sheet_id: 0,
+            before: 5,
+            count: 2,
+        };
+        assert_eq!(
+            classify_span_for_op(&s, Some(&rs), insert_between),
+            SpanShiftPlan::Demote {
+                reason: SpanDemoteReason::MixedReadRegionShift
+            }
+        );
+    }
+
+    #[test]
+    fn classify_span_demotes_when_absolute_column_read_target_is_displaced() {
+        // Column-axis mirror: a horizontal run reading `$A$1` under a
+        // column insert that displaces column A.
+        let s = span(PlacementDomain::col_run(0, 2, 10, 99));
+        let absolute_dep = SpanReadDependency {
+            read_region: Region::point(0, 0, 0),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Absolute { index: 0 },
+                col: AxisProjection::Absolute { index: 0 },
+            },
+        };
+        let relative_dep = SpanReadDependency {
+            read_region: Region::row_interval(0, 0, 10, 99),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Relative { offset: -2 },
+                col: AxisProjection::Relative { offset: 0 },
+            },
+        };
+        let rs = SpanReadSummary {
+            result_region: Region::row_interval(0, 2, 10, 99),
+            dependencies: vec![absolute_dep, relative_dep],
+        };
+        let op = StructuralOp::InsertColumns {
+            sheet_id: 0,
+            before: 0,
+            count: 2,
+        };
+        assert_eq!(
+            classify_span_for_op(&s, Some(&rs), op),
+            SpanShiftPlan::Demote {
+                reason: SpanDemoteReason::AbsoluteReadDisplaced
+            }
         );
     }
 

--- a/crates/formualizer-eval/src/formula_plane/structural_shift.rs
+++ b/crates/formualizer-eval/src/formula_plane/structural_shift.rs
@@ -227,6 +227,124 @@ pub(crate) fn summary_has_displaced_absolute_read(
     })
 }
 
+/// Relative-anchored bounds of `rule` on the op axis, as authored-frame
+/// offsets from the template origin. Returns `None` when the rule carries no
+/// usable axis information (`WholeResult`), which callers must treat as
+/// unverifiable.
+fn rule_relative_offsets_on_op_axis(
+    rule: DirtyProjectionRule,
+    axis: AxisKindForOp,
+) -> Option<[Option<i64>; 2]> {
+    fn offset(projection: AxisProjection) -> Option<i64> {
+        match projection {
+            AxisProjection::Relative { offset } => Some(offset),
+            AxisProjection::Absolute { .. } => None,
+        }
+    }
+    match (rule, axis) {
+        (DirtyProjectionRule::AffineCell { row, .. }, AxisKindForOp::Row) => {
+            Some([offset(row), None])
+        }
+        (DirtyProjectionRule::AffineCell { col, .. }, AxisKindForOp::Col) => {
+            Some([offset(col), None])
+        }
+        (
+            DirtyProjectionRule::AffineRange {
+                row_start, row_end, ..
+            },
+            AxisKindForOp::Row,
+        ) => Some([offset(row_start), offset(row_end)]),
+        (
+            DirtyProjectionRule::AffineRange {
+                col_start, col_end, ..
+            },
+            AxisKindForOp::Col,
+        ) => Some([offset(col_start), offset(col_end)]),
+        (DirtyProjectionRule::WholeColumnRange { col_start, col_end }, AxisKindForOp::Col) => {
+            Some([offset(col_start), offset(col_end)])
+        }
+        // A whole-column read has no row bounds; row-op regions for it are
+        // whole-axis and classify as straddles before rewrite planning.
+        (DirtyProjectionRule::WholeColumnRange { .. }, AxisKindForOp::Row) => Some([None, None]),
+        (DirtyProjectionRule::WholeResult, _) => None,
+    }
+}
+
+/// FRAME INVARIANT (issue #168 rewrite arm). A template's AST authoring
+/// frame and its `origin_{row,col}` fields may legitimately diverge:
+/// `intern_shifted_origin_clone` reuses the source `ast_id` with a new
+/// origin, the mixed-read fast path shifts a domain while pinning the origin
+/// (`origin_delta: 0`), and split lower halves keep the original anchor
+/// while their domain starts at the split boundary. Evaluation only
+/// guarantees that `authored_coord + (placement - origin)` names the right
+/// cell for placements IN THE DOMAIN — the authored coordinates themselves
+/// need not lie inside the read regions.
+///
+/// The shared `ReferenceAdjuster` relocates by AUTHORED coordinate, so a
+/// whole-template rewrite is only equivalent to per-cell adjustment when
+/// every relative-anchored bound on the op axis classifies against the op
+/// boundary exactly the way its read region does (displaced ⟺ displaced,
+/// stationary ⟺ stationary, and never inside a deleted band). When the
+/// frames disagree — e.g. a split lower half whose stale origin sits below a
+/// later insert point that displaces its reads — the rewrite would shear
+/// every relative read by the op count. This check refuses those rewrites
+/// (the caller demotes, which is correct via the per-cell adjuster).
+///
+/// Absolute bounds need no check: their authored coordinate IS the read
+/// region coordinate. Cross-sheet reads are refused outright: the adjuster
+/// relocates by coordinate without honoring the reference's sheet, so their
+/// frame cannot be verified here.
+pub(crate) fn rewrite_frame_is_sound(
+    read_summary: &SpanReadSummary,
+    origin_row: u32,
+    origin_col: u32,
+    op: StructuralOp,
+) -> bool {
+    let axis = op.axis_kind();
+    // Template origins are 1-based; regions and op boundaries are 0-based.
+    let origin_axis0 = match axis {
+        AxisKindForOp::Row => i64::from(origin_row) - 1,
+        AxisKindForOp::Col => i64::from(origin_col) - 1,
+    };
+    for dependency in &read_summary.dependencies {
+        let region_displaced = match op.classify_region(dependency.read_region) {
+            AxisShiftCase::EntirelyBelow => false,
+            AxisShiftCase::EntirelyAboveShift { .. } => true,
+            AxisShiftCase::OtherSheet
+            | AxisShiftCase::Straddles
+            | AxisShiftCase::DeleteFullyContains => return false,
+        };
+        let Some(offsets) = rule_relative_offsets_on_op_axis(dependency.projection, axis) else {
+            return false;
+        };
+        for offset in offsets.into_iter().flatten() {
+            let authored0 = origin_axis0 + offset;
+            if authored0 < 0 {
+                return false;
+            }
+            let authored_displaced = match op {
+                StructuralOp::InsertRows { before, .. }
+                | StructuralOp::InsertColumns { before, .. } => authored0 >= i64::from(before),
+                StructuralOp::DeleteRows { start, count, .. }
+                | StructuralOp::DeleteColumns { start, count, .. } => {
+                    let start = i64::from(start);
+                    let end = start + i64::from(count);
+                    if authored0 >= start && authored0 < end {
+                        // The authored coordinate would become #REF! while
+                        // the read region is uniformly intact.
+                        return false;
+                    }
+                    authored0 >= end
+                }
+            };
+            if authored_displaced != region_displaced {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 pub(crate) fn classify_span_for_op(
     span: &FormulaSpan,
     read_summary: Option<&SpanReadSummary>,
@@ -995,6 +1113,143 @@ mod tests {
                 reason: SpanDemoteReason::MixedReadRegionShift
             }
         );
+    }
+
+    #[test]
+    fn rewrite_frame_soundness_matrix() {
+        fn rel_cell_dep(
+            read_region: Region,
+            row_offset: i64,
+            col_offset: i64,
+        ) -> SpanReadDependency {
+            SpanReadDependency {
+                read_region,
+                projection: DirtyProjectionRule::AffineCell {
+                    row: AxisProjection::Relative { offset: row_offset },
+                    col: AxisProjection::Relative { offset: col_offset },
+                },
+            }
+        }
+        fn summary_of(dependencies: Vec<SpanReadDependency>) -> SpanReadSummary {
+            SpanReadSummary {
+                result_region: Region::col_interval(0, 2, 50, 119),
+                dependencies,
+            }
+        }
+        let insert_rows = |before: u32| StructuralOp::InsertRows {
+            sheet_id: 0,
+            before,
+            count: 3,
+        };
+
+        // Split-lower-half divergence (the #168 composition repro): domain
+        // reads rows 50..119 but the stale origin authors A1 (row 0); an
+        // insert at row 9 displaces the region while the authored coordinate
+        // stays put — rewriting would shear relative reads.
+        let displaced_region = summary_of(vec![rel_cell_dep(
+            Region::col_interval(0, 0, 50, 119),
+            0,
+            -2,
+        )]);
+        assert!(!rewrite_frame_is_sound(
+            &displaced_region,
+            1,
+            3,
+            insert_rows(9)
+        ));
+        // Aligned frame (origin at the domain start): sound.
+        assert!(rewrite_frame_is_sound(
+            &displaced_region,
+            51,
+            3,
+            insert_rows(9)
+        ));
+
+        // Column-axis mirror: relative column bound authored at
+        // origin_col-1; the insert displaces the read region's column but
+        // not the authored column.
+        let displaced_col_region =
+            summary_of(vec![rel_cell_dep(Region::row_interval(0, 10, 3, 3), 0, -1)]);
+        let insert_cols = StructuralOp::InsertColumns {
+            sheet_id: 0,
+            before: 3,
+            count: 1,
+        };
+        assert!(!rewrite_frame_is_sound(
+            &displaced_col_region,
+            11,
+            4,
+            insert_cols
+        ));
+        assert!(rewrite_frame_is_sound(
+            &displaced_col_region,
+            11,
+            5,
+            insert_cols
+        ));
+
+        // Spurious-stationary direction: the region is stationary but the
+        // authored coordinate sits at/above the insert point (requires
+        // origin > domain end, unreachable via engine ops today, covered
+        // defensively).
+        let stationary_region = summary_of(vec![rel_cell_dep(
+            Region::col_interval(0, 0, 44, 54),
+            0,
+            -2,
+        )]);
+        assert!(!rewrite_frame_is_sound(
+            &stationary_region,
+            61,
+            3,
+            insert_rows(56)
+        ));
+        assert!(rewrite_frame_is_sound(
+            &stationary_region,
+            45,
+            3,
+            insert_rows(56)
+        ));
+
+        // Delete removing the authored coordinate while the region is
+        // uniformly displaced.
+        let delete = StructuralOp::DeleteRows {
+            sheet_id: 0,
+            start: 0,
+            count: 1,
+        };
+        assert!(!rewrite_frame_is_sound(&displaced_region, 1, 3, delete));
+
+        // Absolute-only dependencies carry their coordinate in the rule and
+        // never need frame verification.
+        let absolute_only = summary_of(vec![SpanReadDependency {
+            read_region: Region::point(0, 29, 5),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Absolute { index: 29 },
+                col: AxisProjection::Absolute { index: 5 },
+            },
+        }]);
+        assert!(rewrite_frame_is_sound(&absolute_only, 1, 3, insert_rows(9)));
+
+        // WholeResult rules have no axis information: unverifiable.
+        let whole_result = summary_of(vec![SpanReadDependency {
+            read_region: Region::col_interval(0, 0, 50, 119),
+            projection: DirtyProjectionRule::WholeResult,
+        }]);
+        assert!(!rewrite_frame_is_sound(
+            &whole_result,
+            51,
+            3,
+            insert_rows(9)
+        ));
+
+        // Cross-sheet reads are refused: the shared adjuster relocates by
+        // coordinate without honoring the reference's sheet.
+        let cross_sheet = summary_of(vec![rel_cell_dep(
+            Region::col_interval(1, 0, 50, 119),
+            0,
+            -2,
+        )]);
+        assert!(!rewrite_frame_is_sound(&cross_sheet, 51, 3, insert_rows(9)));
     }
 
     #[test]

--- a/crates/formualizer-eval/src/formula_plane/structural_shift.rs
+++ b/crates/formualizer-eval/src/formula_plane/structural_shift.rs
@@ -44,6 +44,16 @@ pub(crate) enum SpanShiftPlan {
         col_delta: i64,
         origin_row_delta: i64,
         origin_col_delta: i64,
+        /// The op displaces the target of at least one absolute-anchored
+        /// read. Origin relocation cannot repoint absolute references, so
+        /// the apply site must rewrite the template AST through the shared
+        /// `ReferenceAdjuster` (issue #168). Whenever this is set the origin
+        /// deltas equal the result deltas: a full-AST rewrite shifts the
+        /// template's displaced relative references too, and moving the
+        /// origin with the block exactly cancels that for stationary
+        /// relative reads while composing correctly with shifted ones —
+        /// replicating per-cell adjustment semantics.
+        rewrite_absolute_reads: bool,
     },
     /// A mid-domain insert straddles the span's result domain. The apply site
     /// may split the domain at the insert boundary into an unshifted upper
@@ -62,13 +72,11 @@ pub(crate) enum SpanDemoteReason {
     ReadRegionStraddles,
     OriginNotShiftedButReadRegionShifts,
     DeletePartiallyOverlaps,
+    /// The template mixes relative reads whose targets the op displaces
+    /// with relative reads whose targets stay put. No origin choice can
+    /// satisfy both, and (unlike absolute reads) a template rewrite for
+    /// relative references is deferred, so the span demotes.
     MixedReadRegionShift,
-    /// The op displaces the target of an absolute (`$`-anchored) read.
-    /// Origin-based relocation can never repoint an absolute reference —
-    /// only a template AST rewrite can (issue #168) — so until the rewrite
-    /// path exists the span must demote to the per-cell path, where the
-    /// shared `ReferenceAdjuster` repoints the reference correctly.
-    AbsoluteReadDisplaced,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -159,39 +167,44 @@ impl StructuralOp {
     }
 }
 
-/// Whether a dirty-projection rule anchors the op's axis with an absolute
-/// (`$`-style) bound. Only such reads need a template AST rewrite when the
-/// op displaces their target: relative bounds are relocated by the origin
-/// choice, and bounds on the other axis are unaffected by the op.
+/// The anchor kinds a dirty-projection rule uses on the op's axis:
+/// `(has_relative, has_absolute)`. Relative bounds are relocated by the
+/// span's origin choice; absolute bounds can only be repointed by a template
+/// AST rewrite. Bounds on the other axis are unaffected by the op.
 ///
 /// `WholeResult` is a test-only rule with no axis information; it is treated
 /// as relative to preserve the legacy region-level classification.
-fn rule_has_absolute_bound_on_op_axis(rule: DirtyProjectionRule, axis: AxisKindForOp) -> bool {
+fn rule_axis_bound_kinds(rule: DirtyProjectionRule, axis: AxisKindForOp) -> (bool, bool) {
     fn is_abs(projection: AxisProjection) -> bool {
         matches!(projection, AxisProjection::Absolute { .. })
     }
+    fn kinds(bounds: &[AxisProjection]) -> (bool, bool) {
+        let has_absolute = bounds.iter().copied().any(is_abs);
+        let has_relative = bounds.iter().copied().any(|bound| !is_abs(bound));
+        (has_relative, has_absolute)
+    }
     match (rule, axis) {
-        (DirtyProjectionRule::AffineCell { row, .. }, AxisKindForOp::Row) => is_abs(row),
-        (DirtyProjectionRule::AffineCell { col, .. }, AxisKindForOp::Col) => is_abs(col),
+        (DirtyProjectionRule::AffineCell { row, .. }, AxisKindForOp::Row) => kinds(&[row]),
+        (DirtyProjectionRule::AffineCell { col, .. }, AxisKindForOp::Col) => kinds(&[col]),
         (
             DirtyProjectionRule::AffineRange {
                 row_start, row_end, ..
             },
             AxisKindForOp::Row,
-        ) => is_abs(row_start) || is_abs(row_end),
+        ) => kinds(&[row_start, row_end]),
         (
             DirtyProjectionRule::AffineRange {
                 col_start, col_end, ..
             },
             AxisKindForOp::Col,
-        ) => is_abs(col_start) || is_abs(col_end),
+        ) => kinds(&[col_start, col_end]),
         (DirtyProjectionRule::WholeColumnRange { col_start, col_end }, AxisKindForOp::Col) => {
-            is_abs(col_start) || is_abs(col_end)
+            kinds(&[col_start, col_end])
         }
         // A whole-column read has no row bounds to displace; row-op regions
         // for it are whole-axis and classify as straddles before this check.
-        (DirtyProjectionRule::WholeColumnRange { .. }, AxisKindForOp::Row) => false,
-        (DirtyProjectionRule::WholeResult, _) => false,
+        (DirtyProjectionRule::WholeColumnRange { .. }, AxisKindForOp::Row) => (true, false),
+        (DirtyProjectionRule::WholeResult, _) => (true, false),
     }
 }
 
@@ -223,18 +236,28 @@ pub(crate) fn classify_span_for_op(
     };
     let result_shifts = row_delta != 0 || col_delta != 0;
 
-    let mut saw_read_shift = false;
-    let mut saw_read_no_shift = false;
+    // Partition read dependencies by (displaced-by-op × anchor kind on the
+    // op axis). Stationary absolute reads impose no constraint: the AST
+    // coordinate already points at the unmoved target and origin relocation
+    // never touches absolute references.
+    let mut saw_shifting_relative = false;
+    let mut saw_stationary_relative = false;
     let mut saw_displaced_absolute = false;
     if let Some(read_summary) = read_summary {
         for dependency in &read_summary.dependencies {
+            let (has_relative, has_absolute) =
+                rule_axis_bound_kinds(dependency.projection, op.axis_kind());
             match op.classify_region(dependency.read_region) {
                 AxisShiftCase::OtherSheet | AxisShiftCase::EntirelyBelow => {
-                    saw_read_no_shift = true;
+                    if has_relative {
+                        saw_stationary_relative = true;
+                    }
                 }
                 AxisShiftCase::EntirelyAboveShift { .. } => {
-                    saw_read_shift = true;
-                    if rule_has_absolute_bound_on_op_axis(dependency.projection, op.axis_kind()) {
+                    if has_relative {
+                        saw_shifting_relative = true;
+                    }
+                    if has_absolute {
                         saw_displaced_absolute = true;
                     }
                 }
@@ -247,36 +270,61 @@ pub(crate) fn classify_span_for_op(
         }
     }
 
-    // An absolute read whose target the op displaces cannot be relocated by
-    // any origin choice; it needs a template AST rewrite. Until that path
-    // lands, demote conservatively so the per-cell adjuster repoints it
-    // (issue #168: previously this fell into the `Shift { origin_delta: 0 }`
-    // arm and silently kept reading the stale coordinate).
-    if result_shifts && saw_displaced_absolute {
-        return SpanShiftPlan::Demote {
-            reason: SpanDemoteReason::AbsoluteReadDisplaced,
+    if !result_shifts {
+        // The span itself does not move. Any displaced read target (relative
+        // or absolute) would require per-read relocation that origin choice
+        // cannot express for a stationary span; demote conservatively.
+        return if saw_shifting_relative || saw_displaced_absolute {
+            SpanShiftPlan::Demote {
+                reason: SpanDemoteReason::OriginNotShiftedButReadRegionShifts,
+            }
+        } else {
+            SpanShiftPlan::NoOp
         };
     }
 
-    match (result_shifts, saw_read_shift, saw_read_no_shift) {
-        (false, false, _) => SpanShiftPlan::NoOp,
-        (false, true, _) => SpanShiftPlan::Demote {
-            reason: SpanDemoteReason::OriginNotShiftedButReadRegionShifts,
-        },
-        (true, false, _) => SpanShiftPlan::Shift {
+    if saw_displaced_absolute {
+        // A displaced absolute read needs a template AST rewrite (issue
+        // #168). The rewrite runs the shared `ReferenceAdjuster` over the
+        // whole template, which also relocates displaced relative reads and
+        // leaves stationary ones alone — so pairing it with an origin that
+        // moves with the block is correct for every read kind (see the
+        // `rewrite_absolute_reads` field docs).
+        return SpanShiftPlan::Shift {
             row_delta,
             col_delta,
             origin_row_delta: row_delta,
             origin_col_delta: col_delta,
+            rewrite_absolute_reads: true,
+        };
+    }
+
+    match (saw_shifting_relative, saw_stationary_relative) {
+        // Mixed relative kinds: no origin choice satisfies both, and the
+        // relative-rewrite upgrade is deferred.
+        (true, true) => SpanShiftPlan::Demote {
+            reason: SpanDemoteReason::MixedReadRegionShift,
         },
-        (true, true, false) => SpanShiftPlan::Shift {
+        // All displaced reads are relative and move with the block: keep the
+        // origin stationary so evaluated relative references shift with the
+        // placements. Stationary absolute reads (e.g. the flagship `$F$1`)
+        // are untouched by the origin and stay correct — this is the P2.5
+        // mixed-read fast path.
+        (true, false) => SpanShiftPlan::Shift {
             row_delta,
             col_delta,
             origin_row_delta: 0,
             origin_col_delta: 0,
+            rewrite_absolute_reads: false,
         },
-        (true, true, true) => SpanShiftPlan::Demote {
-            reason: SpanDemoteReason::MixedReadRegionShift,
+        // No displaced reads at all: move the origin with the block so
+        // stationary relative reads keep pointing at their unmoved targets.
+        (false, _) => SpanShiftPlan::Shift {
+            row_delta,
+            col_delta,
+            origin_row_delta: row_delta,
+            origin_col_delta: col_delta,
+            rewrite_absolute_reads: false,
         },
     }
 }
@@ -536,6 +584,7 @@ mod tests {
                 col_delta: 1,
                 origin_row_delta: 0,
                 origin_col_delta: 1,
+                rewrite_absolute_reads: false,
             }
         );
     }
@@ -556,6 +605,7 @@ mod tests {
                 col_delta: 1,
                 origin_row_delta: 0,
                 origin_col_delta: 0,
+                rewrite_absolute_reads: false,
             }
         );
     }
@@ -784,12 +834,9 @@ mod tests {
     }
 
     #[test]
-    fn classify_span_demotes_when_absolute_read_target_is_displaced() {
-        // Flagship shape (issue #168): a vertical run reading relative
-        // inputs plus an absolute scalar `$F$1`. An insert above everything
-        // displaces the scalar's target; origin relocation cannot repoint
-        // the absolute read, so the span must demote (until the template
-        // rewrite path exists).
+    fn classify_span_routes_absolute_reads_to_rewrite_or_mixed_fast_path() {
+        // Flagship shape (issue #168 / P2.5): a vertical run reading
+        // relative inputs plus an absolute scalar `$F$1`.
         let s = span(PlacementDomain::row_run(0, 10, 99, 2));
         let relative_dep = SpanReadDependency {
             read_region: Region::col_interval(0, 0, 10, 99),
@@ -811,8 +858,9 @@ mod tests {
         };
 
         // Insert above the absolute target: everything (span, relative
-        // inputs, scalar target) shifts, but the absolute read requires a
-        // template rewrite.
+        // inputs, scalar target) shifts. The absolute read requires a
+        // template AST rewrite, which pairs with an origin that moves with
+        // the block.
         let insert_above_all = StructuralOp::InsertRows {
             sheet_id: 0,
             before: 0,
@@ -820,15 +868,19 @@ mod tests {
         };
         assert_eq!(
             classify_span_for_op(&s, Some(&rs), insert_above_all),
-            SpanShiftPlan::Demote {
-                reason: SpanDemoteReason::AbsoluteReadDisplaced
+            SpanShiftPlan::Shift {
+                row_delta: 2,
+                col_delta: 0,
+                origin_row_delta: 2,
+                origin_col_delta: 0,
+                rewrite_absolute_reads: true,
             }
         );
 
         // Insert between the absolute target and the span: the scalar's
-        // target is stationary, so no rewrite is needed — but the relative
-        // reads shift while the absolute read does not, which is the mixed
-        // case that still demotes (upgraded by the read-kind split in P2.5).
+        // target is stationary (absolute reads impose no constraint), the
+        // relative reads shift with the block — the P2.5 mixed-read fast
+        // path: shift with a stationary origin, no rewrite, no demote.
         let insert_between = StructuralOp::InsertRows {
             sheet_id: 0,
             before: 5,
@@ -836,14 +888,18 @@ mod tests {
         };
         assert_eq!(
             classify_span_for_op(&s, Some(&rs), insert_between),
-            SpanShiftPlan::Demote {
-                reason: SpanDemoteReason::MixedReadRegionShift
+            SpanShiftPlan::Shift {
+                row_delta: 2,
+                col_delta: 0,
+                origin_row_delta: 0,
+                origin_col_delta: 0,
+                rewrite_absolute_reads: false,
             }
         );
     }
 
     #[test]
-    fn classify_span_demotes_when_absolute_column_read_target_is_displaced() {
+    fn classify_span_column_absolute_read_displaced_routes_to_rewrite() {
         // Column-axis mirror: a horizontal run reading `$A$1` under a
         // column insert that displaces column A.
         let s = span(PlacementDomain::col_run(0, 2, 10, 99));
@@ -872,8 +928,52 @@ mod tests {
         };
         assert_eq!(
             classify_span_for_op(&s, Some(&rs), op),
+            SpanShiftPlan::Shift {
+                row_delta: 0,
+                col_delta: 2,
+                origin_row_delta: 0,
+                origin_col_delta: 2,
+                rewrite_absolute_reads: true,
+            }
+        );
+    }
+
+    #[test]
+    fn classify_span_mixed_relative_reads_still_demote() {
+        // One relative read shifts with the block, another relative read's
+        // target stays put: no origin choice satisfies both and the
+        // relative-rewrite upgrade is deferred, so the span demotes.
+        // Span rows 50..=80 reading A{r} (shifts with the block) and a far
+        // stationary relative read at rows 0..=5; the insert at row 20 sits
+        // strictly between them so both classify uniformly.
+        let s = span(PlacementDomain::row_run(0, 50, 80, 2));
+        let shifting_rel = SpanReadDependency {
+            read_region: Region::col_interval(0, 0, 50, 80),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Relative { offset: 0 },
+                col: AxisProjection::Relative { offset: -2 },
+            },
+        };
+        let stationary_rel = SpanReadDependency {
+            read_region: Region::col_interval(0, 1, 0, 5),
+            projection: DirtyProjectionRule::AffineCell {
+                row: AxisProjection::Relative { offset: -50 },
+                col: AxisProjection::Relative { offset: -1 },
+            },
+        };
+        let rs = SpanReadSummary {
+            result_region: Region::col_interval(0, 2, 50, 80),
+            dependencies: vec![shifting_rel, stationary_rel],
+        };
+        let op = StructuralOp::InsertRows {
+            sheet_id: 0,
+            before: 20,
+            count: 1,
+        };
+        assert_eq!(
+            classify_span_for_op(&s, Some(&rs), op),
             SpanShiftPlan::Demote {
-                reason: SpanDemoteReason::AbsoluteReadDisplaced
+                reason: SpanDemoteReason::MixedReadRegionShift
             }
         );
     }


### PR DESCRIPTION
## What

Stacked on #165. Makes mixed-read templates — shifting relative reads plus stationary absolute reads, e.g. the flagship `=A2*B2*$F$1` — survive structural row/column ops on the span fast path instead of demoting, and adopts the Excel-correct policy for absolute references under structural edits.

Closes #168.

Three layers:

1. **Shared `ReferenceAdjuster` policy fix (#168):** absolute references now track structural inserts/deletes like relative ones (`$` pins copy/fill only); a delete removing the target yields `#REF!`. Previously the adjuster deliberately skipped absolute refs while `insert_rows` physically moved the referenced value — so both span-ON and span-OFF silently read the vacated cell, invisible to parity testing. Gated by hardcoded-value oracle tests on both axes. Named-range definitions are explicitly kept on the old pinning policy (`AbsShiftPolicy::Pin`) — flipping that surface is a separate decision.
2. **Classifier partitions reads by anchor kind** (via the read summary's `AxisProjection`, no AST scan): stationary absolutes impose no constraint, so the flagship now takes a clean `Shift`/`Split`; displaced absolutes route to a span-preserving template rewrite (reify → shared adjuster → re-intern as a fresh immutable record with re-derived keys, binding slot maps, value-ref patterns, and a fully re-derived read summary).
3. **Frame-divergence guard** (`rewrite_frame_is_sound`): a template's AST authoring frame and its origin field legitimately diverge (split lower halves keep the original anchor; origin-shift clones reuse the source AST). The rewrite is only taken when every relative bound classifies against the op boundary the same way its read region does; otherwise the span demotes conservatively. Found by adversarial review with a two-op composition repro (split, then an insert between the stale origin and the domain start displacing `$F$30` — sheared every relative read). The same invariant audit surfaced and fixed two incremental-dirtiness staleness bugs (one pre-existing: origin-follows shifts never transformed stored placement-relative rule offsets), each pinned red-first.

## Numbers (probe-fp-structural, 100k rows, medians of 3)

| op | span-on before | span-on after |
|---|---:|---:|
| insert_mid_span | 2145 ms | **295 ms** (splits, stays on span path) |
| insert_above_span | 2795 ms | **461 ms** (shifts with template rewrite) |

Post-eval cost drops ~88% on both (16 ms vs 133 ms). Span-OFF within noise.

## Known follow-ups (flagged, not fixed here)

- Named-range absolute anchors still pin through structural ops (policy decision pending).
- Delete-compaction's rule-frame story for head-trimmed compactions needs its own investigation (displaced-absolute flavor is guarded; relative-offset flavor open).
- Engine ingest never forms horizontal (ColRun) spans (`(sheet, hash, col)` grouping); column-axis coverage rides RowRun spans under column ops.
- Unbounded ranges (`A:A`) don't adjust under column inserts (pre-existing early return).

## Testing

Full formualizer-eval suite green (2061 passed), independently re-verified. Oracle tests with hardcoded expected values on both axes (parity alone was blind to the shared corruption), composition regression tests (`split-then-insert-displacing-absolute`, composed pinned-origin column shifts), the frame-soundness unit matrix, and the flipped scope pin: `formula_plane_mixed_read_row_insert_splits_span` now asserts the flagship splits into two live spans with zero graph vertices.
