### PR TITLE
fix(eval): preserve parity on FormulaPlane capacity fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Formualizer will be documented in this file.
 
 - Upgraded Calamine-backed XLSX loading to Calamine 0.36 and a single-pass value/formula metadata stream, preserving formula-only worksheet dimensions, cached-value semantics, load limits, shared-formula relocation, and malformed-family fallback.
 
+### Fixed
+
+- Fixed experimental FormulaPlane capacity fallbacks evaluating legacy readers before required span results were available. Unsafe requests now transactionally demote exactly their scheduled spans, retain pending dirty regions across failed attempts, and fail closed behind a finite materialization limit.
+
 ### Performance
 
 - Proven complete source-formula families now parse and analyze one anchor and avoid per-descendant strings, ASTs, staging entries, and graph vertices. In same-machine release probes, a clean 100k-family load improved from 997 ms and 313 MiB RSS under forced replay to 129 ms and 26 MiB RSS; a 1M-family load completed in 2.2 s at 167 MiB RSS instead of 13.1 s at 3.0 GiB.

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -23,6 +23,7 @@ use crate::engine::{
     FormulaPlaneMode, RowVisibilitySource, ScheduleUnit, Scheduler, VertexId, VertexKind,
     VisibilityMaskMode,
 };
+use crate::formula_plane::authority::PendingChangedRegionsLease;
 use crate::formula_plane::placement::prepare_anchor_once_fragment;
 use crate::formula_plane::placement::{
     CandidateAnalysis, FormulaPlacementCandidate, FormulaPlacementResult, PlacementFallbackReason,
@@ -722,11 +723,10 @@ pub struct Engine<R> {
     /// producers become visible) so the cycle members land on the legacy graph
     /// path. Observational only.
     formula_plane_cycle_member_span_demotions: u64,
-    /// Times the FormulaPlane coordinator failed over to the legacy
-    /// primitive because the mixed schedule reported only non-cycle
-    /// fallbacks (capacity caps, unsupported projections, missing result
-    /// regions). One increment per `evaluate_all`-level bailout — the
-    /// cyclic-span demote loop must never spin on these. Observational only.
+    /// Successfully completed non-cycle unsafe mixed requests. Incremented
+    /// only after every scheduled span has committed demotion and the single
+    /// legacy completion pass succeeds; failed attempts are not counted.
+    /// Observational only.
     formula_plane_capacity_bailouts: u64,
     /// Transient cancellation flag used during evaluation
     active_cancel_flag: Option<Arc<AtomicBool>>,
@@ -3456,6 +3456,11 @@ where
     #[cfg(test)]
     pub(crate) fn formula_plane_capacity_bailouts(&self) -> u64 {
         self.formula_plane_capacity_bailouts
+    }
+
+    #[cfg(test)]
+    pub(crate) fn topology_epoch_for_test(&self) -> u64 {
+        self.topology_epoch
     }
 
     fn record_formula_ingest_report(&mut self, report: FormulaIngestReport) {
@@ -8885,7 +8890,7 @@ where
             origin_row: u32,
             origin_col: u32,
             binding_set_id: Option<crate::formula_plane::runtime::SpanBindingSetId>,
-            placements: Vec<(u32, u32)>,
+            domain: PlacementDomain,
         }
 
         let authority = self.graph.formula_authority();
@@ -8893,7 +8898,13 @@ where
         let expected_indexes_epoch = authority.indexes_epoch();
         let expected_indexed_plane_epoch = authority.indexed_plane_epoch();
         let mut unique = Vec::new();
+        unique
+            .try_reserve_exact(span_refs.len())
+            .map_err(|_| FormulaSpanDemotionError::LoadLimit("allocation_reservation"))?;
         let mut plans = Vec::new();
+        plans
+            .try_reserve_exact(span_refs.len())
+            .map_err(|_| FormulaSpanDemotionError::LoadLimit("allocation_reservation"))?;
         let mut placement_count = 0usize;
         let mut placements_by_sheet: BTreeMap<SheetId, u64> = BTreeMap::new();
         for &span_ref in span_refs {
@@ -8917,6 +8928,14 @@ where
             placement_count = placement_count
                 .checked_add(count)
                 .ok_or(FormulaSpanDemotionError::CountOverflow)?;
+            if u64::try_from(placement_count)
+                .map_err(|_| FormulaSpanDemotionError::CountOverflow)?
+                > self.workbook_load_limits.max_formula_plane_fallback_cells
+            {
+                return Err(FormulaSpanDemotionError::LoadLimit(
+                    "max_formula_plane_fallback_cells",
+                ));
+            }
             let sheet_count = placements_by_sheet.entry(span.sheet_id).or_default();
             *sheet_count = sheet_count
                 .checked_add(span.domain.cell_count())
@@ -8945,12 +8964,6 @@ where
             if !domain_in_bounds {
                 return Err(FormulaSpanDemotionError::LoadLimit("sheet_axis_bounds"));
             }
-            let mut placements = Vec::with_capacity(count);
-            placements.extend(
-                span.domain
-                    .iter()
-                    .map(|coord| (coord.row.saturating_add(1), coord.col.saturating_add(1))),
-            );
             plans.push(SpanMaterialization {
                 span_ref,
                 sheet_id: span.sheet_id,
@@ -8958,12 +8971,17 @@ where
                 origin_row: relocation.anchor_row,
                 origin_col: relocation.anchor_col,
                 binding_set_id: span.binding_set_id,
-                placements,
+                domain: span.domain.clone(),
             });
         }
-        let mut relocated = Vec::with_capacity(placement_count);
+        let mut relocated = Vec::new();
+        relocated
+            .try_reserve_exact(placement_count)
+            .map_err(|_| FormulaSpanDemotionError::LoadLimit("allocation_reservation"))?;
         for plan in &plans {
-            for &(row, col) in &plan.placements {
+            for coord in plan.domain.iter() {
+                let row = coord.row.saturating_add(1);
+                let col = coord.col.saturating_add(1);
                 let bound_ast = if let Some(binding_set_id) = plan.binding_set_id {
                     let authority = self.graph.formula_authority();
                     let binding_set = authority
@@ -9000,7 +9018,10 @@ where
             }
         }
 
-        let mut analyzed = Vec::with_capacity(relocated.len());
+        let mut analyzed = Vec::new();
+        analyzed
+            .try_reserve_exact(relocated.len())
+            .map_err(|_| FormulaSpanDemotionError::LoadLimit("allocation_reservation"))?;
         {
             let mut pipeline = self.ingest_pipeline();
             for (sheet_id, row, col, ast) in relocated {
@@ -12563,6 +12584,17 @@ where
             elapsed: start.elapsed(),
         })
     }
+    fn evaluate_all_legacy_and_ack_pending(
+        &mut self,
+        pending_changed_regions: PendingChangedRegionsLease,
+    ) -> Result<EvalResult, ExcelError> {
+        let result = self.evaluate_all_legacy_impl()?;
+        self.graph
+            .formula_authority_mut()
+            .ack_pending_changed_regions(pending_changed_regions);
+        Ok(result)
+    }
+
     fn evaluate_authoritative_formula_plane_all(&mut self) -> Result<EvalResult, ExcelError> {
         // Fresh per-request cycle counters. Some callers (`evaluate_vertex`,
         // `evaluate_cells*`) reach this coordinator without an entry-point
@@ -12571,6 +12603,11 @@ where
         // below intentionally does not reset, so `evaluate_legacy_cycle_prepass`
         // counts survive into the final telemetry.
         self.begin_evaluation_request();
+        let pending_changed_regions = self
+            .graph
+            .formula_authority_mut()
+            .lease_pending_changed_regions();
+
         // The FormulaPlane coordinator is now selected by mode for evaluate_all.
         // SingletonUnique formulas intentionally remain legacy graph vertices;
         // when no spans are active, execute through the private legacy primitive
@@ -12580,7 +12617,7 @@ where
             {
                 self.last_formula_plane_span_eval_report = None;
             }
-            return self.evaluate_all_legacy_impl();
+            return self.evaluate_all_legacy_and_ack_pending(pending_changed_regions);
         }
 
         // Decide span work seeding strategy: any active span we have not yet
@@ -12593,13 +12630,8 @@ where
         } else {
             SpanSeedMode::DirtyClosure
         };
-        // Take pending regions out of the authority so subsequent reschedules
-        // start from a clean slate after a successful eval pass.
-        let pending_changed_regions = self
-            .graph
-            .formula_authority_mut()
-            .take_pending_changed_regions();
-
+        // Pending regions are leased for the full retry/cycle loop. They are
+        // acknowledged only after authoritative or demotion/legacy completion.
         // Steady-state shortcut: in `DirtyClosure` mode span work is derived
         // exclusively from pending changed regions, so with none pending the
         // mixed schedule could only ever contain dirty legacy vertices (e.g.
@@ -12614,47 +12646,76 @@ where
             {
                 self.last_formula_plane_span_eval_report = None;
             }
-            return self.evaluate_all_legacy_impl();
+            return self.evaluate_all_legacy_and_ack_pending(pending_changed_regions);
         }
 
         let start = crate::instant::FzInstant::now();
         let mut span_seed_mode = span_seed_mode;
-        let mut pending_changed_regions = pending_changed_regions;
         // #CIRC stamps produced by demoting cyclic spans and resolving the
         // residual legacy-only cycle ahead of the mixed schedule (gotcha G8).
         let mut prepass_cycle_errors = 0usize;
         const MAX_CYCLE_DEMOTE_ITERS: usize = 64;
         let mut cycle_demote_iters = 0usize;
         let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) = loop {
-            let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) =
-                self.build_formula_plane_mixed_schedule(span_seed_mode, &pending_changed_regions)?;
+            let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) = self
+                .build_formula_plane_mixed_schedule(
+                    span_seed_mode,
+                    pending_changed_regions.regions(),
+                )?;
 
             if schedule.is_authoritative_safe() {
                 break (schedule, span_refs_by_id, plane_epoch, legacy_vertices);
             }
 
