### PR TITLE
perf(eval): cache mixed FormulaPlane topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Performance
 
+- Experimental authoritative FormulaPlane evaluation now caches compiled mixed producer topology across warm and value-only evaluations. Exact graph, authority, and semantic revisions invalidate the cache on dependency mutations; bounded candidate, edge, and memory limits fail closed through transactional span demotion, while span-free workbooks retain the legacy sparse floor with zero mixed-cache builds.
 - Proven complete source-formula families now parse and analyze one anchor and avoid per-descendant strings, ASTs, staging entries, and graph vertices. In same-machine release probes, a clean 100k-family load improved from 997 ms and 313 MiB RSS under forced replay to 129 ms and 26 MiB RSS; a 1M-family load completed in 2.2 s at 167 MiB RSS instead of 13.1 s at 3.0 GiB.
 
 ## [0.7.1] - 2026-07-02

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -40,7 +40,8 @@ use crate::formula_plane::runtime::{
     FormulaPlane, FormulaSpanId, FormulaSpanRef, PlacementCoord, PlacementDomain, ResultRegion,
 };
 use crate::formula_plane::scheduler::{
-    MixedSchedule, MixedScheduleFallbackReason, build_mixed_schedule,
+    MixedSchedule, MixedScheduleFallbackReason, MixedTopology, MixedTopologyConfig,
+    compile_mixed_topology, schedule_dirty_work,
 };
 #[cfg(test)]
 use crate::formula_plane::span_eval::SpanEvalReport;
@@ -677,6 +678,10 @@ pub struct Engine<R> {
     snapshot_id: std::sync::atomic::AtomicU64,
     topology_epoch: u64,
     cached_static_schedule: Option<CachedScheduleEntry>,
+    cached_mixed_topology: Option<CachedMixedTopology>,
+    mixed_topology_cache_builds: u64,
+    mixed_topology_cache_hits: u64,
+    mixed_topology_cache_overflows: u64,
     spill_mgr: ShimSpillManager,
     /// Arrow-backed storage for sheet values (Phase A)
     arrow_sheets: SheetStore,
@@ -1315,6 +1320,9 @@ pub struct EngineBaselineStats {
     pub formula_plane_active_span_count: usize,
     pub formula_plane_producer_result_entries: usize,
     pub formula_plane_consumer_read_entries: usize,
+    pub formula_plane_mixed_topology_cache_builds: u64,
+    pub formula_plane_mixed_topology_cache_hits: u64,
+    pub formula_plane_mixed_topology_cache_overflows: u64,
     /// Number of spans demoted to legacy because a member participated in a
     /// statically-cyclic SCC (gotcha G8, refs #112).
     pub formula_plane_cycle_member_span_demotions: u64,
@@ -1399,6 +1407,39 @@ struct CachedScheduleEntry {
     topology_epoch: u64,
     candidate_vertices: Vec<VertexId>,
     schedule: crate::engine::scheduler::Schedule,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MixedTopologyCacheKey {
+    engine_topology_epoch: u64,
+    graph_topology_revision: u64,
+    authority_indexes_epoch: u64,
+    function_semantic_epoch: u64,
+    function_provider_revision: Option<u64>,
+    max_candidates: usize,
+    max_edges: usize,
+    max_memory_bytes: usize,
+}
+
+#[derive(Debug)]
+struct CachedMixedTopology {
+    key: MixedTopologyCacheKey,
+    topology: MixedTopology,
+    producer_results: FormulaProducerResultIndex,
+    consumer_reads: FormulaConsumerReadIndex,
+    span_refs_by_id: BTreeMap<FormulaSpanId, FormulaSpanRef>,
+    plane_epoch: u64,
+}
+
+fn estimated_span_bindings_bytes(
+    bindings: &BTreeMap<FormulaSpanId, FormulaSpanRef>,
+) -> Option<usize> {
+    const TREE_ENTRY_OVERHEAD: usize = 4 * std::mem::size_of::<usize>();
+    bindings.len().checked_mul(
+        std::mem::size_of::<FormulaSpanId>()
+            .checked_add(std::mem::size_of::<FormulaSpanRef>())?
+            .checked_add(TREE_ENTRY_OVERHEAD)?,
+    )
 }
 
 type ScheduleBuildOutput = (
@@ -1764,6 +1805,10 @@ where
             snapshot_id: std::sync::atomic::AtomicU64::new(1),
             topology_epoch: 0,
             cached_static_schedule: None,
+            cached_mixed_topology: None,
+            mixed_topology_cache_builds: 0,
+            mixed_topology_cache_hits: 0,
+            mixed_topology_cache_overflows: 0,
             spill_mgr: ShimSpillManager::default(),
             arrow_sheets: SheetStore::default(),
             has_edited: false,
@@ -1858,6 +1903,10 @@ where
             snapshot_id: std::sync::atomic::AtomicU64::new(1),
             topology_epoch: 0,
             cached_static_schedule: None,
+            cached_mixed_topology: None,
+            mixed_topology_cache_builds: 0,
+            mixed_topology_cache_hits: 0,
+            mixed_topology_cache_overflows: 0,
             spill_mgr: ShimSpillManager::default(),
             arrow_sheets: SheetStore::default(),
             has_edited: false,
@@ -2681,6 +2730,9 @@ where
             formula_plane_active_span_count: formula_authority.active_span_count(),
             formula_plane_producer_result_entries: formula_authority.producer_results.len(),
             formula_plane_consumer_read_entries: formula_authority.consumer_reads.len(),
+            formula_plane_mixed_topology_cache_builds: self.mixed_topology_cache_builds,
+            formula_plane_mixed_topology_cache_hits: self.mixed_topology_cache_hits,
+            formula_plane_mixed_topology_cache_overflows: self.mixed_topology_cache_overflows,
             formula_plane_cycle_member_span_demotions: self
                 .formula_plane_cycle_member_span_demotions,
         }
@@ -3286,7 +3338,9 @@ where
         self.snapshot_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.topology_epoch = self.topology_epoch.wrapping_add(1);
+        self.graph.bump_topology_revision();
         self.clear_cached_static_schedule();
+        self.cached_mixed_topology = None;
         self.has_edited = true;
     }
 
@@ -3461,6 +3515,16 @@ where
     #[cfg(test)]
     pub(crate) fn topology_epoch_for_test(&self) -> u64 {
         self.topology_epoch
+    }
+
+    #[cfg(test)]
+    pub(crate) fn graph_topology_revision_for_test(&self) -> u64 {
+        self.graph.topology_revision()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mixed_topology_cache_present_for_test(&self) -> bool {
+        self.cached_mixed_topology.is_some()
     }
 
     fn record_formula_ingest_report(&mut self, report: FormulaIngestReport) {
@@ -6347,7 +6411,19 @@ where
         &mut self,
         batches: Vec<FormulaIngestBatch>,
     ) -> Result<FormulaIngestReport, ExcelError> {
-        self.ingest_formula_batches_inner(batches, [0; 10], None, Vec::new(), Vec::new(), true)
+        let has_formulas = batches.iter().any(|batch| !batch.formulas.is_empty());
+        let report = self.ingest_formula_batches_inner(
+            batches,
+            [0; 10],
+            None,
+            Vec::new(),
+            Vec::new(),
+            true,
+        )?;
+        if has_formulas {
+            self.mark_topology_edited();
+        }
+        Ok(report)
     }
 
     fn ingest_formula_batches_unpublished(
@@ -12900,25 +12976,39 @@ where
         })
     }
 
-    fn build_formula_plane_mixed_schedule(
+    fn mixed_topology_cache_key(&self) -> MixedTopologyCacheKey {
+        MixedTopologyCacheKey {
+            engine_topology_epoch: self.topology_epoch,
+            graph_topology_revision: self.graph.topology_revision(),
+            authority_indexes_epoch: self.graph.formula_authority().indexes_epoch(),
+            function_semantic_epoch: self.function_semantic_epoch_seen,
+            function_provider_revision: self.function_provider_revision_seen,
+            max_candidates: self.config.max_formula_plane_cache_candidates,
+            max_edges: self.config.max_formula_plane_cache_edges,
+            max_memory_bytes: self.config.max_formula_plane_cache_bytes,
+        }
+    }
+
+    fn compile_formula_plane_mixed_topology(
         &self,
-        span_seed_mode: SpanSeedMode,
-        pending_changed_regions: &[Region],
-    ) -> Result<FormulaPlaneMixedScheduleBuild, ExcelError> {
+        key: MixedTopologyCacheKey,
+    ) -> Result<CachedMixedTopology, ExcelError> {
         let authority = self.graph.formula_authority();
         let mut producer_results = FormulaProducerResultIndex::default();
         let mut consumer_reads = FormulaConsumerReadIndex::default();
-        let mut work = Vec::new();
-
-        // Legacy formula producers participate in the mixed runtime only when
-        // they are dirty under graph semantics. Result/read indexes still cover
-        // every legacy formula so that span->legacy and legacy->span ordering is
-        // visible to the scheduler regardless of dirty status, but only dirty
-        // vertices receive scheduled work.
-        let dirty_legacy: rustc_hash::FxHashSet<VertexId> =
-            self.graph.get_evaluation_vertices().into_iter().collect();
-
         let span_refs = authority.active_span_refs();
+        let legacy_vertices = self.graph.formula_vertices();
+        let producer_count = span_refs
+            .len()
+            .checked_add(legacy_vertices.len())
+            .ok_or_else(|| {
+                ExcelError::new(ExcelErrorKind::NImpl)
+                    .with_message("FormulaPlane cache producer count overflow")
+            })?;
+        producer_results.try_reserve(producer_count).map_err(|_| {
+            ExcelError::new(ExcelErrorKind::NImpl)
+                .with_message("FormulaPlane cache producer index reservation failed")
+        })?;
         let span_refs_by_id = span_refs
             .iter()
             .copied()
@@ -12945,6 +13035,10 @@ where
                     .with_message("FormulaPlane active span read summary is stale"));
             }
             for dependency in &read_summary.dependencies {
+                consumer_reads.try_reserve(1).map_err(|_| {
+                    ExcelError::new(ExcelErrorKind::NImpl)
+                        .with_message("FormulaPlane cache read-index reservation failed")
+                })?;
                 consumer_reads.insert_read(
                     FormulaProducerId::Span(span.id),
                     dependency.read_region,
@@ -12952,31 +13046,17 @@ where
                     dependency.projection,
                 );
             }
-            if matches!(span_seed_mode, SpanSeedMode::WholeAll) {
-                work.push(FormulaProducerWork {
-                    producer: FormulaProducerId::Span(span.id),
-                    dirty: ProducerDirtyDomain::Whole,
-                });
-            }
         }
 
