### PR TITLE
feat(eval): prepare transactional span demotion

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -2,6 +2,9 @@ use crate::SheetId;
 use crate::arrow_store::{OverlayFragment, OverlayValue, SheetStore};
 use crate::engine::arena::AstNodeId;
 use crate::engine::eval_delta::{DeltaCollector, DeltaMode, EvalDelta};
+use crate::engine::graph::prepared_legacy_graph::{
+    PreparedLegacyGraphError, PreparedLegacyGraphPlan,
+};
 use crate::engine::ingest_pipeline::{DependencyPlanRow, FormulaAstInput};
 use crate::engine::live_edges::{LiveEdgeCollector, RecordingContext};
 use crate::engine::live_graph::analyze_live_graph;
@@ -251,6 +254,65 @@ type FormulaPlaneMixedScheduleBuild = (
     u64,
     Vec<VertexId>,
 );
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum FormulaSpanDemotionFault {
+    #[default]
+    None,
+    AstPreparation,
+    LegacyGraphPreparation,
+    FinalLegacyGraphValidation,
+    FinalAuthorityValidation,
+    AllocationReservation,
+    BeforeFirstMutation,
+}
+
+#[derive(Debug)]
+pub(crate) enum FormulaSpanDemotionError {
+    StaleAuthority,
+    InvalidSpan,
+    CountOverflow,
+    LoadLimit(&'static str),
+    AstPreparation(ExcelError),
+    LegacyGraph(PreparedLegacyGraphError),
+    Injected(FormulaSpanDemotionFault),
+}
+
+impl std::fmt::Display for FormulaSpanDemotionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StaleAuthority => write!(f, "prepared FormulaPlane demotion is stale"),
+            Self::InvalidSpan => write!(f, "FormulaPlane demotion referenced an invalid span"),
+            Self::CountOverflow => write!(f, "FormulaPlane demotion count overflow"),
+            Self::LoadLimit(reason) => write!(f, "FormulaPlane demotion load limit: {reason}"),
+            Self::AstPreparation(error) => {
+                write!(f, "FormulaPlane demotion analysis failed: {error}")
+            }
+            Self::LegacyGraph(error) => {
+                write!(f, "FormulaPlane demotion graph plan failed: {error}")
+            }
+            Self::Injected(fault) => write!(f, "injected FormulaPlane demotion fault: {fault:?}"),
+        }
+    }
+}
+
+impl std::error::Error for FormulaSpanDemotionError {}
+
+pub(crate) struct PreparedFormulaSpanDemotion {
+    span_refs: Vec<FormulaSpanRef>,
+    expected_plane_epoch: u64,
+    expected_indexes_epoch: u64,
+    expected_indexed_plane_epoch: u64,
+    placement_count: usize,
+    legacy_graph: PreparedLegacyGraphPlan,
+    fault: FormulaSpanDemotionFault,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FormulaSpanDemotionReport {
+    pub(crate) spans_demoted: usize,
+    pub(crate) placements_materialized: usize,
+}
 
 type PlannedFormulaMaterialize = BTreeMap<String, Vec<(u32, u32, AstNodeId, DependencyPlanRow)>>;
 type CompressedReplayBatch = (
@@ -728,6 +790,8 @@ pub struct Engine<R> {
     #[cfg(test)]
     fragmented_commit_fault_for_test:
         Option<crate::engine::fragmented_transaction::FragmentedCommitFault>,
+    #[cfg(test)]
+    formula_span_demotion_fault_for_test: Option<FormulaSpanDemotionFault>,
     #[cfg(test)]
     before_legacy_fallback_final_provider_sample_hook: Option<Box<dyn FnOnce() + Send + Sync>>,
     #[cfg(test)]
@@ -1738,6 +1802,8 @@ where
             #[cfg(test)]
             fragmented_commit_fault_for_test: None,
             #[cfg(test)]
+            formula_span_demotion_fault_for_test: None,
+            #[cfg(test)]
             before_legacy_fallback_final_provider_sample_hook: None,
             #[cfg(test)]
             after_eager_proposal_commit_hook: None,
@@ -1829,6 +1895,8 @@ where
             force_source_family_fallback: false,
             #[cfg(test)]
             fragmented_commit_fault_for_test: None,
+            #[cfg(test)]
+            formula_span_demotion_fault_for_test: None,
             #[cfg(test)]
             before_legacy_fallback_final_provider_sample_hook: None,
             #[cfg(test)]
@@ -8731,6 +8799,339 @@ where
         Ok(())
     }
 
+    /// Prepare an exact-ref, additions-only refinement of FormulaPlane spans
+    /// into legacy graph formulas. All fallible relocation, dependency analysis,
+    /// identifier reservation, and conflict checks happen before commit.
+    pub(crate) fn prepare_formula_span_demotion(
+        &mut self,
+        span_refs: &[FormulaSpanRef],
+    ) -> Result<PreparedFormulaSpanDemotion, FormulaSpanDemotionError> {
+        #[cfg(test)]
+        let fault = self
+            .formula_span_demotion_fault_for_test
+            .take()
+            .unwrap_or_default();
+        #[cfg(not(test))]
+        let fault = FormulaSpanDemotionFault::None;
+
+        if fault == FormulaSpanDemotionFault::AstPreparation {
+            return Err(FormulaSpanDemotionError::Injected(fault));
+        }
+
+        fn substitute_literal_slots(ast: &ASTNode, binding: &[LiteralValue]) -> ASTNode {
+            fn visit(
+                ast: &ASTNode,
+                binding: &[LiteralValue],
+                next: &mut usize,
+                in_array: bool,
+            ) -> ASTNode {
+                let node_type = match &ast.node_type {
+                    ASTNodeType::Literal(_) if !in_array => {
+                        let value = binding.get(*next).cloned().unwrap_or(LiteralValue::Empty);
+                        *next = next.saturating_add(1);
+                        ASTNodeType::Literal(value)
+                    }
+                    ASTNodeType::Literal(value) => ASTNodeType::Literal(value.clone()),
+                    ASTNodeType::Reference {
+                        original,
+                        reference,
+                    } => ASTNodeType::Reference {
+                        original: original.clone(),
+                        reference: reference.clone(),
+                    },
+                    ASTNodeType::UnaryOp { op, expr } => ASTNodeType::UnaryOp {
+                        op: op.clone(),
+                        expr: Box::new(visit(expr, binding, next, in_array)),
+                    },
+                    ASTNodeType::BinaryOp { op, left, right } => ASTNodeType::BinaryOp {
+                        op: op.clone(),
+                        left: Box::new(visit(left, binding, next, in_array)),
+                        right: Box::new(visit(right, binding, next, in_array)),
+                    },
+                    ASTNodeType::Function { name, args } => ASTNodeType::Function {
+                        name: name.clone(),
+                        args: args
+                            .iter()
+                            .map(|arg| visit(arg, binding, next, in_array))
+                            .collect(),
+                    },
+                    ASTNodeType::Call { callee, args } => ASTNodeType::Call {
+                        callee: Box::new(visit(callee, binding, next, in_array)),
+                        args: args
+                            .iter()
+                            .map(|arg| visit(arg, binding, next, in_array))
+                            .collect(),
+                    },
+                    ASTNodeType::Array(rows) => ASTNodeType::Array(
+                        rows.iter()
+                            .map(|row| {
+                                row.iter()
+                                    .map(|cell| visit(cell, binding, next, true))
+                                    .collect()
+                            })
+                            .collect(),
+                    ),
+                };
+                ASTNode::new(node_type, ast.source_token.clone())
+            }
+            let mut next = 0;
+            visit(ast, binding, &mut next, false)
+        }
+
+        struct SpanMaterialization {
+            span_ref: FormulaSpanRef,
+            sheet_id: SheetId,
+            ast: ASTNode,
+            origin_row: u32,
+            origin_col: u32,
+            binding_set_id: Option<crate::formula_plane::runtime::SpanBindingSetId>,
+            placements: Vec<(u32, u32)>,
+        }
+
+        let authority = self.graph.formula_authority();
+        let expected_plane_epoch = authority.plane.epoch().0;
+        let expected_indexes_epoch = authority.indexes_epoch();
+        let expected_indexed_plane_epoch = authority.indexed_plane_epoch();
+        let mut unique = Vec::new();
+        let mut plans = Vec::new();
+        let mut placement_count = 0usize;
+        let mut placements_by_sheet: BTreeMap<SheetId, u64> = BTreeMap::new();
+        for &span_ref in span_refs {
+            if unique.contains(&span_ref) {
+                continue;
+            }
+            unique.push(span_ref);
+            let span = authority
+                .plane
+                .spans
+                .get(span_ref)
+                .ok_or(FormulaSpanDemotionError::InvalidSpan)?;
+            let relocation = span.ast_relocation;
+            let ast = self
+                .graph
+                .data_store()
+                .retrieve_ast(relocation.ast_id, self.graph.sheet_reg())
+                .ok_or(FormulaSpanDemotionError::InvalidSpan)?;
+            let count = usize::try_from(span.domain.cell_count())
+                .map_err(|_| FormulaSpanDemotionError::CountOverflow)?;
+            placement_count = placement_count
+                .checked_add(count)
+                .ok_or(FormulaSpanDemotionError::CountOverflow)?;
+            let sheet_count = placements_by_sheet.entry(span.sheet_id).or_default();
+            *sheet_count = sheet_count
+                .checked_add(span.domain.cell_count())
+                .ok_or(FormulaSpanDemotionError::CountOverflow)?;
+            if *sheet_count > self.workbook_load_limits.max_sheet_logical_cells {
+                return Err(FormulaSpanDemotionError::LoadLimit(
+                    "max_sheet_logical_cells",
+                ));
+            }
+            let domain_in_bounds = match &span.domain {
+                PlacementDomain::RowRun { row_end, col, .. } => {
+                    *row_end < self.workbook_load_limits.max_sheet_rows
+                        && *col < self.workbook_load_limits.max_sheet_cols
+                }
+                PlacementDomain::ColRun { row, col_end, .. } => {
+                    *row < self.workbook_load_limits.max_sheet_rows
+                        && *col_end < self.workbook_load_limits.max_sheet_cols
+                }
+                PlacementDomain::Rect {
+                    row_end, col_end, ..
+                } => {
+                    *row_end < self.workbook_load_limits.max_sheet_rows
+                        && *col_end < self.workbook_load_limits.max_sheet_cols
+                }
+            };
+            if !domain_in_bounds {
+                return Err(FormulaSpanDemotionError::LoadLimit("sheet_axis_bounds"));
+            }
+            let mut placements = Vec::with_capacity(count);
+            placements.extend(
+                span.domain
+                    .iter()
+                    .map(|coord| (coord.row.saturating_add(1), coord.col.saturating_add(1))),
+            );
+            plans.push(SpanMaterialization {
+                span_ref,
+                sheet_id: span.sheet_id,
+                ast,
+                origin_row: relocation.anchor_row,
+                origin_col: relocation.anchor_col,
+                binding_set_id: span.binding_set_id,
+                placements,
+            });
+        }
+        let mut relocated = Vec::with_capacity(placement_count);
+        for plan in &plans {
+            for &(row, col) in &plan.placements {
+                let bound_ast = if let Some(binding_set_id) = plan.binding_set_id {
+                    let authority = self.graph.formula_authority();
+                    let binding_set = authority
+                        .plane
+                        .binding_sets
+                        .get(binding_set_id)
+                        .ok_or(FormulaSpanDemotionError::InvalidSpan)?;
+                    if binding_set.is_single_literal_binding() {
+                        plan.ast.clone()
+                    } else {
+                        let placement = PlacementCoord::new(
+                            plan.sheet_id,
+                            row.saturating_sub(1),
+                            col.saturating_sub(1),
+                        );
+                        let span = authority
+                            .plane
+                            .spans
+                            .get(plan.span_ref)
+                            .ok_or(FormulaSpanDemotionError::InvalidSpan)?;
+                        let binding = binding_set
+                            .literal_bindings_for_placement(&span.domain, placement)
+                            .ok_or(FormulaSpanDemotionError::InvalidSpan)?;
+                        substitute_literal_slots(&plan.ast, binding.as_ref())
+                    }
+                } else {
+                    plan.ast.clone()
+                };
+                let row_delta = i64::from(row) - i64::from(plan.origin_row);
+                let col_delta = i64::from(col) - i64::from(plan.origin_col);
+                let ast = relocate_ast_for_template_placement(&bound_ast, row_delta, col_delta)
+                    .map_err(FormulaSpanDemotionError::AstPreparation)?;
+                relocated.push((plan.sheet_id, row, col, ast));
+            }
+        }
+
+        let mut analyzed = Vec::with_capacity(relocated.len());
+        {
+            let mut pipeline = self.ingest_pipeline();
+            for (sheet_id, row, col, ast) in relocated {
+                let placement = CellRef::new(sheet_id, Coord::from_excel(row, col, true, true));
+                let ingested = pipeline
+                    .ingest_formula(FormulaAstInput::Tree(ast), placement, None)
+                    .map_err(FormulaSpanDemotionError::AstPreparation)?;
+                analyzed.push((sheet_id, row, col, ingested.ast_id, ingested.dep_plan));
+            }
+        }
+
+        if fault == FormulaSpanDemotionFault::LegacyGraphPreparation {
+            return Err(FormulaSpanDemotionError::Injected(fault));
+        }
+        let legacy_graph = self
+            .graph
+            .prepare_legacy_graph_plan_multi_sheet(analyzed)
+            .map_err(FormulaSpanDemotionError::LegacyGraph)?;
+        if let Some(max_vertices) = self.config.max_vertices {
+            let projected = self
+                .graph
+                .baseline_stats()
+                .graph_vertex_count
+                .checked_add(legacy_graph.new_vertex_count())
+                .ok_or(FormulaSpanDemotionError::CountOverflow)?;
+            if projected > max_vertices {
+                return Err(FormulaSpanDemotionError::LoadLimit("max_vertices"));
+            }
+        }
+
+        Ok(PreparedFormulaSpanDemotion {
+            span_refs: unique,
+            expected_plane_epoch,
+            expected_indexes_epoch,
+            expected_indexed_plane_epoch,
+            placement_count,
+            legacy_graph,
+            fault,
+        })
+    }
+
+    pub(crate) fn validate_prepared_formula_span_demotion(
+        &self,
+        prepared: &PreparedFormulaSpanDemotion,
+    ) -> Result<(), FormulaSpanDemotionError> {
+        let authority = self.graph.formula_authority();
+        if authority.plane.epoch().0 != prepared.expected_plane_epoch
+            || authority.indexes_epoch() != prepared.expected_indexes_epoch
+            || authority.indexed_plane_epoch() != prepared.expected_indexed_plane_epoch
+            || prepared
+                .span_refs
+                .iter()
+                .any(|span_ref| authority.plane.spans.get(*span_ref).is_none())
+        {
+            return Err(FormulaSpanDemotionError::StaleAuthority);
+        }
+        self.graph
+            .validate_prepared_legacy_graph_plan(&prepared.legacy_graph)
+            .map_err(FormulaSpanDemotionError::LegacyGraph)
+    }
+
+    /// Validate every recoverable assumption and fault before the first
+    /// mutation, then compose the existing prevalidated graph append with exact
+    /// authority removal. Allocator OOM/panic remains process-fatal, matching
+    /// the E2/E3 prepared-transaction contract; there is no recoverable branch
+    /// after graph application begins.
+    pub(crate) fn commit_prepared_formula_span_demotion(
+        &mut self,
+        prepared: PreparedFormulaSpanDemotion,
+    ) -> Result<FormulaSpanDemotionReport, FormulaSpanDemotionError> {
+        if prepared.fault == FormulaSpanDemotionFault::FinalLegacyGraphValidation {
+            return Err(FormulaSpanDemotionError::Injected(prepared.fault));
+        }
+        self.graph
+            .validate_prepared_legacy_graph_plan(&prepared.legacy_graph)
+            .map_err(FormulaSpanDemotionError::LegacyGraph)?;
+        if prepared.fault == FormulaSpanDemotionFault::FinalAuthorityValidation {
+            return Err(FormulaSpanDemotionError::Injected(prepared.fault));
+        }
+        {
+            let authority = self.graph.formula_authority();
+            if authority.plane.epoch().0 != prepared.expected_plane_epoch
+                || authority.indexes_epoch() != prepared.expected_indexes_epoch
+                || authority.indexed_plane_epoch() != prepared.expected_indexed_plane_epoch
+                || prepared
+                    .span_refs
+                    .iter()
+                    .any(|span_ref| authority.plane.spans.get(*span_ref).is_none())
+            {
+                return Err(FormulaSpanDemotionError::StaleAuthority);
+            }
+        }
+        if matches!(
+            prepared.fault,
+            FormulaSpanDemotionFault::AllocationReservation
+                | FormulaSpanDemotionFault::BeforeFirstMutation
+        ) {
+            return Err(FormulaSpanDemotionError::Injected(prepared.fault));
+        }
+
+        let PreparedFormulaSpanDemotion {
+            span_refs,
+            placement_count,
+            legacy_graph,
+            ..
+        } = prepared;
+        let _ = self
+            .graph
+            .apply_prevalidated_legacy_graph_plan(legacy_graph);
+        let authority = self.graph.formula_authority_mut();
+        for span_ref in &span_refs {
+            authority.plane.remove_overlays_for_source_span(*span_ref);
+            let _ = authority.plane.remove_span(*span_ref);
+        }
+        let _ = authority.rebuild_indexes();
+        self.formula_plane_indexes_epoch_seen = 0;
+        self.mark_topology_edited();
+        Ok(FormulaSpanDemotionReport {
+            spans_demoted: span_refs.len(),
+            placements_materialized: placement_count,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_formula_span_demotion_fault_for_test(
+        &mut self,
+        fault: FormulaSpanDemotionFault,
+    ) {
+        self.formula_span_demotion_fault_for_test = Some(fault);
+    }
+
     /// Collect the [`FormulaSpanRef`]s for span producers the mixed scheduler
     /// reported as cycle members (gotcha G8, refs #112). These spans must be
     /// demoted to legacy so the cycle members are resolved on the legacy SCC
@@ -8758,38 +9159,32 @@ where
     /// Demote the given cyclic spans to legacy graph vertices so their member
     /// cells participate in the legacy Tarjan SCC pass (gotcha G8, refs #112).
     ///
-    /// Reuses the non-structural demotion seam, which materializes each span's
-    /// cells back onto the legacy graph and re-promotes any acyclic remainder
-    /// that still forms a promotable run. We pass a `Region` that covers exactly
-    /// the demote-target span domains so disjoint spans are left untouched.
+    /// Uses one exact-ref prepared transaction for every cyclic span reported
+    /// by this schedule. All recoverable validation and injected faults precede
+    /// the first graph/authority mutation, so a multi-span or multi-sheet cycle
+    /// cannot publish only an earlier subset.
     fn demote_cyclic_spans(&mut self, span_refs: &[FormulaSpanRef]) -> Result<(), ExcelError> {
-        let mut regions: Vec<Region> = Vec::new();
-        {
-            let authority = self.graph.formula_authority();
-            for span_ref in span_refs {
-                if let Some(span) = authority.plane.spans.get(*span_ref) {
-                    regions.push(Region::from_domain(&span.domain));
-                }
-            }
-        }
-        for region in regions {
-            self.demote_spans_preserving_computed_overlays(region.sheet_id(), region)
-                .map_err(|err| {
-                    ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
-                        "FormulaPlane cycle-member span demotion failed: {err:?}"
-                    ))
-                })?;
-        }
+        let prepared = self
+            .prepare_formula_span_demotion(span_refs)
+            .map_err(|error| {
+                ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
+                    "FormulaPlane cycle-member span demotion preparation failed: {error}"
+                ))
+            })?;
+        let report = self
+            .commit_prepared_formula_span_demotion(prepared)
+            .map_err(|error| {
+                ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
+                    "FormulaPlane cycle-member span demotion commit failed: {error}"
+                ))
+            })?;
         self.formula_plane_cycle_member_span_demotions = self
             .formula_plane_cycle_member_span_demotions