-            // The demote loop below can only make progress on cycles: it
-            // demotes cyclic spans and stamps residual legacy-only cycles.
-            // Every other fallback reason (capacity caps, unsupported
-            // projections, missing result regions) is a property of the
-            // inputs — rebuilding the schedule from identical state
-            // reproduces the identical fallback, so iterating would spin
-            // `MAX_CYCLE_DEMOTE_ITERS` times doing O(graph) schedule builds
-            // per iteration before giving up anyway. Fail over to the legacy
-            // primitive immediately instead.
+            // Non-cycle unsafe schedules cannot safely run legacy-only while a
+            // scheduled span remains virtual. Refine exactly every span in this
+            // request's scheduled work, then complete the request in one legacy
+            // pass. Clean, unscheduled spans keep their authority and overlays.
             let has_cycle_fallback = schedule.stats.cycle_count > 0
                 || schedule
                     .fallbacks
                     .iter()
                     .any(|fb| fb.reason == MixedScheduleFallbackReason::CycleDetected);
             if !has_cycle_fallback {
-                self.formula_plane_capacity_bailouts =
-                    self.formula_plane_capacity_bailouts.saturating_add(1);
+                let selected_span_refs = schedule
+                    .layers
+                    .iter()
+                    .flat_map(|layer| layer.work.iter())
+                    .filter_map(|work| match work.producer {
+                        FormulaProducerId::Span(span_id) => span_refs_by_id.get(&span_id).copied(),
+                        FormulaProducerId::Legacy(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+
+                if !selected_span_refs.is_empty() {
+                    let prepared = self
+                        .prepare_formula_span_demotion(&selected_span_refs)
+                        .map_err(|error| {
+                            ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
+                                "FormulaPlane capacity fallback demotion preparation failed: {error}"
+                            ))
+                        })?;
+                    self.commit_prepared_formula_span_demotion(prepared)
+                        .map_err(|error| {
+                            ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
+                                "FormulaPlane capacity fallback demotion commit failed: {error}"
+                            ))
+                        })?;
+                }
+
                 #[cfg(test)]
                 {
                     self.last_formula_plane_span_eval_report = None;
                 }
