### PR TITLE
feat: activate deferred fragmented formula authority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "umya-spreadsheet",
  "zip 7.2.0",
 ]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -74,6 +74,30 @@ The probe generates realistic-ish large XLSX workbooks for three scenario famili
 
 This tooling is intended to help choose sane default ingest limits and identify when load or full-workbook evaluation crosses the 60-second threshold.
 
+## Calamine formula-family ingest probing
+
+`probe-formula-family-ingest` generates genuine OOXML shared-formula families and measures each disposition in independent cold child processes. The default eager path remains available for anchor-once and fallback measurements:
+
+```bash
+cargo run --release -p formualizer-bench-core --features formualizer_runner --bin probe-formula-family-ingest -- \
+  --scenario large-family \
+  --members 100000 \
+  --samples 5
+```
+
+Deferred fragmented authority uses an explicit deferred graph build. The 100k fixtures with 1, 8, or 64 ordinary exceptions automatically enforce the documented minimum 25% load-and-build reduction and 40% RSS reduction versus forced replay:
+
+```bash
+cargo run --release -p formualizer-bench-core --features formualizer_runner --bin probe-formula-family-ingest -- \
+  --scenario hole-exception \
+  --members 100000 \
+  --exclusions 8 \
+  --graph-build deferred \
+  --samples 5
+```
+
+The JSON report includes the fixture SHA-256, graph-build path, per-phase median/MAD, authority and replay counters, and gate results. Off and Shadow remain replay-only measurements. The forced-replay disposition is a benchmark-only path used to establish an equivalent source-family replay baseline.
+
 ## Notable scenarios
 
 - `inc_sparse_dirty_region_1m` is the nightly-scale sparse-locality watchlist scenario.

--- a/crates/formualizer-bench-core/Cargo.toml
+++ b/crates/formualizer-bench-core/Cargo.toml
@@ -25,6 +25,7 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sha2 = "0.10"
 zip = { version = "7.2", default-features = false, features = ["deflate"] }
 formualizer-testkit = { path = "../formualizer-testkit", optional = true }
 formualizer-workbook = { path = "../formualizer-workbook", optional = true, default-features = false, features = ["umya", "calamine"] }

