### PR TITLE
fix(docs-site): SEO quick wins — sitemap dedupe, formula-parser OG image, formualizer.com cross-links

### DIFF
--- a/docs-site/content/docs/quickstarts/python-quickstart.mdx
+++ b/docs-site/content/docs/quickstarts/python-quickstart.mdx
@@ -42,3 +42,4 @@ Formualizer also ships a Pyodide-tagged wheel — `await micropip.install("formu
 - [Pyodide Quickstart](/docs/quickstarts/pyodide-quickstart)
 - [Custom Functions (Rust, Python, JS)](/docs/guides/custom-functions-rust-python-js)
 - [Deterministic Testing](/docs/guides/deterministic-testing)
+- [openpyxl can't calculate formulas — the full recipe](https://formualizer.com/articles/openpyxl-calculate-formulas) — authoring with openpyxl, calculating with formualizer, and writing cached values back into the xlsx

--- a/docs-site/src/app/(home)/page.tsx
+++ b/docs-site/src/app/(home)/page.tsx
@@ -296,6 +296,21 @@ export default function HomePage() {
       </section>
 
       <WorkflowTabs />
+
+      <section className="rounded-2xl border bg-fd-card p-8 text-center">
+        <h2 className="text-2xl font-semibold tracking-tight">Formualizer in production</h2>
+        <p className="mx-auto mt-2 max-w-2xl text-fd-muted-foreground">
+          This engine powers{' '}
+          <a
+            href="https://formualizer.com"
+            className="font-medium text-fd-foreground underline underline-offset-4"
+          >
+            formualizer.com
+          </a>
+          {' '}— permissioned, traceable statements published straight from Excel models, where
+          every figure traces to the cells that produced it.
+        </p>
+      </section>
     </div>
     </>
   );

--- a/docs-site/src/app/formula-parser/page.tsx
+++ b/docs-site/src/app/formula-parser/page.tsx
@@ -25,12 +25,14 @@ export const metadata: Metadata = {
       'Parse and inspect Excel-style formulas in-browser with AST, references, and evaluation flow.',
     url: '/formula-parser',
     type: 'website',
+    images: ['/opengraph-image.png'],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Formula Parser | Formualizer',
     description:
       'Parse and inspect Excel-style formulas with AST, token stream, and diagnostics.',
+    images: ['/twitter-image.png'],
   },
 };
 

--- a/docs-site/src/app/sitemap.ts
+++ b/docs-site/src/app/sitemap.ts
@@ -23,11 +23,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ];
 
-  const docsRoutes: MetadataRoute.Sitemap = source.getPages().map((page) => ({
-    url: `${base}${page.url}`,
-    changeFrequency: 'weekly',
-    priority: page.url.includes('/reference/functions/') ? 0.75 : 0.8,
-  }));
+  const docsRoutes: MetadataRoute.Sitemap = source
+    .getPages()
+    // /docs is already in staticRoutes; the docs root page would duplicate it
+    .filter((page) => page.url !== '/docs')
+    .map((page) => ({
+      url: `${base}${page.url}`,
+      changeFrequency: 'weekly',
+      priority: page.url.includes('/reference/functions/') ? 0.75 : 0.8,
+    }));
 
   return [...staticRoutes, ...docsRoutes];
 }


### PR DESCRIPTION
From the 2026-07-07 formualizer.dev SEO audit. Four surgical fixes, no behavior changes beyond metadata/links:
- **Sitemap dedupe**: `/docs` appeared twice in sitemap.xml (once from staticRoutes, once from the docs root page in `source.getPages()`); the docs root is now filtered from the collection-derived routes.
- **`/formula-parser` OG image**: the page declared `twitter:card=summary_large_image` but shipped no `og:image`/`twitter:image`, so social shares rendered imageless. Both now point at the root images.
- **Cross-link to formualizer.com**: the docs site had zero backlinks to the product site (which already links here). Adds a small 'Formualizer in production' section at the end of the homepage.
- **Python quickstart further-reading link** to the openpyxl-calculate-formulas article on formualizer.com (same audience, extends the recipe with write-back).

`pnpm types:check` passes. Blog WIP in the working tree intentionally excluded.