-                return self.evaluate_all_legacy_impl();
+                let result = self.evaluate_all_legacy_impl()?;
+                self.formula_plane_indexes_epoch_seen =
+                    self.graph.formula_authority().indexes_epoch();
+                self.graph
+                    .formula_authority_mut()
+                    .ack_pending_changed_regions(pending_changed_regions);
+                self.formula_plane_capacity_bailouts =
+                    self.formula_plane_capacity_bailouts.saturating_add(1);
+                return Ok(result);
             }
 
             // Gotcha G8 (refs #112): a span whose member cell participates in a
@@ -12674,7 +12735,7 @@ where
             if self.graph.formula_authority().active_span_count() == 0 {
                 // All spans demoted; nothing left for the FP coordinator. The
                 // legacy evaluator resolves the (now fully legacy) cycle.
-                return self.evaluate_all_legacy_impl();
+                return self.evaluate_all_legacy_and_ack_pending(pending_changed_regions);
             }
 
             // Resolve the residual legacy-only cycle (`handle_cycle_unit`
@@ -12684,21 +12745,14 @@ where
                 prepass_cycle_errors.saturating_add(self.evaluate_legacy_cycle_prepass()?);
 
             // Re-seed every surviving span whole after the geometry/dirty
-            // changes; the demotion already reset
-            // `formula_plane_indexes_epoch_seen` to 0.
+            // changes; the original pending-region lease remains live across
+            // the complete cycle retry loop.
             span_seed_mode = SpanSeedMode::WholeAll;
-            pending_changed_regions = self
-                .graph
-                .formula_authority_mut()
-                .take_pending_changed_regions();
 
             cycle_demote_iters += 1;
             if cycle_demote_iters >= MAX_CYCLE_DEMOTE_ITERS {
-                // Defensive bound: every iteration either demotes ≥1 span or
-                // stamps the legacy cycle, both strictly reducing residual work.
-                // If we somehow fail to converge, fall back to pure legacy to
-                // stay correct rather than spin.
-                return self.evaluate_all_legacy_impl();
+                return Err(ExcelError::new(ExcelErrorKind::NImpl)
+                    .with_message("FormulaPlane cyclic demotion did not converge".to_string()));
             }
         };
 
@@ -12835,6 +12889,9 @@ where
         // Mark this indexes-epoch as fully evaluated so subsequent passes can
         // use bounded span dirty closures rather than whole-span work.
         self.formula_plane_indexes_epoch_seen = self.graph.formula_authority().indexes_epoch();
