### PR TITLE
feat(docs-site): SEO landing pages — Python formula eval + AI agents

### DIFF
--- a/docs-site/content/docs/quickstarts/python-quickstart.mdx
+++ b/docs-site/content/docs/quickstarts/python-quickstart.mdx
@@ -38,6 +38,7 @@ Formualizer also ships a Pyodide-tagged wheel — `await micropip.install("formu
 ## Next
 
 - [Formula Parser](/formula-parser)
+- [Evaluate Excel formulas in Python](/evaluate-excel-formulas-python) — capability tour, comparison table, and write-back recipe for the Python bindings
 - [First Workbook in 5 Minutes](/docs/quickstarts/first-workbook-in-5-minutes)
 - [Pyodide Quickstart](/docs/quickstarts/pyodide-quickstart)
 - [Custom Functions (Rust, Python, JS)](/docs/guides/custom-functions-rust-python-js)

--- a/docs-site/src/app/(home)/evaluate-excel-formulas-python/page.tsx
+++ b/docs-site/src/app/(home)/evaluate-excel-formulas-python/page.tsx
@@ -1,0 +1,412 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
+import { siteUrl } from '@/lib/env';
+
+export const metadata: Metadata = {
+  title: 'Evaluate Excel Formulas in Python',
+  description:
+    'Calculate Excel formulas in Python without Excel installed. Formualizer is a Rust engine with Python bindings — 320+ Excel-compatible functions, incremental recalc, and Arrow-backed storage.',
+  keywords: [
+    'evaluate excel formulas python',
+    'excel formula evaluation library',
+    'python excel formula engine',
+    'calculate excel formulas without excel',
+    'openpyxl calculate formulas',
+    'python spreadsheet engine',
+  ],
+  alternates: {
+    canonical: '/evaluate-excel-formulas-python',
+  },
+  openGraph: {
+    title: 'Evaluate Excel Formulas in Python | Formualizer',
+    description:
+      'Calculate Excel formulas in Python — no Excel, LibreOffice, or JVM. 320+ Excel-compatible functions, incremental recalculation, Arrow-backed storage.',
+    url: '/evaluate-excel-formulas-python',
+    type: 'website',
+    images: ['/opengraph-image.png'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Evaluate Excel Formulas in Python | Formualizer',
+    description:
+      'A Rust spreadsheet engine with Python bindings — evaluate Excel formulas without Excel installed.',
+    images: ['/twitter-image.png'],
+  },
+};
+
+const faqs = [
+  {
+    question: 'Can Python evaluate Excel formulas without Excel installed?',
+    answer:
+      'Yes. Formualizer is a self-contained Rust engine with Python bindings — pip install formualizer, load the workbook, call evaluate_cell. No Excel, LibreOffice, or COM automation involved.',
+  },
+  {
+    question: 'How is this different from openpyxl?',
+    answer:
+      'openpyxl reads and writes the xlsx file format, including formula text, but has no calculation engine. Formualizer evaluates the formulas. They compose: author with openpyxl if you like, calculate with formualizer — see the full recipe.',
+  },
+  {
+    question: 'What happens on a formula error like #DIV/0!?',
+    answer:
+      "You get an error value ({'type': 'Error', 'kind': 'Div'}), not an exception. Check the return value to branch on errors; the rest of the workbook keeps evaluating.",
+  },
+  {
+    question: 'Which Excel functions are supported?',
+    answer:
+      '320+ built-ins across math, lookup (VLOOKUP/XLOOKUP/INDEX/MATCH), text, date/time, financial, statistical, and dynamic arrays. See the function reference for the full list.',
+  },
+  {
+    question: 'Is it fast enough for large workbooks?',
+    answer:
+      'The engine stores data in Arrow columns and vectorizes aggregate-heavy calculations (SUM/SUMIFS over large ranges); recalculation is incremental, so edits recompute only the dirty subgraph.',
+  },
+];
+
+const comparison = {
+  columns: ['formualizer', 'formulas', 'pycel', 'xlcalculator', 'openpyxl'],
+  rows: [
+    {
+      label: 'Evaluates formulas',
+      cells: ['yes — 320+ functions', 'partial', 'partial', 'partial', 'no'],
+    },
+    {
+      label: 'Core',
+      cells: [
+        'Rust (native wheels)',
+        'pure Python',
+        'pure Python',
+        'pure Python',
+        'pure Python',
+      ],
+    },
+    {
+      label: 'Incremental recalc (dependency graph)',
+      cells: ['yes', 'graph, full recompute focus', 'per-target compile', 'model compile', '—'],
+    },
+    {
+      label: 'Deterministic evaluation (seed/clock)',
+      cells: ['yes', 'no', 'no', 'no', '—'],
+    },
+    {
+      label: 'Errors as values',
+      cells: ['yes', 'varies', 'varies', 'varies', '—'],
+    },
+  ],
+};
+
+const evaluateExisting = `import formualizer as fz
+
+wb = fz.load_workbook("model.xlsx")
+value = wb.evaluate_cell("Sheet1", 1, 2)   # row 1, col 2 (B1), 1-based
+print(value)                                # native float/str/bool — not a formula string`;
+
+const buildFromScratch = `import formualizer as fz
+
+wb = fz.Workbook()
+s = wb.sheet("Sheet1")
+s.set_value(1, 1, 1000.0)
+s.set_value(2, 1, 2000.0)
+s.set_value(3, 1, 1500.0)
+s.set_formula(1, 2, "=SUM(A1:A3)")
+print(wb.evaluate_cell("Sheet1", 1, 2))   # 4500.0`;
+
+const writeBack = `import formualizer as fz
+
+summary = fz.recalculate_file("model.xlsx", output="model.recalc.xlsx")
+print(summary["status"], summary["evaluated"], summary["errors"])`;
+
+export default function EvaluateExcelFormulasPythonPage() {
+  const base = siteUrl.replace(/\/$/, '');
+
+  const jsonLd = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: 'Formualizer',
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'Cross-platform',
+      description:
+        'Evaluate Excel formulas in Python with a Rust engine: 320+ Excel-compatible functions, incremental dependency graph, and Arrow-backed columnar storage. No Excel, LibreOffice, or JVM.',
+      url: `${base}/evaluate-excel-formulas-python`,
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+      softwareRequirements: 'Python 3.10+',
+      programmingLanguage: ['Python', 'Rust'],
+      license: 'https://opensource.org/licenses/MIT',
+      codeRepository: 'https://github.com/psu3d0/formualizer',
+      featureList: [
+        '320+ Excel-compatible built-in functions',
+        'Incremental dependency graph with cycle detection',
+        'Arrow-powered columnar storage',
+        'Deterministic evaluation controls',
+        'Errors returned as values, not exceptions',
+      ],
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: faqs.map((faq) => ({
+        '@type': 'Question',
+        name: faq.question,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: faq.answer,
+        },
+      })),
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Formualizer',
+          item: base,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Evaluate Excel formulas in Python',
+          item: `${base}/evaluate-excel-formulas-python`,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-10 px-6 py-10 md:py-14">
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-10">
+          <span className="inline-flex rounded-full border bg-fd-background/90 px-3 py-1 text-xs font-medium text-fd-muted-foreground">
+            Python library
+          </span>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight md:text-5xl">
+            Evaluate Excel formulas in Python
+          </h1>
+          <div className="mt-5 space-y-4 text-base text-fd-muted-foreground md:text-lg">
+            <p>
+              Python can read xlsx files a dozen ways — and calculate them almost none. openpyxl
+              stores formula text without evaluating it. <code>data_only=True</code> replays
+              whatever Excel last cached. The pure-Python evaluators cover a fraction of Excel&apos;s
+              function surface and slow down on real models.
+            </p>
+            <p>
+              Formualizer is a spreadsheet engine written in Rust with first-class Python bindings:
+              320+ Excel-compatible functions, an incremental dependency graph, and Arrow-backed
+              columnar storage. <code>pip install formualizer</code> — no Excel, no LibreOffice, no
+              JVM.
+            </p>
+          </div>
+          <div className="mt-6">
+            <DynamicCodeBlock lang="bash" code="pip install formualizer" />
+          </div>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/docs/quickstarts/python-quickstart"
+              className="rounded-full bg-fd-foreground px-4 py-2 text-sm font-medium text-fd-background transition-opacity hover:opacity-90"
+            >
+              Python quickstart
+            </Link>
+            <a
+              href="https://github.com/psu3d0/formualizer"
+              className="rounded-full border bg-fd-background/85 px-4 py-2 text-sm font-medium hover:bg-fd-background"
+            >
+              GitHub
+            </a>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">Evaluate an existing workbook</h2>
+          <div className="mt-4">
+            <DynamicCodeBlock lang="python" code={evaluateExisting} />
+          </div>
+          <p className="mt-4 text-fd-muted-foreground">
+            Results come back as native Python values: <code>float</code>, <code>str</code>,{' '}
+            <code>bool</code>, <code>None</code>, or nested lists for spilled arrays. Errors are
+            values too — a <code>#DIV/0!</code> returns{' '}
+            <code>{`{'type': 'Error', 'kind': 'Div'}`}</code> instead of raising, so a single bad
+            cell doesn&apos;t abort a batch evaluation.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            Build and calculate a workbook from scratch
+          </h2>
+          <div className="mt-4">
+            <DynamicCodeBlock lang="python" code={buildFromScratch} />
+          </div>
+          <p className="mt-4 text-fd-muted-foreground">
+            Batch APIs (<code>set_values_batch</code>, <code>set_formulas_batch</code>,{' '}
+            <code>evaluate_cells</code>, <code>evaluate_all</code>) cover the write-many/read-many
+            shapes, and <code>to_xlsx_bytes()</code> round-trips the result.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            Write calculated values back into the file
+          </h2>
+          <p className="mt-4 text-fd-muted-foreground">
+            Downstream tools that read Excel&apos;s cached values — including openpyxl&apos;s own{' '}
+            <code>data_only=True</code> — see real numbers after a recalculation pass:
+          </p>
+          <div className="mt-4">
+            <DynamicCodeBlock lang="python" code={writeBack} />
+          </div>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">How it compares</h2>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="px-3 py-2 text-left font-medium text-fd-muted-foreground" />
+                  {comparison.columns.map((col) => (
+                    <th
+                      key={col}
+                      className={`px-3 py-2 text-left font-semibold ${
+                        col === 'formualizer' ? 'text-fd-foreground' : 'text-fd-muted-foreground'
+                      }`}
+                    >
+                      {col}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {comparison.rows.map((row) => (
+                  <tr key={row.label} className="border-b last:border-0 align-top">
+                    <th className="px-3 py-2 text-left font-medium">{row.label}</th>
+                    {row.cells.map((cell, i) => (
+                      <td
+                        key={`${row.label}-${comparison.columns[i]}`}
+                        className={`px-3 py-2 ${
+                          i === 0 ? 'font-medium text-fd-foreground' : 'text-fd-muted-foreground'
+                        }`}
+                      >
+                        {cell === 'no' ? <strong>no</strong> : cell}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">Where it runs</h2>
+          <p className="mt-4 text-fd-muted-foreground">
+            Prebuilt wheels for CPython 3.10–3.13 on Linux, macOS, and Windows — plus a
+            Pyodide-tagged wheel, so the same API runs in the browser. CI, containers, serverless:
+            no office suite to install or babysit.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">FAQ</h2>
+          <div className="mt-6 space-y-6">
+            <div>
+              <h3 className="font-semibold">
+                Can Python evaluate Excel formulas without Excel installed?
+              </h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                Yes. Formualizer is a self-contained Rust engine with Python bindings —{' '}
+                <code>pip install formualizer</code>, load the workbook, call <code>evaluate_cell</code>.
+                No Excel, LibreOffice, or COM automation involved.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold">How is this different from openpyxl?</h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                openpyxl reads and writes the xlsx file format, including formula <em>text</em>, but
+                has no calculation engine. Formualizer evaluates the formulas. They compose: author
+                with openpyxl if you like, calculate with formualizer — see{' '}
+                <a
+                  href="https://formualizer.com/articles/openpyxl-calculate-formulas"
+                  className="font-medium text-fd-foreground underline underline-offset-4"
+                >
+                  the full recipe
+                </a>
+                .
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold">What happens on a formula error like #DIV/0!?</h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                You get an error value (<code>{`{'type': 'Error', 'kind': 'Div'}`}</code>), not an
+                exception. Check the return value to branch on errors; the rest of the workbook keeps
+                evaluating.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold">Which Excel functions are supported?</h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                320+ built-ins across math, lookup (VLOOKUP/XLOOKUP/INDEX/MATCH), text, date/time,
+                financial, statistical, and dynamic arrays. See the{' '}
+                <Link
+                  href="/docs/reference/functions"
+                  className="font-medium text-fd-foreground underline underline-offset-4"
+                >
+                  function reference
+                </Link>{' '}
+                for the full list.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold">Is it fast enough for large workbooks?</h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                The engine stores data in Arrow columns and vectorizes aggregate-heavy calculations
+                (SUM/SUMIFS over large ranges); recalculation is incremental, so edits recompute only
+                the dirty subgraph.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 text-center md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">Start calculating</h2>
+          <p className="mx-auto mt-2 max-w-2xl text-fd-muted-foreground">
+            Install the wheel and evaluate your first workbook in minutes, or explore how the parser
+            and function registry work.
+          </p>
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/docs/quickstarts/python-quickstart"
+              className="rounded-full bg-fd-foreground px-4 py-2 text-sm font-medium text-fd-background transition-opacity hover:opacity-90"
+            >
+              Python quickstart
+            </Link>
+            <Link href="/formula-parser" className="rounded-full border px-4 py-2 text-sm font-medium">
+              Formula parser
+            </Link>
+            <Link
+              href="/docs/reference/functions"
+              className="rounded-full border px-4 py-2 text-sm font-medium"
+            >
+              Function reference
+            </Link>
+            <a
+              href="https://github.com/psu3d0/formualizer"
+              className="rounded-full border px-4 py-2 text-sm font-medium"
+            >
+              GitHub
+            </a>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/docs-site/src/app/(home)/page.tsx
+++ b/docs-site/src/app/(home)/page.tsx
@@ -220,7 +220,13 @@ export default function HomePage() {
         <p className="text-2xl leading-relaxed text-fd-muted-foreground md:text-4xl md:leading-snug">
           Formualizer is a permissively licensed spreadsheet engine with{' '}
           <span className="font-semibold text-fd-foreground">Arrow-powered performance</span>,{' '}
-          <span className="font-semibold text-fd-foreground">deterministic evaluation for agents</span>, and{' '}
+          <Link
+            href="/spreadsheet-engine-for-ai-agents"
+            className="font-semibold text-fd-foreground underline decoration-fd-muted-foreground/40 underline-offset-4 hover:decoration-fd-foreground"
+          >
+            deterministic evaluation for agents
+          </Link>
+          , and{' '}
           <span className="font-semibold text-fd-foreground">consistent Rust, Python, and WASM APIs</span>.
         </p>
       </section>

--- a/docs-site/src/app/(home)/spreadsheet-engine-for-ai-agents/page.tsx
+++ b/docs-site/src/app/(home)/spreadsheet-engine-for-ai-agents/page.tsx
@@ -1,0 +1,393 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
+import { siteUrl } from '@/lib/env';
+
+export const metadata: Metadata = {
+  title: 'A Spreadsheet Engine Built for AI Agents',
+  description:
+    'Deterministic, native spreadsheet evaluation for AI agents. Freeze the clock and RNG, treat workbooks as typed functions with SheetPort, and interrogate a dependency graph — no headless LibreOffice.',
+  keywords: [
+    'spreadsheet engine for AI agents',
+    'deterministic spreadsheet evaluation',
+    'excel MCP server recalculate',
+    'LLM agent excel formulas',
+    'agent spreadsheet tool',
+    'model context protocol spreadsheet',
+  ],
+  alternates: {
+    canonical: '/spreadsheet-engine-for-ai-agents',
+  },
+  openGraph: {
+    title: 'A Spreadsheet Engine Built for AI Agents | Formualizer',
+    description:
+      'Deterministic evaluation, typed workbook contracts, and an inspectable dependency graph — a spreadsheet engine agents can verify against.',
+    url: '/spreadsheet-engine-for-ai-agents',
+    type: 'website',
+    images: ['/opengraph-image.png'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'A Spreadsheet Engine Built for AI Agents | Formualizer',
+    description:
+      'Deterministic evaluation, typed SheetPort contracts, and an inspectable dependency graph for AI agents.',
+    images: ['/twitter-image.png'],
+  },
+};
+
+const faqs = [
+  {
+    question: 'Why does determinism matter for an agent?',
+    answer:
+      "Because verification requires reproducibility. If NOW() or RAND() shifts between runs, the agent can't distinguish \"my edit changed the output\" from \"the clock did.\" Frozen-clock, seeded evaluation makes model runs pure functions.",
+  },
+  {
+    question: "Can't I just use a headless LibreOffice recalc?",
+    answer:
+      "You can — that's what most agent tooling does today. You pay process-spawn latency per recalculation, add a system dependency, and get no dependency tracing or typed I/O. A library call is faster and gives the agent structure to reason over.",
+  },
+  {
+    question: 'What makes spreadsheet-mcp different from other Excel MCP servers?',
+    answer:
+      'Most Excel MCP servers manipulate cells but cannot compute a formula. spreadsheet-mcp evaluates natively with this engine and adds dependency tracing and fork/diff/verify workflows.',
+  },
+  {
+    question: 'Is the license safe for commercial agents?',
+    answer:
+      'Yes — MIT. Embed it in commercial products, SaaS, or internal tools without copyleft obligations.',
+  },
+];
+
+const deterministicCode = `import datetime
+from formualizer import SheetPortSession, Workbook
+
+manifest_yaml = """
+spec: fio
+spec_version: "0.3.0"
+manifest:
+  id: pricing-model
+  name: Pricing Model
+  workbook:
+    uri: memory://pricing.xlsx
+    locale: en-US
+    date_system: 1900
+ports:
+  - id: base_price
+    dir: in
+    shape: scalar
+    location: { a1: Inputs!A1 }
+    schema: { type: number }
+  - id: final_price
+    dir: out
+    shape: scalar
+    location: { a1: Outputs!A1 }
+    schema: { type: number }
+"""
+
+wb = Workbook()
+wb.add_sheet("Inputs")
+wb.add_sheet("Outputs")
+wb.set_formula("Outputs", 1, 1, "=Inputs!A1*1.2")
+
+session = SheetPortSession.from_manifest_yaml(manifest_yaml, wb)
+session.write_inputs({"base_price": 100.0})
+
+out = session.evaluate_once(
+    freeze_volatile=True,
+    rng_seed=42,
+    deterministic_timestamp_utc=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+    deterministic_timezone="utc",
+)
+# same inputs + same seed + same frozen clock => identical outputs, every run`;
+
+const portsYaml = `ports:
+  - id: base_price
+    dir: in
+    shape: scalar
+    location: { a1: Inputs!A1 }
+    schema: { type: number }
+  - id: final_price
+    dir: out
+    shape: scalar
+    location: { a1: Outputs!A1 }
+    schema: { type: number }`;
+
+const astCode = `import formualizer as fz
+
+ast = fz.parse("=SUM(A1:B2) + VLOOKUP(C1, D:E, 2, FALSE)")
+# typed AST — walk references, inspect structure, explain the calculation`;
+
+export default function SpreadsheetEngineForAiAgentsPage() {
+  const base = siteUrl.replace(/\/$/, '');
+
+  const jsonLd = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: 'Formualizer',
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'Cross-platform',
+      description:
+        'A spreadsheet engine built for AI agents: deterministic evaluation, typed SheetPort contracts over workbooks, and an inspectable incremental dependency graph. Native recalculation without headless LibreOffice.',
+      url: `${base}/spreadsheet-engine-for-ai-agents`,
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+      softwareRequirements: 'Rust 1.85+, Python 3.10+, or Node.js 18+ (WASM)',
+      programmingLanguage: ['Rust', 'Python', 'JavaScript', 'TypeScript'],
+      license: 'https://opensource.org/licenses/MIT',
+      codeRepository: 'https://github.com/psu3d0/formualizer',
+      featureList: [
+        'Deterministic evaluation with frozen clock, timezone, and RNG',
+        'SheetPort: typed input/output contracts over workbooks',
+        'Incremental dependency graph with cycle detection',
+        'Formula parsing to a typed, inspectable AST',
+        'Native recalculation MCP server (no LibreOffice)',
+      ],
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: faqs.map((faq) => ({
+        '@type': 'Question',
+        name: faq.question,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: faq.answer,
+        },
+      })),
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Formualizer',
+          item: base,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'A spreadsheet engine built for AI agents',
+          item: `${base}/spreadsheet-engine-for-ai-agents`,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-10 px-6 py-10 md:py-14">
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-10">
+          <span className="inline-flex rounded-full border bg-fd-background/90 px-3 py-1 text-xs font-medium text-fd-muted-foreground">
+            For AI agents
+          </span>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight md:text-5xl">
+            A spreadsheet engine built for AI agents
+          </h1>
+          <div className="mt-5 space-y-4 text-base text-fd-muted-foreground md:text-lg">
+            <p>
+              Agents that work with spreadsheets today mostly don&apos;t compute. The popular Excel
+              MCP servers read and write cells but can&apos;t evaluate a formula. The workaround —
+              shelling out to headless LibreOffice for a recalc — is what even first-party agent
+              tooling ships. That means slow round-trips, a process to babysit, and results that can
+              change under the agent&apos;s feet.
+            </p>
+            <p>
+              An agent needs three things from a spreadsheet engine, and they&apos;re the three
+              things Formualizer was built around.
+            </p>
+          </div>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/docs/quickstarts"
+              className="rounded-full bg-fd-foreground px-4 py-2 text-sm font-medium text-fd-background transition-opacity hover:opacity-90"
+            >
+              Get started
+            </Link>
+            <a
+              href="https://github.com/PSU3D0/spreadsheet-mcp"
+              className="rounded-full border bg-fd-background/85 px-4 py-2 text-sm font-medium hover:bg-fd-background"
+            >
+              spreadsheet-mcp on GitHub
+            </a>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">1. Deterministic evaluation</h2>
+          <p className="mt-4 text-fd-muted-foreground">
+            An agent that can&apos;t reproduce a result can&apos;t verify its own work. Formualizer
+            lets you freeze every source of nondeterminism — volatile functions, the clock, the
+            timezone, the RNG:
+          </p>
+          <div className="mt-4">
+            <DynamicCodeBlock lang="python" code={deterministicCode} />
+          </div>
+          <p className="mt-4 text-fd-muted-foreground">
+            Same inputs, same outputs — NOW(), TODAY(), RAND() included. That turns &quot;run the
+            model&quot; into a pure function an agent can retry, cache, and test against.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            2. Typed contracts over workbooks: SheetPort
+          </h2>
+          <p className="mt-4 text-fd-muted-foreground">
+            A workbook is an API with no schema. SheetPort adds one: a manifest declares named input
+            and output ports (cell locations + JSON-schema types), and the session validates inputs,
+            writes them, evaluates once, and reads typed outputs back:
+          </p>
+          <div className="mt-4">
+            <DynamicCodeBlock lang="yaml" code={portsYaml} />
+          </div>
+          <p className="mt-4 text-fd-muted-foreground">
+            The agent stops guessing which cells matter. The spreadsheet becomes a typed,
+            deterministic function — callable from a tool definition like any other.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            3. A dependency graph the agent can interrogate
+          </h2>
+          <p className="mt-4 text-fd-muted-foreground">
+            Formualizer maintains an incremental dependency graph: edits recompute only the dirty
+            subgraph, cycles are detected and reported, and the formula structure is inspectable —
+            parse any formula to a typed AST, walk its references:
+          </p>
+          <div className="mt-4">
+            <DynamicCodeBlock lang="python" code={astCode} />
+          </div>
+          <p className="mt-4 text-fd-muted-foreground">
+            Errors are values (<code>{`{'type': 'Error', 'kind': 'Div'}`}</code>), not exceptions —
+            an agent inspects failures cell-by-cell instead of losing the whole evaluation to one bad
+            divide.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">The MCP server</h2>
+          <p className="mt-4 text-fd-muted-foreground">
+            <a
+              href="https://github.com/PSU3D0/spreadsheet-mcp"
+              className="font-medium text-fd-foreground underline underline-offset-4"
+            >
+              spreadsheet-mcp
+            </a>{' '}
+            puts this engine behind the Model Context Protocol: native recalculation (no
+            LibreOffice), dependency tracing, and fork/diff/verify loops — an agent forks the
+            workbook, makes a change, recalculates, and diffs the result before committing. It is, as
+            far as we know, the only MCP server that computes rather than just reads.
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">Runs where agents run</h2>
+          <p className="mt-4 text-fd-muted-foreground">
+            Rust core, permissively licensed (MIT). Python wheels for CPython 3.10–3.13, a JS/WASM
+            package for browser and Node, and a Pyodide wheel for in-browser Python. No GPL wall, no
+            office-suite dependency, no license fee to embed it in your product.
+          </p>
+          <p className="mt-4 text-fd-muted-foreground">
+            The engine also powers the SheetPort workflows documented across the{' '}
+            <Link
+              href="/docs"
+              className="font-medium text-fd-foreground underline underline-offset-4"
+            >
+              docs
+            </Link>{' '}
+            and the broader{' '}
+            <a
+              href="https://formualizer.com/open-source"
+              className="font-medium text-fd-foreground underline underline-offset-4"
+            >
+              open-source project
+            </a>
+            .
+          </p>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">FAQ</h2>
+          <div className="mt-6 space-y-6">
+            <div>
+              <h3 className="font-semibold">Why does determinism matter for an agent?</h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                Because verification requires reproducibility. If NOW() or RAND() shifts between
+                runs, the agent can&apos;t distinguish &quot;my edit changed the output&quot; from
+                &quot;the clock did.&quot; Frozen-clock, seeded evaluation makes model runs pure
+                functions.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold">Can&apos;t I just use a headless LibreOffice recalc?</h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                You can — that&apos;s what most agent tooling does today. You pay process-spawn
+                latency per recalculation, add a system dependency, and get no dependency tracing or
+                typed I/O. A library call is faster and gives the agent structure to reason over.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold">
+                What makes spreadsheet-mcp different from other Excel MCP servers?
+              </h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                Most Excel MCP servers manipulate cells but cannot compute a formula. spreadsheet-mcp
+                evaluates natively with this engine and adds dependency tracing and fork/diff/verify
+                workflows.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold">Is the license safe for commercial agents?</h3>
+              <p className="mt-2 text-fd-muted-foreground">
+                Yes — MIT. Embed it in commercial products, SaaS, or internal tools without copyleft
+                obligations.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border bg-fd-card p-6 text-center md:p-8">
+          <h2 className="text-2xl font-semibold tracking-tight">Give your agent a real engine</h2>
+          <p className="mx-auto mt-2 max-w-2xl text-fd-muted-foreground">
+            Start with a quickstart, wire up the MCP server, and inspect the dependency graph your
+            agent reasons over.
+          </p>
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/docs/quickstarts"
+              className="rounded-full bg-fd-foreground px-4 py-2 text-sm font-medium text-fd-background transition-opacity hover:opacity-90"
+            >
+              Get started
+            </Link>
+            <Link
+              href="/docs/core-concepts/dependency-graph-and-recalc"
+              className="rounded-full border px-4 py-2 text-sm font-medium"
+            >
+              Dependency graph
+            </Link>
+            <Link href="/formula-parser" className="rounded-full border px-4 py-2 text-sm font-medium">
+              Formula parser
+            </Link>
+            <a
+              href="https://github.com/PSU3D0/spreadsheet-mcp"
+              className="rounded-full border px-4 py-2 text-sm font-medium"
+            >
+              spreadsheet-mcp
+            </a>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/docs-site/src/app/sitemap.ts
+++ b/docs-site/src/app/sitemap.ts
@@ -24,6 +24,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.9,
     },
+    {
+      url: `${base}/evaluate-excel-formulas-python`,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${base}/spreadsheet-engine-for-ai-agents`,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
   ];
 
   const docsRoutes: MetadataRoute.Sitemap = source


### PR DESCRIPTION
Adds two SEO landing pages to the docs site (docs-site/), both server components under the `(home)` route group so they inherit the site nav/footer chrome. Prose ships verbatim from the finalized source drafts; code samples are the PyPI-verified snippets from those drafts.

## Pages

`/evaluate-excel-formulas-python` — library landing for the Python bindings. Target queries: "evaluate excel formulas python", "excel formula evaluation library", "python excel formula engine", "calculate excel formulas without excel". Capability tour (evaluate existing workbook, build from scratch, write calculated values back), a styled comparison table vs formulas/pycel/xlcalculator/openpyxl, "Where it runs", and a 5-question FAQ. Internal links to /docs/quickstarts/python-quickstart, /docs/reference/functions, /formula-parser, and the .com openpyxl recipe.

`/spreadsheet-engine-for-ai-agents` — thesis landing. Target queries: "spreadsheet engine for AI agents", "deterministic spreadsheet evaluation", "excel MCP server recalculate", "LLM agent excel formulas". Three-part argument (deterministic evaluation, SheetPort typed contracts, an interrogable dependency graph), the spreadsheet-mcp section, licensing, and a 4-question FAQ. The section-1 SheetPort example is self-contained: the full verified fio manifest and the `wb` setup are inlined so the `evaluate_once` snippet runs as shown. Internal links to /docs/quickstarts, /docs/core-concepts/dependency-graph-and-recalc, /formula-parser, /docs, and formualizer.com/open-source.

## Metadata and structured data

Each page has title/description/canonical/openGraph/twitter metadata (og:image reuses the root /opengraph-image.png, matching formula-parser) plus JSON-LD: SoftwareApplication (mirroring the homepage schema), FAQPage, and BreadcrumbList. Visible FAQ copy matches the FAQPage JSON-LD text exactly.

## Wiring

Both routes added to src/app/sitemap.ts staticRoutes at priority 0.9, weekly. Homepage links to /spreadsheet-engine-for-ai-agents from the "deterministic evaluation for agents" phrase in the hero prose. python-quickstart's "Next" list links to /evaluate-excel-formulas-python. llms.txt was left unchanged: it only enumerates docs pages (source.getPages()) and does not include app-route landing pages like /formula-parser, so these two are consistent with that existing behavior.

## Copy deviations

None beyond the instructed benchmark-link omissions: the "For engine-vs-engine numbers, see the benchmark. [LINK pending gate]" clause in the Python page's large-workbook FAQ and the trailing "[BENCHMARK LINK pending workstream B gate]" in the agents page's LibreOffice FAQ are dropped (benchmarks unpublished). The Python comparison section's parenthetical implementer note (which contained the other pending benchmark link) is editorial guidance, not page copy, so it is not rendered.

## Verification

`pnpm types:check` passes. `pnpm build` passes; both routes prerender as static HTML in out/. Confirmed in the emitted HTML: SoftwareApplication + FAQPage + BreadcrumbList JSON-LD present on both pages, visible-FAQ/JSON-LD parity, the full manifest inlined on the agents page, no "[BENCHMARK]"/"pending gate" strings leaked, and sitemap.xml contains both URLs.