-        let legacy_vertices = self.graph.formula_vertices();
-        let mut scheduled_legacy_vertices = Vec::new();
         for vertex in &legacy_vertices {
             let Some(cell) = self.graph.get_cell_ref_for_vertex(*vertex) else {
                 continue;
             };
-            let result_region = Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col());
-            producer_results.insert_producer(FormulaProducerId::Legacy(*vertex), result_region);
-            if dirty_legacy.contains(vertex) {
-                scheduled_legacy_vertices.push(*vertex);
-                work.push(FormulaProducerWork {
-                    producer: FormulaProducerId::Legacy(*vertex),
-                    dirty: ProducerDirtyDomain::Whole,
-                });
-            }
+            producer_results.insert_producer(
+                FormulaProducerId::Legacy(*vertex),
+                Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col()),
+            );
         }
-
         for vertex in &legacy_vertices {
             let Some(cell) = self.graph.get_cell_ref_for_vertex(*vertex) else {
                 continue;
@@ -12993,6 +13073,10 @@ where
                     dep_cell.coord.col(),
                 );
                 if seen.insert(read_region) {
+                    consumer_reads.try_reserve(1).map_err(|_| {
+                        ExcelError::new(ExcelErrorKind::NImpl)
+                            .with_message("FormulaPlane cache read-index reservation failed")
+                    })?;
                     consumer_reads.insert_read(
                         FormulaProducerId::Legacy(*vertex),
                         read_region,
@@ -13007,6 +13091,10 @@ where
                         continue;
                     };
                     if seen.insert(read_region) {
+                        consumer_reads.try_reserve(1).map_err(|_| {
+                            ExcelError::new(ExcelErrorKind::NImpl)
+                                .with_message("FormulaPlane cache read-index reservation failed")
+                        })?;
                         consumer_reads.insert_read(
                             FormulaProducerId::Legacy(*vertex),
                             read_region,
@@ -13018,35 +13106,120 @@ where
             }
         }
 
-        // When span seed mode is DirtyClosure, derive bounded span work from
-        // captured changed regions via the consumer-read index. This avoids
-        // recomputing every active span on edits that only touch a small
-        // number of cells.
+        let retained_memory_bytes = std::mem::size_of::<CachedMixedTopology>()
+            .checked_add(
+                producer_results
+                    .estimated_memory_bytes()
+                    .unwrap_or(usize::MAX),
+            )
+            .and_then(|bytes| {
+                bytes.checked_add(
+                    consumer_reads
+                        .estimated_memory_bytes()
+                        .unwrap_or(usize::MAX),
+                )
+            })
+            .and_then(|bytes| bytes.checked_add(estimated_span_bindings_bytes(&span_refs_by_id)?))
+            .unwrap_or(usize::MAX);
+        let config = MixedTopologyConfig {
+            max_candidates: self.config.max_formula_plane_cache_candidates,
+            max_edges: self.config.max_formula_plane_cache_edges,
+            max_memory_bytes: self.config.max_formula_plane_cache_bytes,
+            retained_memory_bytes,
+        };
+        let topology = compile_mixed_topology(&producer_results, &consumer_reads, &config);
+        Ok(CachedMixedTopology {
+            key,
+            topology,
+            producer_results,
+            consumer_reads,
+            span_refs_by_id,
+            plane_epoch: authority.plane.epoch().0,
+        })
+    }
+
+    fn build_formula_plane_mixed_schedule(
+        &mut self,
+        span_seed_mode: SpanSeedMode,
+        pending_changed_regions: &[Region],
+    ) -> Result<FormulaPlaneMixedScheduleBuild, ExcelError> {
+        let key = self.mixed_topology_cache_key();
+        let active_refs = self
+            .graph
+            .formula_authority()
+            .active_span_refs()
+            .into_iter()
+            .map(|span_ref| (span_ref.id, span_ref))
+            .collect::<BTreeMap<_, _>>();
+        let cache_hit = self
+            .cached_mixed_topology
+            .as_ref()
+            .is_some_and(|cached| cached.key == key && cached.span_refs_by_id == active_refs);
+        let mut uncached_topology = None;
+        if cache_hit {
+            self.mixed_topology_cache_hits = self.mixed_topology_cache_hits.saturating_add(1);
+        } else {
+            let compiled = self.compile_formula_plane_mixed_topology(key)?;
+            self.mixed_topology_cache_builds = self.mixed_topology_cache_builds.saturating_add(1);
+            if compiled.topology.is_complete() {
+                self.cached_mixed_topology = Some(compiled);
+            } else {
+                self.mixed_topology_cache_overflows =
+                    self.mixed_topology_cache_overflows.saturating_add(1);
+                uncached_topology = Some(compiled);
+            }
+        }
+
+        let cached = uncached_topology
+            .as_ref()
+            .or(self.cached_mixed_topology.as_ref())
+            .expect("mixed topology available for request");
+        let dirty_legacy = self.graph.get_evaluation_vertices();
+        let mut work = Vec::new();
+        let mut scheduled_legacy_vertices = Vec::new();
+        if matches!(span_seed_mode, SpanSeedMode::WholeAll) {
+            for span_id in cached.span_refs_by_id.keys().copied() {
+                work.push(FormulaProducerWork {
+                    producer: FormulaProducerId::Span(span_id),
+                    dirty: ProducerDirtyDomain::Whole,
+                });
+            }
+        }
+        for vertex in dirty_legacy {
+            let producer = FormulaProducerId::Legacy(vertex);
+            if cached
+                .producer_results
+                .producer_result_region(producer)
+                .is_some()
+            {
+                scheduled_legacy_vertices.push(vertex);
+                work.push(FormulaProducerWork {
+                    producer,
+                    dirty: ProducerDirtyDomain::Whole,
+                });
+            }
+        }
+
         if matches!(span_seed_mode, SpanSeedMode::DirtyClosure)
             && !pending_changed_regions.is_empty()
         {
             use crate::formula_plane::producer::compute_dirty_closure;
-            let producer_results_ref = &producer_results;
             let closure = compute_dirty_closure(
-                &consumer_reads,
+                &cached.consumer_reads,
                 pending_changed_regions.iter().copied(),
-                |producer| producer_results_ref.producer_result_region(producer),
+                |producer| cached.producer_results.producer_result_region(producer),
             );
-            for fallback_work in closure.work {
-                work.push(fallback_work);
-            }
-            // Any unsupported/conservative fallbacks for spans imply we may have
-            // missed work; in that case demote to whole-span for affected spans.
+            work.extend(closure.work);
             if !closure.fallbacks.is_empty() {
-                let mut already_whole: rustc_hash::FxHashSet<_> = work
+                let mut already_whole = work
                     .iter()
-                    .filter_map(|w| match (w.producer, &w.dirty) {
+                    .filter_map(|item| match (item.producer, &item.dirty) {
                         (FormulaProducerId::Span(id), ProducerDirtyDomain::Whole) => Some(id),
                         _ => None,
                     })
-                    .collect();
-                for fb in &closure.fallbacks {
-                    if let FormulaProducerId::Span(id) = fb.consumer
+                    .collect::<rustc_hash::FxHashSet<_>>();
+                for fallback in closure.fallbacks {
+                    if let FormulaProducerId::Span(id) = fallback.consumer
                         && already_whole.insert(id)
                     {
                         work.push(FormulaProducerWork {
@@ -13058,11 +13231,11 @@ where
             }
         }
 
-        let schedule = build_mixed_schedule(work, &producer_results, &consumer_reads);
+        let schedule = schedule_dirty_work(work, &cached.producer_results, &cached.topology, 256);
         Ok((
             schedule,
-            span_refs_by_id,
-            authority.plane.epoch().0,
+            cached.span_refs_by_id.clone(),
+            cached.plane_epoch,
             scheduled_legacy_vertices,
         ))
     }

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -284,6 +284,8 @@ pub struct DependencyGraph {
 
     // Evaluation configuration
     config: super::EvalConfig,
+    /// Low-level monotonic dependency-topology revision used by engine caches.
+    topology_revision: u64,
 
     // Graph-owned FormulaPlane authority shell. Inert until a later runtime cut-over.
     formula_authority: FormulaAuthority,
@@ -1116,6 +1118,7 @@ impl DependencyGraph {
             cell_to_name_dependents: FxHashMap::default(),
             name_to_cell_dependencies: FxHashMap::default(),
             config: config.clone(),
+            topology_revision: 0,
             formula_authority: FormulaAuthority::default(),
             pk_order: None,
             spill_anchor_to_cells: FxHashMap::default(),
@@ -1379,6 +1382,14 @@ impl DependencyGraph {
 
     pub(crate) fn vertex_len(&self) -> usize {
         self.store.len()
+    }
+
+    pub(crate) fn topology_revision(&self) -> u64 {
+        self.topology_revision
+    }
+
+    pub(crate) fn bump_topology_revision(&mut self) {
+        self.topology_revision = self.topology_revision.wrapping_add(1);
     }
 
     /// Get mutable access to a sheet's index, creating it if it doesn't exist

--- a/crates/formualizer-eval/src/engine/interval_tree.rs
+++ b/crates/formualizer-eval/src/engine/interval_tree.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
+use std::ops::ControlFlow;
 
 /// Custom interval tree optimized for spreadsheet cell indexing.
 ///
@@ -90,6 +91,51 @@ impl<T: Clone + Eq + std::hash::Hash> IntervalTree<T> {
             }
         }
         results
+    }
+
+    /// Visits matching values without cloning or materializing the query.
+    /// Returning `Break` from the visitor stops traversal immediately.
+    pub(crate) fn visit_query(
+        &self,
+        q_low: u32,
+        q_high: u32,
+        mut visitor: impl FnMut(Option<&T>) -> ControlFlow<()>,
+    ) -> ControlFlow<()> {
+        for (_low, nodes) in self.map.range(..=q_high) {
+            for node in nodes {
+                visitor(None)?;
+                if node.high < q_low {
+                    continue;
+                }
+                for value in &node.values {
+                    visitor(Some(value))?;
+                }
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
+    pub(crate) fn estimated_heap_bytes(&self) -> Option<usize> {
+        const NODE_ALLOCATION_OVERHEAD: usize = 3 * std::mem::size_of::<usize>();
+        let mut bytes = 0usize;
+        for nodes in self.map.values() {
+            bytes = bytes.checked_add(
+                std::mem::size_of::<u32>()
+                    .checked_add(std::mem::size_of::<Vec<IntervalNode<T>>>())?
+                    .checked_add(NODE_ALLOCATION_OVERHEAD)?,
+            )?;
+            bytes = bytes.checked_add(
+                nodes
+                    .capacity()
+                    .checked_mul(std::mem::size_of::<IntervalNode<T>>())?,
+            )?;
+            for node in nodes {
+                bytes = bytes.checked_add(node.values.capacity().checked_mul(
+                    std::mem::size_of::<T>().checked_add(std::mem::size_of::<usize>())?,
+                )?)?;
+            }
+        }
+        Some(bytes)
     }
 
     pub fn remove(&mut self, low: u32, high: u32, value: &T) -> bool {

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -789,6 +789,12 @@ pub struct EvalConfig {
     /// `Shadow` may report candidate span opportunities but must still materialize
     /// every formula via the legacy graph path.
     pub formula_plane_mode: FormulaPlaneMode,
+    /// Hard candidate bound for compiling mixed FormulaPlane topology.
+    pub max_formula_plane_cache_candidates: usize,
+    /// Hard relationship bound for compiled mixed FormulaPlane topology.
+    pub max_formula_plane_cache_edges: usize,
+    /// Hard byte estimate bound for compiled mixed FormulaPlane topology.
+    pub max_formula_plane_cache_bytes: usize,
 
     /// Maximum bytes for the engine-side lookup-index cache.
     pub lookup_index_cache_max_bytes: usize,
@@ -846,6 +852,9 @@ impl Default for EvalConfig {
             defer_graph_building: false,
             enable_virtual_dep_telemetry: false,
             formula_plane_mode: FormulaPlaneMode::Off,
+            max_formula_plane_cache_candidates: 100_000,
+            max_formula_plane_cache_edges: 100_000,
+            max_formula_plane_cache_bytes: 64 * 1024 * 1024,
             lookup_index_cache_max_bytes: 64 * 1024 * 1024,
         }
     }

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -168,7 +168,7 @@ fn assert_full_capacity_corpus_parity(
 }
 
 #[test]
-fn capacity_fallback_matches_off_first_warm_and_post_edit() {
+fn cached_mixed_topology_matches_off_first_warm_and_post_edit() {
     let build = |mode| build_mixed_engine(mode, |row| format!("=SUM($A{row}:$B${ROWS})"));
     let mut off = build(FormulaPlaneMode::Off);
     let mut authoritative = build(FormulaPlaneMode::AuthoritativeExperimental);
@@ -184,22 +184,22 @@ fn capacity_fallback_matches_off_first_warm_and_post_edit() {
 
     off.evaluate_all().unwrap();
     authoritative.evaluate_all().unwrap();
-    assert_eq!(authoritative.formula_plane_capacity_bailouts(), 1);
-    assert_eq!(
-        authoritative
-            .baseline_stats()
-            .formula_plane_active_span_count,
-        0,
-        "first-eval WholeAll must select and demote every scheduled span"
-    );
+    assert_eq!(authoritative.formula_plane_capacity_bailouts(), 0);
+    let first_stats = authoritative.baseline_stats();
+    assert_eq!(first_stats.formula_plane_active_span_count, 1);
+    assert_eq!(first_stats.formula_plane_mixed_topology_cache_builds, 1);
+    assert_eq!(first_stats.formula_plane_mixed_topology_cache_hits, 0);
     assert_full_capacity_corpus_parity(&off, &authoritative);
 
     off.evaluate_all().unwrap();
     authoritative.evaluate_all().unwrap();
+    assert_eq!(authoritative.formula_plane_capacity_bailouts(), 0);
     assert_eq!(
-        authoritative.formula_plane_capacity_bailouts(),
+        authoritative
+            .baseline_stats()
+            .formula_plane_mixed_topology_cache_builds,
         1,
-        "successful fallback telemetry increments once, not on warm legacy recalc"
+        "warm recalculation must not rebuild mixed topology"
     );
     assert_full_capacity_corpus_parity(&off, &authoritative);
 
@@ -209,7 +209,10 @@ fn capacity_fallback_matches_off_first_warm_and_post_edit() {
             .unwrap();
         engine.evaluate_all().unwrap();
     }
-    assert_eq!(authoritative.formula_plane_capacity_bailouts(), 1);
+    assert_eq!(authoritative.formula_plane_capacity_bailouts(), 0);
+    let edited_stats = authoritative.baseline_stats();
+    assert_eq!(edited_stats.formula_plane_mixed_topology_cache_builds, 1);
+    assert_eq!(edited_stats.formula_plane_mixed_topology_cache_hits, 1);
     assert_full_capacity_corpus_parity(&off, &authoritative);
 }
 
@@ -313,6 +316,7 @@ fn fallback_cap_failure_retains_exact_state_and_pending_lease_for_retry() {
     let mut engine = build_mixed_engine(FormulaPlaneMode::AuthoritativeExperimental, |row| {
         format!("=SUM($A{row}:$B${ROWS})")
     });
+    engine.config.max_formula_plane_cache_candidates = 0;
     add_capacity_source_overlay(&mut engine);
     let mut limits = engine.workbook_load_limits().clone();
     limits.max_formula_plane_fallback_cells = u64::from(ROWS - 1);
@@ -394,6 +398,7 @@ fn capacity_faults_retain_pending_lease_and_count_only_successful_retry() {
         let mut engine = build_mixed_engine(FormulaPlaneMode::AuthoritativeExperimental, |row| {
             format!("=SUM($A{row}:$B${ROWS})")
         });
+        engine.config.max_formula_plane_cache_candidates = 0;
         add_capacity_source_overlay(&mut engine);
         let refs = engine.graph.formula_authority().active_span_refs();
         let pending = engine
@@ -489,6 +494,7 @@ fn capacity_fallback_demotes_only_scheduled_dirty_span() {
     engine.evaluate_all().expect("initial span-only evaluation");
     assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
     assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    engine.config.max_formula_plane_cache_candidates = 0;
 
     let topology_epoch = engine.topology_epoch_for_test();
     engine
@@ -543,4 +549,191 @@ fn clean_spans_remain_authoritative_when_only_legacy_work_is_dirty() {
             .pending_changed_regions()
             .is_empty()
     );
+}
+
+fn cached_topology_engine() -> Engine<TestWorkbook> {
+    build_mixed_engine(FormulaPlaneMode::AuthoritativeExperimental, |row| {
+        format!("=SUM($A{row}:$A${ROWS})")
+    })
+}
+
+fn assert_mutation_invalidates_cache_once(
+    label: &str,
+    mut engine: Engine<TestWorkbook>,
+    mutate: impl FnOnce(&mut Engine<TestWorkbook>),
+) {
+    engine.evaluate_all().unwrap();
+    let before = engine.baseline_stats();
+    let revision = engine.graph_topology_revision_for_test();
+    assert!(engine.mixed_topology_cache_present_for_test());
+
+    mutate(&mut engine);
+
+    assert_eq!(
+        engine.graph_topology_revision_for_test(),
+        revision + 1,
+        "{label} must bump graph topology revision once",
+    );
+    assert!(!engine.mixed_topology_cache_present_for_test());
+    engine
+        .set_cell_value(SHEET, 1, 1, LiteralValue::Number(10_001.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine
+            .baseline_stats()
+            .formula_plane_mixed_topology_cache_builds,
+        before.formula_plane_mixed_topology_cache_builds + 1
+    );
+}
+
+#[test]
+fn mixed_topology_cache_mutation_class_invalidation_audit() {
+    use crate::engine::named_range::{NameScope, NamedDefinition};
+    use crate::reference::{CellRef, Coord, RangeRef};
+
+    assert_mutation_invalidates_cache_once("formula", cached_topology_engine(), |engine| {
+        engine
+            .set_cell_formula(SHEET, ROWS + 10, 10, parse("=1+1").unwrap())
+            .unwrap();
+    });
+    assert_mutation_invalidates_cache_once("sheet", cached_topology_engine(), |engine| {
+        engine.add_sheet("Added").unwrap();
+    });
+    assert_mutation_invalidates_cache_once("structural", cached_topology_engine(), |engine| {
+        engine.insert_rows(SHEET, ROWS + 10, 1).unwrap();
+    });
+    assert_mutation_invalidates_cache_once("name", cached_topology_engine(), |engine| {
+        engine
+            .define_name(
+                "CacheAuditName",
+                NamedDefinition::Literal(LiteralValue::Number(1.0)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+    });
+    assert_mutation_invalidates_cache_once("table", cached_topology_engine(), |engine| {
+        let sheet_id = engine.graph.sheet_id(SHEET).unwrap();
+        let range = RangeRef::new(
+            CellRef::new(sheet_id, Coord::from_excel(1, 1, true, true)),
+            CellRef::new(sheet_id, Coord::from_excel(2, 1, true, true)),
+        );
+        engine
+            .define_table("CacheAuditTable", range, true, vec!["Value".into()], false)
+            .unwrap();
+    });
+    assert_mutation_invalidates_cache_once("span", cached_topology_engine(), |engine| {
+        let formulas = (1..=120)
+            .map(|row| record(engine, row, 5, &format!("=A{row}*3")))
+            .collect();
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+            .unwrap();
+    });
+}
+
+#[test]
+fn mixed_topology_cache_rejects_stale_span_ref_even_without_epoch_change() {
+    let mut engine = cached_topology_engine();
+    engine.evaluate_all().unwrap();
+    let before = engine.baseline_stats();
+    let span_ref = engine.graph.formula_authority().active_span_refs()[0];
+    engine
+        .graph
+        .formula_authority_mut()
+        .plane
+        .spans
+        .get_mut_for_test(span_ref)
+        .unwrap()
+        .version = span_ref.version.wrapping_add(1);
+    engine
+        .set_cell_value(SHEET, 1, 1, LiteralValue::Number(11.0))
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine
+            .baseline_stats()
+            .formula_plane_mixed_topology_cache_builds,
+        before.formula_plane_mixed_topology_cache_builds + 1
+    );
+}
+
+#[test]
+fn span_free_authoritative_workbook_never_builds_mixed_topology_cache() {
+    let config =
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    engine
+        .set_cell_formula(SHEET, 1, 1, parse("=1+1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+        .set_cell_value(SHEET, 2, 1, LiteralValue::Number(3.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    let stats = engine.baseline_stats();
+    assert_eq!(stats.formula_plane_active_span_count, 0);
+    assert_eq!(stats.formula_plane_mixed_topology_cache_builds, 0);
+    assert_eq!(stats.formula_plane_mixed_topology_cache_hits, 0);
+}
+
+#[test]
+fn prepared_demotion_failure_keeps_revision_and_cache_success_invalidates_once() {
+    use crate::engine::eval::FormulaSpanDemotionFault;
+
+    let mut failed = cached_topology_engine();
+    failed.evaluate_all().unwrap();
+    let refs = failed.graph.formula_authority().active_span_refs();
+    let revision = failed.graph_topology_revision_for_test();
+    let stats = failed.baseline_stats();
+    failed.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
+    let prepared = failed.prepare_formula_span_demotion(&refs).unwrap();
+    assert!(
+        failed
+            .commit_prepared_formula_span_demotion(prepared)
+            .is_err()
+    );
+    assert_eq!(failed.graph_topology_revision_for_test(), revision);
+    assert!(failed.mixed_topology_cache_present_for_test());
+    assert_eq!(
+        failed
+            .baseline_stats()
+            .formula_plane_mixed_topology_cache_builds,
+        stats.formula_plane_mixed_topology_cache_builds
+    );
+
+    let mut committed = cached_topology_engine();
+    committed.evaluate_all().unwrap();
+    let refs = committed.graph.formula_authority().active_span_refs();
+    let revision = committed.graph_topology_revision_for_test();
+    let prepared = committed.prepare_formula_span_demotion(&refs).unwrap();
+    committed
+        .commit_prepared_formula_span_demotion(prepared)
+        .unwrap();
+    assert_eq!(committed.graph_topology_revision_for_test(), revision + 1);
+    assert!(!committed.mixed_topology_cache_present_for_test());
+}
+
+#[test]
+fn cache_edge_and_memory_caps_route_fail_closed_through_demotion() {
+    for limit_kind in ["edges", "memory"] {
+        let mut engine = build_mixed_engine(FormulaPlaneMode::AuthoritativeExperimental, |row| {
+            format!("=SUM($A{row}:$B${ROWS})")
+        });
+        match limit_kind {
+            "edges" => engine.config.max_formula_plane_cache_edges = 0,
+            "memory" => engine.config.max_formula_plane_cache_bytes = 0,
+            _ => unreachable!(),
+        }
+        engine.evaluate_all().unwrap();
+        let stats = engine.baseline_stats();
+        assert_eq!(stats.formula_plane_mixed_topology_cache_builds, 1);
+        assert_eq!(stats.formula_plane_mixed_topology_cache_overflows, 1);
+        assert_eq!(stats.formula_plane_mixed_topology_cache_hits, 0);
+        assert!(!engine.mixed_topology_cache_present_for_test());
+        assert_eq!(engine.formula_plane_capacity_bailouts(), 1);
+        assert_eq!(stats.formula_plane_active_span_count, 0);
+    }
 }

--- a/crates/formualizer-eval/src/formula_plane/producer.rs
+++ b/crates/formualizer-eval/src/formula_plane/producer.rs
@@ -5,7 +5,7 @@
 //! dirty projections. It does not wire FormulaPlane into graph dirty routing,
 //! scheduling, ingest cut-over, or evaluation.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, TryReserveError, VecDeque};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -15,7 +15,8 @@ use crate::engine::sheet_registry::SheetRegistry;
 
 use super::dependency_summary::{FormulaClass, FormulaDependencySummary, PrecedentPattern};
 use super::region_index::{
-    AxisRange, Region, RegionKey, RegionMatch, RegionQueryResult, SheetRegionIndex,
+    AxisRange, BoundedRegionQueryResult, Region, RegionKey, RegionMatch, RegionQueryResult,
+    SheetRegionIndex,
 };
 use super::runtime::{FormulaSpanId, ResultRegion};
 use super::template_canonical::{AxisRef, SheetBinding};
@@ -129,6 +130,30 @@ pub(crate) struct FormulaProducerResultIndex {
 }
 
 impl FormulaProducerResultIndex {
+    pub(crate) fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.entries.try_reserve(additional)?;
+        self.by_producer.try_reserve(additional)?;
+        self.index.try_reserve_entries(additional)
+    }
+
+    pub(crate) fn estimated_memory_bytes(&self) -> Option<usize> {
+        let mut bytes = std::mem::size_of::<Self>();
+        bytes = bytes.checked_add(
+            self.entries
+                .capacity()
+                .checked_mul(std::mem::size_of::<FormulaProducerResultEntry>())?,
+        )?;
+        bytes = bytes.checked_add(
+            self.by_producer.capacity().checked_mul(
+                std::mem::size_of::<FormulaProducerId>()
+                    .checked_add(std::mem::size_of::<Region>())?
+                    .checked_add(std::mem::size_of::<usize>())?,
+            )?,
+        )?;
+        bytes = bytes.checked_add(self.index.estimated_heap_bytes()?)?;
+        Some(bytes)
+    }
+
     pub(crate) fn insert_producer(
         &mut self,
         producer: FormulaProducerId,
@@ -165,6 +190,10 @@ impl FormulaProducerResultIndex {
 
     pub(crate) fn producer_result_region(&self, producer: FormulaProducerId) -> Option<Region> {
         self.by_producer.get(&producer).copied()
+    }
+
+    pub(crate) fn producers(&self) -> impl Iterator<Item = FormulaProducerId> + '_ {
+        self.entries.iter().map(|entry| entry.producer)
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -208,6 +237,22 @@ pub(crate) struct FormulaConsumerReadIndex {
 }
 
 impl FormulaConsumerReadIndex {
+    pub(crate) fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.entries.try_reserve(additional)?;
+        self.index.try_reserve_entries(additional)
+    }
+
+    pub(crate) fn estimated_memory_bytes(&self) -> Option<usize> {
+        let mut bytes = std::mem::size_of::<Self>();
+        bytes = bytes.checked_add(
+            self.entries
+                .capacity()
+                .checked_mul(std::mem::size_of::<FormulaConsumerReadEntry>())?,
+        )?;
+        bytes = bytes.checked_add(self.index.estimated_heap_bytes()?)?;
+        Some(bytes)
+    }
+
     pub(crate) fn insert_read(
         &mut self,
         consumer: FormulaProducerId,
@@ -263,6 +308,47 @@ impl FormulaConsumerReadIndex {
                 })
                 .collect(),
             stats: result.stats,
+        }
+    }
+
+    pub(crate) fn query_changed_region_bounded(
+        &self,
+        changed: Region,
+        max_candidates: usize,
+    ) -> BoundedRegionQueryResult<FormulaConsumerDirtyCandidate> {
+        match self.index.query_bounded(changed, max_candidates) {
+            BoundedRegionQueryResult::Incomplete {
+                observed_candidates,
+            } => BoundedRegionQueryResult::Incomplete {
+                observed_candidates,
+            },
+            BoundedRegionQueryResult::Complete(result) => {
+                BoundedRegionQueryResult::Complete(RegionQueryResult {
+                    stats: result.stats,
+                    matches: result
+                        .matches
+                        .into_iter()
+                        .map(|matched| {
+                            let entry = self.entries[matched.value.0].clone();
+                            let dirty = entry.projection.project_changed_region(
+                                changed,
+                                entry.read_region,
+                                entry.consumer_result_region,
+                            );
+                            RegionMatch {
+                                indexed_region: matched.indexed_region,
+                                value: FormulaConsumerDirtyCandidate {
+                                    consumer: entry.consumer,
+                                    read_region: entry.read_region,
+                                    consumer_result_region: entry.consumer_result_region,
+                                    projection: entry.projection,
+                                    dirty,
+                                },
+                            }
+                        })
+                        .collect(),
+                })
+            }
         }
     }
 

--- a/crates/formualizer-eval/src/formula_plane/region_index.rs
+++ b/crates/formualizer-eval/src/formula_plane/region_index.rs
@@ -3,7 +3,8 @@
 //! This module is internal FormulaPlane substrate only. It does not wire dirty
 //! routing into the engine, graph, scheduler, or evaluator.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, TryReserveError};
+use std::ops::ControlFlow;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -426,6 +427,7 @@ impl RegionSet {
 pub(crate) struct RegionQueryStats {
     pub(crate) candidate_count: usize,
     pub(crate) exact_filter_drop_count: usize,
+    pub(crate) visited_index_entries: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -440,23 +442,124 @@ pub(crate) struct RegionQueryResult<T> {
     pub(crate) stats: RegionQueryStats,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum BoundedRegionQueryResult<T> {
+    Complete(RegionQueryResult<T>),
+    Incomplete { observed_candidates: usize },
+}
+
 #[derive(Clone, Debug)]
 struct RegionEntry<T> {
     value: T,
     region: Region,
 }
 
+struct BoundedCandidateVisitor {
+    max: usize,
+    visited: usize,
+    ids: Vec<usize>,
+    seen: FxHashSet<usize>,
+}
+
+const TREE_ENTRY_OVERHEAD: usize = 4 * std::mem::size_of::<usize>();
+
+fn estimate_btree_vec_map<K>(map: &BTreeMap<K, Vec<usize>>) -> Option<usize> {
+    let mut bytes = map.len().checked_mul(
+        std::mem::size_of::<K>()
+            .checked_add(std::mem::size_of::<Vec<usize>>())?
+            .checked_add(TREE_ENTRY_OVERHEAD)?,
+    )?;
+    for ids in map.values() {
+        bytes = bytes.checked_add(ids.capacity().checked_mul(std::mem::size_of::<usize>())?)?;
+    }
+    Some(bytes)
+}
+
+fn estimate_hash_vec_map<K>(map: &FxHashMap<K, Vec<usize>>) -> Option<usize> {
+    let mut bytes = map.capacity().checked_mul(
+        std::mem::size_of::<K>()
+            .checked_add(std::mem::size_of::<Vec<usize>>())?
+            .checked_add(std::mem::size_of::<usize>())?,
+    )?;
+    for ids in map.values() {
+        bytes = bytes.checked_add(ids.capacity().checked_mul(std::mem::size_of::<usize>())?)?;
+    }
+    Some(bytes)
+}
+
+fn estimate_nested_btree_vec_map(
+    map: &FxHashMap<SheetId, BTreeMap<u32, Vec<usize>>>,
+) -> Option<usize> {
+    let mut bytes = map.capacity().checked_mul(
+        std::mem::size_of::<SheetId>()
+            .checked_add(std::mem::size_of::<BTreeMap<u32, Vec<usize>>>())?
+            .checked_add(std::mem::size_of::<usize>())?,
+    )?;
+    for inner in map.values() {
+        bytes = bytes.checked_add(estimate_btree_vec_map(inner)?)?;
+    }
+    Some(bytes)
+}
+
+fn estimate_interval_map(map: &BTreeMap<(SheetId, u32), IntervalTree<usize>>) -> Option<usize> {
+    let mut bytes = map.len().checked_mul(
+        std::mem::size_of::<(SheetId, u32)>()
+            .checked_add(std::mem::size_of::<IntervalTree<usize>>())?
+            .checked_add(TREE_ENTRY_OVERHEAD)?,
+    )?;
+    for tree in map.values() {
+        bytes = bytes.checked_add(tree.estimated_heap_bytes()?)?;
+    }
+    Some(bytes)
+}
+
+impl BoundedCandidateVisitor {
+    fn new(max: usize) -> Self {
+        Self {
+            max,
+            visited: 0,
+            ids: Vec::new(),
+            seen: FxHashSet::default(),
+        }
+    }
+
+    fn inspect(&mut self) -> ControlFlow<()> {
+        self.visited = self.visited.saturating_add(1);
+        if self.visited > self.max {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    }
+
+    fn accept(&mut self, id: usize) -> ControlFlow<()> {
+        if self.seen.insert(id) {
+            if self.ids.len() == self.max {
+                return ControlFlow::Break(());
+            }
+            self.ids.push(id);
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn visit(&mut self, id: usize) -> ControlFlow<()> {
+        self.inspect()?;
+        self.accept(id)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct SheetRegionIndex<T: Clone> {
     entries: Vec<RegionEntry<T>>,
-    points: FxHashMap<RegionKey, Vec<usize>>,
-    col_intervals: FxHashMap<(SheetId, u32), IntervalTree<usize>>,
-    row_intervals: FxHashMap<(SheetId, u32), IntervalTree<usize>>,
-    rect_buckets: FxHashMap<(SheetId, u32, u32), Vec<usize>>,
+    points_by_row: BTreeMap<(SheetId, u32, u32), Vec<usize>>,
+    points_by_col: BTreeMap<(SheetId, u32, u32), Vec<usize>>,
+    col_intervals: BTreeMap<(SheetId, u32), IntervalTree<usize>>,
+    row_intervals: BTreeMap<(SheetId, u32), IntervalTree<usize>>,
+    rect_buckets: BTreeMap<(SheetId, u32, u32), Vec<usize>>,
     rows_from: FxHashMap<SheetId, BTreeMap<u32, Vec<usize>>>,
     cols_from: FxHashMap<SheetId, BTreeMap<u32, Vec<usize>>>,
-    whole_rows: FxHashMap<(SheetId, u32), Vec<usize>>,
-    whole_cols: FxHashMap<(SheetId, u32), Vec<usize>>,
+    whole_rows: BTreeMap<(SheetId, u32), Vec<usize>>,
+    whole_cols: BTreeMap<(SheetId, u32), Vec<usize>>,
     whole_sheets: FxHashMap<SheetId, Vec<usize>>,
     rect_bucket_rows: u32,
     rect_bucket_cols: u32,
@@ -487,14 +590,15 @@ impl<T: Clone> SheetRegionIndex<T> {
         assert!(rect_bucket_cols > 0, "rect_bucket_cols must be nonzero");
         Self {
             entries: Vec::new(),
-            points: FxHashMap::default(),
-            col_intervals: FxHashMap::default(),
-            row_intervals: FxHashMap::default(),
-            rect_buckets: FxHashMap::default(),
+            points_by_row: BTreeMap::new(),
+            points_by_col: BTreeMap::new(),
+            col_intervals: BTreeMap::new(),
+            row_intervals: BTreeMap::new(),
+            rect_buckets: BTreeMap::new(),
             rows_from: FxHashMap::default(),
             cols_from: FxHashMap::default(),
-            whole_rows: FxHashMap::default(),
-            whole_cols: FxHashMap::default(),
+            whole_rows: BTreeMap::new(),
+            whole_cols: BTreeMap::new(),
             whole_sheets: FxHashMap::default(),
             rect_bucket_rows,
             rect_bucket_cols,
@@ -519,7 +623,8 @@ impl<T: Clone> SheetRegionIndex<T> {
 
     pub(crate) fn clear(&mut self) {
         self.entries.clear();
-        self.points.clear();
+        self.points_by_row.clear();
+        self.points_by_col.clear();
         self.col_intervals.clear();
         self.row_intervals.clear();
         self.rect_buckets.clear();
@@ -568,7 +673,313 @@ impl<T: Clone> SheetRegionIndex<T> {
             stats: RegionQueryStats {
                 candidate_count,
                 exact_filter_drop_count,
+                visited_index_entries: candidate_count,
             },
+        }
+    }
+
+    /// Bounded exact visitor used by topology compilation. Candidate IDs are
+    /// obtained from the coordinate indexes rather than scanning `entries`.
+    /// Both unique candidates and raw index-entry visits stop at the bound,
+    /// and no partial matches escape on overflow.
+    pub(crate) fn query_bounded(
+        &self,
+        query: Region,
+        max_candidates: usize,
+    ) -> BoundedRegionQueryResult<T> {
+        let mut visitor = BoundedCandidateVisitor::new(max_candidates);
+        if self
+            .visit_bounded_candidates(query.normalized(), &mut visitor)
+            .is_break()
+        {
+            return BoundedRegionQueryResult::Incomplete {
+                observed_candidates: max_candidates.saturating_add(1),
+            };
+        }
+        let indexed_candidate_count = visitor.ids.len();
+        let visited_index_entries = visitor.visited;
+        let mut matches = Vec::with_capacity(indexed_candidate_count);
+        for id in visitor.ids {
+            let entry = &self.entries[id];
+            if entry.region.intersects(&query) {
+                matches.push(RegionMatch {
+                    value: entry.value.clone(),
+                    indexed_region: entry.region,
+                });
+            }
+        }
+        let candidate_count = matches.len();
+        let exact_filter_drop_count = indexed_candidate_count.saturating_sub(candidate_count);
+        BoundedRegionQueryResult::Complete(RegionQueryResult {
+            stats: RegionQueryStats {
+                candidate_count,
+                exact_filter_drop_count,
+                visited_index_entries,
+            },
+            matches,
+        })
+    }
+
+    pub(crate) fn try_reserve_entries(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.entries.try_reserve(additional)
+    }
+
+    pub(crate) fn estimated_heap_bytes(&self) -> Option<usize> {
+        let mut bytes = self
+            .entries
+            .capacity()
+            .checked_mul(std::mem::size_of::<RegionEntry<T>>())?;
+        bytes = bytes.checked_add(estimate_btree_vec_map(&self.points_by_row)?)?;
+        bytes = bytes.checked_add(estimate_btree_vec_map(&self.points_by_col)?)?;
+        bytes = bytes.checked_add(estimate_interval_map(&self.col_intervals)?)?;
+        bytes = bytes.checked_add(estimate_interval_map(&self.row_intervals)?)?;
+        bytes = bytes.checked_add(estimate_btree_vec_map(&self.rect_buckets)?)?;
+        bytes = bytes.checked_add(estimate_nested_btree_vec_map(&self.rows_from)?)?;
+        bytes = bytes.checked_add(estimate_nested_btree_vec_map(&self.cols_from)?)?;
+        bytes = bytes.checked_add(estimate_btree_vec_map(&self.whole_rows)?)?;
+        bytes = bytes.checked_add(estimate_btree_vec_map(&self.whole_cols)?)?;
+        bytes = bytes.checked_add(estimate_hash_vec_map(&self.whole_sheets)?)?;
+        Some(bytes)
+    }
+
+    fn visit_bounded_candidates(
+        &self,
+        query: Region,
+        visitor: &mut BoundedCandidateVisitor,
+    ) -> ControlFlow<()> {
+        let sheet_id = query.sheet_id();
+        let visit_ids = |ids: &[usize], visitor: &mut BoundedCandidateVisitor| {
+            for &id in ids {
+                visitor.visit(id)?;
+            }
+            ControlFlow::Continue(())
+        };
+        let visit_tree =
+            |tree: &IntervalTree<usize>, low, high, visitor: &mut BoundedCandidateVisitor| {
+                tree.visit_query(low, high, |event| match event {
+                    None => visitor.inspect(),
+                    Some(id) => visitor.accept(*id),
+                })
+            };
+        let visit_common = |row_end: u32,
+                            col_end: u32,
+                            row_range: Option<(u32, u32)>,
+                            col_range: Option<(u32, u32)>,
+                            visitor: &mut BoundedCandidateVisitor| {
+            if let Some(rows_from) = self.rows_from.get(&sheet_id) {
+                for ids in rows_from.range(..=row_end).map(|(_, ids)| ids) {
+                    visit_ids(ids, visitor)?;
+                }
+            }
+            if let Some(cols_from) = self.cols_from.get(&sheet_id) {
+                for ids in cols_from.range(..=col_end).map(|(_, ids)| ids) {
+                    visit_ids(ids, visitor)?;
+                }
+            }
+            if let Some((start, end)) = row_range {
+                for ids in self
+                    .whole_rows
+                    .range((sheet_id, start)..=(sheet_id, end))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+            }
+            if let Some((start, end)) = col_range {
+                for ids in self
+                    .whole_cols
+                    .range((sheet_id, start)..=(sheet_id, end))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+            }
+            if let Some(ids) = self.whole_sheets.get(&sheet_id) {
+                visit_ids(ids, visitor)?;
+            }
+            ControlFlow::Continue(())
+        };
+
+        match query.axis_ranges() {
+            (AxisRange::Point(row), AxisRange::Point(col)) => {
+                if let Some(ids) = self.points_by_row.get(&(sheet_id, row, col)) {
+                    visit_ids(ids, visitor)?;
+                }
+                if let Some(tree) = self.col_intervals.get(&(sheet_id, col)) {
+                    visit_tree(tree, row, row, visitor)?;
+                }
+                if let Some(tree) = self.row_intervals.get(&(sheet_id, row)) {
+                    visit_tree(tree, col, col, visitor)?;
+                }
+                if let Some(ids) =
+                    self.rect_buckets
+                        .get(&(sheet_id, self.row_bucket(row), self.col_bucket(col)))
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                visit_common(row, col, Some((row, row)), Some((col, col)), visitor)
+            }
+            (AxisRange::Span(row_start, row_end), AxisRange::Point(col)) => {
+                for ids in self
+                    .points_by_col
+                    .range((sheet_id, col, row_start)..=(sheet_id, col, row_end))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                if let Some(tree) = self.col_intervals.get(&(sheet_id, col)) {
+                    visit_tree(tree, row_start, row_end, visitor)?;
+                }
+                for tree in self
+                    .row_intervals
+                    .range((sheet_id, row_start)..=(sheet_id, row_end))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, col, col, visitor)?;
+                }
+                let col_bucket = self.col_bucket(col);
+                for row_bucket in self.row_bucket(row_start)..=self.row_bucket(row_end) {
+                    if let Some(ids) = self.rect_buckets.get(&(sheet_id, row_bucket, col_bucket)) {
+                        visit_ids(ids, visitor)?;
+                    }
+                }
+                visit_common(
+                    row_end,
+                    col,
+                    Some((row_start, row_end)),
+                    Some((col, col)),
+                    visitor,
+                )
+            }
+            (AxisRange::Point(row), AxisRange::Span(col_start, col_end)) => {
+                for ids in self
+                    .points_by_row
+                    .range((sheet_id, row, col_start)..=(sheet_id, row, col_end))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                for tree in self
+                    .col_intervals
+                    .range((sheet_id, col_start)..=(sheet_id, col_end))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, row, row, visitor)?;
+                }
+                if let Some(tree) = self.row_intervals.get(&(sheet_id, row)) {
+                    visit_tree(tree, col_start, col_end, visitor)?;
+                }
+                let row_bucket = self.row_bucket(row);
+                for col_bucket in self.col_bucket(col_start)..=self.col_bucket(col_end) {
+                    if let Some(ids) = self.rect_buckets.get(&(sheet_id, row_bucket, col_bucket)) {
+                        visit_ids(ids, visitor)?;
+                    }
+                }
+                visit_common(
+                    row,
+                    col_end,
+                    Some((row, row)),
+                    Some((col_start, col_end)),
+                    visitor,
+                )
+            }
+            (AxisRange::Span(row_start, row_end), AxisRange::Span(col_start, col_end)) => {
+                let row_width = row_end.saturating_sub(row_start);
+                let col_width = col_end.saturating_sub(col_start);
+                if row_width <= col_width {
+                    for ((_, _, col), ids) in self
+                        .points_by_row
+                        .range((sheet_id, row_start, 0)..=(sheet_id, row_end, u32::MAX))
+                    {
+                        for &id in ids {
+                            visitor.inspect()?;
+                            if col_start <= *col && *col <= col_end {
+                                visitor.accept(id)?;
+                            }
+                        }
+                    }
+                } else {
+                    for ((_, _, row), ids) in self
+                        .points_by_col
+                        .range((sheet_id, col_start, 0)..=(sheet_id, col_end, u32::MAX))
+                    {
+                        for &id in ids {
+                            visitor.inspect()?;
+                            if row_start <= *row && *row <= row_end {
+                                visitor.accept(id)?;
+                            }
+                        }
+                    }
+                }
+                for tree in self
+                    .col_intervals
+                    .range((sheet_id, col_start)..=(sheet_id, col_end))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, row_start, row_end, visitor)?;
+                }
+                for tree in self
+                    .row_intervals
+                    .range((sheet_id, row_start)..=(sheet_id, row_end))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, col_start, col_end, visitor)?;
+                }
+                for row_bucket in self.row_bucket(row_start)..=self.row_bucket(row_end) {
+                    for col_bucket in self.col_bucket(col_start)..=self.col_bucket(col_end) {
+                        if let Some(ids) =
+                            self.rect_buckets.get(&(sheet_id, row_bucket, col_bucket))
+                        {
+                            visit_ids(ids, visitor)?;
+                        }
+                    }
+                }
+                visit_common(
+                    row_end,
+                    col_end,
+                    Some((row_start, row_end)),
+                    Some((col_start, col_end)),
+                    visitor,
+                )
+            }
+            (AxisRange::All, AxisRange::All) => {
+                for ids in self
+                    .points_by_row
+                    .range((sheet_id, 0, 0)..=(sheet_id, u32::MAX, u32::MAX))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                for tree in self
+                    .col_intervals
+                    .range((sheet_id, 0)..=(sheet_id, u32::MAX))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, 0, u32::MAX, visitor)?;
+                }
+                for tree in self
+                    .row_intervals
+                    .range((sheet_id, 0)..=(sheet_id, u32::MAX))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, 0, u32::MAX, visitor)?;
+                }
+                for ids in self
+                    .rect_buckets
+                    .range((sheet_id, 0, 0)..=(sheet_id, u32::MAX, u32::MAX))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                visit_common(
+                    u32::MAX,
+                    u32::MAX,
+                    Some((0, u32::MAX)),
+                    Some((0, u32::MAX)),
+                    visitor,
+                )
+            }
+            _ => ControlFlow::Break(()),
         }
     }
 
@@ -580,8 +991,12 @@ impl<T: Clone> SheetRegionIndex<T> {
                 let (AxisRange::Point(row), AxisRange::Point(col)) = (rows, cols) else {
                     unreachable!()
                 };
-                self.points
-                    .entry(RegionKey::new(sheet_id, row, col))
+                self.points_by_row
+                    .entry((sheet_id, row, col))
+                    .or_default()
+                    .push(id);
+                self.points_by_col
+                    .entry((sheet_id, col, row))
                     .or_default()
                     .push(id);
             }
@@ -674,7 +1089,7 @@ impl<T: Clone> SheetRegionIndex<T> {
                 let (AxisRange::Point(row), AxisRange::Point(col)) = (rows, cols) else {
                     unreachable!()
                 };
-                if let Some(ids) = self.points.get(&RegionKey::new(sheet_id, row, col)) {
+                if let Some(ids) = self.points_by_row.get(&(sheet_id, row, col)) {
                     Self::extend_ids(out, ids);
                 }
                 self.collect_col_interval_exact_col(sheet_id, col, row, row, out);
@@ -946,8 +1361,9 @@ impl<T: Clone> SheetRegionIndex<T> {
     ) where
         F: Fn(RegionKey) -> bool,
     {
-        for (&key, ids) in &self.points {
-            if key.sheet_id == sheet_id && matches_key(key) {
+        for (&(entry_sheet, row, col), ids) in &self.points_by_row {
+            let key = RegionKey::new(entry_sheet, row, col);
+            if entry_sheet == sheet_id && matches_key(key) {
                 Self::extend_ids(out, ids);
             }
         }
@@ -2246,5 +2662,60 @@ mod tests {
         let result = index.query_changed_region(Region::point(6, 4, 1));
 
         assert!(result.matches.is_empty());
+    }
+
+    #[test]
+    fn bounded_query_large_disjoint_corpus_visits_only_addressed_index_entries() {
+        let mut index = SheetRegionIndex::default();
+        for row in 0..20_000 {
+            index.insert(Region::point(0, row, 100), row);
+            index.insert(Region::col_interval(0, 101, row, row + 1), row);
+            index.insert(Region::row_interval(0, row, 102, 103), row);
+            index.insert(Region::rect(0, row, row + 1, 104, 105), row);
+        }
+
+        let BoundedRegionQueryResult::Complete(result) =
+            index.query_bounded(Region::point(0, 30_000, 500), 8)
+        else {
+            panic!("disjoint indexed query must complete");
+        };
+        assert!(result.matches.is_empty());
+        assert_eq!(result.stats.candidate_count, 0);
+        assert_eq!(result.stats.visited_index_entries, 0);
+
+        assert_eq!(
+            index.query_bounded(Region::rect(0, 0, 19_999, 500, 501), 8),
+            BoundedRegionQueryResult::Incomplete {
+                observed_candidates: 9,
+            },
+            "a broad sparse query must stop at the visit budget rather than scan all reads"
+        );
+    }
+
+    #[test]
+    fn bounded_query_reports_incomplete_without_partial_matches() {
+        let mut index = SheetRegionIndex::default();
+        for row in 0..4 {
+            index.insert(Region::point(0, row, 0), row);
+        }
+        assert_eq!(
+            index.query_bounded(Region::whole_sheet(0), 2),
+            BoundedRegionQueryResult::Incomplete {
+                observed_candidates: 3,
+            }
+        );
+        let BoundedRegionQueryResult::Complete(result) =
+            index.query_bounded(Region::whole_sheet(0), 4)
+        else {
+            panic!("four-candidate bound must complete");
+        };
+        assert_eq!(
+            result
+                .matches
+                .into_iter()
+                .map(|m| m.value)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
     }
 }

--- a/crates/formualizer-eval/src/formula_plane/scheduler.rs
+++ b/crates/formualizer-eval/src/formula_plane/scheduler.rs
@@ -10,10 +10,10 @@ use std::collections::{BTreeMap, VecDeque};
 use rustc_hash::FxHashSet;
 
 use super::producer::{
-    FormulaConsumerReadIndex, FormulaProducerId, FormulaProducerResultIndex, FormulaProducerWork,
-    ProducerDirtyDomain, ProjectionResult,
+    DirtyProjectionRule, FormulaConsumerReadIndex, FormulaProducerId, FormulaProducerResultIndex,
+    FormulaProducerWork, ProducerDirtyDomain, ProjectionResult,
 };
-use super::region_index::Region;
+use super::region_index::{BoundedRegionQueryResult, Region};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct MixedSchedule {
@@ -86,7 +86,427 @@ pub(crate) enum MixedScheduleFallbackReason {
     UnsupportedProjection,
     MaxEdgesExceeded,
     MaxCandidatesExceeded,
+    CacheMemoryExceeded,
     CycleDetected,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MixedTopologyConfig {
+    pub(crate) max_candidates: usize,
+    pub(crate) max_edges: usize,
+    pub(crate) max_memory_bytes: usize,
+    /// Memory retained beside `MixedTopology` in `CachedMixedTopology`.
+    pub(crate) retained_memory_bytes: usize,
+}
+
+impl Default for MixedTopologyConfig {
+    fn default() -> Self {
+        Self {
+            max_candidates: 100_000,
+            max_edges: 100_000,
+            max_memory_bytes: 64 * 1024 * 1024,
+            retained_memory_bytes: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct MixedTopologyCompileStats {
+    pub(crate) producers: usize,
+    pub(crate) candidates: usize,
+    pub(crate) relationships: usize,
+    pub(crate) estimated_memory_bytes: usize,
+    pub(crate) candidate_overflow_count: usize,
+    pub(crate) edge_overflow_count: usize,
+    pub(crate) memory_overflow_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompiledRelationship {
+    target: FormulaProducerId,
+    read_region: Region,
+    consumer_result_region: Region,
+    projection: DirtyProjectionRule,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MixedTopology {
+    relationships: BTreeMap<FormulaProducerId, Vec<CompiledRelationship>>,
+    pub(crate) stats: MixedTopologyCompileStats,
+    pub(crate) fallbacks: Vec<MixedScheduleFallback>,
+    complete: bool,
+}
+
+impl MixedTopology {
+    pub(crate) fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    fn estimated_memory_bytes(
+        relationships: &BTreeMap<FormulaProducerId, Vec<CompiledRelationship>>,
+        fallback_capacity: usize,
+        retained_memory_bytes: usize,
+    ) -> Option<usize> {
+        const TREE_ENTRY_OVERHEAD: usize = 4 * std::mem::size_of::<usize>();
+        let mut bytes = retained_memory_bytes.checked_add(std::mem::size_of::<Self>())?;
+        for compiled in relationships.values() {
+            bytes = bytes.checked_add(
+                std::mem::size_of::<FormulaProducerId>()
+                    .checked_add(std::mem::size_of::<Vec<CompiledRelationship>>())?
+                    .checked_add(TREE_ENTRY_OVERHEAD)?,
+            )?;
+            bytes = bytes.checked_add(
+                compiled
+                    .capacity()
+                    .checked_mul(std::mem::size_of::<CompiledRelationship>())?,
+            )?;
+        }
+        bytes = bytes.checked_add(
+            fallback_capacity.checked_mul(std::mem::size_of::<MixedScheduleFallback>())?,
+        )?;
+        Some(bytes)
+    }
+}
+
+pub(crate) fn compile_mixed_topology(
+    producer_results: &FormulaProducerResultIndex,
+    consumer_reads: &FormulaConsumerReadIndex,
+    config: &MixedTopologyConfig,
+) -> MixedTopology {
+    let mut producers = Vec::new();
+    let producer_count = producer_results.len();
+    if producers.try_reserve_exact(producer_count).is_err() {
+        return memory_overflow_topology(
+            MixedTopologyCompileStats {
+                producers: producer_count,
+                ..MixedTopologyCompileStats::default()
+            },
+            producer_results
+                .producers()
+                .next()
+                .unwrap_or(FormulaProducerId::Legacy(crate::engine::VertexId(0))),
+            usize::MAX,
+        );
+    }
+    producers.extend(producer_results.producers());
+    let mut producer_set = FxHashSet::default();
+    if producer_set.try_reserve(producers.len()).is_err() {
+        return memory_overflow_topology(
+            MixedTopologyCompileStats {
+                producers: producers.len(),
+                ..MixedTopologyCompileStats::default()
+            },
+            producers
+                .first()
+                .copied()
+                .unwrap_or(FormulaProducerId::Legacy(crate::engine::VertexId(0))),
+            usize::MAX,
+        );
+    }
+    producer_set.extend(producers.iter().copied());
+    let mut stats = MixedTopologyCompileStats {
+        producers: producers.len(),
+        ..MixedTopologyCompileStats::default()
+    };
+    let mut relationships = BTreeMap::new();
+    let mut fallbacks = Vec::new();
+    let mut complete = true;
+    let initial_memory = MixedTopology::estimated_memory_bytes(
+        &relationships,
+        fallbacks.capacity(),
+        config.retained_memory_bytes,
+    );
+    stats.estimated_memory_bytes = initial_memory.unwrap_or(usize::MAX);
+    if initial_memory.is_none() || stats.estimated_memory_bytes > config.max_memory_bytes {
+        return memory_overflow_topology(
+            stats,
+            producers
+                .first()
+                .copied()
+                .unwrap_or(FormulaProducerId::Legacy(crate::engine::VertexId(0))),
+            initial_memory.unwrap_or(usize::MAX),
+        );
+    }
+
+    for producer in producers {
+        let Some(result_region) = producer_results.producer_result_region(producer) else {
+            complete = false;
+            fallbacks.push(MixedScheduleFallback {
+                producer,
+                reason: MixedScheduleFallbackReason::MissingProducerResultRegion,
+            });
+            break;
+        };
+        let remaining = config.max_candidates.saturating_sub(stats.candidates);
+        let query = consumer_reads.query_changed_region_bounded(result_region, remaining);
+        let result = match query {
+            BoundedRegionQueryResult::Incomplete {
+                observed_candidates,
+            } => {
+                stats.candidates = stats.candidates.saturating_add(observed_candidates);
+                stats.candidate_overflow_count = stats.candidate_overflow_count.saturating_add(1);
+                complete = false;
+                fallbacks.push(MixedScheduleFallback {
+                    producer,
+                    reason: MixedScheduleFallbackReason::MaxCandidatesExceeded,
+                });
+                break;
+            }
+            BoundedRegionQueryResult::Complete(result) => result,
+        };
+        stats.candidates = stats
+            .candidates
+            .saturating_add(result.stats.candidate_count);
+        for matched in result.matches {
+            let candidate = matched.value;
+            if candidate.consumer == producer || !producer_set.contains(&candidate.consumer) {
+                continue;
+            }
+            match candidate.dirty {
+                ProjectionResult::NoIntersection => continue,
+                ProjectionResult::Unsupported(_) => {
+                    complete = false;
+                    fallbacks.push(MixedScheduleFallback {
+                        producer: candidate.consumer,
+                        reason: MixedScheduleFallbackReason::UnsupportedProjection,
+                    });
+                    break;
+                }
+                ProjectionResult::Exact(_) | ProjectionResult::Conservative { .. } => {}
+            }
+            stats.relationships = stats.relationships.saturating_add(1);
+            if stats.relationships > config.max_edges {
+                stats.edge_overflow_count = stats.edge_overflow_count.saturating_add(1);
+                complete = false;
+                fallbacks.push(MixedScheduleFallback {
+                    producer,
+                    reason: MixedScheduleFallbackReason::MaxEdgesExceeded,
+                });
+                break;
+            }
+            let compiled = relationships.entry(producer).or_insert_with(Vec::new);
+            if compiled.try_reserve(1).is_err() {
+                stats.estimated_memory_bytes = usize::MAX;
+                stats.memory_overflow_count = stats.memory_overflow_count.saturating_add(1);
+                complete = false;
+                fallbacks.push(MixedScheduleFallback {
+                    producer,
+                    reason: MixedScheduleFallbackReason::CacheMemoryExceeded,
+                });
+                break;
+            }
+            compiled.push(CompiledRelationship {
+                target: candidate.consumer,
+                read_region: candidate.read_region,
+                consumer_result_region: candidate.consumer_result_region,
+                projection: candidate.projection,
+            });
+            let estimated = MixedTopology::estimated_memory_bytes(
+                &relationships,
+                fallbacks.capacity(),
+                config.retained_memory_bytes,
+            );
+            stats.estimated_memory_bytes = estimated.unwrap_or(usize::MAX);
+            if estimated.is_none() || stats.estimated_memory_bytes > config.max_memory_bytes {
+                stats.memory_overflow_count = stats.memory_overflow_count.saturating_add(1);
+                complete = false;
+                fallbacks.push(MixedScheduleFallback {
+                    producer,
+                    reason: MixedScheduleFallbackReason::CacheMemoryExceeded,
+                });
+                break;
+            }
+        }
+        if !complete {
+            break;
+        }
+    }
+
+    if !complete {
+        relationships.clear();
+    }
+    MixedTopology {
+        relationships,
+        stats,
+        fallbacks,
+        complete,
+    }
+}
+
+fn memory_overflow_topology(
+    mut stats: MixedTopologyCompileStats,
+    producer: FormulaProducerId,
+    estimated_memory_bytes: usize,
+) -> MixedTopology {
+    stats.estimated_memory_bytes = estimated_memory_bytes;
+    stats.memory_overflow_count = stats.memory_overflow_count.saturating_add(1);
+    let mut fallbacks = Vec::new();
+    let _ = fallbacks.try_reserve_exact(1);
+    fallbacks.push(MixedScheduleFallback {
+        producer,
+        reason: MixedScheduleFallbackReason::CacheMemoryExceeded,
+    });
+    MixedTopology {
+        relationships: BTreeMap::new(),
+        stats,
+        fallbacks,
+        complete: false,
+    }
+}
+
+pub(crate) fn schedule_dirty_work(
+    work: impl IntoIterator<Item = FormulaProducerWork>,
+    producer_results: &FormulaProducerResultIndex,
+    topology: &MixedTopology,
+    max_precise_edge_regions: usize,
+) -> MixedSchedule {
+    let (merged_work, mut stats) = merge_work_items(work);
+    let scheduled = merged_work
+        .iter()
+        .map(|item| item.producer)
+        .collect::<FxHashSet<_>>();
+    stats.unique_producers = scheduled.len();
+    stats.merged_work_items = merged_work.len();
+    let mut fallbacks = topology.fallbacks.clone();
+    let mut edges: BTreeMap<FormulaProducerId, FxHashSet<FormulaProducerId>> = BTreeMap::new();
+    let mut reverse_edges: BTreeMap<FormulaProducerId, FxHashSet<FormulaProducerId>> =
+        BTreeMap::new();
+
+    if topology.complete {
+        for item in &merged_work {
+            let Some(result_region) = producer_results.producer_result_region(item.producer) else {
+                fallbacks.push(MixedScheduleFallback {
+                    producer: item.producer,
+                    reason: MixedScheduleFallbackReason::MissingProducerResultRegion,
+                });
+                continue;
+            };
+            let changed_regions = edge_derivation_regions(
+                &item.dirty,
+                result_region,
+                max_precise_edge_regions,
+                &mut stats,
+            );
+            for relationship in topology
+                .relationships
+                .get(&item.producer)
+                .into_iter()
+                .flatten()
+            {
+                if !scheduled.contains(&relationship.target) {
+                    continue;
+                }
+                let mut applies = false;
+                for changed in &changed_regions {
+                    match relationship.projection.project_changed_region(
+                        *changed,
+                        relationship.read_region,
+                        relationship.consumer_result_region,
+                    ) {
+                        ProjectionResult::Exact(_) | ProjectionResult::Conservative { .. } => {
+                            applies = true;
+                            break;
+                        }
+                        ProjectionResult::NoIntersection => {}
+                        ProjectionResult::Unsupported(_) => {
+                            fallbacks.push(MixedScheduleFallback {
+                                producer: relationship.target,
+                                reason: MixedScheduleFallbackReason::UnsupportedProjection,
+                            });
+                            break;
+                        }
+                    }
+                }
+                if applies
+                    && add_edge(
+                        item.producer,
+                        relationship.target,
+                        &mut edges,
+                        &mut reverse_edges,
+                    )
+                {
+                    stats.edges_added = stats.edges_added.saturating_add(1);
+                }
+            }
+        }
+    }
+
+    finish_schedule(merged_work, edges, reverse_edges, stats, fallbacks)
+}
+
+fn finish_schedule(
+    merged_work: Vec<FormulaProducerWork>,
+    edges: BTreeMap<FormulaProducerId, FxHashSet<FormulaProducerId>>,
+    reverse_edges: BTreeMap<FormulaProducerId, FxHashSet<FormulaProducerId>>,
+    mut stats: MixedScheduleStats,
+    mut fallbacks: Vec<MixedScheduleFallback>,
+) -> MixedSchedule {
+    let mut indegree = merged_work
+        .iter()
+        .map(|item| (item.producer, 0usize))
+        .collect::<BTreeMap<_, _>>();
+    for (consumer, deps) in &reverse_edges {
+        if let Some(count) = indegree.get_mut(consumer) {
+            *count = deps.len();
+        }
+    }
+    let work_by_producer = merged_work
+        .into_iter()
+        .map(|item| (item.producer, item))
+        .collect::<BTreeMap<_, _>>();
+    let mut ready = indegree
+        .iter()
+        .filter_map(|(producer, count)| (*count == 0).then_some(*producer))
+        .collect::<VecDeque<_>>();
+    let mut scheduled_count = 0usize;
+    let mut layers = Vec::new();
+    while !ready.is_empty() {
+        let layer_len = ready.len();
+        let mut layer_work = Vec::with_capacity(layer_len);
+        for _ in 0..layer_len {
+            let Some(producer) = ready.pop_front() else {
+                continue;
+            };
+            scheduled_count = scheduled_count.saturating_add(1);
+            if let Some(work) = work_by_producer.get(&producer) {
+                layer_work.push(work.clone());
+            }
+            if let Some(consumers) = edges.get(&producer) {
+                let mut consumers = consumers.iter().copied().collect::<Vec<_>>();
+                consumers.sort_unstable();
+                for consumer in consumers {
+                    let Some(count) = indegree.get_mut(&consumer) else {
+                        continue;
+                    };
+                    *count = count.saturating_sub(1);
+                    if *count == 0 {
+                        ready.push_back(consumer);
+                    }
+                }
+            }
+        }
+        layer_work.sort_by_key(|item| item.producer);
+        layers.push(MixedLayer { work: layer_work });
+    }
+    if scheduled_count < work_by_producer.len() {
+        let cyclic = indegree
+            .iter()
+            .filter_map(|(producer, count)| (*count > 0).then_some(*producer))
+            .collect::<Vec<_>>();
+        stats.cycle_count = cyclic.len();
+        for producer in cyclic {
+            fallbacks.push(MixedScheduleFallback {
+                producer,
+                reason: MixedScheduleFallbackReason::CycleDetected,
+            });
+        }
+    }
+    stats.layers = layers.len();
+    MixedSchedule {
+        layers,
+        stats,
+        fallbacks,
+    }
 }
 
 pub(crate) fn build_mixed_schedule(
@@ -823,5 +1243,151 @@ mod tests {
         assert!(schedule.fallbacks.iter().any(|fallback| {
             fallback.reason == MixedScheduleFallbackReason::MaxCandidatesExceeded
         }));
+    }
+
+    fn two_producer_topology_inputs() -> (FormulaProducerResultIndex, FormulaConsumerReadIndex) {
+        let mut results = FormulaProducerResultIndex::default();
+        results.insert_producer(span(1), Region::col_interval(0, 0, 0, 2));
+        results.insert_producer(span(2), cell(0, 10, 0));
+        let mut reads = FormulaConsumerReadIndex::default();
+        reads.insert_read(
+            span(2),
+            cell(0, 1, 0),
+            cell(0, 10, 0),
+            DirtyProjectionRule::WholeResult,
+        );
+        (results, reads)
+    }
+
+    #[test]
+    fn compiled_topology_candidate_overflow_is_atomic() {
+        let (results, reads) = two_producer_topology_inputs();
+        let topology = compile_mixed_topology(
+            &results,
+            &reads,
+            &MixedTopologyConfig {
+                max_candidates: 0,
+                ..MixedTopologyConfig::default()
+            },
+        );
+        assert!(!topology.is_complete());
+        assert_eq!(topology.stats.candidate_overflow_count, 1);
+        let schedule = schedule_dirty_work(
+            [
+                work(span(1), ProducerDirtyDomain::Whole),
+                work(span(2), ProducerDirtyDomain::Whole),
+            ],
+            &results,
+            &topology,
+            256,
+        );
+        assert!(!schedule.is_authoritative_safe());
+        assert_eq!(schedule.layers.len(), 1, "partial edges must not escape");
+    }
+
+    #[test]
+    fn compiled_topology_edge_and_memory_caps_fail_closed() {
+        let (results, reads) = two_producer_topology_inputs();
+        let edge_limited = compile_mixed_topology(
+            &results,
+            &reads,
+            &MixedTopologyConfig {
+                max_edges: 0,
+                ..MixedTopologyConfig::default()
+            },
+        );
+        assert!(!edge_limited.is_complete());
+        assert_eq!(edge_limited.stats.edge_overflow_count, 1);
+
+        let memory_limited = compile_mixed_topology(
+            &results,
+            &reads,
+            &MixedTopologyConfig {
+                max_memory_bytes: 0,
+                ..MixedTopologyConfig::default()
+            },
+        );
+        assert!(!memory_limited.is_complete());
+        assert_eq!(memory_limited.stats.memory_overflow_count, 1);
+    }
+
+    #[test]
+    fn zero_memory_budget_rejects_large_disjoint_retained_indexes() {
+        let mut results = FormulaProducerResultIndex::default();
+        let mut reads = FormulaConsumerReadIndex::default();
+        for id in 1..=5_000 {
+            let producer = span(id);
+            let result = Region::point(0, id, 0);
+            results.insert_producer(producer, result);
+            reads.insert_read(
+                producer,
+                Region::point(0, id, 100),
+                result,
+                DirtyProjectionRule::WholeResult,
+            );
+        }
+        let retained_memory_bytes = results
+            .estimated_memory_bytes()
+            .and_then(|bytes| bytes.checked_add(reads.estimated_memory_bytes()?))
+            .and_then(|bytes| {
+                bytes.checked_add(5_000usize.checked_mul(
+                    std::mem::size_of::<FormulaProducerId>()
+                        + std::mem::size_of::<crate::formula_plane::runtime::FormulaSpanRef>()
+                        + 4 * std::mem::size_of::<usize>(),
+                )?)
+            })
+            .expect("bounded test accounting");
+
+        let topology = compile_mixed_topology(
+            &results,
+            &reads,
+            &MixedTopologyConfig {
+                max_memory_bytes: 0,
+                retained_memory_bytes,
+                ..MixedTopologyConfig::default()
+            },
+        );
+
+        assert!(!topology.is_complete());
+        assert_eq!(topology.stats.relationships, 0);
+        assert_eq!(topology.stats.memory_overflow_count, 1);
+        assert!(topology.stats.estimated_memory_bytes >= retained_memory_bytes);
+        assert!(topology.fallbacks.iter().any(|fallback| {
+            fallback.reason == MixedScheduleFallbackReason::CacheMemoryExceeded
+        }));
+    }
+
+    #[test]
+    fn cached_relationships_preserve_precise_dirty_placement() {
+        let (results, reads) = two_producer_topology_inputs();
+        let topology = compile_mixed_topology(&results, &reads, &MixedTopologyConfig::default());
+        assert!(topology.is_complete());
+        let unrelated = schedule_dirty_work(
+            [
+                work(
+                    span(1),
+                    ProducerDirtyDomain::Cells(vec![RegionKey::new(0, 0, 0)]),
+                ),
+                work(span(2), ProducerDirtyDomain::Whole),
+            ],
+            &results,
+            &topology,
+            256,
+        );
+        assert_eq!(unrelated.layers.len(), 1);
+
+        let related = schedule_dirty_work(
+            [
+                work(
+                    span(1),
+                    ProducerDirtyDomain::Cells(vec![RegionKey::new(0, 1, 0)]),
+                ),
+                work(span(2), ProducerDirtyDomain::Whole),
+            ],
+            &results,
+            &topology,
+            256,
+        );
+        assert_eq!(related.layers.len(), 2);
     }
 }

--- a/docs/architecture/adaptive-formula-partition.md
+++ b/docs/architecture/adaptive-formula-partition.md
@@ -285,8 +285,14 @@ side exit without waiting for topology unification:
   are generation-leased until successful completion, and a finite fallback-cell cap fails
   closed without partial graph, authority, overlay, telemetry, or dirty-state publication.
   This directly closes #144 while T1 removes the dual-authority boundary that produced it.
+- **T1.1 — Cached mixed topology.** Compile immutable producer relationships and dirty
+  projections once per exact graph/authority/semantic revision, then derive each request's
+  schedule from its current dirty domains. Indexed candidate visitors and finite candidate,
+  edge, and retained-memory budgets stop atomically and route overflow through T1.0b; no
+  partial topology is cached. Value-only edits reuse the cache, dependency mutations rebuild
+  it, and span-free workbooks perform zero mixed-topology builds.
 
-1. **T1 — Single dirty authority.** Move region dirtiness into the graph: `mark_dirty`
+1. **T1 — Single dirty authority (T1.2–T1.3 remaining).** Move region dirtiness into the graph: `mark_dirty`
    probes the region index natively; `pending_changed_regions` and the FP-side dirty
    seeding retire; replace `WholeAll` epoch escalation with translated interval
    dirtiness for shifts. Profile and eliminate the warm tax (§1) — the per-cycle


### PR DESCRIPTION
## Summary
- compile and cache immutable mixed FormulaPlane producer topology in `Engine`
- key cache reuse to exact graph, authority, provider, and semantic revisions while preserving request-local dirty projections
- bound candidate traversal, compiled edges, and retained cache memory with atomic fail-closed overflow routing through transactional demotion
- keep span-free workbooks on the legacy sparse floor with zero mixed-cache builds

## Correctness
- value-only edits reuse cached topology; formula, span, structural, name, table, sheet, and prepared-transaction topology mutations invalidate it
- indexed region visitors stop before publishing partial candidates
- incomplete or over-budget topology is never installed
- pure legacy cycle handling remains delegated to the existing cycle prepass

## Validation
- independent blocker/high review: PASS
- `cargo test -p formualizer-eval --lib` — 2,220 passed, 12 ignored
- `cargo test -p formualizer-eval --all-features --lib` — 2,221 passed, 12 ignored
- strict all-target/all-feature Clippy passed
- wasm32 all-feature evaluator check passed
- focused cache, mutation, region-index, scheduler, cycle, fragmented-transaction, and structural oracle suites passed
- release FormulaPlane coverage probe reported zero value mismatches and a zero-millisecond warm delta

Stacked on #185; retarget to `main` after #185 merges.