+        self.graph
+            .formula_authority_mut()
+            .ack_pending_changed_regions(pending_changed_regions);
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
         Ok(EvalResult {
             computed_vertices,

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -633,6 +633,8 @@ pub struct WorkbookLoadLimits {
     pub max_sheet_cols: u32,
     /// Hard cap for the rectangular logical area a backend may materialize.
     pub max_sheet_logical_cells: u64,
+    /// Hard cap for formulas materialized by one FormulaPlane fallback.
+    pub max_formula_plane_fallback_cells: u64,
     /// Sparse-sheet checks only trigger once a sheet reaches this many logical cells.
     pub sparse_sheet_cell_threshold: u64,
     /// Maximum allowed logical-to-populated-cell ratio once the sparse threshold is crossed.
@@ -657,6 +659,7 @@ impl Default for WorkbookLoadLimits {
             max_sheet_rows: 1_048_576,
             max_sheet_cols: 16_384,
             max_sheet_logical_cells: 128_000_000,
+            max_formula_plane_fallback_cells: 2_000_000,
             sparse_sheet_cell_threshold: 250_000,
             max_sparse_cell_ratio: 1_024,
             max_formula_spool_bytes_per_sheet: 256 * 1024 * 1024,

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
@@ -495,10 +495,19 @@ fn two_sheet_cyclic_demotion_is_one_atomic_batch() {
 
     let mut failed = build_two_sheet_cycle_workbook();
     let refs = failed.graph.formula_authority().active_span_refs();
+    let pending = failed
+        .graph
+        .formula_authority()
+        .pending_changed_regions()
+        .to_vec();
     let before = failed.baseline_stats();
     failed.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
     assert!(failed.evaluate_all().is_err());
     assert_eq!(failed.graph.formula_authority().active_span_refs(), refs);
+    assert_eq!(
+        failed.graph.formula_authority().pending_changed_regions(),
+        pending
+    );
     let after = failed.baseline_stats();
     assert_eq!(after.graph_vertex_count, before.graph_vertex_count);
     assert_eq!(
@@ -523,6 +532,14 @@ fn two_sheet_cyclic_demotion_is_one_atomic_batch() {
             .formula_authority()
             .active_span_refs()
             .is_empty()
+    );
+    assert!(
+        committed
+            .graph
+            .formula_authority()
+            .pending_changed_regions()
+            .is_empty(),
+        "successful cyclic demotion plus legacy completion acknowledges the lease"
     );
     for sheet in ["Sheet1", "Sheet2"] {
         assert!(is_circ(&committed, sheet, 5, 2));

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -75,9 +75,11 @@ fn numeric_value(engine: &Engine<TestWorkbook>, row: u32, col: u32) -> f64 {
 /// different but value-identical template (`...+0`): each resulting family has
 /// row gaps (`UnsupportedShapeOrGaps`), keeping all tail readers legacy while
 /// preserving the original read-region geometry and candidate counts.
-fn build_mixed_engine(tail_formula: impl Fn(u32) -> String) -> Engine<TestWorkbook> {
-    let config =
-        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+fn build_mixed_engine(
+    mode: FormulaPlaneMode,
+    tail_formula: impl Fn(u32) -> String,
+) -> Engine<TestWorkbook> {
+    let config = EvalConfig::default().with_formula_plane_mode(mode);
     let mut engine = Engine::new(TestWorkbook::default(), config);
     let mut formulas = Vec::with_capacity(2 * ROWS as usize);
     for row in 1..=ROWS {
@@ -95,13 +97,15 @@ fn build_mixed_engine(tail_formula: impl Fn(u32) -> String) -> Engine<TestWorkbo
     let report = engine
         .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
         .expect("ingest formulas");
-    assert_eq!(
-        report.shadow_accepted_span_cells,
-        u64::from(ROWS),
-        "only the B column family may span; tail readers must stay legacy \
-         (histogram: {:?})",
-        report.fallback_reasons
-    );
+    if mode == FormulaPlaneMode::AuthoritativeExperimental {
+        assert_eq!(
+            report.shadow_accepted_span_cells,
+            u64::from(ROWS),
+            "only the B column family may span; tail readers must stay legacy \
+             (histogram: {:?})",
+            report.fallback_reasons
+        );
+    }
     engine
 }
 
@@ -115,7 +119,9 @@ fn mixed_tail_reads_complete_in_one_authoritative_pass() {
     // Single-column tail reads: with degenerate-span normalization these
     // index as per-column intervals, so legacy point-result queries on other
     // columns see zero candidates and the schedule stays authoritative-safe.
-    let mut engine = build_mixed_engine(|row| format!("=SUM($A{row}:$A${ROWS})"));
+    let mut engine = build_mixed_engine(FormulaPlaneMode::AuthoritativeExperimental, |row| {
+        format!("=SUM($A{row}:$A${ROWS})")
+    });
 
     engine.evaluate_all().unwrap();
 
@@ -146,45 +152,395 @@ fn mixed_tail_reads_complete_in_one_authoritative_pass() {
     assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
 }
 
-#[test]
-fn capacity_fallback_bails_to_legacy_once_per_eval_not_demote_spin() {
-    // Two-column tail reads stay rect-bucketed (a real rect has no precise
-    // interval-tree form), so the cumulative candidate cap legitimately
-    // trips. The coordinator must fail over to the legacy primitive exactly
-    // once per evaluate_all — the cyclic-span demote loop cannot make
-    // progress on capacity fallbacks and used to spin its full 64-iteration
-    // budget (each iteration an O(graph) schedule build + Tarjan prepass).
-    let mut engine = build_mixed_engine(|row| format!("=SUM($A{row}:$B${ROWS})"));
-
-    engine.evaluate_all().unwrap();
-    assert_eq!(
-        engine.formula_plane_capacity_bailouts(),
-        1,
-        "capacity fallback must bail exactly once, not iterate the demote loop"
-    );
-
-    // The legacy bail cannot evaluate span cells; the follow-up recalc
-    // (WholeAll seeding, no dirty legacy producers) picks them up.
-    engine.evaluate_all().unwrap();
-    assert_eq!(
-        engine.formula_plane_capacity_bailouts(),
-        1,
-        "span-only follow-up schedule must be authoritative-safe"
-    );
-    assert!(
-        engine.last_formula_plane_span_eval_report().is_some(),
-        "follow-up recalc must evaluate the spans the bail pass skipped"
-    );
-
-    for row in [1, 2, ROWS / 2, ROWS] {
-        assert_eq!(numeric_value(&engine, row, 2), row as f64 + 1.0);
+fn assert_full_capacity_corpus_parity(
+    off: &Engine<TestWorkbook>,
+    authoritative: &Engine<TestWorkbook>,
+) {
+    for row in 1..=ROWS {
+        for col in [2, 4] {
+            assert_eq!(
+                authoritative.get_cell_value(SHEET, row, col),
+                off.get_cell_value(SHEET, row, col),
+                "Off/authoritative mismatch at {SHEET}!R{row}C{col}"
+            );
+        }
     }
-    // KNOWN PRE-EXISTING GAP (not pinned here): the legacy tail readers in
-    // column D evaluated during the bail pass while the span cells in column
-    // B were still empty, and computed-overlay flushes do not re-dirty
-    // dependent legacy vertices, so their values remain stale
-    // (`tail_sum(A)` only) on every subsequent quiescent recalc. The old
-    // demote-spin path reached the identical state after its 64 iterations;
-    // fixing it requires the capacity-bail path to either demote affected
-    // spans or re-dirty legacy readers of span result regions.
+}
+
+#[test]
+fn capacity_fallback_matches_off_first_warm_and_post_edit() {
+    let build = |mode| build_mixed_engine(mode, |row| format!("=SUM($A{row}:$B${ROWS})"));
+    let mut off = build(FormulaPlaneMode::Off);
+    let mut authoritative = build(FormulaPlaneMode::AuthoritativeExperimental);
+
+    let default_fallback_cap = authoritative
+        .workbook_load_limits()
+        .max_formula_plane_fallback_cells;
+    assert!(default_fallback_cap < u64::MAX);
+    assert!(
+        default_fallback_cap >= u64::from(ROWS),
+        "the finite default fallback cap must admit the #144 corpus"
+    );
+
+    off.evaluate_all().unwrap();
+    authoritative.evaluate_all().unwrap();
+    assert_eq!(authoritative.formula_plane_capacity_bailouts(), 1);
+    assert_eq!(
+        authoritative
+            .baseline_stats()
+            .formula_plane_active_span_count,
+        0,
+        "first-eval WholeAll must select and demote every scheduled span"
+    );
+    assert_full_capacity_corpus_parity(&off, &authoritative);
+
+    off.evaluate_all().unwrap();
+    authoritative.evaluate_all().unwrap();
+    assert_eq!(
+        authoritative.formula_plane_capacity_bailouts(),
+        1,
+        "successful fallback telemetry increments once, not on warm legacy recalc"
+    );
+    assert_full_capacity_corpus_parity(&off, &authoritative);
+
+    for engine in [&mut off, &mut authoritative] {
+        engine
+            .set_cell_value(SHEET, ROWS / 2, 1, LiteralValue::Number(10_000.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+    }
+    assert_eq!(authoritative.formula_plane_capacity_bailouts(), 1);
+    assert_full_capacity_corpus_parity(&off, &authoritative);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CapacityOverlaySnapshot {
+    overlay_ref: crate::formula_plane::runtime::FormulaOverlayRef,
+    id: crate::formula_plane::runtime::FormulaOverlayEntryId,
+    generation: u32,
+    sheet_id: crate::SheetId,
+    domain: crate::formula_plane::runtime::PlacementDomain,
+    source_span: Option<crate::formula_plane::runtime::FormulaSpanRef>,
+    kind: crate::formula_plane::runtime::FormulaOverlayEntryKind,
+    created_epoch: u64,
+}
+
+fn add_capacity_source_overlay(engine: &mut Engine<TestWorkbook>) {
+    use crate::formula_plane::runtime::{FormulaOverlayEntryKind, PlacementDomain};
+
+    let span_ref = engine.graph.formula_authority().active_span_refs()[0];
+    let sheet_id = engine
+        .graph
+        .formula_authority()
+        .plane
+        .spans
+        .get(span_ref)
+        .unwrap()
+        .sheet_id;
+    engine.graph.formula_authority_mut().plane.insert_overlay(
+        sheet_id,
+        PlacementDomain::row_run(sheet_id, 9, 9, 1),
+        FormulaOverlayEntryKind::ValueOverride,
+        Some(span_ref),
+    );
+    engine.graph.formula_authority_mut().rebuild_indexes();
+}
+
+fn capacity_overlay_snapshot(engine: &Engine<TestWorkbook>) -> Vec<CapacityOverlaySnapshot> {
+    engine
+        .graph
+        .formula_authority()
+        .plane
+        .formula_overlay
+        .active_entries()
+        .map(|(entry, overlay_ref)| CapacityOverlaySnapshot {
+            overlay_ref,
+            id: entry.id,
+            generation: entry.generation,
+            sheet_id: entry.sheet_id,
+            domain: entry.domain.clone(),
+            source_span: entry.source_span,
+            kind: entry.kind.clone(),
+            created_epoch: entry.created_epoch,
+        })
+        .collect()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CapacityGraphVertexSnapshot {
+    cell: crate::reference::CellRef,
+    vertex: crate::engine::VertexId,
+    formula: Option<crate::engine::arena::AstNodeId>,
+    dependencies: Vec<crate::engine::VertexId>,
+    dirty: bool,
+}
+
+fn capacity_graph_snapshot(engine: &Engine<TestWorkbook>) -> Vec<CapacityGraphVertexSnapshot> {
+    let mut snapshot = engine
+        .graph
+        .cell_to_vertex()
+        .iter()
+        .map(|(&cell, &vertex)| {
+            let mut dependencies = engine.graph.get_dependencies(vertex);
+            dependencies.sort_unstable();
+            CapacityGraphVertexSnapshot {
+                cell,
+                vertex,
+                formula: engine.graph.get_formula_id(vertex),
+                dependencies,
+                dirty: engine.graph.is_dirty(vertex),
+            }
+        })
+        .collect::<Vec<_>>();
+    snapshot.sort_unstable_by_key(|entry| entry.cell);
+    snapshot
+}
+
+fn capacity_visible_snapshot(
+    engine: &Engine<TestWorkbook>,
+) -> Vec<(u32, u32, Option<LiteralValue>)> {
+    let mut values = Vec::with_capacity(ROWS as usize * 3);
+    for row in 1..=ROWS {
+        for col in [1, 2, 4] {
+            values.push((row, col, engine.get_cell_value(SHEET, row, col)));
+        }
+    }
+    values
+}
+
+#[test]
+fn fallback_cap_failure_retains_exact_state_and_pending_lease_for_retry() {
+    let mut engine = build_mixed_engine(FormulaPlaneMode::AuthoritativeExperimental, |row| {
+        format!("=SUM($A{row}:$B${ROWS})")
+    });
+    add_capacity_source_overlay(&mut engine);
+    let mut limits = engine.workbook_load_limits().clone();
+    limits.max_formula_plane_fallback_cells = u64::from(ROWS - 1);
+    engine.set_workbook_load_limits(limits);
+
+    let refs = engine.graph.formula_authority().active_span_refs();
+    let pending = engine
+        .graph
+        .formula_authority()
+        .pending_changed_regions()
+        .to_vec();
+    let epochs = (
+        engine.graph.formula_authority().plane.epoch(),
+        engine.graph.formula_authority().indexes_epoch(),
+        engine.graph.formula_authority().indexed_plane_epoch(),
+    );
+    let graph = capacity_graph_snapshot(&engine);
+    let overlays = capacity_overlay_snapshot(&engine);
+    let values = capacity_visible_snapshot(&engine);
+    let before = engine.baseline_stats();
+
+    assert!(engine.evaluate_all().is_err());
+    let after = engine.baseline_stats();
+    assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
+    assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+    assert_eq!(
+        engine.graph.formula_authority().pending_changed_regions(),
+        pending
+    );
+    assert_eq!(
+        (
+            engine.graph.formula_authority().plane.epoch(),
+            engine.graph.formula_authority().indexes_epoch(),
+            engine.graph.formula_authority().indexed_plane_epoch(),
+        ),
+        epochs
+    );
+    assert_eq!(capacity_graph_snapshot(&engine), graph);
+    assert_eq!(capacity_overlay_snapshot(&engine), overlays);
+    assert_eq!(capacity_visible_snapshot(&engine), values);
+    assert_eq!(after.graph_vertex_count, before.graph_vertex_count);
+    assert_eq!(
+        after.graph_formula_vertex_count,
+        before.graph_formula_vertex_count
+    );
+    assert_eq!(after.graph_edge_count, before.graph_edge_count);
+    assert_eq!(after.dirty_vertex_count, before.dirty_vertex_count);
+
+    let mut limits = engine.workbook_load_limits().clone();
+    limits.max_formula_plane_fallback_cells = u64::from(ROWS);
+    engine.set_workbook_load_limits(limits);
+    engine
+        .evaluate_all()
+        .expect("raised-cap retry must succeed");
+    assert_eq!(engine.formula_plane_capacity_bailouts(), 1);
+    assert!(
+        engine
+            .graph
+            .formula_authority()
+            .pending_changed_regions()
+            .is_empty()
+    );
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+}
+
+#[test]
+fn capacity_faults_retain_pending_lease_and_count_only_successful_retry() {
+    use crate::engine::eval::{FormulaSpanDemotionFault, FormulaSpanDemotionFault::*};
+
+    let faults: [FormulaSpanDemotionFault; 6] = [
+        AstPreparation,
+        LegacyGraphPreparation,
+        FinalLegacyGraphValidation,
+        FinalAuthorityValidation,
+        AllocationReservation,
+        BeforeFirstMutation,
+    ];
+    for fault in faults {
+        let mut engine = build_mixed_engine(FormulaPlaneMode::AuthoritativeExperimental, |row| {
+            format!("=SUM($A{row}:$B${ROWS})")
+        });
+        add_capacity_source_overlay(&mut engine);
+        let refs = engine.graph.formula_authority().active_span_refs();
+        let pending = engine
+            .graph
+            .formula_authority()
+            .pending_changed_regions()
+            .to_vec();
+        let epochs = (
+            engine.graph.formula_authority().plane.epoch(),
+            engine.graph.formula_authority().indexes_epoch(),
+            engine.graph.formula_authority().indexed_plane_epoch(),
+        );
+        let graph = capacity_graph_snapshot(&engine);
+        let overlays = capacity_overlay_snapshot(&engine);
+        let values = capacity_visible_snapshot(&engine);
+
+        engine.set_formula_span_demotion_fault_for_test(fault);
+        assert!(engine.evaluate_all().is_err(), "fault {fault:?} must fail");
+        assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
+        assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+        assert_eq!(
+            engine.graph.formula_authority().pending_changed_regions(),
+            pending
+        );
+        assert_eq!(
+            (
+                engine.graph.formula_authority().plane.epoch(),
+                engine.graph.formula_authority().indexes_epoch(),
+                engine.graph.formula_authority().indexed_plane_epoch(),
+            ),
+            epochs
+        );
+        assert_eq!(capacity_graph_snapshot(&engine), graph);
+        assert_eq!(capacity_overlay_snapshot(&engine), overlays);
+        assert_eq!(capacity_visible_snapshot(&engine), values);
+
+        engine.evaluate_all().expect("fault retry must succeed");
+        assert_eq!(engine.formula_plane_capacity_bailouts(), 1);
+        assert!(
+            engine
+                .graph
+                .formula_authority()
+                .pending_changed_regions()
+                .is_empty()
+        );
+    }
+}
+
+fn build_selective_capacity_engine() -> (Engine<TestWorkbook>, Vec<crate::engine::VertexId>) {
+    use crate::reference::{CellRef, Coord};
+
+    let config =
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    let mut formulas = Vec::with_capacity(3 * ROWS as usize);
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, row, 3, LiteralValue::Number((row * 10) as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}+1")));
+        formulas.push(record(&mut engine, row, 5, &format!("=C{row}+1")));
+        let tail = if row % 2 == 0 {
+            format!("=SUM($A{row}:$B${ROWS})+0")
+        } else {
+            format!("=SUM($A{row}:$B${ROWS})")
+        };
+        formulas.push(record(&mut engine, row, 7, &tail));
+    }
+    let report = engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .unwrap();
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(2 * ROWS));
+
+    let sheet_id = engine.graph.sheet_id(SHEET).unwrap();
+    let tail_vertices = (1..=ROWS)
+        .map(|row| {
+            let cell = CellRef::new(sheet_id, Coord::from_excel(row, 7, true, true));
+            *engine.graph.get_vertex_id_for_address(&cell).unwrap()
+        })
+        .collect::<Vec<_>>();
+    engine.graph.clear_dirty_flags(&tail_vertices);
+    (engine, tail_vertices)
+}
+
+#[test]
+fn capacity_fallback_demotes_only_scheduled_dirty_span() {
+    use crate::formula_plane::runtime::PlacementCoord;
+
+    let (mut engine, tail_vertices) = build_selective_capacity_engine();
+    engine.evaluate_all().expect("initial span-only evaluation");
+    assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+
+    let topology_epoch = engine.topology_epoch_for_test();
+    engine
+        .set_cell_value(SHEET, ROWS / 2, 1, LiteralValue::Number(10_000.0))
+        .unwrap();
+    engine.graph.mark_dirty_many(&tail_vertices);
+    engine.evaluate_all().expect("selective capacity fallback");
+
+    assert_eq!(engine.formula_plane_capacity_bailouts(), 1);
+    assert_eq!(engine.topology_epoch_for_test(), topology_epoch + 1);
+    let refs = engine.graph.formula_authority().active_span_refs();
+    assert_eq!(refs.len(), 1, "the unrelated clean span must remain active");
+    let survivor = engine
+        .graph
+        .formula_authority()
+        .plane
+        .spans
+        .get(refs[0])
+        .unwrap();
+    assert!(
+        survivor
+            .domain
+            .contains(PlacementCoord::new(survivor.sheet_id, ROWS / 2 - 1, 4,)),
+        "the clean column-E span must retain authority"
+    );
+    assert_eq!(numeric_value(&engine, ROWS / 2, 2), 10_001.0);
+    assert_eq!(numeric_value(&engine, ROWS / 2, 5), 3_001.0);
+    assert!(
+        engine
+            .graph
+            .formula_authority()
+            .pending_changed_regions()
+            .is_empty()
+    );
+}
+
+#[test]
+fn clean_spans_remain_authoritative_when_only_legacy_work_is_dirty() {
+    let (mut engine, tail_vertices) = build_selective_capacity_engine();
+    engine.evaluate_all().expect("initial span-only evaluation");
+    let refs = engine.graph.formula_authority().active_span_refs();
+
+    engine.graph.mark_dirty_many(&tail_vertices);
+    engine.evaluate_all().expect("pure legacy completion");
+
+    assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
+    assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+    assert!(
+        engine
+            .graph
+            .formula_authority()
+            .pending_changed_regions()
+            .is_empty()
+    );
 }

--- a/crates/formualizer-eval/src/formula_plane/authority.rs
+++ b/crates/formualizer-eval/src/formula_plane/authority.rs
@@ -23,10 +23,29 @@ pub(crate) struct FormulaAuthority {
     #[cfg(test)]
     pub(crate) prepared_append_failure_for_test: bool,
     /// Externally-observed changed regions accumulated since the last
-    /// `take_pending_changed_regions` call. Edits that intersect span read
+    /// successful evaluation acknowledgement. Edits that intersect span read
     /// regions drive bounded span dirty work via `compute_dirty_closure`.
     pending_changed_regions: Vec<Region>,
     pending_seen: FxHashSet<Region>,
+    pending_lease_generation: u64,
+    active_pending_lease_generation: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingChangedRegionsLease {
+    generation: u64,
+    prefix_len: usize,
+    regions: Vec<Region>,
+}
+
+impl PendingChangedRegionsLease {
+    pub(crate) fn regions(&self) -> &[Region] {
+        &self.regions
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -72,9 +91,29 @@ impl FormulaAuthority {
         }
     }
 
-    pub(crate) fn take_pending_changed_regions(&mut self) -> Vec<Region> {
+    pub(crate) fn lease_pending_changed_regions(&mut self) -> PendingChangedRegionsLease {
+        self.pending_lease_generation = self.pending_lease_generation.wrapping_add(1);
+        let generation = self.pending_lease_generation;
+        self.active_pending_lease_generation = Some(generation);
+        let lease = PendingChangedRegionsLease {
+            generation,
+            prefix_len: self.pending_changed_regions.len(),
+            regions: self.pending_changed_regions.clone(),
+        };
+        // The leased prefix remains queued but no longer participates in
+        // dedupe. Identical post-lease changes therefore append as new work,
+        // while this set dedupes only within the new generation.
         self.pending_seen.clear();
-        std::mem::take(&mut self.pending_changed_regions)
+        lease
+    }
+
+    pub(crate) fn ack_pending_changed_regions(&mut self, lease: PendingChangedRegionsLease) {
+        if self.active_pending_lease_generation != Some(lease.generation) {
+            return;
+        }
+        let prefix_len = lease.prefix_len.min(self.pending_changed_regions.len());
+        self.pending_changed_regions.drain(..prefix_len);
+        self.active_pending_lease_generation = None;
     }
 
     pub(crate) fn pending_changed_regions(&self) -> &[Region] {
@@ -451,5 +490,81 @@ mod tests {
         assert_eq!(second.producer_result_entries, 0);
         assert_eq!(authority.producer_results.len(), 0);
         assert!(authority.indexes_epoch() > first.indexes_epoch);
+    }
+
+    #[test]
+    fn pending_lease_ack_preserves_identical_region_recorded_after_lease() {
+        let mut authority = FormulaAuthority::default();
+        let region = Region::point(0, 1, 1);
+        authority.record_changed_region(region);
+        let lease = authority.lease_pending_changed_regions();
+        authority.record_changed_region(region);
+        authority.record_changed_region(region);
+        assert_eq!(authority.pending_changed_regions(), &[region, region]);
+
+        authority.ack_pending_changed_regions(lease);
+
+        assert_eq!(authority.pending_changed_regions(), &[region]);
+    }
+
+    #[test]
+    fn pending_lease_ack_preserves_different_later_regions_in_order() {
+        let mut authority = FormulaAuthority::default();
+        let leased_region = Region::point(0, 1, 1);
+        let later_a = Region::point(0, 2, 2);
+        let later_b = Region::point(0, 3, 3);
+        authority.record_changed_region(leased_region);
+        let lease = authority.lease_pending_changed_regions();
+        authority.record_changed_region(later_a);
+        authority.record_changed_region(later_b);
+        authority.record_changed_region(later_a);
+
+        authority.ack_pending_changed_regions(lease);
+
+        assert_eq!(authority.pending_changed_regions(), &[later_a, later_b]);
+    }
+
+    #[test]
+    fn pending_lease_multiple_ack_cycles_keep_generation_local_dedupe() {
+        let mut authority = FormulaAuthority::default();
+        let first = Region::point(0, 1, 1);
+        let second = Region::point(0, 2, 2);
+        authority.record_changed_region(first);
+        let first_lease = authority.lease_pending_changed_regions();
+        authority.record_changed_region(second);
+        authority.record_changed_region(second);
+        authority.ack_pending_changed_regions(first_lease);
+        assert_eq!(authority.pending_changed_regions(), &[second]);
+
+        let second_lease = authority.lease_pending_changed_regions();
+        authority.record_changed_region(first);
+        authority.record_changed_region(first);
+        authority.ack_pending_changed_regions(second_lease);
+        assert_eq!(authority.pending_changed_regions(), &[first]);
+
+        let final_lease = authority.lease_pending_changed_regions();
+        authority.ack_pending_changed_regions(final_lease);
+        assert!(authority.pending_changed_regions().is_empty());
+    }
+
+    #[test]
+    fn abandoned_pending_lease_retains_original_work_for_failed_evaluation_retry() {
+        let mut authority = FormulaAuthority::default();
+        let original = Region::point(0, 1, 1);
+        let during_failed_evaluation = Region::point(0, 2, 2);
+        authority.record_changed_region(original);
+        let abandoned = authority.lease_pending_changed_regions();
+        authority.record_changed_region(during_failed_evaluation);
+        drop(abandoned);
+        assert_eq!(
+            authority.pending_changed_regions(),
+            &[original, during_failed_evaluation]
+        );
+
+        let retry = authority.lease_pending_changed_regions();
+        assert_eq!(retry.regions(), &[original, during_failed_evaluation]);
+        authority.record_changed_region(original);
+        authority.ack_pending_changed_regions(retry);
+        assert_eq!(authority.pending_changed_regions(), &[original]);
     }
 }

--- a/docs/architecture/adaptive-formula-partition.md
+++ b/docs/architecture/adaptive-formula-partition.md
@@ -274,6 +274,18 @@ Each tranche is independently shippable behind the existing
 `FormulaPlaneMode::AuthoritativeExperimental` gate, lands with the §6 gates, and is
 sequenced so the open boundary bugs are *eliminated by construction* rather than patched.
 
+Before the main T1 migration, a bounded correctness bridge removes the unsafe capacity-bail
+side exit without waiting for topology unification:
+
+- **T1.0a — Transactional span demotion.** Prepare, validate, and commit exact-ref,
+  multi-sheet span demotion as one additions-only graph/authority transaction; cyclic span
+  demotion uses the same batch so a later failure cannot publish an earlier subset.
+- **T1.0b — Capacity-bail parity.** Unsafe non-cycle schedules transactionally demote
+  exactly their scheduled spans before one legacy completion pass. Pending changed regions
+  are generation-leased until successful completion, and a finite fallback-cell cap fails
+  closed without partial graph, authority, overlay, telemetry, or dirty-state publication.
+  This directly closes #144 while T1 removes the dual-authority boundary that produced it.
+
 1. **T1 — Single dirty authority.** Move region dirtiness into the graph: `mark_dirty`
    probes the region index natively; `pending_changed_regions` and the FP-side dirty
    seeding retire; replace `WholeAll` epoch escalation with translated interval


### PR DESCRIPTION
## Summary

- route unsafe non-cycle mixed schedules through exact-ref transactional demotion of every scheduled span
- retain clean, unscheduled spans and their overlays
- replace destructive pending-region consumption with generation-scoped prefix leases acknowledged only after successful completion
- add a finite 2,000,000-cell FormulaPlane fallback materialization limit with retry-safe failure
- count capacity bailouts only after committed demotion and successful legacy completion
- replace the #144 known-gap fixture with full Off/authoritative parity on first evaluation, warm recalculation, and post-edit recalculation
- document the reviewed T1.0a/T1.0b correctness bridge

## Stack

This PR is intentionally based on #184 (`feat/transactional-span-demotion`). It contains only T1.0b changes and will be retargeted to `main` after #184 merges.

Closes #144.

## Validation

- capacity fallback suite: 6 passed
- cyclic demotion suite: 9 passed
- fragmented transaction suite: 21 passed
- structural W0 oracle suite: 14 passed
- evaluator default library suite: 2,206 passed, 12 ignored
- evaluator all-feature library suite: 2,207 passed, 12 ignored
- evaluator integration parity test passed
- strict all-target/all-feature Clippy passed
- wasm32 all-feature evaluator check passed
- Rust formatting and diff checks passed
- independent blocker/high review: PASS after fixing generation-scoped pending-region lease semantics