-            .saturating_add(span_refs.len() as u64);
-        // Mirror the demotion into the cumulative ingest report's fallback
-        // histogram so cycle exclusions are visible like every other placement
-        // fallback reason.
+            .saturating_add(report.spans_demoted as u64);
         Self::record_shadow_fallback_reason(
             &mut self.formula_ingest_report_total,
             PlacementFallbackReason::CycleMember,
-            span_refs.len() as u64,
+            report.spans_demoted as u64,
         );
         Ok(())
     }

--- a/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
+++ b/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
@@ -113,6 +113,7 @@ impl SymbolMetadata {
 
 #[derive(Debug, Clone, PartialEq)]
 struct SymbolBinding {
+    sheet_id: SheetId,
     kind: SymbolKind,
     name: String,
     metadata: SymbolMetadata,
@@ -120,6 +121,7 @@ struct SymbolBinding {
 
 #[derive(Debug)]
 struct PreparedFormula {
+    current_sheet_id: SheetId,
     target: VertexId,
     target_packed: PackedSheetCell,
     ast_id: AstNodeId,
@@ -137,7 +139,6 @@ struct PreparedFormula {
 /// only appends the reserved vertices and installs this plan's formulas.
 #[derive(Debug)]
 pub(crate) struct PreparedLegacyGraphPlan {
-    sheet_id: SheetId,
     sheet_names: Vec<(SheetId, String)>,
     expected_vertex_len: usize,
     coordinates: BTreeMap<PackedSheetCell, VertexId>,
@@ -164,7 +165,7 @@ impl PreparedLegacyGraphPlan {
             let range_contains_target = formula.plan.range_deps.iter().any(|range| {
                 let sheet_id = match range.sheet {
                     SharedSheetLocator::Id(id) => id,
-                    _ => self.sheet_id,
+                    _ => formula.current_sheet_id,
                 };
                 sheet_id == target.sheet_id()
                     && range
@@ -238,6 +239,7 @@ impl DependencyGraph {
                 .unwrap_or(SymbolMetadata::Missing),
         };
         SymbolBinding {
+            sheet_id: sheet,
             kind,
             name: name.to_string(),
             metadata,
@@ -249,28 +251,44 @@ impl DependencyGraph {
         sheet_id: SheetId,
         planned: Vec<(u32, u32, AstNodeId, DependencyPlanRow)>,
     ) -> Result<PreparedLegacyGraphPlan, PreparedLegacyGraphError> {
+        self.prepare_legacy_graph_plan_multi_sheet(
+            planned
+                .into_iter()
+                .map(|(row, col, ast_id, plan)| (sheet_id, row, col, ast_id, plan))
+                .collect(),
+        )
+    }
+
+    /// Prepare one additions-only graph plan spanning any number of sheets.
+    /// All targets and cross-sheet placeholders share one vertex-id reservation.
+    pub(crate) fn prepare_legacy_graph_plan_multi_sheet(
+        &self,
+        planned: Vec<(SheetId, u32, u32, AstNodeId, DependencyPlanRow)>,
+    ) -> Result<PreparedLegacyGraphPlan, PreparedLegacyGraphError> {
         if self.pk_order.is_some() {
             return Err(PreparedLegacyGraphError::DynamicTopologyUnsupported);
         }
         let mut sheet_names = BTreeMap::new();
-        sheet_names.insert(sheet_id, self.checked_sheet_name(sheet_id)?);
         let mut packed_inputs = Vec::new();
         let mut target_inputs = Vec::with_capacity(planned.len());
         let mut seen_targets = std::collections::BTreeSet::new();
-        for (row, col, ast_id, plan) in &planned {
+        for (sheet_id, row, col, ast_id, plan) in &planned {
+            sheet_names
+                .entry(*sheet_id)
+                .or_insert(self.checked_sheet_name(*sheet_id)?);
             if self.data_store.get_node(*ast_id).is_none() {
                 return Err(PreparedLegacyGraphError::InvalidAst(*ast_id));
             }
-            let target = PackedSheetCell::try_from_excel_1based(sheet_id, *row, *col).ok_or(
+            let target = PackedSheetCell::try_from_excel_1based(*sheet_id, *row, *col).ok_or(
                 PreparedLegacyGraphError::InvalidCoordinate {
-                    sheet: sheet_id,
+                    sheet: *sheet_id,
                     row: *row,
                     col: *col,
                 },
             )?;
             if !seen_targets.insert(target) {
                 return Err(PreparedLegacyGraphError::DuplicateTarget {
-                    sheet: sheet_id,
+                    sheet: *sheet_id,
                     row: *row,
                     col: *col,
                 });
@@ -298,7 +316,7 @@ impl DependencyGraph {
                 }
                 let range_sheet = match range.sheet {
                     SharedSheetLocator::Id(id) => id,
-                    _ => sheet_id,
+                    _ => *sheet_id,
                 };
                 for bound in [range.start_row, range.end_row].into_iter().flatten() {
                     if bound.index > PackedSheetCell::MAX_ROW0 {
@@ -392,7 +410,9 @@ impl DependencyGraph {
 
         let mut symbols = Vec::new();
         let mut formulas = Vec::with_capacity(planned.len());
-        for ((_, _, ast_id, plan), target_packed) in planned.into_iter().zip(target_inputs) {
+        for ((current_sheet_id, _, _, ast_id, plan), target_packed) in
+            planned.into_iter().zip(target_inputs)
+        {
             let target = coordinates
                 .get(&target_packed)
                 .copied()
@@ -416,13 +436,17 @@ impl DependencyGraph {
                 .iter()
                 .chain(plan.named_refs.iter())
             {
-                let binding = self.prepared_symbol_binding(SymbolKind::Name, name, sheet_id);
+                let binding =
+                    self.prepared_symbol_binding(SymbolKind::Name, name, current_sheet_id);
                 if let Some(id) = binding.metadata.vertex() {
                     push_unique(&mut named_dependencies, id);
                     push_unique(&mut other_dependencies, id);
                 } else {
-                    let scalar =
-                        self.prepared_symbol_binding(SymbolKind::SourceScalar, name, sheet_id);
+                    let scalar = self.prepared_symbol_binding(
+                        SymbolKind::SourceScalar,
+                        name,
+                        current_sheet_id,
+                    );
                     if let Some(id) = scalar.metadata.vertex() {
                         push_unique(&mut other_dependencies, id);
                     } else {
@@ -433,22 +457,26 @@ impl DependencyGraph {
                 symbols.push(binding);
             }
             for name in &plan.source_refs {
-                let scalar = self.prepared_symbol_binding(SymbolKind::SourceScalar, name, sheet_id);
-                let table = self.prepared_symbol_binding(SymbolKind::SourceTable, name, sheet_id);
+                let scalar =
+                    self.prepared_symbol_binding(SymbolKind::SourceScalar, name, current_sheet_id);
+                let table =
+                    self.prepared_symbol_binding(SymbolKind::SourceTable, name, current_sheet_id);
                 if let Some(id) = scalar.metadata.vertex().or_else(|| table.metadata.vertex()) {
                     push_unique(&mut other_dependencies, id);
                 }
                 symbols.extend([scalar, table]);
             }
             for name in &plan.table_refs {
-                let table = self.prepared_symbol_binding(SymbolKind::Table, name, sheet_id);
-                let source = self.prepared_symbol_binding(SymbolKind::SourceTable, name, sheet_id);
+                let table = self.prepared_symbol_binding(SymbolKind::Table, name, current_sheet_id);
+                let source =
+                    self.prepared_symbol_binding(SymbolKind::SourceTable, name, current_sheet_id);
                 if let Some(id) = table.metadata.vertex().or_else(|| source.metadata.vertex()) {
                     push_unique(&mut other_dependencies, id);
                 }
                 symbols.extend([table, source]);
             }
             formulas.push(PreparedFormula {
+                current_sheet_id,
                 target,
                 target_packed,
                 ast_id,
@@ -460,7 +488,6 @@ impl DependencyGraph {
             });
         }
         Ok(PreparedLegacyGraphPlan {
-            sheet_id,
             sheet_names: sheet_names.into_iter().collect(),
             expected_vertex_len: self.store.len(),
             coordinates,
@@ -532,7 +559,7 @@ impl DependencyGraph {
             return Err(PreparedLegacyGraphError::Stale);
         }
         for binding in &plan.symbols {
-            if self.prepared_symbol_binding(binding.kind.clone(), &binding.name, plan.sheet_id)
+            if self.prepared_symbol_binding(binding.kind.clone(), &binding.name, binding.sheet_id)
                 != *binding
             {
                 return Err(PreparedLegacyGraphError::Stale);
@@ -605,7 +632,7 @@ impl DependencyGraph {
                 self.attach_vertex_to_names(formula.target, &formula.named_dependencies);
             }
             for name in &formula.unresolved_names {
-                self.record_pending_name_reference(plan.sheet_id, name, formula.target);
+                self.record_pending_name_reference(formula.current_sheet_id, name, formula.target);
             }
             let mut deps = formula.direct_dependencies.clone();
             for id in &formula.other_dependencies {
@@ -614,7 +641,11 @@ impl DependencyGraph {
             if !deps.is_empty() {
                 self.add_dependent_edges_nobatch(formula.target, &deps);
             }
-            self.add_range_dependent_edges(formula.target, &formula.plan.range_deps, plan.sheet_id);
+            self.add_range_dependent_edges(
+                formula.target,
+                &formula.plan.range_deps,
+                formula.current_sheet_id,
+            );
         }
         self.edges.end_batch_deferred();
         let _ = self.mark_dirty_many(&targets);
@@ -657,6 +688,35 @@ mod tests {
             ..DependencyPlanRow::default()
         };
         (row, col, ast_id, plan)
+    }
+
+    #[test]
+    fn multi_sheet_plan_reserves_targets_and_cross_sheet_placeholders_once() {
+        let (mut graph, sheet1) = graph();
+        let sheet2 = graph.sheet_id_mut("Sheet2");
+        let ast1 = graph.store_ast(&parse("=Sheet2!B1").unwrap());
+        let ast2 = graph.store_ast(&parse("=Sheet1!B1").unwrap());
+        let plan1 = DependencyPlanRow {
+            direct_cell_deps: vec![CellRef::new(sheet2, Coord::from_excel(1, 2, true, true))],
+            ..DependencyPlanRow::default()
+        };
+        let plan2 = DependencyPlanRow {
+            direct_cell_deps: vec![CellRef::new(sheet1, Coord::from_excel(1, 2, true, true))],
+            ..DependencyPlanRow::default()
+        };
+        let plan = graph
+            .prepare_legacy_graph_plan_multi_sheet(vec![
+                (sheet1, 1, 1, ast1, plan1),
+                (sheet2, 1, 1, ast2, plan2),
+            ])
+            .unwrap();
+        assert_eq!(plan.new_vertex_count(), 4);
+        assert_eq!(plan.planned_edge_count(), Some(2));
+        assert_eq!(graph.apply_prepared_legacy_graph_plan(plan).unwrap(), 2);
+        let stats = graph.baseline_stats();
+        assert_eq!(stats.graph_vertex_count, 4);
+        assert_eq!(stats.graph_formula_vertex_count, 2);
+        assert_eq!(stats.graph_edge_count, 2);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
@@ -237,3 +237,371 @@ fn phantom_cycle_through_span_member_yields_value_under_runtime() {
         "B10 = A10 + D10 = 10 + 0"
     );
 }
+
+fn build_two_sheet_cycle_workbook() -> Engine<TestWorkbook> {
+    let mut engine = authoritative_engine(CycleDetection::Static);
+    engine.add_sheet("Sheet2").unwrap();
+    for sheet in ["Sheet1", "Sheet2"] {
+        let mut formulas = Vec::new();
+        for row in 1..=120 {
+            engine
+                .set_cell_value(sheet, row, 1, LiteralValue::Number(row as f64))
+                .unwrap();
+            formulas.push(record(&mut engine, row, 2, &format!("=A{row}+C{row}")));
+        }
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new(sheet, formulas)])
+            .unwrap();
+        engine
+            .set_cell_formula(sheet, 5, 3, parse("=B5").unwrap())
+            .unwrap();
+    }
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    engine
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OverlaySnapshot {
+    overlay_ref: crate::formula_plane::runtime::FormulaOverlayRef,
+    id: crate::formula_plane::runtime::FormulaOverlayEntryId,
+    generation: u32,
+    sheet_id: crate::SheetId,
+    domain: crate::formula_plane::runtime::PlacementDomain,
+    source_span: Option<crate::formula_plane::runtime::FormulaSpanRef>,
+    kind: crate::formula_plane::runtime::FormulaOverlayEntryKind,
+    created_epoch: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct GraphVertexSnapshot {
+    cell: crate::reference::CellRef,
+    vertex: crate::engine::VertexId,
+    kind: crate::engine::VertexKind,
+    formula: Option<crate::engine::arena::AstNodeId>,
+    dependencies: Vec<crate::engine::VertexId>,
+    dependents: Vec<crate::engine::VertexId>,
+    dirty: bool,
+    flags: u8,
+}
+
+#[derive(Debug, PartialEq)]
+struct DemotionStateSnapshot {
+    span_refs: Vec<crate::formula_plane::runtime::FormulaSpanRef>,
+    plane_epoch: crate::formula_plane::runtime::FormulaPlaneEpoch,
+    indexes_epoch: u64,
+    indexed_plane_epoch: u64,
+    overlays: Vec<OverlaySnapshot>,
+    graph_vertices: Vec<GraphVertexSnapshot>,
+    graph_counts: (usize, usize, usize, usize),
+    visible_values: Vec<(String, u32, u32, Option<LiteralValue>)>,
+    cycle_member_span_demotions: u64,
+}
+
+fn active_span_refs_by_sheet(
+    engine: &Engine<TestWorkbook>,
+) -> Vec<crate::formula_plane::runtime::FormulaSpanRef> {
+    let authority = engine.graph.formula_authority();
+    let mut refs = authority
+        .active_span_refs()
+        .into_iter()
+        .map(|span_ref| {
+            let sheet_id = authority.plane.spans.get(span_ref).unwrap().sheet_id;
+            (sheet_id, span_ref)
+        })
+        .collect::<Vec<_>>();
+    refs.sort_unstable_by_key(|(sheet_id, _)| *sheet_id);
+    refs.into_iter().map(|(_, span_ref)| span_ref).collect()
+}
+
+fn add_two_sheet_source_overlays(engine: &mut Engine<TestWorkbook>) {
+    use crate::formula_plane::runtime::{FormulaOverlayEntryKind, PlacementDomain};
+
+    let refs = active_span_refs_by_sheet(engine);
+    assert_eq!(refs.len(), 2);
+    for (index, span_ref) in refs.into_iter().enumerate() {
+        let sheet_id = engine
+            .graph
+            .formula_authority()
+            .plane
+            .spans
+            .get(span_ref)
+            .unwrap()
+            .sheet_id;
+        let (row, kind) = if index == 0 {
+            (9, FormulaOverlayEntryKind::ValueOverride)
+        } else {
+            (10, FormulaOverlayEntryKind::Cleared)
+        };
+        engine.graph.formula_authority_mut().plane.insert_overlay(
+            sheet_id,
+            PlacementDomain::row_run(sheet_id, row, row, 1),
+            kind,
+            Some(span_ref),
+        );
+    }
+    engine.graph.formula_authority_mut().rebuild_indexes();
+}
+
+fn snapshot_demotion_state(engine: &Engine<TestWorkbook>) -> DemotionStateSnapshot {
+    let authority = engine.graph.formula_authority();
+    let overlays = authority
+        .plane
+        .formula_overlay
+        .active_entries()
+        .map(|(entry, overlay_ref)| OverlaySnapshot {
+            overlay_ref,
+            id: entry.id,
+            generation: entry.generation,
+            sheet_id: entry.sheet_id,
+            domain: entry.domain.clone(),
+            source_span: entry.source_span,
+            kind: entry.kind.clone(),
+            created_epoch: entry.created_epoch,
+        })
+        .collect();
+
+    let mut graph_vertices = engine
+        .graph
+        .cell_to_vertex()
+        .iter()
+        .map(|(&cell, &vertex)| {
+            let mut dependencies = engine.graph.get_dependencies(vertex);
+            dependencies.sort_unstable();
+            let mut dependents = engine.graph.get_dependents(vertex);
+            dependents.sort_unstable();
+            GraphVertexSnapshot {
+                cell,
+                vertex,
+                kind: engine.graph.get_vertex_kind(vertex),
+                formula: engine.graph.get_formula_id(vertex),
+                dependencies,
+                dependents,
+                dirty: engine.graph.is_dirty(vertex),
+                flags: engine.graph.get_flags(vertex),
+            }
+        })
+        .collect::<Vec<_>>();
+    graph_vertices.sort_unstable_by_key(|snapshot| snapshot.cell);
+
+    let mut visible_values = Vec::new();
+    for sheet in ["Sheet1", "Sheet2"] {
+        for (row, col) in [(5, 1), (5, 2), (5, 3), (10, 2), (11, 2), (120, 2)] {
+            visible_values.push((
+                sheet.to_string(),
+                row,
+                col,
+                engine.get_cell_value(sheet, row, col),
+            ));
+        }
+    }
+
+    let stats = engine.baseline_stats();
+    assert_eq!(
+        graph_vertices.len(),
+        stats.graph_vertex_count,
+        "snapshot must cover every graph vertex"
+    );
+    DemotionStateSnapshot {
+        span_refs: authority.active_span_refs(),
+        plane_epoch: authority.plane.epoch(),
+        indexes_epoch: authority.indexes_epoch(),
+        indexed_plane_epoch: authority.indexed_plane_epoch(),
+        overlays,
+        graph_vertices,
+        graph_counts: (
+            stats.graph_vertex_count,
+            stats.graph_formula_vertex_count,
+            stats.graph_edge_count,
+            stats.dirty_vertex_count,
+        ),
+        visible_values,
+        cycle_member_span_demotions: stats.formula_plane_cycle_member_span_demotions,
+    }
+}
+
+#[test]
+fn two_sheet_span_demotion_fault_matrix_preserves_exact_transaction_state() {
+    use crate::engine::eval::FormulaSpanDemotionFault;
+
+    let faults = [
+        FormulaSpanDemotionFault::AstPreparation,
+        FormulaSpanDemotionFault::LegacyGraphPreparation,
+        FormulaSpanDemotionFault::FinalLegacyGraphValidation,
+        FormulaSpanDemotionFault::FinalAuthorityValidation,
+        FormulaSpanDemotionFault::AllocationReservation,
+        FormulaSpanDemotionFault::BeforeFirstMutation,
+    ];
+    for fault in faults {
+        let mut engine = build_two_sheet_cycle_workbook();
+        add_two_sheet_source_overlays(&mut engine);
+        let refs = active_span_refs_by_sheet(&engine);
+        let before = snapshot_demotion_state(&engine);
+
+        engine.set_formula_span_demotion_fault_for_test(fault);
+        let result = engine
+            .prepare_formula_span_demotion(&refs)
+            .and_then(|prepared| engine.commit_prepared_formula_span_demotion(prepared));
+        assert!(result.is_err(), "fault {fault:?} must fail");
+        assert_eq!(
+            snapshot_demotion_state(&engine),
+            before,
+            "fault {fault:?} changed exact multi-sheet transaction state"
+        );
+    }
+}
+
+#[test]
+fn stale_second_exact_ref_cannot_commit_first_span() {
+    use crate::engine::eval::FormulaSpanDemotionError;
+
+    let mut engine = build_two_sheet_cycle_workbook();
+    add_two_sheet_source_overlays(&mut engine);
+    let refs = active_span_refs_by_sheet(&engine);
+    let prepared = engine.prepare_formula_span_demotion(&refs).unwrap();
+
+    let first_ref = refs[0];
+    let stale_second_ref = refs[1];
+    assert!(
+        engine
+            .graph
+            .formula_authority_mut()
+            .plane
+            .remove_span(stale_second_ref)
+    );
+    engine.graph.formula_authority_mut().rebuild_indexes();
+    let before = snapshot_demotion_state(&engine);
+    assert_eq!(before.span_refs, vec![first_ref]);
+
+    assert!(matches!(
+        engine.commit_prepared_formula_span_demotion(prepared),
+        Err(FormulaSpanDemotionError::StaleAuthority)
+    ));
+    assert_eq!(snapshot_demotion_state(&engine), before);
+    assert!(
+        engine
+            .graph
+            .formula_authority()
+            .plane
+            .spans
+            .get(first_ref)
+            .is_some(),
+        "the first exact ref must remain authoritative"
+    );
+}
+
+#[test]
+fn two_sheet_cyclic_demotion_is_one_atomic_batch() {
+    use crate::engine::eval::FormulaSpanDemotionFault;
+
+    let mut failed = build_two_sheet_cycle_workbook();
+    let refs = failed.graph.formula_authority().active_span_refs();
+    let before = failed.baseline_stats();
+    failed.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
+    assert!(failed.evaluate_all().is_err());
+    assert_eq!(failed.graph.formula_authority().active_span_refs(), refs);
+    let after = failed.baseline_stats();
+    assert_eq!(after.graph_vertex_count, before.graph_vertex_count);
+    assert_eq!(
+        after.graph_formula_vertex_count,
+        before.graph_formula_vertex_count
+    );
+    assert_eq!(after.graph_edge_count, before.graph_edge_count);
+    assert_eq!(after.dirty_vertex_count, before.dirty_vertex_count);
+
+    let mut committed = build_two_sheet_cycle_workbook();
+    let result = committed.evaluate_all().expect("batch demotion commits");
+    assert_eq!(result.cycle_errors, 2);
+    assert_eq!(
+        committed
+            .baseline_stats()
+            .formula_plane_cycle_member_span_demotions,
+        2
+    );
+    assert!(
+        committed
+            .graph
+            .formula_authority()
+            .active_span_refs()
+            .is_empty()
+    );
+    for sheet in ["Sheet1", "Sheet2"] {
+        assert!(is_circ(&committed, sheet, 5, 2));
+        assert!(is_circ(&committed, sheet, 5, 3));
+        assert_eq!(num(&committed, sheet, 10, 2), 10.0);
+    }
+}
+
+#[test]
+fn prepared_span_demotion_rejects_stale_authority_before_graph_mutation() {
+    let mut engine = build_workbook(CycleDetection::Static);
+    let refs = engine.graph.formula_authority().active_span_refs();
+    let prepared = engine.prepare_formula_span_demotion(&refs).unwrap();
+    engine
+        .graph
+        .formula_authority_mut()
+        .mark_all_active_spans_dirty();
+    let before = engine.baseline_stats();
+    let live_refs = engine.graph.formula_authority().active_span_refs();
+
+    assert!(
+        engine
+            .commit_prepared_formula_span_demotion(prepared)
+            .is_err()
+    );
+    let after = engine.baseline_stats();
+    assert_eq!(
+        engine.graph.formula_authority().active_span_refs(),
+        live_refs
+    );
+    assert_eq!(after.graph_vertex_count, before.graph_vertex_count);
+    assert_eq!(
+        after.graph_formula_vertex_count,
+        before.graph_formula_vertex_count
+    );
+    assert_eq!(after.graph_edge_count, before.graph_edge_count);
+    assert_eq!(after.dirty_vertex_count, before.dirty_vertex_count);
+}
+
+#[test]
+fn exact_ref_preparation_rejects_invalid_generation_without_mutation() {
+    let mut engine = build_workbook(CycleDetection::Static);
+    let mut refs = engine.graph.formula_authority().active_span_refs();
+    refs[0].generation = refs[0].generation.wrapping_add(1);
+    let before = engine.baseline_stats();
+    let live_refs = engine.graph.formula_authority().active_span_refs();
+
+    assert!(engine.prepare_formula_span_demotion(&refs).is_err());
+    let after = engine.baseline_stats();
+    assert_eq!(
+        engine.graph.formula_authority().active_span_refs(),
+        live_refs
+    );
+    assert_eq!(after.graph_vertex_count, before.graph_vertex_count);
+    assert_eq!(
+        after.graph_formula_vertex_count,
+        before.graph_formula_vertex_count
+    );
+    assert_eq!(after.graph_edge_count, before.graph_edge_count);
+    assert_eq!(after.dirty_vertex_count, before.dirty_vertex_count);
+}
+
+#[test]
+fn span_demotion_preparation_checks_existing_load_limits_without_mutation() {
+    let mut engine = build_workbook(CycleDetection::Static);
+    let refs = engine.graph.formula_authority().active_span_refs();
+    let before = engine.baseline_stats();
+    let mut limits = engine.workbook_load_limits().clone();
+    limits.max_sheet_rows = 100;
+    engine.set_workbook_load_limits(limits);
+
+    assert!(engine.prepare_formula_span_demotion(&refs).is_err());
+    let after = engine.baseline_stats();
+    assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+    assert_eq!(after.graph_vertex_count, before.graph_vertex_count);
+    assert_eq!(
+        after.graph_formula_vertex_count,
+        before.graph_formula_vertex_count
+    );
+    assert_eq!(after.graph_edge_count, before.graph_edge_count);
+    assert_eq!(after.dirty_vertex_count, before.dirty_vertex_count);
+}


### PR DESCRIPTION
## Summary

- add an exact-reference `PreparedFormulaSpanDemotion` prepare/validate/commit transaction
- extend `PreparedLegacyGraphPlan` with one multi-sheet reservation for formula targets and cross-sheet placeholders
- migrate cyclic FormulaPlane demotion from sequential region commits to one atomic batch
- add six pre-mutation fault seams plus exact two-sheet graph, authority, overlay, dirty-state, and visible-value snapshots
- prove a stale second exact ref cannot commit the first span

## Scope

This is Adaptive Partition T1.0a only. It does not route non-cycle capacity fallback, change pending-region semantics, add fallback materialization limits, cache mixed topology, or introduce the T1 dirty authority. The capacity parity fix tracked by #144 follows in T1.0b.

All recoverable validation and injected-fault paths precede the first graph/authority mutation. After final validation the transaction composes the existing prevalidated E2 graph append with exact authority removal; allocator OOM/panic remains process-fatal under the existing E2/E3 contract.

## Validation

- focused cyclic transaction module: 9 passed
- evaluator default library suite: 2,199 passed, 12 ignored
- evaluator all-feature library suite: 2,201 passed, 12 ignored
- strict all-target/all-feature Clippy
- Rust formatting and diff checks
- independent blocker/high review: PASS
