### PR TITLE
fix(clippy): drop needless borrow in W0 oracle test

### DIFF
--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural_w0_oracle.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural_w0_oracle.rs
@@ -114,7 +114,7 @@ fn build_flagship(engine: &mut Engine<TestWorkbook>, span_start: u32, span_end: 
             SHEET,
             1,
             5,
-            parse(&format!("=SUM(C{span_start}:C{span_end})")).unwrap(),
+            parse(format!("=SUM(C{span_start}:C{span_end})")).unwrap(),
         )
         .unwrap();
     engine.evaluate_all().unwrap();


### PR DESCRIPTION
One-line lint fix for the main CI failure after #169: the W0 oracle harness passed `&format!(...)` to a generic `parse`, tripping `needless_borrows_for_generic_args` under CI's `--all-targets -D warnings` (the pre-merge verification ran clippy on `--lib` only). Verified locally with `cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings` clean and the 14 W0 tests green. The concurrent WASM workflow failure on main is an unrelated infrastructure flake (binaryen release download failed); re-running it.