--- a/crates/formualizer-bench-core/src/bin/probe-formula-family-ingest.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-formula-family-ingest.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "formualizer_runner")]
 use std::{
+    collections::BTreeSet,
     fs,
     io::{Cursor, Write},
     path::{Path, PathBuf},
@@ -20,6 +21,8 @@ use formualizer_workbook::{
 #[cfg(feature = "formualizer_runner")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "formualizer_runner")]
+use sha2::{Digest, Sha256};
+#[cfg(feature = "formualizer_runner")]
 use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 #[cfg(not(feature = "formualizer_runner"))]
@@ -38,10 +41,16 @@ fn main() -> Result<()> {
         let gate_failed = report
             .nested_authoritative_load_gate
             .as_ref()
-            .is_some_and(|gate| !gate.passed);
+            .is_some_and(|gate| !gate.passed)
+            || report
+                .deferred_fragmented_gates
+                .as_ref()
+                .is_some_and(|gates| {
+                    !gates.load_and_build_speedup.passed || !gates.rss_reduction.passed
+                });
         println!("{}", serde_json::to_string_pretty(&report)?);
         if gate_failed {
-            bail!("nested authoritative load median exceeded the arithmetic direct gate");
+            bail!("one or more formula-family benchmark gates failed");
         }
     }
     Ok(())
@@ -55,8 +64,14 @@ struct Cli {
     scenario: Scenario,
     #[arg(long, value_enum, default_value_t = ProbeMode::All)]
     mode: ProbeMode,
+    /// Build formulas during load or stage them for an explicit deferred graph build.
+    #[arg(long, value_enum, default_value_t = GraphBuild::Eager)]
+    graph_build: GraphBuild,
     #[arg(long, default_value_t = 100)]
     members: u32,
+    /// Number of evenly spaced ordinary exceptions in `hole-exception`.
+    #[arg(long, default_value_t = 1)]
+    exclusions: u32,
     #[arg(long)]
     input: Option<PathBuf>,
     #[arg(long)]
@@ -78,6 +93,24 @@ enum ProbeMode {
     Shadow,
     Authoritative,
     ForcedReplay,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum GraphBuild {
+    Eager,
+    Deferred,
+}
+
+#[cfg(feature = "formualizer_runner")]
+impl GraphBuild {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Eager => "eager",
+            Self::Deferred => "deferred",
+        }
+    }
 }
 
 #[cfg(feature = "formualizer_runner")]
@@ -104,14 +137,28 @@ impl Scenario {
             Self::FullSheetTwoPoint => "full_sheet_two_point",
         }
     }
+
+    fn arg(self) -> &'static str {
+        match self {
+            Self::LargeFamily => "large-family",
+            Self::NestedFunctionFamily => "nested-function-family",
+            Self::ManyTinyFamilies => "many-tiny-families",
+            Self::ForwardAnchor => "forward-anchor",
+            Self::HoleException => "hole-exception",
+            Self::FullSheetTwoPoint => "full-sheet-two-point",
+        }
+    }
 }
 
 #[cfg(feature = "formualizer_runner")]
 #[derive(Debug, Serialize)]
 struct MatrixReport {
     scenario: Scenario,
+    graph_build: GraphBuild,
     members: u32,
+    exclusions: u32,
     fixture: String,
+    fixture_sha256: String,
     generated: bool,
     generation_ms: f64,
     fixture_bytes: u64,
@@ -120,6 +167,7 @@ struct MatrixReport {
     summaries: Vec<DispositionSummary>,
     arithmetic_direct_baseline: Option<ArithmeticBaseline>,
     nested_authoritative_load_gate: Option<RelativeGate>,
+    deferred_fragmented_gates: Option<DeferredFragmentedGates>,
 }
 
 #[cfg(feature = "formualizer_runner")]
@@ -138,6 +186,8 @@ struct DispositionSummary {
     maximum_resident_set_kib: MedianMad,
     total_elapsed_ms: MedianMad,
     load_ms: MedianMad,
+    graph_build_ms: MedianMad,
+    load_and_build_ms: MedianMad,
     evaluate_ms: MedianMad,
     collection_ms: Option<MedianMad>,
     preparation_ms: Option<MedianMad>,
@@ -164,6 +214,24 @@ struct RelativeGate {
 
 #[cfg(feature = "formualizer_runner")]
 #[derive(Debug, Serialize)]
+struct DeferredFragmentedGates {
+    load_and_build_speedup: ReductionGate,
+    rss_reduction: ReductionGate,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
+struct ReductionGate {
+    metric: &'static str,
+    minimum_reduction_percent: f64,
+    baseline_median: f64,
+    candidate_median: f64,
+    reduction_percent: f64,
+    passed: bool,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
 struct ChildMeasurement {
     disposition: String,
     sample: usize,
@@ -175,8 +243,11 @@ struct ChildMeasurement {
 #[derive(Debug, Serialize, Deserialize)]
 struct ModeReport {
     disposition: String,
+    graph_build: GraphBuild,
     total_elapsed_ms: f64,
     load_ms: f64,
+    graph_build_ms: f64,
+    load_and_build_ms: f64,
     evaluate_ms: f64,
     collection_ms: Option<f64>,
     preparation_ms: Option<f64>,
@@ -298,10 +369,16 @@ fn fixture_path(cli: &Cli) -> PathBuf {
         .clone()
         .or_else(|| cli.fixture_out.clone())
         .unwrap_or_else(|| {
+            let exclusions = if matches!(cli.scenario, Scenario::HoleException) {
+                format!("-exclusions-{}", cli.exclusions)
+            } else {
+                String::new()
+            };
             PathBuf::from("scratch/formula-family-anchor-once-bench").join(format!(
-                "{}-{}.xlsx",
+                "{}-{}{}.xlsx",
                 cli.scenario.label(),
-                cli.members
+                cli.members,
+                exclusions,
             ))
         })
 }
@@ -318,6 +395,16 @@ fn is_nested_load_gate_run(cli: &Cli) -> bool {
 }
 
 #[cfg(feature = "formualizer_runner")]
+fn is_deferred_fragmented_gate_run(cli: &Cli) -> bool {
+    matches!(cli.scenario, Scenario::HoleException)
+        && cli.graph_build == GraphBuild::Deferred
+        && cli.members >= 100_000
+        && matches!(cli.exclusions, 1 | 8 | 64)
+        && cli.mode == ProbeMode::All
+        && !cli.generate_only
+}
+
+#[cfg(feature = "formualizer_runner")]
 fn run_matrix(cli: &Cli) -> Result<MatrixReport> {
     if cli.members == 0 {
         bail!("--members must be at least 1")
@@ -325,14 +412,22 @@ fn run_matrix(cli: &Cli) -> Result<MatrixReport> {
     if cli.samples == 0 {
         bail!("--samples must be at least 1")
     }
+    if matches!(cli.scenario, Scenario::HoleException)
+        && (cli.exclusions == 0 || cli.exclusions >= cli.members.saturating_sub(1))
+    {
+        bail!("hole-exception requires 1 <= --exclusions < --members - 1")
+    }
     if is_nested_load_gate_run(cli) && cli.samples < 5 {
         bail!("nested-function-family 100k gate runs require at least five cold samples")
+    }
+    if is_deferred_fragmented_gate_run(cli) && cli.samples < 5 {
+        bail!("deferred fragmented 100k gate runs require at least five cold samples")
     }
     let fixture = fixture_path(cli);
     let generated = cli.input.is_none();
     let started = Instant::now();
     if generated {
-        let bytes = generate_xlsx(cli.scenario, cli.members)?;
+        let bytes = generate_xlsx(cli.scenario, cli.members, cli.exclusions)?;
         if let Some(p) = fixture.parent() {
             fs::create_dir_all(p)?
         }
@@ -340,6 +435,7 @@ fn run_matrix(cli: &Cli) -> Result<MatrixReport> {
     }
     let generation_ms = started.elapsed().as_secs_f64() * 1000.0;
     let fixture_bytes = fs::metadata(&fixture)?.len();
+    let fixture_sha256 = format!("{:x}", Sha256::digest(fs::read(&fixture)?));
     let mut children = Vec::new();
     if !cli.generate_only {
         for mode in [
@@ -369,7 +465,7 @@ fn run_matrix(cli: &Cli) -> Result<MatrixReport> {
         }
         fs::write(
             &baseline_fixture,
-            generate_xlsx(Scenario::LargeFamily, cli.members)?,
+            generate_xlsx(Scenario::LargeFamily, cli.members, 0)?,
         )?;
         let mut baseline_children = Vec::with_capacity(cli.samples);
         for sample in 1..=cli.samples {
@@ -397,10 +493,39 @@ fn run_matrix(cli: &Cli) -> Result<MatrixReport> {
             summaries: baseline_summaries,
         });
     }
+    let deferred_fragmented_gates = if is_deferred_fragmented_gate_run(cli) {
+        let candidate = summary_for(&summaries, "authoritative")
+            .context("deferred fragmented run did not produce an authoritative summary")?;
+        let baseline = summary_for(&summaries, "forced-replay")
+            .context("deferred fragmented run did not produce a forced-replay summary")?;
+        Some(DeferredFragmentedGates {
+            load_and_build_speedup: reduction_gate(
+                "authoritative_load_and_build_ms",
+                baseline.load_and_build_ms.median,
+                candidate.load_and_build_ms.median,
+                25.0,
+            ),
+            rss_reduction: reduction_gate(
+                "authoritative_maximum_resident_set_kib",
+                baseline.maximum_resident_set_kib.median,
+                candidate.maximum_resident_set_kib.median,
+                40.0,
+            ),
+        })
+    } else {
+        None
+    };
     Ok(MatrixReport {
         scenario: cli.scenario,
+        graph_build: cli.graph_build,
         members: cli.members,
+        exclusions: if matches!(cli.scenario, Scenario::HoleException) {
+            cli.exclusions
+        } else {
+            0
+        },
         fixture: fixture.display().to_string(),
+        fixture_sha256,
         generated,
         generation_ms,
         fixture_bytes,
@@ -409,6 +534,7 @@ fn run_matrix(cli: &Cli) -> Result<MatrixReport> {
         summaries,
         arithmetic_direct_baseline,
         nested_authoritative_load_gate,
+        deferred_fragmented_gates,
     })
 }
 
@@ -481,6 +607,20 @@ fn summarize_dispositions(children: &[ChildMeasurement]) -> Vec<DispositionSumma
                 .expect("non-empty finite total samples"),
                 load_ms: median_mad(samples.iter().map(|sample| sample.report.load_ms).collect())
                     .expect("non-empty finite load samples"),
+                graph_build_ms: median_mad(
+                    samples
+                        .iter()
+                        .map(|sample| sample.report.graph_build_ms)
+                        .collect(),
+                )
+                .expect("non-empty finite graph-build samples"),
+                load_and_build_ms: median_mad(
+                    samples
+                        .iter()
+                        .map(|sample| sample.report.load_and_build_ms)
+                        .collect(),
+                )
+                .expect("non-empty finite load-and-build samples"),
                 evaluate_ms: median_mad(
                     samples
                         .iter()
@@ -529,6 +669,28 @@ fn relative_gate(
 }
 
 #[cfg(feature = "formualizer_runner")]
+fn reduction_gate(
+    metric: &'static str,
+    baseline_median: f64,
+    candidate_median: f64,
+    minimum_reduction_percent: f64,
+) -> ReductionGate {
+    let reduction_percent = if baseline_median > 0.0 {
+        (1.0 - candidate_median / baseline_median) * 100.0
+    } else {
+        f64::NEG_INFINITY
+    };
+    ReductionGate {
+        metric,
+        minimum_reduction_percent,
+        baseline_median,
+        candidate_median,
+        reduction_percent,
+        passed: reduction_percent >= minimum_reduction_percent,
+    }
+}
+
+#[cfg(feature = "formualizer_runner")]
 fn run_child(
     cli: &Cli,
     fixture: &Path,
@@ -548,7 +710,18 @@ fn run_child(
         .arg(exe)
         .args(["--child", "--input"])
         .arg(fixture)
-        .args(["--members", &cli.members.to_string(), "--mode", mode_arg])
+        .args([
+            "--scenario",
+            cli.scenario.arg(),
+            "--graph-build",
+            cli.graph_build.label(),
+            "--members",
+            &cli.members.to_string(),
+            "--exclusions",
+            &cli.exclusions.to_string(),
+            "--mode",
+            mode_arg,
+        ])
         .output()
         .context("launch timed cold child through /usr/bin/time -v")?;
     if !output.status.success() {
@@ -599,13 +772,20 @@ fn probe_child(cli: &Cli) -> Result<ModeReport> {
     }
     let total = Instant::now();
     let adapter = CalamineAdapter::open_path(&path)?;
+    let mut config = WorkbookConfig::ephemeral().with_formula_plane_mode(mode);
+    config.eval.defer_graph_building = cli.graph_build == GraphBuild::Deferred;
     let load = Instant::now();
-    let (mut workbook, adapter_stats) = Workbook::from_reader_with_adapter_stats(
-        adapter,
-        LoadStrategy::EagerAll,
-        WorkbookConfig::ephemeral().with_formula_plane_mode(mode),
-    )?;
+    let (mut workbook, adapter_stats) =
+        Workbook::from_reader_with_adapter_stats(adapter, LoadStrategy::EagerAll, config)?;
     let load_ms = load.elapsed().as_secs_f64() * 1000.0;
+    let graph_build_ms = if cli.graph_build == GraphBuild::Deferred {
+        let graph_build = Instant::now();
+        workbook.prepare_graph_all()?;
+        graph_build.elapsed().as_secs_f64() * 1000.0
+    } else {
+        0.0
+    };
+    let load_and_build_ms = load_ms + graph_build_ms;
     let eval = Instant::now();
     workbook.evaluate_all()?;
     let evaluate_ms = eval.elapsed().as_secs_f64() * 1000.0;
@@ -625,6 +805,48 @@ fn probe_child(cli: &Cli) -> Result<ModeReport> {
             ingest.formula_cells_seen
         );
     }
+    if !forced
+        && mode == FormulaPlaneMode::AuthoritativeExperimental
+        && ingest.source_family_promoted > 0
+        && (stats.formula_plane_active_span_count == 0
+            || ingest.graph_formula_cells_materialized + ingest.source_family_promoted_cells
+                != ingest.formula_cells_seen)
+    {
+        bail!(
+            "authoritative promotion must reconcile every formula (spans={}, graph={}, promoted={}, formulas={})",
+            stats.formula_plane_active_span_count,
+            ingest.graph_formula_cells_materialized,
+            ingest.source_family_promoted_cells,
+            ingest.formula_cells_seen
+        );
+    }
+    if !forced
+        && mode == FormulaPlaneMode::AuthoritativeExperimental
+        && cli.graph_build == GraphBuild::Deferred
+        && matches!(cli.scenario, Scenario::HoleException)
+        && cli.members >= 100_000
+        && cli.exclusions <= 64
+    {
+        let expected_exclusions = u64::from(cli.exclusions);
+        let expected_spans = cli.exclusions as usize + 1;
+        if ingest.source_family_promoted != 1
+            || ingest.source_family_fallback != 0
+            || ingest.graph_formula_cells_materialized != expected_exclusions
+            || stats.graph_formula_vertex_count as u64 != expected_exclusions
+            || stats.formula_plane_active_span_count != expected_spans
+        {
+            bail!(
+                "deferred fragmented benchmark missed authority path (families={}, fallback={}, graph={}, vertices={}, spans={}, expected exclusions={}, expected spans={})",
+                ingest.source_family_promoted,
+                ingest.source_family_fallback,
+                ingest.graph_formula_cells_materialized,
+                stats.graph_formula_vertex_count,
+                stats.formula_plane_active_span_count,
+                expected_exclusions,
+                expected_spans,
+            );
+        }
+    }
     let storage_kind = if ingest.source_spool_spilled_bytes > 0 {
         "native_file"
     } else if ingest.source_formula_records_spooled > 0 {
@@ -640,8 +862,11 @@ fn probe_child(cli: &Cli) -> Result<ModeReport> {
     };
     Ok(ModeReport {
         disposition: label.into(),
+        graph_build: cli.graph_build,
         total_elapsed_ms: total.elapsed().as_secs_f64() * 1000.0,
         load_ms,
+        graph_build_ms,
+        load_and_build_ms,
         evaluate_ms,
         collection_ms: None,
         preparation_ms: None,
@@ -656,8 +881,8 @@ fn probe_child(cli: &Cli) -> Result<ModeReport> {
 }
 
 #[cfg(feature = "formualizer_runner")]
-fn generate_xlsx(scenario: Scenario, members: u32) -> Result<Vec<u8>> {
-    let sheet = sheet_xml(scenario, members)?;
+fn generate_xlsx(scenario: Scenario, members: u32, exclusions: u32) -> Result<Vec<u8>> {
+    let sheet = sheet_xml(scenario, members, exclusions)?;
     let cursor = Cursor::new(Vec::new());
     let mut zip = ZipWriter::new(cursor);
     let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
@@ -675,10 +900,18 @@ fn generate_xlsx(scenario: Scenario, members: u32) -> Result<Vec<u8>> {
 }
 
 #[cfg(feature = "formualizer_runner")]
-fn sheet_xml(scenario: Scenario, members: u32) -> Result<String> {
+fn sheet_xml(scenario: Scenario, members: u32, exclusions: u32) -> Result<String> {
     let rows = match scenario {
         Scenario::FullSheetTwoPoint => 2,
         _ => members,
+    };
+    let exception_rows: BTreeSet<u32> = if matches!(scenario, Scenario::HoleException) {
+        let denominator = u64::from(exclusions) + 1;
+        (1..=exclusions)
+            .map(|index| 1 + ((u64::from(index) * u64::from(rows - 1)) / denominator) as u32)
+            .collect()
+    } else {
+        BTreeSet::new()
     };
     if rows > 1_048_576 {
         bail!("--members exceeds the XLSX row limit");
@@ -722,7 +955,7 @@ fn sheet_xml(scenario: Scenario, members: u32) -> Result<String> {
                     xml.push_str(r#"<f t="shared" si="1"/>"#);
                 }
             }
-            Scenario::HoleException if row == (rows / 2).max(1) => {
+            Scenario::HoleException if exception_rows.contains(&row) => {
                 xml.push_str(&format!("<f>{formula}</f>"));
             }
             Scenario::NestedFunctionFamily => {
@@ -772,8 +1005,8 @@ mod tests {
 
     #[test]
     fn fixture_generation_is_deterministic_and_contains_shared_ooxml() {
-        let first = generate_xlsx(Scenario::LargeFamily, 100).unwrap();
-        let second = generate_xlsx(Scenario::LargeFamily, 100).unwrap();
+        let first = generate_xlsx(Scenario::LargeFamily, 100, 0).unwrap();
+        let second = generate_xlsx(Scenario::LargeFamily, 100, 0).unwrap();
         assert_eq!(first, second);
         let mut archive = ZipArchive::new(Cursor::new(first)).unwrap();
         let mut xml = String::new();
@@ -788,7 +1021,7 @@ mod tests {
 
     #[test]
     fn nested_function_fixture_is_one_genuine_shared_family() {
-        let xml = sheet_xml(Scenario::NestedFunctionFamily, 100).unwrap();
+        let xml = sheet_xml(Scenario::NestedFunctionFamily, 100, 0).unwrap();
         assert!(xml.contains("ROUND(ABS(A1)+SUM(A1:A1)+COUNTIF"));
         assert!(xml.contains("VLOOKUP(A1,A1:A1,1,FALSE)"));
         assert_eq!(xml.matches("t=\"shared\"").count(), 100);
@@ -797,9 +1030,23 @@ mod tests {
 
     #[test]
     fn pathological_fixture_declares_full_sheet_without_materializing_it() {
-        let xml = sheet_xml(Scenario::FullSheetTwoPoint, 2).unwrap();
+        let xml = sheet_xml(Scenario::FullSheetTwoPoint, 2, 0).unwrap();
         assert!(xml.contains("ref=\"B1:B1048576\""));
         assert_eq!(xml.matches("<row ").count(), 2);
+    }
+
+    #[test]
+    fn fragmented_fixture_places_requested_ordinary_exceptions() {
+        let xml = sheet_xml(Scenario::HoleException, 100_000, 64).unwrap();
+        assert_eq!(xml.matches("<f>A").count(), 64);
+        assert_eq!(xml.matches("t=\"shared\"").count(), 100_000 - 64);
+        assert_eq!(xml.matches("ref=\"B1:B100000\"").count(), 1);
+
+        let dense = sheet_xml(Scenario::HoleException, 100, 64).unwrap();
+        assert_eq!(dense.matches("<f>A").count(), 64);
+        assert_eq!(dense.matches("t=\"shared\"").count(), 100 - 64);
+        assert_eq!(dense.matches("ref=\"B1:B100\"").count(), 1);
+        assert!(dense.contains("<f t=\"shared\" si=\"1\" ref=\"B1:B100\">A1+1</f>"));
     }
 
     #[test]
@@ -807,7 +1054,9 @@ mod tests {
         let cli = |members| Cli {
             scenario: Scenario::NestedFunctionFamily,
             mode: ProbeMode::Authoritative,
+            graph_build: GraphBuild::Eager,
             members,
+            exclusions: 1,
             input: None,
             fixture_out: None,
             generate_only: false,
@@ -816,6 +1065,52 @@ mod tests {
         };
         assert!(!is_nested_load_gate_run(&cli(100)));
         assert!(is_nested_load_gate_run(&cli(100_000)));
+    }
+
+    #[test]
+    fn deferred_fragmented_gate_requires_the_cold_100k_matrix() {
+        let cli = |exclusions, graph_build, mode| Cli {
+            scenario: Scenario::HoleException,
+            mode,
+            graph_build,
+            members: 100_000,
+            exclusions,
+            input: None,
+            fixture_out: None,
+            generate_only: false,
+            samples: 5,
+            child: false,
+        };
+        assert!(is_deferred_fragmented_gate_run(&cli(
+            1,
+            GraphBuild::Deferred,
+            ProbeMode::All,
+        )));
+        assert!(is_deferred_fragmented_gate_run(&cli(
+            8,
+            GraphBuild::Deferred,
+            ProbeMode::All,
+        )));
+        assert!(is_deferred_fragmented_gate_run(&cli(
+            64,
+            GraphBuild::Deferred,
+            ProbeMode::All,
+        )));
+        assert!(!is_deferred_fragmented_gate_run(&cli(
+            2,
+            GraphBuild::Deferred,
+            ProbeMode::All,
+        )));
+        assert!(!is_deferred_fragmented_gate_run(&cli(
+            1,
+            GraphBuild::Eager,
+            ProbeMode::All,
+        )));
+        assert!(!is_deferred_fragmented_gate_run(&cli(
+            1,
+            GraphBuild::Deferred,
+            ProbeMode::Authoritative,
+        )));
     }
 
     #[test]
@@ -847,6 +1142,13 @@ mod tests {
         assert!(!fail.passed);
         assert!(fail.overhead_percent > fail.limit_percent);
         assert!(!relative_gate("authoritative_load_ms", 0.0, 1.0, 10.0).passed);
+
+        let pass = reduction_gate("rss", 100.0, 59.9, 40.0);
+        assert!(pass.passed);
+        assert!(pass.reduction_percent > pass.minimum_reduction_percent);
+        let fail = reduction_gate("rss", 100.0, 60.1, 40.0);
+        assert!(!fail.passed);
+        assert!(!reduction_gate("rss", 0.0, 0.0, 40.0).passed);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4724,6 +4724,21 @@ where
         if self.config.formula_plane_mode != FormulaPlaneMode::AuthoritativeExperimental {
             return Ok(preparation);
         }
+        #[cfg(feature = "benchmark_internal")]
+        let benchmark_forced_replay =
+            std::env::var_os("FORMUALIZER_BENCH_FORCE_FORMULA_FAMILY_REPLAY").is_some();
+        #[cfg(not(feature = "benchmark_internal"))]
+        let benchmark_forced_replay = false;
+        let authority_partitions = if benchmark_forced_replay {
+            for partition in authority_partitions {
+                preparation
+                    .rejected
+                    .insert(partition.source_id, "ForcedReplay".to_string());
+            }
+            &[][..]
+        } else {
+            authority_partitions
+        };
         let authority_ids: BTreeSet<_> = authority_partitions
             .iter()
             .map(|partition| partition.source_id)

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -92,7 +92,7 @@ impl StagedSheet {
             .ok()
             .and_then(|mut replay| replay.formula_at(row, col).ok())
             .flatten()
-            .and_then(|record| record.family);
+            .and_then(|record| record.partition_owner.or(record.family));
         if let Some(family) = family {
             package.invalidated.insert(family);
         } else {
@@ -102,6 +102,12 @@ impl StagedSheet {
             package
                 .invalidated
                 .extend(package.families.iter().map(|family| family.source_id));
+            package.invalidated.extend(
+                package
+                    .partitioned_families
+                    .iter()
+                    .map(|family| family.source_id),
+            );
         }
         package.suppressed.insert((row, col));
     }
@@ -294,12 +300,14 @@ where
     ) -> Result<crate::engine::FormulaCompressedPreparation, ExcelError> {
         self.engine.observe_function_semantic_epoch()?;
         let replay = Arc::new(std::sync::Mutex::new(replay));
-        self.engine.prepare_eager_source_formula_proposals(
+        self.engine.prepare_source_formula_proposals(
             sheet_name,
             families,
             partitions,
+            partitions,
             formula_record_count,
             replay,
+            &BTreeSet::new(),
         )
     }
 
@@ -326,7 +334,7 @@ where
             crate::engine::FormulaCompressedPreparation,
         )>,
     ) -> Result<FormulaIngestReport, ExcelError> {
-        self.engine.finish_eager_compressed_formula_sources(batches)
+        self.engine.finish_compressed_formula_sources(batches)
     }
 }
 
@@ -4698,22 +4706,39 @@ where
         preparation
     }
 
-    fn prepare_eager_source_formula_proposals(
+    fn prepare_source_formula_proposals(
         &mut self,
         sheet_name: &str,
         families: &[crate::engine::SourceFormulaFamily],
-        partitions: &[crate::engine::PartitionedSourceFormulaFamily],
+        authority_partitions: &[crate::engine::PartitionedSourceFormulaFamily],
+        replay_partitions: &[crate::engine::PartitionedSourceFormulaFamily],
         formula_record_count: u64,
         replay: Arc<std::sync::Mutex<Box<dyn crate::engine::DeferredFormulaReplay>>>,
+        suppressed: &BTreeSet<(u32, u32)>,
     ) -> Result<crate::engine::FormulaCompressedPreparation, ExcelError> {
         let mut preparation = self.prepare_source_formula_families(sheet_name, families);
         preparation.exact_replay = Some(Arc::clone(&replay));
-        if self.config.formula_plane_mode != FormulaPlaneMode::AuthoritativeExperimental
-            || self.config.defer_graph_building
-        {
+        preparation
+            .replay_disposition
+            .extend_suppressed_excel_coords(suppressed.iter().copied());
+        if self.config.formula_plane_mode != FormulaPlaneMode::AuthoritativeExperimental {
             return Ok(preparation);
         }
-        if partitions.is_empty()
+        let authority_ids: BTreeSet<_> = authority_partitions
+            .iter()
+            .map(|partition| partition.source_id)
+            .collect();
+        for partition in replay_partitions {
+            if !authority_ids.contains(&partition.source_id) {
+                preparation
+                    .replay_disposition
+                    .register_partition(partition, false)
+                    .map_err(|reason| {
+                        ExcelError::new(ExcelErrorKind::Value).with_message(reason)
+                    })?;
+            }
+        }
+        if replay_partitions.is_empty()
             && preparation.rejected.is_empty()
             && preparation.direct_cell_count() == formula_record_count
         {
@@ -4721,7 +4746,7 @@ where
         }
 
         let mut analyzed = Vec::new();
-        for source in partitions {
+        for source in authority_partitions {
             preparation
                 .fragmented_sources
                 .insert(source.source_id, source.clone());
@@ -4773,7 +4798,7 @@ where
                 ExcelError::new(ExcelErrorKind::Value)
                     .with_message("compressed formula exact replay lock poisoned")
             })?
-            .replay_partitioned(&preparation.replay_disposition, partitions)
+            .replay_partitioned(&preparation.replay_disposition, replay_partitions)
             .map_err(|message| ExcelError::new(ExcelErrorKind::Value).with_message(message))?;
         preparation.preparation_spool_replays = 1;
         let sheet_id = self.graph.sheet_id_mut(sheet_name);
@@ -4837,7 +4862,7 @@ where
             })();
             match result {
                 Ok((prepared_family, legacy)) => preparation.fragmented.push(
-                    crate::engine::formula_source::PreparedEagerFragmentedProposal {
+                    crate::engine::formula_source::PreparedFragmentedSourceProposal {
                         source: source.clone(),
                         prepared: prepared_family,
                         legacy,
@@ -4865,7 +4890,7 @@ where
                     ExcelError::new(ExcelErrorKind::Value)
                         .with_message("compressed formula exact replay lock poisoned")
                 })?
-                .replay_partitioned(&preparation.replay_disposition, partitions)
+                .replay_partitioned(&preparation.replay_disposition, replay_partitions)
                 .map_err(|message| ExcelError::new(ExcelErrorKind::Value).with_message(message))?
         } else {
             initial_replay
@@ -5159,17 +5184,22 @@ where
         Ok((plan, formula_count))
     }
 
-    fn publish_eager_partial_report(
+    fn publish_compressed_partial_report(
         &mut self,
         report: &FormulaIngestReport,
         direct_report: &FormulaIngestReport,
     ) {
+        if direct_report.source_family_promoted == 0
+            && direct_report.graph_formula_cells_materialized == 0
+        {
+            return;
+        }
         let mut published = report.clone();
         published.accumulate(direct_report);
         self.record_formula_ingest_report(published);
     }
 
-    fn finish_eager_compressed_formula_sources(
+    fn finish_compressed_formula_sources(
         &mut self,
         batches: Vec<(
             FormulaIngestBatch,
@@ -5182,13 +5212,13 @@ where
             !Arc::ptr_eq(&preparation.engine_token, &self.source_formula_token)
         }) {
             return Err(ExcelError::new(ExcelErrorKind::Value)
-                .with_message("compressed formula preparation belongs to another engine"));
+                .with_message("compressed source preparation belongs to another engine"));
         }
         if batches.iter().any(|(fallback, _, preparation)| {
             preparation.sheet_name.as_ref() != fallback.sheet_name
         }) {
             return Err(ExcelError::new(ExcelErrorKind::Value)
-                .with_message("compressed formula preparation sheet mismatch"));
+                .with_message("compressed source preparation sheet mismatch"));
         }
         let initial_guard = crate::function_registry::semantic_epoch_read_guard();
         let initial_epoch = initial_guard.epoch();
@@ -5201,12 +5231,13 @@ where
             for formula in fallback.formulas.drain(..) {
                 let source_order = formula.source_order.ok_or_else(|| {
                     ExcelError::new(ExcelErrorKind::Value).with_message(
-                        "eager compressed backend supplied formulas without source-order proof",
+                        "compressed source supplied formulas without source-order proof",
                     )
                 })?;
                 let text = formula.formula_text.ok_or_else(|| {
-                    ExcelError::new(ExcelErrorKind::Value)
-                        .with_message("ordered eager fallback formula has no exact source text")
+                    ExcelError::new(ExcelErrorKind::Value).with_message(
+                        "ordered compressed fallback formula has no exact source text",
+                    )
                 })?;
                 preparation
                     .eager_replay
@@ -5371,7 +5402,7 @@ where
                     let exact = match self.replay_prepared_families_exact_records(&preparation) {
                         Ok(exact) => exact,
                         Err(error) => {
-                            self.publish_eager_partial_report(&report, &direct_report);
+                            self.publish_compressed_partial_report(&report, &direct_report);
                             return Err(error);
                         }
                     };
@@ -5411,7 +5442,7 @@ where
 
             // Preserve source order across clean and fragmented families. Every clean
             // placement uses E3's incremental append, so no global index rebuild is needed.
-            enum EagerProposal {
+            enum SourceProposal {
                 KnownFallback {
                     source_order: crate::engine::SourceFormulaOrder,
                     records: Vec<crate::engine::DeferredReplayFormula>,
@@ -5421,10 +5452,10 @@ where
                     crate::engine::SourceFormulaOrder,
                     crate::formula_plane::placement::PreparedAnchorOncePlacement,
                 ),
-                Fragment(crate::engine::formula_source::PreparedEagerFragmentedProposal),
+                Fragment(crate::engine::formula_source::PreparedFragmentedSourceProposal),
             }
 
-            impl EagerProposal {
+            impl SourceProposal {
                 fn source_order(&self) -> crate::engine::SourceFormulaOrder {
                     match self {
                         Self::KnownFallback { source_order, .. } => *source_order,
@@ -5444,7 +5475,7 @@ where
                 );
                 proposals.extend(preparation.prepared.drain(..).map(
                     |(source_id, source_order, prepared)| {
-                        EagerProposal::Clean(source_id, source_order, prepared)
+                        SourceProposal::Clean(source_id, source_order, prepared)
                     },
                 ));
 
@@ -5464,7 +5495,7 @@ where
                     if let Some(owner) = record.partition_owner.or(record.family) {
                         family_fallbacks.entry(owner).or_default().push(record);
                     } else {
-                        proposals.push(EagerProposal::KnownFallback {
+                        proposals.push(SourceProposal::KnownFallback {
                             source_order: record.source_order,
                             records: vec![record],
                         });
@@ -5476,17 +5507,17 @@ where
                         .windows(2)
                         .any(|window| window[0].source_order == window[1].source_order)
                     {
-                        self.publish_eager_partial_report(&report, &direct_report);
+                        self.publish_compressed_partial_report(&report, &direct_report);
                         return Err(ExcelError::new(ExcelErrorKind::Value)
                             .with_message("duplicate exact-replay source-order proof"));
                     }
                     let Some(source_order) = records.first().map(|record| record.source_order)
                     else {
-                        self.publish_eager_partial_report(&report, &direct_report);
+                        self.publish_compressed_partial_report(&report, &direct_report);
                         return Err(ExcelError::new(ExcelErrorKind::Value)
                             .with_message("empty exact-replay fallback family"));
                     };
-                    proposals.push(EagerProposal::KnownFallback {
+                    proposals.push(SourceProposal::KnownFallback {
                         source_order,
                         records,
                     });
@@ -5495,28 +5526,28 @@ where
                     preparation
                         .fragmented
                         .drain(..)
-                        .map(EagerProposal::Fragment),
+                        .map(SourceProposal::Fragment),
                 );
-                proposals.sort_by_key(EagerProposal::source_order);
+                proposals.sort_by_key(SourceProposal::source_order);
                 if proposals
                     .windows(2)
                     .any(|window| window[0].source_order() == window[1].source_order())
                 {
-                    self.publish_eager_partial_report(&report, &direct_report);
+                    self.publish_compressed_partial_report(&report, &direct_report);
                     return Err(ExcelError::new(ExcelErrorKind::Value)
-                        .with_message("ambiguous eager source-order proof"));
+                        .with_message("ambiguous compressed source-order proof"));
                 }
 
                 for proposal in proposals {
                     match proposal {
-                        EagerProposal::KnownFallback { records, .. } => {
+                        SourceProposal::KnownFallback { records, .. } => {
                             let batch = match self.formula_batch_from_exact_replay(
                                 preparation.sheet_name.as_ref(),
                                 records,
                             ) {
                                 Ok(batch) => batch,
                                 Err(error) => {
-                                    self.publish_eager_partial_report(&report, &direct_report);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
                                     return Err(error);
                                 }
                             };
@@ -5526,7 +5557,7 @@ where
                             let snapshot = match self.fallback_planning_snapshot(&batch) {
                                 Ok(snapshot) => snapshot,
                                 Err(error) => {
-                                    self.publish_eager_partial_report(&report, &direct_report);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
                                     return Err(error);
                                 }
                             };
@@ -5540,25 +5571,26 @@ where
                                 })
                             {
                                 drop(commit_guard);
-                                self.publish_eager_partial_report(&report, &direct_report);
+                                self.publish_compressed_partial_report(&report, &direct_report);
                                 return Err(ExcelError::new(ExcelErrorKind::Value).with_message(
                                     "ordered fallback planning snapshot became stale",
                                 ));
                             }
-                            let (plan, formula_count) =
-                                match self.prepare_legacy_batch_fallback(batch, &snapshot) {
-                                    Ok(plan) => plan,
-                                    Err(error) => {
-                                        drop(commit_guard);
-                                        self.publish_eager_partial_report(&report, &direct_report);
-                                        return Err(error);
-                                    }
-                                };
+                            let (plan, formula_count) = match self
+                                .prepare_legacy_batch_fallback(batch, &snapshot)
+                            {
+                                Ok(plan) => plan,
+                                Err(error) => {
+                                    drop(commit_guard);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
+                                    return Err(error);
+                                }
+                            };
                             let provider_revision_after =
                                 self.resolver.planning_semantic_revision();
                             if provider_revision_after != provider_revision_initial {
                                 drop(commit_guard);
-                                self.publish_eager_partial_report(&report, &direct_report);
+                                self.publish_compressed_partial_report(&report, &direct_report);
                                 return Err(ExcelError::new(ExcelErrorKind::Value).with_message(
                                     "function provider changed while preparing ordered fallback",
                                 ));
@@ -5566,7 +5598,7 @@ where
                             let graph_vertices = plan.new_vertex_count();
                             let Some(graph_edges) = plan.planned_edge_count() else {
                                 drop(commit_guard);
-                                self.publish_eager_partial_report(&report, &direct_report);
+                                self.publish_compressed_partial_report(&report, &direct_report);
                                 return Err(ExcelError::new(ExcelErrorKind::Value)
                                     .with_message("prepared ordered fallback size overflow"));
                             };
@@ -5574,7 +5606,7 @@ where
                                 self.graph.validate_prepared_legacy_graph_plan(&plan)
                             {
                                 drop(commit_guard);
-                                self.publish_eager_partial_report(&report, &direct_report);
+                                self.publish_compressed_partial_report(&report, &direct_report);
                                 return Err(ExcelError::new(ExcelErrorKind::Value)
                                     .with_message(error.to_string()));
                             }
@@ -5589,7 +5621,7 @@ where
                                 self.resolver.planning_semantic_revision();
                             if provider_revision_final != provider_revision_initial {
                                 drop(commit_guard);
-                                self.publish_eager_partial_report(&report, &direct_report);
+                                self.publish_compressed_partial_report(&report, &direct_report);
                                 return Err(ExcelError::new(ExcelErrorKind::Value).with_message(
                                     "function provider changed after ordered fallback validation",
                                 ));
@@ -5609,7 +5641,7 @@ where
                                 .graph_edges_created
                                 .saturating_add(graph_edges as u64);
                         }
-                        EagerProposal::Clean(source_id, _, prepared) => {
+                        SourceProposal::Clean(source_id, _, prepared) => {
                             let commit_guard =
                                 crate::function_registry::semantic_epoch_read_guard();
                             let commit_epoch = commit_guard.epoch();
@@ -5723,7 +5755,7 @@ where
                                     ) {
                                         Ok(batch) => batch,
                                         Err(error) => {
-                                            self.publish_eager_partial_report(
+                                            self.publish_compressed_partial_report(
                                                 &report,
                                                 &direct_report,
                                             );
@@ -5733,7 +5765,7 @@ where
                                     let snapshot = match self.fallback_planning_snapshot(&batch) {
                                         Ok(snapshot) => snapshot,
                                         Err(error) => {
-                                            self.publish_eager_partial_report(
+                                            self.publish_compressed_partial_report(
                                                 &report,
                                                 &direct_report,
                                             );
@@ -5750,7 +5782,10 @@ where
                                         })
                                     {
                                         drop(commit_guard);
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(ExcelError::new(ExcelErrorKind::Value)
                                             .with_message(
                                                 "clean-family fallback planning snapshot became stale",
@@ -5762,7 +5797,7 @@ where
                                         Ok(plan) => plan,
                                         Err(error) => {
                                             drop(commit_guard);
-                                            self.publish_eager_partial_report(
+                                            self.publish_compressed_partial_report(
                                                 &report,
                                                 &direct_report,
                                             );
@@ -5773,7 +5808,10 @@ where
                                         self.resolver.planning_semantic_revision();
                                     if provider_revision_after != provider_revision {
                                         drop(commit_guard);
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(ExcelError::new(ExcelErrorKind::Value)
                                             .with_message(
                                                 "function provider changed while preparing clean-family fallback",
@@ -5782,7 +5820,10 @@ where
                                     let graph_vertices = plan.new_vertex_count();
                                     let Some(graph_edges) = plan.planned_edge_count() else {
                                         drop(commit_guard);
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(ExcelError::new(ExcelErrorKind::Value)
                                             .with_message(
                                                 "prepared clean-family fallback size overflow",
@@ -5792,7 +5833,10 @@ where
                                         self.graph.validate_prepared_legacy_graph_plan(&plan)
                                     {
                                         drop(commit_guard);
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(ExcelError::new(ExcelErrorKind::Value)
                                             .with_message(error.to_string()));
                                     }
@@ -5807,7 +5851,10 @@ where
                                         self.resolver.planning_semantic_revision();
                                     if provider_revision_final != provider_revision {
                                         drop(commit_guard);
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(ExcelError::new(ExcelErrorKind::Value)
                                             .with_message(
                                                 "function provider changed after clean-family fallback validation",
@@ -5844,7 +5891,7 @@ where
                                 }
                             }
                         }
-                        EagerProposal::Fragment(fragment) => {
+                        SourceProposal::Fragment(fragment) => {
                             let commit_guard =
                                 crate::function_registry::semantic_epoch_read_guard();
                             let commit_epoch = commit_guard.epoch();
@@ -5942,7 +5989,10 @@ where
                                 let replayed = match replayed {
                                     Ok(replayed) => replayed,
                                     Err(error) => {
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(error);
                                     }
                                 };
@@ -5952,14 +6002,20 @@ where
                                 ) {
                                     Ok(batch) => batch,
                                     Err(error) => {
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(error);
                                     }
                                 };
                                 let snapshot = match self.fallback_planning_snapshot(&batch) {
                                     Ok(snapshot) => snapshot,
                                     Err(error) => {
-                                        self.publish_eager_partial_report(&report, &direct_report);
+                                        self.publish_compressed_partial_report(
+                                            &report,
+                                            &direct_report,
+                                        );
                                         return Err(error);
                                     }
                                 };
@@ -5971,7 +6027,7 @@ where
                                         .provider_revision()
                                         .is_some_and(|revision| Some(revision) != provider_revision)
                                 {
-                                    self.publish_eager_partial_report(&report, &direct_report);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
                                     return Err(ExcelError::new(ExcelErrorKind::Value).with_message(
                                         format!(
                                             "whole-family fallback planning snapshot became stale: epoch {} != {}, provider {:?} != {:?}",
@@ -5982,21 +6038,23 @@ where
                                         ),
                                     ));
                                 }
-                                let (plan, formula_count) = match self
-                                    .prepare_legacy_batch_fallback(batch, &snapshot)
-                                {
-                                    Ok(plan) => plan,
-                                    Err(error) => {
-                                        drop(commit_guard);
-                                        self.publish_eager_partial_report(&report, &direct_report);
-                                        return Err(error);
-                                    }
-                                };
+                                let (plan, formula_count) =
+                                    match self.prepare_legacy_batch_fallback(batch, &snapshot) {
+                                        Ok(plan) => plan,
+                                        Err(error) => {
+                                            drop(commit_guard);
+                                            self.publish_compressed_partial_report(
+                                                &report,
+                                                &direct_report,
+                                            );
+                                            return Err(error);
+                                        }
+                                    };
                                 let provider_revision_after =
                                     self.resolver.planning_semantic_revision();
                                 if provider_revision_after != provider_revision {
                                     drop(commit_guard);
-                                    self.publish_eager_partial_report(&report, &direct_report);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
                                     return Err(ExcelError::new(ExcelErrorKind::Value)
                                         .with_message(
                                             "function provider changed while preparing whole-family fallback",
@@ -6005,7 +6063,7 @@ where
                                 let graph_vertices = plan.new_vertex_count();
                                 let Some(graph_edges) = plan.planned_edge_count() else {
                                     drop(commit_guard);
-                                    self.publish_eager_partial_report(&report, &direct_report);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
                                     return Err(ExcelError::new(ExcelErrorKind::Value)
                                         .with_message(
                                             "prepared whole-family fallback size overflow",
@@ -6015,7 +6073,7 @@ where
                                     self.graph.validate_prepared_legacy_graph_plan(&plan)
                                 {
                                     drop(commit_guard);
-                                    self.publish_eager_partial_report(&report, &direct_report);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
                                     return Err(ExcelError::new(ExcelErrorKind::Value)
                                         .with_message(error.to_string()));
                                 }
@@ -6030,7 +6088,7 @@ where
                                     self.resolver.planning_semantic_revision();
                                 if provider_revision_final != provider_revision {
                                     drop(commit_guard);
-                                    self.publish_eager_partial_report(&report, &direct_report);
+                                    self.publish_compressed_partial_report(&report, &direct_report);
                                     return Err(ExcelError::new(ExcelErrorKind::Value).with_message(
                                         "function provider changed after whole-family fallback validation",
                                     ));
@@ -6449,7 +6507,7 @@ where
             let _ = self.ingest_compressed_formula_source_batches(compressed)?;
         }
         if !direct.is_empty() {
-            let _ = self.finish_eager_compressed_formula_sources(direct)?;
+            let _ = self.finish_compressed_formula_sources(direct)?;
         }
         Ok(())
     }
@@ -6489,64 +6547,83 @@ where
                     .filter(|family| !package.invalidated.contains(&family.source_id))
                     .cloned()
                     .collect();
-                let mut preparation = (self.config.formula_plane_mode
-                    == FormulaPlaneMode::AuthoritativeExperimental)
-                    .then(|| self.prepare_source_formula_families(sheet, &eligible));
-                let mut replay_disposition = preparation
-                    .as_ref()
-                    .map(|preparation| preparation.replay_disposition.clone())
-                    .unwrap_or_default();
-                for partition in package
+                let eligible_partitions: Vec<_> = package
                     .partitioned_families
                     .iter()
                     .filter(|family| !package.invalidated.contains(&family.source_id))
-                {
-                    replay_disposition
-                        .register_partition(partition, false)
-                        .map_err(|reason| {
-                            ExcelError::new(ExcelErrorKind::Value).with_message(reason)
-                        })?;
-                }
-                replay_disposition
-                    .extend_suppressed_excel_coords(package.suppressed.iter().copied());
-                let replayed = package
-                    .replay
-                    .lock()
-                    .map_err(|_| {
-                        ExcelError::new(ExcelErrorKind::Value)
-                            .with_message("deferred formula spool lock poisoned")
-                    })?
-                    .replay(&replay_disposition)
-                    .map_err(|message| {
-                        ExcelError::new(ExcelErrorKind::Value).with_message(message)
-                    })?;
-                if let Some(mut prepared) = preparation.take() {
-                    prepared.replay_disposition = replay_disposition;
-                    preparation = Some(prepared.with_exact_replay(
+                    .cloned()
+                    .collect();
+                if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental {
+                    let mut preparation = self.prepare_source_formula_proposals(
+                        sheet,
+                        &eligible,
+                        &eligible_partitions,
+                        &package.partitioned_families,
+                        package.report.source_formula_records_spooled,
                         Arc::clone(&package.replay),
-                        package.suppressed.clone(),
-                    ));
-                }
-                entries.extend(replayed.into_iter().map(|record| {
-                    (
-                        record.row,
-                        record.col,
-                        record.text.clone(),
-                        Some((record.source_order, record.family, record.partition_owner)),
-                    )
-                }));
-                let mut report = package.report.clone();
-                report.source_spool_replays = report.source_spool_replays.saturating_add(1);
-                if let Some(preparation) = preparation {
-                    deferred_source = Some((report, preparation));
+                        &package.suppressed,
+                    )?;
+                    let replay_records = std::mem::take(&mut preparation.eager_replay);
+                    let (fragment_legacy, ordered_fallback): (Vec<_>, Vec<_>) = {
+                        let accepted: BTreeMap<_, _> = preparation
+                            .fragmented
+                            .iter()
+                            .map(|fragment| (fragment.source.source_id, &fragment.source))
+                            .collect();
+                        replay_records.into_iter().partition(|record| {
+                            record.partition_owner.is_some_and(|owner| {
+                                accepted.get(&owner).is_some_and(|source| {
+                                    Self::exact_replay_record_is_prepared_partition_legacy(
+                                        source, record,
+                                    )
+                                })
+                            })
+                        })
+                    };
+                    preparation.eager_replay = fragment_legacy;
+                    entries.extend(ordered_fallback.into_iter().map(|record| {
+                        (
+                            record.row,
+                            record.col,
+                            record.text,
+                            Some((record.source_order, record.family, record.partition_owner)),
+                        )
+                    }));
+                    deferred_source = Some((package.report.clone(), preparation));
                 } else {
-                    let partitions = package
-                        .partitioned_families
-                        .iter()
-                        .filter(|family| !package.invalidated.contains(&family.source_id))
-                        .cloned()
-                        .collect();
-                    deferred_fallback = Some((report, package.families.clone(), partitions));
+                    let mut replay_disposition = crate::engine::FormulaReplayDisposition::default();
+                    for partition in &eligible_partitions {
+                        replay_disposition
+                            .register_partition(partition, false)
+                            .map_err(|reason| {
+                                ExcelError::new(ExcelErrorKind::Value).with_message(reason)
+                            })?;
+                    }
+                    replay_disposition
+                        .extend_suppressed_excel_coords(package.suppressed.iter().copied());
+                    let replayed = package
+                        .replay
+                        .lock()
+                        .map_err(|_| {
+                            ExcelError::new(ExcelErrorKind::Value)
+                                .with_message("deferred formula spool lock poisoned")
+                        })?
+                        .replay(&replay_disposition)
+                        .map_err(|message| {
+                            ExcelError::new(ExcelErrorKind::Value).with_message(message)
+                        })?;
+                    entries.extend(replayed.into_iter().map(|record| {
+                        (
+                            record.row,
+                            record.col,
+                            record.text,
+                            Some((record.source_order, record.family, record.partition_owner)),
+                        )
+                    }));
+                    let mut report = package.report.clone();
+                    report.source_spool_replays = report.source_spool_replays.saturating_add(1);
+                    deferred_fallback =
+                        Some((report, package.families.clone(), eligible_partitions));
                 }
             }
 

--- a/crates/formualizer-eval/src/engine/formula_source.rs
+++ b/crates/formualizer-eval/src/engine/formula_source.rs
@@ -1020,7 +1020,7 @@ pub struct FormulaCompressedSourceBatch {
     partitioned_families: Vec<PartitionedSourceFormulaFamily>,
 }
 
-pub(crate) struct PreparedEagerFragmentedProposal {
+pub(crate) struct PreparedFragmentedSourceProposal {
     pub(crate) source: PartitionedSourceFormulaFamily,
     pub(crate) prepared: super::fragmented_transaction::PreparedPartitionedSourceFamily,
     pub(crate) legacy: Vec<super::fragmented_transaction::PreparedFragmentedLegacyFormula>,
@@ -1042,7 +1042,7 @@ pub struct FormulaCompressedPreparation {
         PreparedAnchorOncePlacement,
     )>,
     pub(crate) rejected: BTreeMap<SourceFamilyId, String>,
-    pub(crate) fragmented: Vec<PreparedEagerFragmentedProposal>,
+    pub(crate) fragmented: Vec<PreparedFragmentedSourceProposal>,
     pub(crate) fragmented_sources: BTreeMap<SourceFamilyId, PartitionedSourceFormulaFamily>,
     pub(crate) eager_replay: Vec<DeferredReplayFormula>,
     pub(crate) preparation_spool_replays: u64,

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_ingest_shadow.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_ingest_shadow.rs
@@ -2326,6 +2326,35 @@ fn changed_function_ast_discovery_covers_stale_prefix_unresolved_and_calls() {
 }
 
 #[test]
+fn deferred_fragmented_build_reuses_bounded_source_transaction_without_rebuild() {
+    let source = include_str!("../eval.rs");
+    let start = source
+        .find("fn prepare_staged_formula_batches(")
+        .expect("deferred preparation function");
+    let end = source[start..]
+        .find("pub fn begin_bulk_ingest_arrow(")
+        .map(|offset| start + offset)
+        .expect("end of deferred preparation function");
+    let body = &source[start..end];
+    assert!(body.contains("prepare_source_formula_proposals("));
+    assert!(body.contains("exact_replay_record_is_prepared_partition_legacy("));
+    assert!(!body.contains("rebuild_indexes"));
+    assert!(!body.contains("baseline_stats"));
+
+    let finish = source
+        .find("fn finish_compressed_formula_sources(")
+        .expect("shared source finalization function");
+    let finish_end = source[finish..]
+        .find("pub(crate) fn ingest_compressed_formula_source_batches(")
+        .map(|offset| finish + offset)
+        .expect("end of shared source finalization function");
+    let finish_body = &source[finish..finish_end];
+    assert!(finish_body.contains("commit_fragmented_source_transaction("));
+    assert!(finish_body.contains("apply_prevalidated_legacy_graph_plan("));
+    assert!(!finish_body.contains("rebuild_indexes"));
+}
+
+#[test]
 fn semantic_epoch_guard_covers_public_formula_plane_flows() {
     let source = include_str!("../eval.rs");
     for signature in [
@@ -2342,7 +2371,7 @@ fn semantic_epoch_guard_covers_public_formula_plane_flows() {
         "pub fn evaluate_until_cancellable(",
         "pub fn evaluate_all_logged(",
         "fn ingest_formula_batches_inner(",
-        "fn finish_eager_compressed_formula_sources(",
+        "fn finish_compressed_formula_sources(",
     ] {
         let start = source
             .find(signature)

--- a/crates/formualizer-eval/src/engine/tests/fragmented_source_transaction.rs
+++ b/crates/formualizer-eval/src/engine/tests/fragmented_source_transaction.rs
@@ -7,7 +7,7 @@ use crate::engine::fragmented_transaction::{
 };
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::{
-    DeferredFormulaReplay, DeferredReplayFormula, Engine, EvalConfig,
+    DeferredFormulaPackage, DeferredFormulaReplay, DeferredReplayFormula, Engine, EvalConfig,
     ExplicitPartitionLegacyMembers, FormulaCompressedSourceReport, FormulaIngestBatch,
     FormulaParsePolicy, FormulaReplayDisposition, PartitionLegacyMember, PartitionLegacyMemberKind,
     PartitionReconciliation, PartitionedSourceFormulaFamily, PlacementDomainTransport, SourceCoord,
@@ -354,11 +354,31 @@ fn transaction(
     transaction_for_source(family(shape, source_index))
 }
 
+struct EmptyDeferredReplay;
+
+impl DeferredFormulaReplay for EmptyDeferredReplay {
+    fn replay(
+        &mut self,
+        _disposition: &FormulaReplayDisposition,
+    ) -> Result<Vec<DeferredReplayFormula>, String> {
+        Ok(Vec::new())
+    }
+
+    fn formula_at(
+        &mut self,
+        _row: u32,
+        _col: u32,
+    ) -> Result<Option<DeferredReplayFormula>, String> {
+        Ok(None)
+    }
+}
+
 struct PartitionSetReplay {
     source: PartitionedSourceFormulaFamily,
     initial: Vec<DeferredReplayFormula>,
     full: Vec<DeferredReplayFormula>,
     fail_full: bool,
+    require_legacy_partition_routing: bool,
 }
 
 impl DeferredFormulaReplay for PartitionSetReplay {
@@ -376,8 +396,26 @@ impl DeferredFormulaReplay for PartitionSetReplay {
     fn replay_partitioned(
         &mut self,
         disposition: &FormulaReplayDisposition,
-        _partitions: &[PartitionedSourceFormulaFamily],
+        partitions: &[PartitionedSourceFormulaFamily],
     ) -> Result<Vec<DeferredReplayFormula>, String> {
+        if self.require_legacy_partition_routing {
+            if !partitions
+                .iter()
+                .any(|partition| partition.source_id == self.source.source_id)
+            {
+                return Err("invalidated partition missing from exact replay routing".to_string());
+            }
+            let ordinary = self
+                .source
+                .legacy_members
+                .as_slice()
+                .iter()
+                .find(|member| member.kind == PartitionLegacyMemberKind::OrdinaryException)
+                .ok_or_else(|| "test partition has no ordinary exception".to_string())?;
+            if disposition.ordinary_disposition(ordinary.coord).1 != Some(self.source.source_id) {
+                return Err("invalidated ordinary exception lost partition ownership".to_string());
+            }
+        }
         if disposition.partition_disposition(&self.source, self.source.template_origin0)
             == Some(crate::engine::FormulaReplayCoordinateDisposition::Direct)
         {
@@ -385,7 +423,27 @@ impl DeferredFormulaReplay for PartitionSetReplay {
         } else if self.fail_full {
             Err("injected whole-family replay failure".to_string())
         } else {
-            Ok(self.full.clone())
+            Ok(self
+                .full
+                .iter()
+                .filter(|record| {
+                    let coord = SourceCoord {
+                        row: record.row - 1,
+                        col: record.col - 1,
+                    };
+                    match record.family {
+                        Some(family) => {
+                            disposition.shared_disposition(family, coord)
+                                == crate::engine::FormulaReplayCoordinateDisposition::LegacyShared
+                        }
+                        None => {
+                            disposition.ordinary_disposition(coord).0
+                                == crate::engine::FormulaReplayCoordinateDisposition::LegacyOrdinary
+                        }
+                    }
+                })
+                .cloned()
+                .collect())
         }
     }
 
@@ -413,6 +471,109 @@ fn replay_record(
     }
 }
 
+fn deferred_partition_package(
+    source: PartitionedSourceFormulaFamily,
+    fail_full: bool,
+    require_legacy_partition_routing: bool,
+) -> DeferredFormulaPackage {
+    let make_record = |coord: SourceCoord, kind: PartitionLegacyMemberKind| DeferredReplayFormula {
+        source_order: crate::engine::SourceFormulaOrder::new(u64::from(coord.row)),
+        row: coord.row + 1,
+        col: coord.col + 1,
+        text: match kind {
+            PartitionLegacyMemberKind::SharedFamilyMember => source.template_text.to_string(),
+            PartitionLegacyMemberKind::OrdinaryException => "$A$1+5".to_string(),
+        },
+        family: (kind == PartitionLegacyMemberKind::SharedFamilyMember).then_some(source.source_id),
+        partition_owner: Some(source.source_id),
+    };
+    let initial = source
+        .legacy_members
+        .as_slice()
+        .iter()
+        .map(|member| make_record(member.coord, member.kind))
+        .collect();
+    let full = (0..=5)
+        .map(|row| {
+            make_record(
+                SourceCoord { row, col: 2 },
+                if row == 3 {
+                    PartitionLegacyMemberKind::OrdinaryException
+                } else {
+                    PartitionLegacyMemberKind::SharedFamilyMember
+                },
+            )
+        })
+        .collect();
+    let report = FormulaCompressedSourceReport {
+        source_formula_records_spooled: 6,
+        families_seen: 1,
+        family_cells_seen: source.surviving_member_count,
+        source_fragmentable_families: 1,
+        source_fragmentable_cells: source.surviving_member_count,
+        source_fragment_count: source.fragments.len() as u64,
+        source_hole_exclusions: source.reconciliation.holes,
+        source_ordinary_exclusions: source.reconciliation.ordinary_exceptions,
+        ..FormulaCompressedSourceReport::default()
+    };
+    DeferredFormulaPackage::new(
+        "Sheet1".to_string(),
+        report,
+        Vec::new(),
+        vec![source.clone()],
+        Box::new(PartitionSetReplay {
+            source,
+            initial,
+            full,
+            fail_full,
+            require_legacy_partition_routing,
+        }),
+    )
+}
+
+fn deferred_engine() -> Engine<TestWorkbook> {
+    let mut engine = make_engine();
+    engine.config.defer_graph_building = true;
+    engine
+}
+
+fn deferred_cross_fragment_package(
+    source: PartitionedSourceFormulaFamily,
+) -> DeferredFormulaPackage {
+    let full = (100..=299)
+        .map(|row| DeferredReplayFormula {
+            source_order: crate::engine::SourceFormulaOrder::new(u64::from(row - 100)),
+            row: row + 1,
+            col: 3,
+            text: format!("C{}+1", row + 101),
+            family: Some(source.source_id),
+            partition_owner: Some(source.source_id),
+        })
+        .collect();
+    let report = FormulaCompressedSourceReport {
+        source_formula_records_spooled: 200,
+        families_seen: 1,
+        family_cells_seen: 200,
+        source_fragmentable_families: 1,
+        source_fragmentable_cells: 200,
+        source_fragment_count: 2,
+        ..FormulaCompressedSourceReport::default()
+    };
+    DeferredFormulaPackage::new(
+        "Sheet1".to_string(),
+        report,
+        Vec::new(),
+        vec![source.clone()],
+        Box::new(PartitionSetReplay {
+            source,
+            initial: Vec::new(),
+            full,
+            fail_full: false,
+            require_legacy_partition_routing: false,
+        }),
+    )
+}
+
 fn state(engine: &Engine<TestWorkbook>) -> String {
     format!(
         "{:?}|{:?}|{:?}|{:?}|{:?}",
@@ -422,6 +583,155 @@ fn state(engine: &Engine<TestWorkbook>) -> String {
         engine.last_virtual_dep_telemetry(),
         engine.last_cycle_telemetry(),
     )
+}
+
+#[test]
+fn deferred_partition_commits_through_composed_transaction() {
+    let mut engine = deferred_engine();
+    let source = family(Shape::Row, 110);
+    engine
+        .source_formula_ingress()
+        .stage_deferred(deferred_partition_package(source, false, false));
+
+    engine.build_graph_all().unwrap();
+    let report = engine.last_formula_ingest_report().unwrap();
+    assert!(!engine.has_staged_formulas());
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 2);
+    assert_eq!(report.source_family_promoted, 1, "{report:?}");
+    assert_eq!(report.source_partitioned_families_prepared, 1, "{report:?}");
+    assert_eq!(report.graph_formula_cells_materialized, 2, "{report:?}");
+    assert_eq!(report.source_spool_replays, 1, "{report:?}");
+}
+
+#[test]
+fn deferred_invalidated_partition_keeps_ordinary_exception_ownership() {
+    let mut engine = deferred_engine();
+    let source = family(Shape::Row, 115);
+    engine
+        .source_formula_ingress()
+        .stage_deferred(deferred_partition_package(source, false, true));
+
+    // Replacing one shared member invalidates the whole partition. Exact replay
+    // must still receive the partition as routing evidence so its ordinary
+    // exception remains owned by the same family during atomic fallback.
+    engine.stage_formula_text("Sheet1", 1, 3, "=$A$1+99".to_string());
+    engine.build_graph_all().unwrap();
+
+    let report = engine.last_formula_ingest_report().unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 6);
+    assert_eq!(report.source_family_promoted, 0, "{report:?}");
+    assert_eq!(report.source_family_fallback, 1, "{report:?}");
+    assert_eq!(report.graph_formula_cells_materialized, 6, "{report:?}");
+    assert_eq!(report.source_spool_replays, 1, "{report:?}");
+}
+
+#[test]
+fn deferred_partition_precommit_fault_replays_whole_family_once() {
+    let mut engine = deferred_engine();
+    let source = family(Shape::Row, 111);
+    engine
+        .source_formula_ingress()
+        .stage_deferred(deferred_partition_package(source, false, false));
+    engine.set_fragmented_commit_fault_for_test(FragmentedCommitFault::FormulaPlaneFinalCheck);
+
+    engine.build_graph_all().unwrap();
+    let report = engine.last_formula_ingest_report().unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 6);
+    assert_eq!(report.source_family_promoted, 0, "{report:?}");
+    assert_eq!(report.source_family_fallback, 1, "{report:?}");
+    assert_eq!(report.graph_formula_cells_materialized, 6, "{report:?}");
+    assert_eq!(report.source_spool_replays, 2, "{report:?}");
+    assert_eq!(
+        report
+            .fallback_reasons
+            .get("Injected(FormulaPlaneFinalCheck)"),
+        Some(&1),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn deferred_partition_provider_change_falls_back_before_mutation() {
+    let (mut engine, revision) = make_engine_and_revision();
+    engine.config.defer_graph_building = true;
+    let source = function_family(113);
+    engine
+        .source_formula_ingress()
+        .stage_deferred(deferred_partition_package(source, false, false));
+    engine.set_before_prepared_span_commit_hook(move || {
+        revision.fetch_add(1, Ordering::AcqRel);
+    });
+
+    engine.build_graph_all().unwrap();
+    let report = engine.last_formula_ingest_report().unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 6);
+    assert_eq!(report.source_family_promoted, 0, "{report:?}");
+    assert_eq!(report.source_family_fallback, 1, "{report:?}");
+    assert_eq!(report.graph_formula_cells_materialized, 6, "{report:?}");
+    assert_eq!(report.source_spool_replays, 2, "{report:?}");
+    assert!(
+        report
+            .fallback_reasons
+            .contains_key("FunctionProviderRevisionChanged"),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn deferred_cross_fragment_dependency_replays_without_partial_authority() {
+    let mut engine = deferred_engine();
+    let source = cross_fragment_family(114, false);
+    engine
+        .source_formula_ingress()
+        .stage_deferred(deferred_cross_fragment_package(source));
+
+    engine.build_graph_all().unwrap();
+    let report = engine.last_formula_ingest_report().unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 200);
+    assert_eq!(report.source_family_promoted, 0, "{report:?}");
+    assert_eq!(report.source_family_fallback, 1, "{report:?}");
+    assert_eq!(report.graph_formula_cells_materialized, 200, "{report:?}");
+    assert_eq!(report.source_spool_replays, 2, "{report:?}");
+    assert!(
+        report
+            .fallback_reasons
+            .keys()
+            .any(|reason| reason.contains("CrossFragmentDependency")),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn deferred_partition_late_replay_failure_leaves_current_family_unmodified() {
+    let mut engine = deferred_engine();
+    let source = family(Shape::Row, 112);
+    engine
+        .source_formula_ingress()
+        .stage_deferred(deferred_partition_package(source, true, false));
+    engine.set_fragmented_commit_fault_for_test(FragmentedCommitFault::FormulaPlaneFinalCheck);
+
+    let error = engine.build_graph_all().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("injected whole-family replay failure"),
+        "{error}"
+    );
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
+    assert!(engine.last_formula_ingest_report().is_none());
+    assert_eq!(
+        engine
+            .formula_ingest_report_total()
+            .graph_formula_cells_materialized,
+        0
+    );
+    assert!(!engine.has_staged_formulas());
 }
 
 #[test]
@@ -472,6 +782,7 @@ fn eager_partition_initial_replay_rejects_missing_and_extra_legacy_ownership() {
                     initial,
                     full,
                     fail_full: false,
+                    require_legacy_partition_routing: false,
                 }),
             )
             .unwrap();
@@ -586,6 +897,82 @@ fn clean_families_follow_source_order_not_shared_index_order() {
 }
 
 #[test]
+fn deferred_clean_families_follow_source_order_not_shared_index_order() {
+    let later_low_si = SourceFormulaFamily {
+        source_order: crate::engine::SourceFormulaOrder::new(10),
+        source_id: SourceFamilyId {
+            sheet_instance: 405,
+            source_index: 1,
+        },
+        anchor_coord0: SourceCoord { row: 0, col: 6 },
+        anchor_text: Arc::from("$A$1+1"),
+        members: SourceFamilyMembers::CompleteDomain(PlacementDomainTransport::RowRun {
+            row_start: 0,
+            row_end: 1,
+            col: 6,
+        }),
+        member_count: 2,
+    };
+    let earlier_high_si = SourceFormulaFamily {
+        source_order: crate::engine::SourceFormulaOrder::new(0),
+        source_id: SourceFamilyId {
+            sheet_instance: 405,
+            source_index: 99,
+        },
+        anchor_coord0: SourceCoord { row: 0, col: 5 },
+        anchor_text: Arc::from("$A$1+1"),
+        members: SourceFamilyMembers::CompleteDomain(PlacementDomainTransport::RowRun {
+            row_start: 0,
+            row_end: 1,
+            col: 5,
+        }),
+        member_count: 2,
+    };
+    let package = DeferredFormulaPackage::new(
+        "Sheet1".to_string(),
+        FormulaCompressedSourceReport {
+            source_formula_records_spooled: 4,
+            families_seen: 2,
+            family_cells_seen: 4,
+            source_clean_families: 2,
+            source_clean_cells: 4,
+            ..FormulaCompressedSourceReport::default()
+        },
+        vec![later_low_si, earlier_high_si],
+        Vec::new(),
+        Box::new(EmptyDeferredReplay),
+    );
+    let mut engine = deferred_engine();
+    engine.source_formula_ingress().stage_deferred(package);
+    engine.build_graph_all().unwrap();
+
+    let spans = engine.graph.formula_authority().active_span_refs();
+    assert_eq!(spans.len(), 2);
+    let sheet_id = engine.graph.sheet_id("Sheet1").unwrap();
+    let first = engine
+        .graph
+        .formula_authority()
+        .plane
+        .spans
+        .get(spans[0])
+        .unwrap();
+    assert!(
+        first
+            .domain
+            .contains(crate::formula_plane::runtime::PlacementCoord::new(
+                sheet_id, 0, 5
+            ))
+    );
+    assert_eq!(
+        engine
+            .last_formula_ingest_report()
+            .unwrap()
+            .source_spool_replays,
+        0
+    );
+}
+
+#[test]
 fn late_fallback_replay_failure_keeps_current_family_untouched_and_publishes_prior_clean_commit() {
     let mut engine = make_engine();
     let source = family(Shape::Row, 99);
@@ -635,6 +1022,7 @@ fn late_fallback_replay_failure_keeps_current_family_untouched_and_publishes_pri
                 initial,
                 full,
                 fail_full: true,
+                require_legacy_partition_routing: false,
             }),
         )
         .unwrap();
@@ -729,6 +1117,7 @@ fn late_fallback_parse_failure_keeps_current_family_untouched_and_reports_prior_
                 initial,
                 full,
                 fail_full: false,
+                require_legacy_partition_routing: false,
             }),
         )
         .unwrap();
@@ -799,6 +1188,7 @@ fn late_fallback_success_reports_exact_whole_family_e2_deltas_once() {
                 initial,
                 full,
                 fail_full: false,
+                require_legacy_partition_routing: false,
             }),
         )
         .unwrap();
@@ -884,6 +1274,7 @@ fn provider_change_after_fallback_validation_fails_before_mutation() {
                 initial,
                 full,
                 fail_full: false,
+                require_legacy_partition_routing: false,
             }),
         )
         .unwrap();

--- a/crates/formualizer-workbook/tests/calamine/shared_formulas.rs
+++ b/crates/formualizer-workbook/tests/calamine/shared_formulas.rs
@@ -321,6 +321,46 @@ fn two_shared_sheets_xlsx() -> Vec<u8> {
     output.finish().unwrap().into_inner()
 }
 
+fn two_fragmented_sheets_xlsx() -> Vec<u8> {
+    let mut book = umya_spreadsheet::new_file();
+    book.new_sheet("Other").unwrap();
+    for name in ["Sheet1", "Other"] {
+        let sheet = book.get_sheet_by_name_mut(name).unwrap();
+        sheet.get_cell_mut("A1").set_value_number(1);
+        for row in [1, 2, 4, 6] {
+            sheet.get_cell_mut((2, row)).set_formula("$A$1+1");
+        }
+        sheet.get_cell_mut("B5").set_formula("$A$1+100");
+    }
+    let mut original = Vec::new();
+    umya_spreadsheet::writer::xlsx::write_writer(&book, &mut original).unwrap();
+    let mut input = ZipArchive::new(Cursor::new(original)).unwrap();
+    let mut output = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    for index in 0..input.len() {
+        let mut entry = input.by_index(index).unwrap();
+        let name = entry.name().to_string();
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes).unwrap();
+        if name.starts_with("xl/worksheets/sheet") && name.ends_with(".xml") {
+            let xml = String::from_utf8(bytes).unwrap();
+            let xml = xml
+                .replacen(
+                    "<f>$A$1+1</f>",
+                    "<f t=\"shared\" si=\"91\" ref=\"B1:B6\">$A$1+1</f>",
+                    1,
+                )
+                .replacen("<f>$A$1+1</f>", "<f t=\"shared\" si=\"91\"></f>", 1)
+                .replacen("<f>$A$1+1</f>", "<f t=\"shared\" si=\"91\"></f>", 1)
+                .replacen("<f>$A$1+1</f>", "<f t=\"shared\" si=\"91\"></f>", 1);
+            bytes = xml.into_bytes();
+        }
+        output.start_file(name, options).unwrap();
+        output.write_all(&bytes).unwrap();
+    }
+    output.finish().unwrap().into_inner()
+}
+
 fn column_letters(mut col1: u32) -> String {
     let mut out = String::new();
     while col1 != 0 {
@@ -772,7 +812,7 @@ fn fragmented_family_replays_whole_and_exact_eager_deferred_in_every_mode() {
             } else {
                 assert_eq!(
                     report.source_partitioned_families_rejected,
-                    u64::from(mode == FormulaPlaneMode::AuthoritativeExperimental && !deferred),
+                    u64::from(mode == FormulaPlaneMode::AuthoritativeExperimental),
                     "{mode:?}/{deferred}: {report:?}"
                 );
                 assert_eq!(report.source_partitioned_families_prepared, 0);
@@ -782,7 +822,7 @@ fn fragmented_family_replays_whole_and_exact_eager_deferred_in_every_mode() {
 }
 
 #[test]
-fn fragmented_constant_family_prepares_once_and_only_eager_authority_commits() {
+fn fragmented_constant_family_prepares_once_and_authority_commits_eager_and_deferred() {
     for (mode, deferred) in [
         (FormulaPlaneMode::Shadow, false),
         (FormulaPlaneMode::Shadow, true),
@@ -814,7 +854,7 @@ fn fragmented_constant_family_prepares_once_and_only_eager_authority_commits() {
         );
         let report = engine.last_formula_ingest_report().unwrap();
         assert_eq!(report.source_partitioned_families_seen, 1, "{report:?}");
-        if mode == FormulaPlaneMode::AuthoritativeExperimental && !deferred {
+        if mode == FormulaPlaneMode::AuthoritativeExperimental {
             assert_eq!(report.source_partitioned_families_prepared, 1, "{report:?}");
             assert_eq!(report.source_partitioned_families_rejected, 0, "{report:?}");
             assert_eq!(report.source_family_promoted, 1, "{report:?}");
@@ -839,7 +879,7 @@ fn fragmented_constant_family_prepares_once_and_only_eager_authority_commits() {
 }
 
 #[test]
-fn eager_fragmented_relative_family_preserves_replay_values_lookup_edits_and_structure() {
+fn fragmented_relative_family_preserves_replay_values_lookup_edits_and_structure_eager_deferred() {
     fn loaded(
         mode: FormulaPlaneMode,
         deferred: bool,
@@ -863,6 +903,7 @@ fn eager_fragmented_relative_family_preserves_replay_values_lookup_edits_and_str
 
     let mut replay = loaded(FormulaPlaneMode::Off, false);
     let mut direct = loaded(FormulaPlaneMode::AuthoritativeExperimental, false);
+    let mut deferred = loaded(FormulaPlaneMode::AuthoritativeExperimental, true);
     let report = direct.last_formula_ingest_report().unwrap();
     assert_eq!(report.source_family_promoted, 1, "{report:?}");
     assert_eq!(report.source_family_fallback, 0, "{report:?}");
@@ -877,12 +918,24 @@ fn eager_fragmented_relative_family_preserves_replay_values_lookup_edits_and_str
     assert_eq!(report.graph_formula_cells_materialized, 1, "{report:?}");
     assert_eq!(report.source_spool_replays, 1, "{report:?}");
     assert_eq!(direct.baseline_stats().formula_plane_active_span_count, 3);
+    let deferred_report = deferred.last_formula_ingest_report().unwrap();
+    assert_eq!(deferred_report.graph_formula_cells_materialized, 1);
+    assert_eq!(deferred.baseline_stats().formula_plane_active_span_count, 3);
+    assert_eq!(deferred_report.source_partitioned_families_prepared, 1);
+    assert_eq!(deferred_report.source_family_promoted, 1);
+    assert_eq!(deferred_report.source_spool_replays, 1);
 
     for row in [1, 39, 41, 79, 80, 81, 120] {
+        let replay_value = replay.get_cell_value("Sheet1", row, 2);
         assert_eq!(
             direct.get_cell_value("Sheet1", row, 2),
-            replay.get_cell_value("Sheet1", row, 2),
-            "row {row}"
+            replay_value,
+            "eager row {row}"
+        );
+        assert_eq!(
+            deferred.get_cell_value("Sheet1", row, 2),
+            replay_value,
+            "deferred row {row}"
         );
     }
     assert_eq!(direct.get_cell_value("Sheet1", 40, 2), None);
@@ -898,7 +951,7 @@ fn eager_fragmented_relative_family_preserves_replay_values_lookup_edits_and_str
             .fingerprint()
     );
 
-    for engine in [&mut replay, &mut direct] {
+    for engine in [&mut replay, &mut direct, &mut deferred] {
         engine
             .set_cell_value("Sheet1", 20, 2, LiteralValue::Number(999.0))
             .unwrap();
@@ -906,22 +959,22 @@ fn eager_fragmented_relative_family_preserves_replay_values_lookup_edits_and_str
         engine.evaluate_all().unwrap();
     }
     for row in [1, 20, 39, 41, 61, 81, 82, 83, 122] {
+        let replay_value = replay.get_cell_value("Sheet1", row, 2);
         assert_eq!(
             direct.get_cell_value("Sheet1", row, 2),
-            replay.get_cell_value("Sheet1", row, 2),
-            "post-edit row {row}"
+            replay_value,
+            "post-edit eager row {row}"
+        );
+        assert_eq!(
+            deferred.get_cell_value("Sheet1", row, 2),
+            replay_value,
+            "post-edit deferred row {row}"
         );
     }
-
-    let deferred = loaded(FormulaPlaneMode::AuthoritativeExperimental, true);
-    let deferred_report = deferred.last_formula_ingest_report().unwrap();
-    assert_eq!(deferred_report.graph_formula_cells_materialized, 119);
-    assert_eq!(deferred.baseline_stats().formula_plane_active_span_count, 0);
-    assert_eq!(deferred_report.source_partitioned_families_prepared, 0);
 }
 
 #[test]
-fn eager_fragmented_row_and_rect_domains_relocate_without_synthesizing_holes() {
+fn fragmented_row_and_rect_domains_relocate_eager_and_deferred_without_synthesizing_holes() {
     for (fixture, checks) in [
         (
             large_fragmented_horizontal_xlsx(120, 40, 80),
@@ -932,27 +985,40 @@ fn eager_fragmented_row_and_rect_domains_relocate_without_synthesizing_holes() {
             vec![(1, 2, 2.0), (6, 5, 7.0), (9, 9, 109.0), (12, 13, 13.0)],
         ),
     ] {
-        let config = EvalConfig {
-            formula_plane_mode: FormulaPlaneMode::AuthoritativeExperimental,
-            ..EvalConfig::default()
-        };
-        let mut engine = Engine::new(formualizer_eval::test_workbook::TestWorkbook::new(), config);
-        let mut adapter = CalamineAdapter::open_bytes(fixture).unwrap();
-        adapter.stream_into_engine(&mut engine).unwrap();
-        engine.evaluate_all().unwrap();
-        let report = engine.last_formula_ingest_report().unwrap();
-        assert_eq!(report.source_family_promoted, 1, "{report:?}");
-        assert_eq!(report.source_family_fallback, 0, "{report:?}");
-        assert_eq!(report.source_partitioned_families_prepared, 1, "{report:?}");
-        assert_eq!(report.source_partition_holes, 1, "{report:?}");
-        assert_eq!(report.source_partition_ordinary_exceptions, 1, "{report:?}");
-        assert!(engine.baseline_stats().formula_plane_active_span_count >= 2);
-        for (row, col, expected) in checks {
+        for deferred in [false, true] {
+            let config = EvalConfig {
+                formula_plane_mode: FormulaPlaneMode::AuthoritativeExperimental,
+                defer_graph_building: deferred,
+                ..EvalConfig::default()
+            };
+            let mut engine =
+                Engine::new(formualizer_eval::test_workbook::TestWorkbook::new(), config);
+            let mut adapter = CalamineAdapter::open_bytes(fixture.clone()).unwrap();
+            adapter.stream_into_engine(&mut engine).unwrap();
+            if deferred {
+                engine.build_graph_all().unwrap();
+            }
+            engine.evaluate_all().unwrap();
+            let report = engine.last_formula_ingest_report().unwrap();
+            assert_eq!(report.source_family_promoted, 1, "{deferred}: {report:?}");
+            assert_eq!(report.source_family_fallback, 0, "{deferred}: {report:?}");
             assert_eq!(
-                engine.get_cell_value("Sheet1", row, col),
-                Some(LiteralValue::Number(expected)),
-                "R{row}C{col}: {report:?}"
+                report.source_partitioned_families_prepared, 1,
+                "{deferred}: {report:?}"
             );
+            assert_eq!(report.source_partition_holes, 1, "{deferred}: {report:?}");
+            assert_eq!(
+                report.source_partition_ordinary_exceptions, 1,
+                "{deferred}: {report:?}"
+            );
+            assert!(engine.baseline_stats().formula_plane_active_span_count >= 2);
+            for &(row, col, expected) in &checks {
+                assert_eq!(
+                    engine.get_cell_value("Sheet1", row, col),
+                    Some(LiteralValue::Number(expected)),
+                    "{deferred} R{row}C{col}: {report:?}"
+                );
+            }
         }
     }
 }
@@ -1152,6 +1218,98 @@ fn deferred_all_and_selected_builds_are_differentially_identical() {
 }
 
 #[test]
+fn deferred_fragmented_selected_build_commits_only_selected_package() {
+    let config = EvalConfig {
+        formula_plane_mode: FormulaPlaneMode::AuthoritativeExperimental,
+        defer_graph_building: true,
+        ..EvalConfig::default()
+    };
+    let mut engine = Engine::new(formualizer_eval::test_workbook::TestWorkbook::new(), config);
+    let mut adapter = CalamineAdapter::open_bytes(two_fragmented_sheets_xlsx()).unwrap();
+    adapter.stream_into_engine(&mut engine).unwrap();
+
+    engine.build_graph_for_sheets(["Sheet1"]).unwrap();
+    assert!(engine.has_staged_formulas());
+    assert_eq!(engine.staged_formula_count(), 5);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(
+        engine.formula_ingest_report_total().source_family_promoted,
+        1
+    );
+    assert_eq!(
+        engine.get_staged_formula_text("Other", 6, 2).as_deref(),
+        Some("$A$1+1")
+    );
+
+    engine.build_graph_for_sheets(["Other"]).unwrap();
+    assert!(!engine.has_staged_formulas());
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    assert_eq!(
+        engine.formula_ingest_report_total().source_family_promoted,
+        2
+    );
+    assert_eq!(
+        engine
+            .formula_ingest_report_total()
+            .source_partitioned_families_prepared,
+        2
+    );
+    engine.evaluate_all().unwrap();
+    for sheet in ["Sheet1", "Other"] {
+        assert_eq!(
+            engine.get_cell_value(sheet, 6, 2),
+            Some(LiteralValue::Number(2.0))
+        );
+        assert_eq!(
+            engine.get_cell_value(sheet, 5, 2),
+            Some(LiteralValue::Number(101.0))
+        );
+    }
+}
+
+#[test]
+fn deferred_fragmented_replacement_invalidates_whole_family_before_authority() {
+    for edited_row in [20, 80] {
+        let config = EvalConfig {
+            formula_plane_mode: FormulaPlaneMode::AuthoritativeExperimental,
+            defer_graph_building: true,
+            ..EvalConfig::default()
+        };
+        let mut engine = Engine::new(formualizer_eval::test_workbook::TestWorkbook::new(), config);
+        let mut adapter =
+            CalamineAdapter::open_bytes(large_fragmented_vertical_xlsx(120, 40, 80, false))
+                .unwrap();
+        adapter.stream_into_engine(&mut engine).unwrap();
+        engine.stage_formula_text("Sheet1", edited_row, 2, format!("=A{edited_row}+1000"));
+
+        engine.build_graph_all().unwrap();
+        engine.evaluate_all().unwrap();
+        let report = engine.last_formula_ingest_report().unwrap();
+        assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+        assert_eq!(
+            report.source_family_promoted, 0,
+            "row {edited_row}: {report:?}"
+        );
+        assert_eq!(
+            report.source_family_fallback, 1,
+            "row {edited_row}: {report:?}"
+        );
+        assert_eq!(
+            report.graph_formula_cells_materialized, 119,
+            "row {edited_row}: {report:?}"
+        );
+        assert_eq!(
+            report.source_spool_replays, 1,
+            "row {edited_row}: {report:?}"
+        );
+        assert_eq!(
+            engine.get_cell_value("Sheet1", edited_row, 2),
+            Some(LiteralValue::Number(f64::from(edited_row) + 1000.0))
+        );
+    }
+}
+
+#[test]
 fn deferred_structural_edits_materialize_before_shift_and_match_eager_coordinates() {
     fn loaded(deferred: bool) -> Engine<formualizer_eval::test_workbook::TestWorkbook> {
         let config = EvalConfig {
@@ -1206,14 +1364,70 @@ fn deferred_structural_edits_materialize_before_shift_and_match_eager_coordinate
 }
 
 #[test]
-fn deferred_package_rename_moves_identity_and_remove_drops_it() {
+fn deferred_fragmented_structural_edits_materialize_before_shift() {
+    fn loaded(deferred: bool) -> Engine<formualizer_eval::test_workbook::TestWorkbook> {
+        let config = EvalConfig {
+            formula_plane_mode: FormulaPlaneMode::AuthoritativeExperimental,
+            defer_graph_building: deferred,
+            ..EvalConfig::default()
+        };
+        let mut engine = Engine::new(formualizer_eval::test_workbook::TestWorkbook::new(), config);
+        let mut adapter =
+            CalamineAdapter::open_bytes(large_fragmented_vertical_xlsx(120, 40, 80, false))
+                .unwrap();
+        adapter.stream_into_engine(&mut engine).unwrap();
+        engine
+    }
+    fn snapshot(
+        engine: &Engine<formualizer_eval::test_workbook::TestWorkbook>,
+    ) -> Vec<Option<LiteralValue>> {
+        (1..=125)
+            .flat_map(|row| (1..=4).map(move |col| engine.get_cell_value("Sheet1", row, col)))
+            .collect()
+    }
+
+    for operation in 0..4 {
+        let mut eager = loaded(false);
+        let mut deferred = loaded(true);
+        match operation {
+            0 => {
+                eager.insert_rows("Sheet1", 60, 2).unwrap();
+                deferred.insert_rows("Sheet1", 60, 2).unwrap();
+            }
+            1 => {
+                eager.delete_rows("Sheet1", 60, 2).unwrap();
+                deferred.delete_rows("Sheet1", 60, 2).unwrap();
+            }
+            2 => {
+                eager.insert_columns("Sheet1", 2, 1).unwrap();
+                deferred.insert_columns("Sheet1", 2, 1).unwrap();
+            }
+            _ => {
+                eager.delete_columns("Sheet1", 1, 1).unwrap();
+                deferred.delete_columns("Sheet1", 1, 1).unwrap();
+            }
+        }
+        eager.evaluate_all().unwrap();
+        deferred.evaluate_all().unwrap();
+        assert_eq!(
+            snapshot(&deferred),
+            snapshot(&eager),
+            "fragmented operation {operation}"
+        );
+        assert!(!deferred.has_staged_formulas());
+    }
+}
+
+#[test]
+fn deferred_fragmented_package_rename_moves_identity_and_remove_drops_it() {
     let config = EvalConfig {
         formula_plane_mode: FormulaPlaneMode::AuthoritativeExperimental,
         defer_graph_building: true,
         ..EvalConfig::default()
     };
     let mut engine = Engine::new(formualizer_eval::test_workbook::TestWorkbook::new(), config);
-    let mut adapter = CalamineAdapter::open_bytes(large_shared_vertical_xlsx(100, "A1+1")).unwrap();
+    let mut adapter =
+        CalamineAdapter::open_bytes(large_fragmented_vertical_xlsx(120, 40, 80, false)).unwrap();
     adapter.stream_into_engine(&mut engine).unwrap();
 
     let sheet_id = engine.sheet_id("Sheet1").unwrap();

--- a/docs/architecture/formula-function-closure-fragmented-families.md
+++ b/docs/architecture/formula-function-closure-fragmented-families.md
@@ -412,6 +412,9 @@ cargo test -p formualizer-eval formula_plane_ingest_shadow
 cargo test -p formualizer-workbook --features calamine --test calamine shared_formulas
 cargo test -p formualizer-workbook --features calamine --test load_limits
 cargo test -p formualizer-bench-core --features formualizer_runner --bin probe-formula-family-ingest
+cargo run --release -p formualizer-bench-core --features formualizer_runner --bin probe-formula-family-ingest -- --scenario hole-exception --members 100000 --exclusions 1 --graph-build deferred --samples 5
+cargo run --release -p formualizer-bench-core --features formualizer_runner --bin probe-formula-family-ingest -- --scenario hole-exception --members 100000 --exclusions 8 --graph-build deferred --samples 5
+cargo run --release -p formualizer-bench-core --features formualizer_runner --bin probe-formula-family-ingest -- --scenario hole-exception --members 100000 --exclusions 64 --graph-build deferred --samples 5
 cargo fmt --all -- --check
 cargo clippy -p formualizer-eval -p formualizer-workbook --all-targets --features formualizer-workbook/calamine -- -D warnings
 ```

--- a/docs/architecture/formula-function-closure-fragmented-families.md
+++ b/docs/architecture/formula-function-closure-fragmented-families.md
@@ -57,7 +57,7 @@ Conclusion: keep `FnCaps` and `arg_schema`, but add **one central semantic contr
 10. Holes and exception cells are never synthesized, masked inside a rectangle, or hidden by a span. They are exact replay records/legacy graph cells.
 11. Fragment preparation is family-atomic. Either all proposed spans and all fallback cells are preflighted and committed as one disposition, or the complete source family replays.
 12. Fragment and exclusion limits disable only the optimization. Evidence/spool limits retain their current fail-closed behavior.
-13. Eager authority lands before deferred fragmented authority. Deferred packages remain whole-family replay on fragmented evidence until lifecycle tests pass.
+13. Eager authority lands before deferred fragmented authority. Deferred authority is enabled only for `AuthoritativeExperimental` after selected-build, invalidation, structure, exact replay, and bounded-transaction lifecycle tests pass; Off and Shadow remain replay-only.
 
 ## 4. Central function semantic contract
 
@@ -249,7 +249,7 @@ Each fragment is an existing independent span, so scheduling, dirty projection, 
 - mixed-schedule cycle detection may demote one or several fragments. Materialization uses each fragment's `SpanAstRelocation`; no family-wide live transaction is needed after initial commit;
 - dependency edges/read regions are per fragment. A read intersecting any fragment's own result region triggers the existing internal-dependency gate for that fragment during preparation; because initial disposition is family-atomic, it replays the family.
 
-Deferred `DeferredFormulaPackage` continues whole-family replay for fragmented families until selected-build, rename/remove, replacement invalidation, random formula read, and spool cleanup tests support coordinate dispositions. Do not broaden deferred authority in the eager swatch.
+Deferred `DeferredFormulaPackage` uses the same prepared source transaction and coordinate disposition as eager authority in `AuthoritativeExperimental`. Package replay is completed during selected/all-sheet build; accepted fragment legacy records remain transaction-owned, ordered fallback records are parsed before finalization, and package invalidation or suppression forces exact legacy materialization. Invalidated partitions remain replay-routing evidence registered as legacy-only, so ordinary exceptions retain family ownership even though the partition is ineligible for authority. Off and Shadow continue whole-family replay. Selected-build, rename/remove, replacement invalidation, random formula read, structure, and spool cleanup remain lifecycle gates rather than alternate authority paths.
 
 ### 6.5 Transaction-foundation sequence
 
@@ -260,9 +260,10 @@ Adversarial Tranche E attempts proved that eager activation cannot safely be add
 3. **E2 — prepared legacy graph plan.** Plan checked sheet/vertex IDs, formula assignments, dependencies, dirty state, and exact capacity reservations without mutation. Commit only bounded delta work and never clone or rebuild the existing graph.
 4. **E3 — checked FormulaPlane append batch.** Preassign checked IDs, deduplicate immutable stores, prove overlap, reserve touched indexes, and install incremental producer/consumer deltas without `rebuild_indexes`.
 5. **E4 — composed Shadow transaction.** Combine replay, legacy graph, authority, and unpublished report deltas; fix stale-disposition exclusivity; exercise the complete fault matrix with no authority publication.
-6. **E5 — eager activation.** Publish fragmented authority only after E4 passes independent review. Deferred fragmented authority remains disabled.
+6. **E5 — eager activation.** Publish eager fragmented authority only after E4 passes independent review.
+7. **E6 — deferred activation.** Reuse E0-E5 preparation and finalization during selected/all deferred package builds; never introduce a deferred-only transaction, geometry model, or index rebuild.
 
-E2 and E3 have no semantic dependency on each other, but repository work remains single-writer and is reviewed one phase at a time. E4 depends on E0–E3; E5 is activation, not another transaction design.
+E2 and E3 have no semantic dependency on each other, but repository work remains single-writer and is reviewed one phase at a time. E4 depends on E0-E3; E5 and E6 are lifecycle activations, not new transaction designs.
 
 ## 7. FormulaPlane gate reuse
 
@@ -389,15 +390,15 @@ Compose exact replay, legacy graph, FormulaPlane append, reconciliation, stale-d
 
 ### Swatch 14 / E5: eager fragmented authority
 
-Enable eager partition dispositions through `SourceFormulaIngress` using only the reviewed composed commit. Deferred fragmented evidence continues whole-family replay.
+Enable eager partition dispositions through `SourceFormulaIngress` using only the reviewed composed commit. Deferred fragmented evidence remains replay-only until Swatch 15.
 
 **Gate:** direct shared + legacy shared equals surviving shared; adding ordinary exceptions and holes equals the declared area; Off/Shadow remain unchanged; edit, structural, formula lookup, cycle, scaling, and full validation suites pass.
 
 ### Swatch 15: deferred lifecycle and rollout
 
-Add deferred authority only in a later milestone after selected-build isolation, package move/drop, random formula lookup, rename/remove, replacement invalidation, undo/redo, cleanup, bounded telemetry, coverage artifacts, and the full benchmark matrix all pass.
+Enable deferred authority by routing `DeferredFormulaPackage` through the same source preparation and finalization used by eager authority. Selected-build isolation, package move/drop, random formula lookup, rename/remove, replacement invalidation, structural materialization, cleanup, bounded telemetry, coverage artifacts, and the benchmark matrix remain rollout gates.
 
-**Gate:** eager/deferred parity, no spool leak or cross-sheet consume, no descendant strings, and every functional/performance gate in section 8. Deferred fragmentation remains disabled if any gate fails.
+**Gate:** eager/deferred parity, no spool leak or cross-sheet consume, no descendant strings, and every functional/performance gate in section 8. Off and Shadow remain replay-only, and deferred activation fails closed if any gate fails.
 
 ## 10. Validation matrix
 


### PR DESCRIPTION
## Summary

- Activate fragmented source-family authority for deferred `AuthoritativeExperimental` all-sheet and selected-sheet builds.
- Reuse the accepted E0-E5 source preparation, source-order, exact replay, E2 legacy graph, E3 FormulaPlane append, and composed E2→E3 transaction paths.
- Keep Off and Shadow deferred packages replay-only.
- Preserve invalidated partitions as legacy-only replay-routing evidence so ordinary exceptions retain exact family ownership.
- Extend the existing Calamine source-family probe with explicit deferred graph builds, 1/8/64 ordinary-exception fixtures, fixture hashes, cold-process median/MAD reporting, and executable performance gates.

## Lifecycle coverage

- Selected-sheet package isolation.
- Replacement invalidation and suppression.
- Sheet rename/removal and structural materialization.
- Eager/deferred value, formula lookup, edit, row/column/rectangle, hole, and ordinary-exception parity.
- Provider staleness, cross-fragment dependency, pre-commit fault, late replay failure, and source-order coverage.

## Validation

- Default evaluator: 2,194 passed, 12 ignored.
- All-feature evaluator: 2,195 passed, 12 ignored.
- Calamine workbook suite: 83 passed, 1 ignored in the latest post-probe run; focused shared-formula suite: 34 passed.
- Strict Clippy passed for eval/workbook all targets with Calamine and for the benchmark crate all targets with `formualizer_runner`.
- wasm32 all-feature workbook check passed.
- Formatting and diff checks passed.
- Formula-family benchmark probe tests: 9 passed.
- Deferred implementation Sol blocker/high review: `VERDICT PASS`.
- Fresh benchmark-delta blocker/high review: `VERDICT PASS`.

## Cold deferred benchmark matrix

Five independent cold child processes per disposition, release profile, system allocator, rustc 1.92.0, AMD Ryzen 9 3900XT, performance governor, boost enabled. Candidate source is commit `2295138c`.

| Exceptions | Authority load+build median ± MAD | Forced replay median ± MAD | Reduction | Authority RSS median ± MAD | Forced replay RSS median ± MAD | Reduction | Authority spans / graph vertices |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 126.38 ± 0.35 ms | 1622.87 ± 8.32 ms | 92.21% | 26,092 ± 580 KiB | 221,472 ± 484 KiB | 88.22% | 2 / 1 |
| 8 | 127.17 ± 1.65 ms | 1636.92 ± 9.01 ms | 92.23% | 22,348 ± 176 KiB | 221,320 ± 296 KiB | 89.90% | 9 / 8 |
| 64 | 130.32 ± 0.51 ms | 1592.36 ± 14.50 ms | 91.82% | 20,664 ± 104 KiB | 221,120 ± 384 KiB | 90.65% | 65 / 64 |

All six gates passed: each fixture exceeded the required 25% load-and-build reduction and 40% RSS reduction versus forced replay. Authority reconciled to 99,999 / 99,992 / 99,936 promoted cells, while forced replay produced zero spans and 100,000 graph vertices in every run.

Fixture SHA-256:

- 1 exception: `e4931433363952f7b9015e99c6a246223998c52e09f57a2643746223d2a6536f`
- 8 exceptions: `607476171960e8fa9eddf67ad62668df25c949067fcf8192faee96e4a47ccaad`
- 64 exceptions: `0d8603253253693e6fa7f46e7e6436116fc8f11c7d088a74ad65fd57648453f4`
