### PR TITLE
feat(python): load XLSX bytes with Calamine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Added
 
+- Added Calamine-backed in-memory XLSX loading to the native Python binding and made it the default for `Workbook.from_bytes` and `load_workbook_bytes`; Pyodide retains its Umya fallback.
 - Added backend-neutral source-family ingest with anchor-once FormulaPlane authority for proven complete domains. Calamine supplies bounded XLSX evidence and exact replay for eager and deferred loading, with structural-edit, cycle-demotion, and source-family telemetry support.
 - Added registry-owned function semantic contracts so safe current and future ordinary functions can use FormulaPlane authority without a secondary supported-name list, while exceptional and untrusted functions continue to replay conservatively.
 - Added bounded fragmented shared-formula evidence, exact coordinate-disposition replay, one-analysis Shadow preparation, and typed ordinary-exception ownership as the replay-only foundation for transactional fragmented authority.

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -41,7 +41,7 @@ formualizer = { path = "../../crates/formualizer", default-features = false, fea
 
 # Pyodide 0.29's wasm-EH sysroot is pinned to Rust 1.86, while Calamine 0.36
 # requires Rust 1.88. Pyodide retains the Umya byte-oriented XLSX path and
-# reports the unavailable Calamine file backend explicitly at runtime.
+# reports the unavailable Calamine backend explicitly at runtime.
 [target.'cfg(target_os = "emscripten")'.dependencies]
 formualizer = { path = "../../crates/formualizer", default-features = false, features = ["eval", "workbook", "sheetport", "parse", "umya"] }
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -68,13 +68,13 @@ print(wb.evaluate_cell("Summary", 1, 2))
 import formualizer as fz
 
 payload = open("financial_model.xlsx", "rb").read()
-wb = fz.load_workbook_bytes(payload, backend="umya")
+wb = fz.load_workbook_bytes(payload)
 print(wb.evaluate_cell("Summary", 1, 2))
 
 out = wb.to_xlsx_bytes()
 ```
 
-`backend="umya"` is currently the byte-oriented XLSX path. Path-based loading still defaults to `calamine`.
+Native Python builds use `calamine` by default for both path-based and byte-oriented XLSX loading. Pyodide currently defaults to `umya`, which also remains available explicitly on native builds. XLSX byte export uses `umya` because Calamine is read-only.
 
 ### Recalculate XLSX cached values (writeback)
 
@@ -338,7 +338,7 @@ wb.evaluate_cell("Sheet1", 1, 2)  # -> 42.0
 
 **Pyodide-specific behavior:**
 - `EvaluationConfig()` and `Workbook()` default `enable_parallel = False` on `sys.platform == "emscripten"` (Pyodide has no threads). You can still opt in, but it falls back to single-threaded execution.
-- XLSX byte I/O (`Workbook.to_xlsx_bytes`, `Workbook.from_bytes`, `load_workbook_bytes`) uses the `umya` backend on all platforms.
+- Native XLSX byte loading (`Workbook.from_bytes`, `load_workbook_bytes`) defaults to `calamine`; Pyodide defaults to `umya`. XLSX byte export uses `umya` on all platforms.
 - Python UDFs registered via `Workbook.register_function` work identically to native; single-cell refs arrive as scalars (Excel-native semantics).
 
 ### Building a Pyodide wheel from source

--- a/bindings/python/formualizer/__init__.pyi
+++ b/bindings/python/formualizer/__init__.pyi
@@ -1126,8 +1126,8 @@ class Workbook:
         
         Args:
             data: XLSX payload as `bytes`.
-            backend: Backend name. Defaults to `umya` because `calamine` byte-open
-                is not currently supported in this repository.
+            backend: Backend name. Defaults to `calamine` in native Python builds
+                and `umya` in Pyodide builds where Calamine is unavailable.
             mode/config: Optional workbook configuration.
         """
     def to_xlsx_bytes(self, backend: typing.Optional[builtins.str] = None) -> bytes:
@@ -1430,8 +1430,9 @@ def load_workbook_bytes(data: bytes, strategy: typing.Optional[builtins.str] = N
     r"""
     Load an XLSX workbook from in-memory bytes.
     
-    This is the byte-oriented counterpart to `load_workbook(...)` and defaults to
-    the `umya` backend because `calamine` byte-open is not yet supported here.
+    This is the byte-oriented counterpart to `load_workbook(...)`. Native Python
+    builds default to `calamine`; Pyodide defaults to `umya` because Calamine is
+    not currently compiled into that target.
     """
 
 def parse(formula: builtins.str, dialect: typing.Optional[FormulaDialect] = None) -> ASTNode:

--- a/bindings/python/scripts/pyodide-smoke.py
+++ b/bindings/python/scripts/pyodide-smoke.py
@@ -43,11 +43,18 @@ xlsx_bytes = wb.to_xlsx_bytes()
 assert isinstance(xlsx_bytes, bytes)
 assert len(xlsx_bytes) > 100
 
-from_bytes = fz.Workbook.from_bytes(xlsx_bytes, backend="umya")
+from_bytes = fz.Workbook.from_bytes(xlsx_bytes)
 assert from_bytes.evaluate_cell("Sheet1", 1, 2) == 42.0
 
-from_top_level = fz.load_workbook_bytes(xlsx_bytes)
+from_top_level = fz.load_workbook_bytes(xlsx_bytes, backend="umya")
 assert from_top_level.evaluate_cell("Sheet1", 1, 2) == 42.0
+
+try:
+    fz.Workbook.from_bytes(xlsx_bytes, backend="calamine")
+except NotImplementedError:
+    pass
+else:
+    raise AssertionError("Pyodide must reject unavailable backend='calamine'")
 
 summary = {
     "ast_formula": ast.to_formula(),

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -138,8 +138,9 @@ fn load_workbook(
 
 /// Load an XLSX workbook from in-memory bytes.
 ///
-/// This is the byte-oriented counterpart to `load_workbook(...)` and defaults to
-/// the `umya` backend because `calamine` byte-open is not yet supported here.
+/// This is the byte-oriented counterpart to `load_workbook(...)`. Native Python
+/// builds default to `calamine`; Pyodide defaults to `umya` because Calamine is
+/// not currently compiled into that target.
 #[gen_stub_pyfunction(module = "formualizer")]
 #[pyfunction]
 #[pyo3(signature = (data, strategy=None, backend=None, *, span_evaluation=None))]
@@ -154,7 +155,7 @@ fn load_workbook_bytes<'py>(
     workbook::PyWorkbook::from_bytes(
         &py.get_type::<workbook::PyWorkbook>(),
         data,
-        Some(backend.unwrap_or("umya")),
+        Some(backend.unwrap_or(workbook::DEFAULT_XLSX_BYTE_BACKEND)),
         None,
         None,
         span_evaluation,

--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -17,6 +17,14 @@ type SheetCache = HashMap<String, SheetCellMap>;
 
 type PyObject = pyo3::Py<pyo3::PyAny>;
 
+#[cfg(not(target_os = "emscripten"))]
+pub(crate) const DEFAULT_XLSX_BYTE_BACKEND: &str = "calamine";
+
+// Pyodide currently excludes Calamine because its Rust sysroot is older than
+// Calamine 0.36's MSRV. Keep the existing Umya byte path as its default.
+#[cfg(target_os = "emscripten")]
+pub(crate) const DEFAULT_XLSX_BYTE_BACKEND: &str = "umya";
+
 fn validate_cell_coords(row: u32, col: u32) -> PyResult<()> {
     if row == 0 || col == 0 {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -327,8 +335,8 @@ impl PyWorkbook {
     ///
     /// Args:
     ///     data: XLSX payload as `bytes`.
-    ///     backend: Backend name. Defaults to `umya` because `calamine` byte-open
-    ///         is not currently supported in this repository.
+    ///     backend: Backend name. Defaults to `calamine` in native Python builds
+    ///         and `umya` in Pyodide builds where Calamine is unavailable.
     ///     mode/config: Optional workbook configuration.
     #[classmethod]
     #[pyo3(signature = (data, backend=None, *, mode=None, config=None, span_evaluation=None))]
@@ -341,7 +349,11 @@ impl PyWorkbook {
         span_evaluation: Option<bool>,
     ) -> PyResult<Self> {
         let cfg = resolve_workbook_config(mode, config, span_evaluation)?;
-        Self::from_bytes_impl(data.as_bytes().to_vec(), backend.unwrap_or("umya"), cfg)
+        Self::from_bytes_impl(
+            data.as_bytes().to_vec(),
+            backend.unwrap_or(DEFAULT_XLSX_BYTE_BACKEND),
+            cfg,
+        )
     }
 
     /// Serialize the current workbook contents into XLSX bytes.
@@ -1295,9 +1307,36 @@ impl PyWorkbook {
                 })?;
                 Ok(Self::from_inner_workbook(wb))
             }
-            "calamine" => Err(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
-                "backend='calamine' does not currently support XLSX byte open; use backend='umya'",
-            )),
+            "calamine" => {
+                #[cfg(target_os = "emscripten")]
+                {
+                    let _ = (data, cfg);
+                    Err(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
+                        "backend='calamine' is unavailable in the Pyodide build; use backend='umya' with in-memory XLSX bytes",
+                    ))
+                }
+                #[cfg(not(target_os = "emscripten"))]
+                {
+                    use formualizer::workbook::backends::CalamineAdapter;
+                    use formualizer::workbook::traits::SpreadsheetReader;
+
+                    let adapter = <CalamineAdapter as SpreadsheetReader>::open_bytes(data)
+                        .map_err(|e| {
+                            PyErr::new::<pyo3::exceptions::PyIOError, _>(format!(
+                                "open failed: {e}"
+                            ))
+                        })?;
+                    let wb = formualizer::workbook::Workbook::from_reader(
+                        adapter,
+                        formualizer::workbook::LoadStrategy::EagerAll,
+                        cfg,
+                    )
+                    .map_err(|e| {
+                        PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("load failed: {e}"))
+                    })?;
+                    Ok(Self::from_inner_workbook(wb))
+                }
+            }
             other => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
                 "Unsupported backend: {other}"
             ))),
@@ -1374,7 +1413,7 @@ fn resolve_workbook_config(
 
 #[cfg(test)]
 mod tests {
-    use super::{PyWorkbookConfig, resolve_workbook_config};
+    use super::{DEFAULT_XLSX_BYTE_BACKEND, PyWorkbookConfig, resolve_workbook_config};
     use crate::enums::PyWorkbookMode;
     use formualizer::eval::engine::{EvalConfig, FormulaPlaneMode};
 
@@ -1388,6 +1427,12 @@ mod tests {
         assert!(resolved.enable_changelog);
         assert!(resolved.eval.defer_graph_building);
         assert_eq!(resolved.eval.formula_plane_mode, FormulaPlaneMode::Off);
+    }
+
+    #[cfg(not(target_os = "emscripten"))]
+    #[test]
+    fn native_xlsx_byte_loads_default_to_calamine() {
+        assert_eq!(DEFAULT_XLSX_BYTE_BACKEND, "calamine");
     }
 
     #[test]

--- a/bindings/python/tests/test_workbook_bytes.py
+++ b/bindings/python/tests/test_workbook_bytes.py
@@ -13,26 +13,29 @@ except Exception:  # pragma: no cover - allow skipping if not present in dev env
 pytestmark = pytest.mark.skipif(openpyxl is None, reason="openpyxl not installed")
 
 
-def test_load_workbook_bytes_uses_umya_for_xlsx(xlsx_builder):
+def test_load_workbook_bytes_defaults_to_calamine(xlsx_builder):
     path = xlsx_builder(lambda wb: _populate_input_workbook(wb))
     payload = Path(path).read_bytes()
 
     wb = fz.load_workbook_bytes(payload)
     assert wb.evaluate_cell("Sheet1", 1, 2) == 42.0
 
-    wb2 = fz.Workbook.from_bytes(payload, backend="umya")
+    wb2 = fz.Workbook.from_bytes(payload)
     assert wb2.evaluate_cell("Sheet1", 1, 2) == 42.0
 
 
-def test_load_workbook_bytes_rejects_calamine_for_now(xlsx_builder):
+def test_load_workbook_bytes_accepts_explicit_backends(xlsx_builder):
     path = xlsx_builder(lambda wb: _populate_input_workbook(wb))
     payload = Path(path).read_bytes()
 
-    with pytest.raises(NotImplementedError, match="calamine"):
-        fz.load_workbook_bytes(payload, backend="calamine")
+    calamine = fz.load_workbook_bytes(payload, backend="calamine")
+    assert calamine.evaluate_cell("Sheet1", 1, 2) == 42.0
 
-    with pytest.raises(NotImplementedError, match="calamine"):
-        fz.Workbook.from_bytes(payload, backend="calamine")
+    calamine_classmethod = fz.Workbook.from_bytes(payload, backend="calamine")
+    assert calamine_classmethod.evaluate_cell("Sheet1", 1, 2) == 42.0
+
+    umya = fz.Workbook.from_bytes(payload, backend="umya")
+    assert umya.evaluate_cell("Sheet1", 1, 2) == 42.0
 
 
 def test_to_xlsx_bytes_roundtrip_preserves_workbook_content():


### PR DESCRIPTION
## Summary

- route native Python `Workbook.from_bytes` and `load_workbook_bytes` through `CalamineAdapter::open_bytes`
- make Calamine the default XLSX byte-loading backend in native Python builds while preserving explicit Umya selection
- retain Umya as the Pyodide default and keep explicit Calamine rejection there until Calamine is compiled for Emscripten
- update Python docs, generated stubs, changelog, native regression tests, and Pyodide smoke coverage

## Validation

- `cargo check -p formualizer-python`
- `cargo clippy -p formualizer-python --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- native Python suite: 55 passed
- focused XLSX byte tests: 3 passed
- `ruff check .`
- `ruff format --check .`
- `mypy formualizer`
- built the Pyodide 0.29.3 wheel and passed its runtime smoke test, including the Umya default and explicit Calamine rejection
