### PR TITLE
refactor(eval): centralize formula dirty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Formualizer will be documented in this file.
 - Added backend-neutral source-family ingest with anchor-once FormulaPlane authority for proven complete domains. Calamine supplies bounded XLSX evidence and exact replay for eager and deferred loading, with structural-edit, cycle-demotion, and source-family telemetry support.
 - Added registry-owned function semantic contracts so safe current and future ordinary functions can use FormulaPlane authority without a secondary supported-name list, while exceptional and untrusted functions continue to replay conservatively.
 - Added bounded fragmented shared-formula evidence, exact coordinate-disposition replay, one-analysis Shadow preparation, and typed ordinary-exception ownership as the replay-only foundation for transactional fragmented authority.
+- Added graph-owned FormulaPlane dirty authority with generation-leased region and exact-span work, unified sparse legacy dirty tracking, explicit global-invalidation telemetry, and retry-safe prefix acknowledgement.
 
 ### Improved
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -5,6 +5,7 @@ use crate::engine::eval_delta::{DeltaCollector, DeltaMode, EvalDelta};
 use crate::engine::graph::prepared_legacy_graph::{
     PreparedLegacyGraphError, PreparedLegacyGraphPlan,
 };
+use crate::engine::graph::{FormulaDirtyLease, WholeSpanDirtyReason};
 use crate::engine::ingest_pipeline::{DependencyPlanRow, FormulaAstInput};
 use crate::engine::live_edges::{LiveEdgeCollector, RecordingContext};
 use crate::engine::live_graph::analyze_live_graph;
@@ -23,7 +24,6 @@ use crate::engine::{
     FormulaPlaneMode, RowVisibilitySource, ScheduleUnit, Scheduler, VertexId, VertexKind,
     VisibilityMaskMode,
 };
-use crate::formula_plane::authority::PendingChangedRegionsLease;
 use crate::formula_plane::placement::prepare_anchor_once_fragment;
 use crate::formula_plane::placement::{
     CandidateAnalysis, FormulaPlacementCandidate, FormulaPlacementResult, PlacementFallbackReason,
@@ -775,11 +775,6 @@ pub struct Engine<R> {
     /// Empty unless something iterated — zero cost otherwise.
     iterative_state_values: FxHashMap<VertexId, LiteralValue>,
 
-    /// FormulaPlane authority `indexes_epoch` observed by the most recent
-    /// successful `evaluate_all` pass. Used to schedule whole-span work for
-    /// any active span the engine has not yet evaluated under the current
-    /// indexes generation; subsequent passes use bounded dirty closures.
-    formula_plane_indexes_epoch_seen: u64,
     /// Global function-registry semantic epoch observed after the latest
     /// conservative FormulaPlane invalidation.
     function_semantic_epoch_seen: u64,
@@ -792,6 +787,8 @@ pub struct Engine<R> {
     before_prepared_span_commit_hook: Option<Box<dyn FnOnce() + Send + Sync>>,
     #[cfg(test)]
     force_source_family_fallback: bool,
+    #[cfg(test)]
+    rerecord_cycle_retry_span_after_lease_extension_for_test: bool,
     #[cfg(test)]
     fragmented_commit_fault_for_test:
         Option<crate::engine::fragmented_transaction::FragmentedCommitFault>,
@@ -1323,6 +1320,10 @@ pub struct EngineBaselineStats {
     pub formula_plane_mixed_topology_cache_builds: u64,
     pub formula_plane_mixed_topology_cache_hits: u64,
     pub formula_plane_mixed_topology_cache_overflows: u64,
+    pub formula_plane_dirty_pending_events: usize,
+    pub formula_plane_dirty_region_events_recorded: u64,
+    pub formula_plane_dirty_whole_span_seeds_recorded: u64,
+    pub formula_plane_dirty_global_invalidations: u64,
     /// Number of spans demoted to legacy because a member participated in a
     /// statically-cyclic SCC (gotcha G8, refs #112).
     pub formula_plane_cycle_member_span_demotions: u64,
@@ -1836,7 +1837,6 @@ where
             last_cycle_telemetry: CycleTelemetry::default(),
             pending_iterative_redirty: Vec::new(),
             iterative_state_values: FxHashMap::default(),
-            formula_plane_indexes_epoch_seen: 0,
             function_semantic_epoch_seen: crate::function_registry::semantic_epoch(),
             function_provider_revision_seen,
             #[cfg(test)]
@@ -1844,6 +1844,8 @@ where
             before_prepared_span_commit_hook: None,
             #[cfg(test)]
             force_source_family_fallback: false,
+            #[cfg(test)]
+            rerecord_cycle_retry_span_after_lease_extension_for_test: false,
             #[cfg(test)]
             fragmented_commit_fault_for_test: None,
             #[cfg(test)]
@@ -1934,7 +1936,6 @@ where
             last_cycle_telemetry: CycleTelemetry::default(),
             pending_iterative_redirty: Vec::new(),
             iterative_state_values: FxHashMap::default(),
-            formula_plane_indexes_epoch_seen: 0,
             function_semantic_epoch_seen: crate::function_registry::semantic_epoch(),
             function_provider_revision_seen,
             #[cfg(test)]
@@ -1942,6 +1943,8 @@ where
             before_prepared_span_commit_hook: None,
             #[cfg(test)]
             force_source_family_fallback: false,
+            #[cfg(test)]
+            rerecord_cycle_retry_span_after_lease_extension_for_test: false,
             #[cfg(test)]
             fragmented_commit_fault_for_test: None,
             #[cfg(test)]
@@ -2382,10 +2385,7 @@ where
     pub fn add_sheet(&mut self, name: &str) -> Result<SheetId, ExcelError> {
         let id = self.graph.add_sheet(name)?;
         self.ensure_arrow_sheet(name);
-        // Adding a sheet does not invalidate existing SheetId-based FormulaPlane
-        // spans. `graph.add_sheet` handles legacy orphan-healing for formulas
-        // that were explicitly tombstoned for this sheet name; avoid a global
-        // FormulaPlane demotion/dirty mark for unrelated spans.
+        // Adding a sheet does not change any existing span result or dependency.
         self.mark_topology_edited();
         Ok(id)
     }
@@ -2410,6 +2410,8 @@ where
 
         self.clear_all_computed_overlays();
         self.mark_all_formula_vertices_dirty();
+        self.graph
+            .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
         self.mark_topology_edited();
         Ok(new_id)
     }
@@ -2480,9 +2482,7 @@ where
                 for v_id in sheet_vertices {
                     self.graph.mark_vertex_dirty(v_id);
                 }
-                // Sheet rename is metadata-only and preserves SheetId. References resolve by
-                // SheetId, so no FormulaPlane changed region is required. Removing this avoids
-                // re-evaluating every span that reads the renamed sheet.
+                // Sheet rename preserves SheetId and therefore formula dependencies.
                 self.mark_topology_edited();
                 Ok(())
             }
@@ -2718,6 +2718,7 @@ where
     pub fn baseline_stats(&self) -> EngineBaselineStats {
         let graph = self.graph.baseline_stats();
         let formula_authority = self.graph.formula_authority();
+        let formula_dirty = self.graph.formula_dirty_stats();
         EngineBaselineStats {
             graph_vertex_count: graph.graph_vertex_count,
             graph_formula_vertex_count: graph.graph_formula_vertex_count,
@@ -2733,6 +2734,10 @@ where
             formula_plane_mixed_topology_cache_builds: self.mixed_topology_cache_builds,
             formula_plane_mixed_topology_cache_hits: self.mixed_topology_cache_hits,
             formula_plane_mixed_topology_cache_overflows: self.mixed_topology_cache_overflows,
+            formula_plane_dirty_pending_events: formula_dirty.pending_events,
+            formula_plane_dirty_region_events_recorded: formula_dirty.region_events_recorded,
+            formula_plane_dirty_whole_span_seeds_recorded: formula_dirty.whole_span_seeds_recorded,
+            formula_plane_dirty_global_invalidations: formula_dirty.global_whole_span_invalidations,
             formula_plane_cycle_member_span_demotions: self
                 .formula_plane_cycle_member_span_demotions,
         }
@@ -3476,6 +3481,11 @@ where
     #[cfg(test)]
     pub(crate) fn force_source_family_fallback_for_test(&mut self, force: bool) {
         self.force_source_family_fallback = force;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn rerecord_cycle_retry_span_after_lease_extension_for_test(&mut self) {
+        self.rerecord_cycle_retry_span_after_lease_extension_for_test = true;
     }
 
     #[cfg(test)]
@@ -4309,6 +4319,12 @@ where
         Vec<FormulaIngestBatch>,
         PlannedFormulaMaterialize,
     ) {
+        let existing_span_refs = self
+            .graph
+            .formula_authority()
+            .active_span_refs()
+            .into_iter()
+            .collect::<rustc_hash::FxHashSet<_>>();
         let mut report =
             FormulaIngestReport::with_mode(FormulaPlaneMode::AuthoritativeExperimental);
         report.formula_cells_seen = batches.iter().map(|batch| batch.len() as u64).sum();
@@ -4557,6 +4573,15 @@ where
         }
 
         let _index_report = self.graph.formula_authority_mut().rebuild_indexes();
+        let new_span_refs = self
+            .graph
+            .formula_authority()
+            .active_span_refs()
+            .into_iter()
+            .filter(|span_ref| !existing_span_refs.contains(span_ref))
+            .collect::<Vec<_>>();
+        self.graph
+            .mark_formula_spans_dirty(new_span_refs, WholeSpanDirtyReason::NewSpan);
 
         let fallback_batches = fallback
             .into_iter()
@@ -5843,6 +5868,10 @@ where
                                         .graph
                                         .formula_authority_mut()
                                         .apply_prevalidated_formula_plane_append(append);
+                                    self.graph.mark_formula_spans_dirty(
+                                        placement_report.spans.iter().copied(),
+                                        WholeSpanDirtyReason::NewSpan,
+                                    );
                                     direct_report.formula_cells_seen =
                                         direct_report.formula_cells_seen.saturating_add(cells);
                                     direct_report.shadow_candidate_cells =
@@ -7472,25 +7501,27 @@ where
             .collect::<BTreeMap<_, _>>();
         let mut dirty_coords = FxHashSet::default();
 
-        if self.formula_plane_indexes_epoch_seen != authority.indexes_epoch() {
-            for span_ref in span_refs {
+        for span_ref in self.graph.pending_formula_dirty_whole_spans() {
+            if span_refs_by_id.get(&span_ref.id) == Some(&span_ref) {
                 self.insert_formula_plane_dirty_coords_for_span(
                     span_ref,
                     ProducerDirtyDomain::Whole,
                     &mut dirty_coords,
                 )?;
             }
-            return Ok(dirty_coords);
         }
 
-        let pending_changed_regions = authority.pending_changed_regions();
+        let pending_changed_regions = self
+            .graph
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>();
         if pending_changed_regions.is_empty() {
             return Ok(dirty_coords);
         }
 
         let closure = compute_dirty_closure(
             &authority.consumer_reads,
-            pending_changed_regions.iter().copied(),
+            pending_changed_regions,
             |producer| authority.producer_results.producer_result_region(producer),
         );
         for work in closure.work {
@@ -8501,7 +8532,9 @@ where
                 }
             }
         }
-        if !shift_plans.is_empty() || !split_plans.is_empty() || !remove_refs.is_empty() {
+        let span_geometry_changed =
+            !shift_plans.is_empty() || !split_plans.is_empty() || !remove_refs.is_empty();
+        if span_geometry_changed {
             // Rewritten template ASTs must be interned into the graph's AST
             // arena before the authority is borrowed mutably; the literal
             // slot map is keyed by the freshly interned arena node ids.
@@ -8738,7 +8771,10 @@ where
                 }
             }
             authority.rebuild_indexes();
-            self.formula_plane_indexes_epoch_seen = 0;
+        }
+        if span_geometry_changed {
+            self.graph
+                .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
         }
 
         let mut span_plans = Vec::new();
@@ -8876,7 +8912,6 @@ where
                 }
             }
         }
-        self.formula_plane_indexes_epoch_seen = 0;
         Ok(())
     }
 
@@ -9213,7 +9248,6 @@ where
             let _ = authority.plane.remove_span(*span_ref);
         }
         let _ = authority.rebuild_indexes();
-        self.formula_plane_indexes_epoch_seen = 0;
         self.mark_topology_edited();
         Ok(FormulaSpanDemotionReport {
             spans_demoted: span_refs.len(),
@@ -11299,18 +11333,14 @@ where
         match scope {
             StructuralScope::Cell { sheet, row, col } => {
                 self.graph
-                    .formula_authority_mut()
-                    .record_changed_region(Region::point(sheet, row, col));
+                    .mark_formula_region_dirty(Region::point(sheet, row, col));
             }
             StructuralScope::Region(region) => {
-                self.graph
-                    .formula_authority_mut()
-                    .record_changed_region(region);
+                self.graph.mark_formula_region_dirty(region);
             }
             StructuralScope::Sheet(sheet_id) => {
                 self.graph
-                    .formula_authority_mut()
-                    .record_changed_region(Region::whole_sheet(sheet_id));
+                    .mark_formula_region_dirty(Region::whole_sheet(sheet_id));
             }
             StructuralScope::RemovedSheet(sheet_id) => {
                 let removed_refs = {
@@ -11329,17 +11359,20 @@ where
                         .collect::<Vec<_>>()
                 };
 
-                let authority = self.graph.formula_authority_mut();
-                for span_ref in removed_refs {
-                    authority.plane.remove_span(span_ref);
+                {
+                    let authority = self.graph.formula_authority_mut();
+                    for span_ref in removed_refs {
+                        authority.plane.remove_span(span_ref);
+                    }
+                    let _ = authority.rebuild_indexes();
                 }
-                authority.mark_all_active_spans_dirty();
-                let _ = authority.rebuild_indexes();
+                self.graph
+                    .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
             }
             StructuralScope::AllSheets => {
-                let authority = self.graph.formula_authority_mut();
-                authority.mark_all_active_spans_dirty();
-                let _ = authority.rebuild_indexes();
+                let _ = self.graph.formula_authority_mut().rebuild_indexes();
+                self.graph
+                    .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
             }
         }
     }
@@ -12660,14 +12693,12 @@ where
             elapsed: start.elapsed(),
         })
     }
-    fn evaluate_all_legacy_and_ack_pending(
+    fn evaluate_all_legacy_and_ack_dirty(
         &mut self,
-        pending_changed_regions: PendingChangedRegionsLease,
+        formula_dirty: FormulaDirtyLease,
     ) -> Result<EvalResult, ExcelError> {
         let result = self.evaluate_all_legacy_impl()?;
-        self.graph
-            .formula_authority_mut()
-            .ack_pending_changed_regions(pending_changed_regions);
+        self.graph.ack_formula_dirty(formula_dirty);
         Ok(result)
     }
 
@@ -12679,64 +12710,42 @@ where
         // below intentionally does not reset, so `evaluate_legacy_cycle_prepass`
         // counts survive into the final telemetry.
         self.begin_evaluation_request();
-        let pending_changed_regions = self
-            .graph
-            .formula_authority_mut()
-            .lease_pending_changed_regions();
+        let mut formula_dirty = self.graph.lease_formula_dirty();
 
-        // The FormulaPlane coordinator is now selected by mode for evaluate_all.
         // SingletonUnique formulas intentionally remain legacy graph vertices;
-        // when no spans are active, execute through the private legacy primitive
-        // rather than the public legacy entry path.
+        // when no spans are active, execute through the private legacy primitive.
         if self.graph.formula_authority().active_span_count() == 0 {
             #[cfg(test)]
             {
                 self.last_formula_plane_span_eval_report = None;
             }
-            return self.evaluate_all_legacy_and_ack_pending(pending_changed_regions);
+            return self.evaluate_all_legacy_and_ack_dirty(formula_dirty);
         }
 
-        // Decide span work seeding strategy: any active span we have not yet
-        // evaluated under the current authority indexes generation must run
-        // whole; subsequent passes use bounded dirty closures derived from
-        // captured changed regions.
-        let current_indexes_epoch = self.graph.formula_authority().indexes_epoch();
-        let span_seed_mode = if self.formula_plane_indexes_epoch_seen != current_indexes_epoch {
-            SpanSeedMode::WholeAll
-        } else {
-            SpanSeedMode::DirtyClosure
-        };
-        // Pending regions are leased for the full retry/cycle loop. They are
-        // acknowledged only after authoritative or demotion/legacy completion.
-        // Steady-state shortcut: in `DirtyClosure` mode span work is derived
-        // exclusively from pending changed regions, so with none pending the
-        // mixed schedule could only ever contain dirty legacy vertices (e.g.
-        // re-dirtied volatiles). Skip the O(all formula vertices)
-        // producer/consumer index rebuild and run them through the legacy
-        // primitive directly — identical evaluation set, with the legacy
-        // path's native cycle/virtual-dep handling.
-        if matches!(span_seed_mode, SpanSeedMode::DirtyClosure)
-            && pending_changed_regions.is_empty()
-        {
+        // With no graph-owned span/region dirtiness, only sparse legacy work
+        // (including volatiles) can remain. Preserve the warm no-op fast path.
+        if formula_dirty.is_empty() {
             #[cfg(test)]
             {
                 self.last_formula_plane_span_eval_report = None;
             }
-            return self.evaluate_all_legacy_and_ack_pending(pending_changed_regions);
+            return self.evaluate_all_legacy_and_ack_dirty(formula_dirty);
         }
 
         let start = crate::instant::FzInstant::now();
-        let mut span_seed_mode = span_seed_mode;
         // #CIRC stamps produced by demoting cyclic spans and resolving the
         // residual legacy-only cycle ahead of the mixed schedule (gotcha G8).
         let mut prepass_cycle_errors = 0usize;
         const MAX_CYCLE_DEMOTE_ITERS: usize = 64;
         let mut cycle_demote_iters = 0usize;
+        let mut include_dirty_regions = true;
+        let mut retry_whole_spans = Vec::new();
         let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) = loop {
             let (schedule, span_refs_by_id, plane_epoch, legacy_vertices) = self
                 .build_formula_plane_mixed_schedule(
-                    span_seed_mode,
-                    pending_changed_regions.regions(),
+                    &formula_dirty,
+                    &retry_whole_spans,
+                    include_dirty_regions,
                 )?;
 
             if schedule.is_authoritative_safe() {
@@ -12784,11 +12793,7 @@ where
                     self.last_formula_plane_span_eval_report = None;
                 }
                 let result = self.evaluate_all_legacy_impl()?;
-                self.formula_plane_indexes_epoch_seen =
-                    self.graph.formula_authority().indexes_epoch();
-                self.graph
-                    .formula_authority_mut()
-                    .ack_pending_changed_regions(pending_changed_regions);
+                self.graph.ack_formula_dirty(formula_dirty);
                 self.formula_plane_capacity_bailouts =
                     self.formula_plane_capacity_bailouts.saturating_add(1);
                 return Ok(result);
@@ -12811,7 +12816,7 @@ where
             if self.graph.formula_authority().active_span_count() == 0 {
                 // All spans demoted; nothing left for the FP coordinator. The
                 // legacy evaluator resolves the (now fully legacy) cycle.
-                return self.evaluate_all_legacy_and_ack_pending(pending_changed_regions);
+                return self.evaluate_all_legacy_and_ack_dirty(formula_dirty);
             }
 
             // Resolve the residual legacy-only cycle (`handle_cycle_unit`
@@ -12820,10 +12825,31 @@ where
             prepass_cycle_errors =
                 prepass_cycle_errors.saturating_add(self.evaluate_legacy_cycle_prepass()?);
 
-            // Re-seed every surviving span whole after the geometry/dirty
-            // changes; the original pending-region lease remains live across
-            // the complete cycle retry loop.
-            span_seed_mode = SpanSeedMode::WholeAll;
+            // Re-seed every surviving span explicitly through the graph-owned
+            // dirty authority, then renew the lease so successful completion
+            // acknowledges both the original prefix and retry seeds.
+            retry_whole_spans = self.graph.formula_authority().active_span_refs();
+            self.graph.mark_formula_spans_dirty(
+                retry_whole_spans.iter().copied(),
+                WholeSpanDirtyReason::CycleRetry,
+            );
+            // Only the first renewal can enlarge this generation's owned
+            // prefix. If another cycle iteration is required, its redundant
+            // retry seeds stay pending rather than risking acknowledgement of
+            // work recorded after the first renewal.
+            if let Some(extended) = self.graph.extend_formula_dirty_lease(formula_dirty.clone()) {
+                formula_dirty = extended;
+                #[cfg(test)]
+                if std::mem::take(
+                    &mut self.rerecord_cycle_retry_span_after_lease_extension_for_test,
+                ) {
+                    self.graph.mark_formula_spans_dirty(
+                        retry_whole_spans.iter().copied().take(1),
+                        WholeSpanDirtyReason::GlobalInvalidation,
+                    );
+                }
+            }
+            include_dirty_regions = false;
 
             cycle_demote_iters += 1;
             if cycle_demote_iters >= MAX_CYCLE_DEMOTE_ITERS {
@@ -12962,12 +12988,7 @@ where
         // vertices weren't in the dirty subset (e.g. recently-introduced span
         // result cells); legacy clear_dirty_flags is safe over the full set.
         self.redirty_for_next_recalc();
-        // Mark this indexes-epoch as fully evaluated so subsequent passes can
-        // use bounded span dirty closures rather than whole-span work.
-        self.formula_plane_indexes_epoch_seen = self.graph.formula_authority().indexes_epoch();
-        self.graph
-            .formula_authority_mut()
-            .ack_pending_changed_regions(pending_changed_regions);
+        self.graph.ack_formula_dirty(formula_dirty);
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
         Ok(EvalResult {
             computed_vertices,
@@ -13140,8 +13161,9 @@ where
 
     fn build_formula_plane_mixed_schedule(
         &mut self,
-        span_seed_mode: SpanSeedMode,
-        pending_changed_regions: &[Region],
+        formula_dirty: &FormulaDirtyLease,
+        retry_whole_spans: &[FormulaSpanRef],
+        include_dirty_regions: bool,
     ) -> Result<FormulaPlaneMixedScheduleBuild, ExcelError> {
         let key = self.mixed_topology_cache_key();
         let active_refs = self
@@ -13177,10 +13199,13 @@ where
         let dirty_legacy = self.graph.get_evaluation_vertices();
         let mut work = Vec::new();
         let mut scheduled_legacy_vertices = Vec::new();
-        if matches!(span_seed_mode, SpanSeedMode::WholeAll) {
-            for span_id in cached.span_refs_by_id.keys().copied() {
+        for span_ref in formula_dirty
+            .whole_spans()
+            .chain(retry_whole_spans.iter().copied())
+        {
+            if cached.span_refs_by_id.get(&span_ref.id) == Some(&span_ref) {
                 work.push(FormulaProducerWork {
-                    producer: FormulaProducerId::Span(span_id),
+                    producer: FormulaProducerId::Span(span_ref.id),
                     dirty: ProducerDirtyDomain::Whole,
                 });
             }
@@ -13200,9 +13225,8 @@ where
             }
         }
 
-        if matches!(span_seed_mode, SpanSeedMode::DirtyClosure)
-            && !pending_changed_regions.is_empty()
-        {
+        let pending_changed_regions = formula_dirty.regions().collect::<Vec<_>>();
+        if include_dirty_regions && !pending_changed_regions.is_empty() {
             use crate::formula_plane::producer::compute_dirty_closure;
             let closure = compute_dirty_closure(
                 &cached.consumer_reads,
@@ -13239,15 +13263,6 @@ where
             scheduled_legacy_vertices,
         ))
     }
-}
-
-/// Strategy for seeding span producer work in the FP mixed runtime.
-/// `WholeAll` schedules every active span as `Whole`; `DirtyClosure`
-/// computes bounded work from captured changed regions only.
-#[derive(Clone, Copy, Debug)]
-enum SpanSeedMode {
-    WholeAll,
-    DirtyClosure,
 }
 
 impl<R> Engine<R>

--- a/crates/formualizer-eval/src/engine/fragmented_transaction.rs
+++ b/crates/formualizer-eval/src/engine/fragmented_transaction.rs
@@ -618,6 +618,10 @@ impl DependencyGraph {
         let plane = self
             .formula_authority_mut()
             .apply_prevalidated_formula_plane_append(prepared.formula_plane);
+        self.mark_formula_spans_dirty(
+            plane.spans.iter().copied(),
+            super::graph::WholeSpanDirtyReason::NewSpan,
+        );
         FragmentedCommitDecision::Committed(FragmentedCommitSuccess {
             source_id: prepared.source_id,
             graph_formulas,

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -704,7 +704,7 @@ impl<'g> VertexEditor<'g> {
         // formula evaluation through `vertex_formulas`.
         self.graph.vertex_formulas.remove(&id);
         self.graph.vertex_values.remove(&id);
-        self.graph.dirty_vertices.remove(&id);
+        self.graph.clear_formula_vertex_dirty(id);
         self.graph.mark_volatile(id, false);
         self.graph.store.set_kind(id, VertexKind::Empty);
         self.graph.store.set_dynamic(id, false);

--- a/crates/formualizer-eval/src/engine/graph/formula_dirty.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_dirty.rs
@@ -1,0 +1,345 @@
+use rustc_hash::FxHashSet;
+
+use crate::engine::VertexId;
+use crate::formula_plane::region_index::Region;
+use crate::formula_plane::runtime::FormulaSpanRef;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WholeSpanDirtyReason {
+    NewSpan,
+    GlobalInvalidation,
+    CycleRetry,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FormulaDirtyEvent {
+    Region(Region),
+    WholeSpan(FormulaSpanRef),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FormulaDirtyLease {
+    generation: u64,
+    prefix_len: usize,
+    events: Vec<FormulaDirtyEvent>,
+}
+
+impl FormulaDirtyLease {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    pub(crate) fn regions(&self) -> impl Iterator<Item = Region> + '_ {
+        self.events.iter().filter_map(|event| match event {
+            FormulaDirtyEvent::Region(region) => Some(*region),
+            FormulaDirtyEvent::WholeSpan(_) => None,
+        })
+    }
+
+    pub(crate) fn whole_spans(&self) -> impl Iterator<Item = FormulaSpanRef> + '_ {
+        self.events.iter().filter_map(|event| match event {
+            FormulaDirtyEvent::Region(_) => None,
+            FormulaDirtyEvent::WholeSpan(span_ref) => Some(*span_ref),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct FormulaDirtyStats {
+    pub(crate) pending_events: usize,
+    pub(crate) region_events_recorded: u64,
+    pub(crate) whole_span_seeds_recorded: u64,
+    pub(crate) global_whole_span_invalidations: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct FormulaDirtyState {
+    legacy_vertices: FxHashSet<VertexId>,
+    events: Vec<FormulaDirtyEvent>,
+    pending_regions_seen: FxHashSet<Region>,
+    pending_spans_seen: FxHashSet<FormulaSpanRef>,
+    lease_generation: u64,
+    active_lease: Option<ActiveFormulaDirtyLease>,
+    region_events_recorded: u64,
+    whole_span_seeds_recorded: u64,
+    global_whole_span_invalidations: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ActiveFormulaDirtyLease {
+    generation: u64,
+    prefix_len: usize,
+    extended: bool,
+}
+
+impl FormulaDirtyState {
+    pub(super) fn legacy_len(&self) -> usize {
+        self.legacy_vertices.len()
+    }
+
+    pub(super) fn legacy_contains(&self, vertex: &VertexId) -> bool {
+        self.legacy_vertices.contains(vertex)
+    }
+
+    pub(super) fn legacy_insert(&mut self, vertex: VertexId) {
+        self.legacy_vertices.insert(vertex);
+    }
+
+    pub(super) fn legacy_extend(&mut self, vertices: impl IntoIterator<Item = VertexId>) {
+        self.legacy_vertices.extend(vertices);
+    }
+
+    pub(super) fn legacy_remove(&mut self, vertex: &VertexId) {
+        self.legacy_vertices.remove(vertex);
+    }
+
+    pub(super) fn legacy_reserve(&mut self, additional: usize) {
+        self.legacy_vertices.reserve(additional);
+    }
+
+    pub(super) fn legacy_iter(&self) -> impl Iterator<Item = &VertexId> {
+        self.legacy_vertices.iter()
+    }
+
+    pub(super) fn record_region(&mut self, region: Region) {
+        if self.pending_regions_seen.insert(region) {
+            self.events.push(FormulaDirtyEvent::Region(region));
+            self.region_events_recorded = self.region_events_recorded.saturating_add(1);
+        }
+    }
+
+    pub(super) fn record_whole_spans(
+        &mut self,
+        spans: impl IntoIterator<Item = FormulaSpanRef>,
+        reason: WholeSpanDirtyReason,
+    ) {
+        let mut inserted = 0u64;
+        let mut saw_span = false;
+        for span_ref in spans {
+            saw_span = true;
+            if self.pending_spans_seen.insert(span_ref) {
+                self.events.push(FormulaDirtyEvent::WholeSpan(span_ref));
+                inserted = inserted.saturating_add(1);
+            }
+        }
+        self.whole_span_seeds_recorded = self.whole_span_seeds_recorded.saturating_add(inserted);
+        if reason == WholeSpanDirtyReason::GlobalInvalidation && saw_span {
+            self.global_whole_span_invalidations =
+                self.global_whole_span_invalidations.saturating_add(1);
+        }
+    }
+
+    pub(super) fn lease(&mut self) -> FormulaDirtyLease {
+        self.lease_generation = self.lease_generation.wrapping_add(1);
+        let generation = self.lease_generation;
+        let prefix_len = self.events.len();
+        self.active_lease = Some(ActiveFormulaDirtyLease {
+            generation,
+            prefix_len,
+            extended: false,
+        });
+        let lease = FormulaDirtyLease {
+            generation,
+            prefix_len,
+            events: self.events.clone(),
+        };
+        self.pending_regions_seen.clear();
+        self.pending_spans_seen.clear();
+        lease
+    }
+
+    pub(super) fn extend(&mut self, lease: FormulaDirtyLease) -> Option<FormulaDirtyLease> {
+        let active = self.active_lease?;
+        if active.generation != lease.generation
+            || active.prefix_len != lease.prefix_len
+            || active.extended
+        {
+            return None;
+        }
+
+        let prefix_len = self.events.len();
+        self.active_lease = Some(ActiveFormulaDirtyLease {
+            generation: active.generation,
+            prefix_len,
+            extended: true,
+        });
+        let lease = FormulaDirtyLease {
+            generation: active.generation,
+            prefix_len,
+            events: self.events[..prefix_len].to_vec(),
+        };
+        self.pending_regions_seen.clear();
+        self.pending_spans_seen.clear();
+        Some(lease)
+    }
+
+    pub(super) fn ack(&mut self, lease: FormulaDirtyLease) -> bool {
+        let Some(active) = self.active_lease else {
+            return false;
+        };
+        if active.generation != lease.generation || active.prefix_len != lease.prefix_len {
+            return false;
+        }
+        let prefix_len = lease.prefix_len.min(self.events.len());
+        self.events.drain(..prefix_len);
+        self.active_lease = None;
+        true
+    }
+
+    pub(super) fn pending_regions(&self) -> impl Iterator<Item = Region> + '_ {
+        self.events.iter().filter_map(|event| match event {
+            FormulaDirtyEvent::Region(region) => Some(*region),
+            FormulaDirtyEvent::WholeSpan(_) => None,
+        })
+    }
+
+    pub(super) fn pending_whole_spans(&self) -> impl Iterator<Item = FormulaSpanRef> + '_ {
+        self.events.iter().filter_map(|event| match event {
+            FormulaDirtyEvent::Region(_) => None,
+            FormulaDirtyEvent::WholeSpan(span_ref) => Some(*span_ref),
+        })
+    }
+
+    pub(super) fn pending_event_count(&self) -> usize {
+        self.events.len()
+    }
+
+    pub(super) fn stats(&self) -> FormulaDirtyStats {
+        FormulaDirtyStats {
+            pending_events: self.events.len(),
+            region_events_recorded: self.region_events_recorded,
+            whole_span_seeds_recorded: self.whole_span_seeds_recorded,
+            global_whole_span_invalidations: self.global_whole_span_invalidations,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formula_plane::runtime::FormulaSpanId;
+
+    fn span(id: u32) -> FormulaSpanRef {
+        FormulaSpanRef {
+            id: FormulaSpanId(id),
+            generation: 0,
+            version: 0,
+        }
+    }
+
+    #[test]
+    fn lease_ack_preserves_identical_and_later_events() {
+        let mut dirty = FormulaDirtyState::default();
+        let region = Region::point(0, 1, 1);
+        dirty.record_region(region);
+        dirty.record_whole_spans([span(1)], WholeSpanDirtyReason::NewSpan);
+        let lease = dirty.lease();
+        dirty.record_region(region);
+        dirty.record_region(region);
+        dirty.record_whole_spans([span(1)], WholeSpanDirtyReason::CycleRetry);
+        assert!(dirty.ack(lease));
+        assert_eq!(dirty.pending_regions().collect::<Vec<_>>(), vec![region]);
+        assert_eq!(
+            dirty.pending_whole_spans().collect::<Vec<_>>(),
+            vec![span(1)]
+        );
+    }
+
+    #[test]
+    fn extended_lease_owns_retry_seed_but_not_later_identical_event() {
+        let mut dirty = FormulaDirtyState::default();
+        let region = Region::point(0, 1, 1);
+        let retry_span = span(1);
+        dirty.record_region(region);
+        let original = dirty.lease();
+
+        dirty.record_whole_spans([retry_span], WholeSpanDirtyReason::CycleRetry);
+        let extended = dirty.extend(original.clone()).expect("lease must extend");
+        dirty.record_whole_spans([retry_span], WholeSpanDirtyReason::NewSpan);
+
+        assert!(!dirty.ack(original));
+        assert!(dirty.ack(extended));
+        assert_eq!(dirty.pending_regions().collect::<Vec<_>>(), Vec::new());
+        assert_eq!(
+            dirty.pending_whole_spans().collect::<Vec<_>>(),
+            vec![retry_span]
+        );
+    }
+
+    #[test]
+    fn stale_or_repeated_extension_cannot_expand_owned_prefix() {
+        let mut dirty = FormulaDirtyState::default();
+        dirty.record_region(Region::point(0, 1, 1));
+        let original = dirty.lease();
+        dirty.record_whole_spans([span(1)], WholeSpanDirtyReason::CycleRetry);
+        let extended = dirty.extend(original.clone()).expect("lease must extend");
+
+        dirty.record_whole_spans([span(2)], WholeSpanDirtyReason::NewSpan);
+        assert!(dirty.extend(original).is_none());
+        assert!(dirty.extend(extended.clone()).is_none());
+        assert!(dirty.ack(extended));
+        assert_eq!(
+            dirty.pending_whole_spans().collect::<Vec<_>>(),
+            vec![span(2)]
+        );
+    }
+
+    #[test]
+    fn abandoned_extended_lease_retains_owned_and_later_work() {
+        let mut dirty = FormulaDirtyState::default();
+        let region = Region::point(0, 1, 1);
+        dirty.record_region(region);
+        let original = dirty.lease();
+        dirty.record_whole_spans([span(1)], WholeSpanDirtyReason::CycleRetry);
+        let abandoned = dirty.extend(original).expect("lease must extend");
+        dirty.record_whole_spans([span(1)], WholeSpanDirtyReason::NewSpan);
+        drop(abandoned);
+
+        let retry = dirty.lease();
+        assert_eq!(retry.regions().collect::<Vec<_>>(), vec![region]);
+        assert_eq!(
+            retry.whole_spans().collect::<Vec<_>>(),
+            vec![span(1), span(1)]
+        );
+    }
+
+    #[test]
+    fn stale_generation_cannot_ack_newer_lease() {
+        let mut dirty = FormulaDirtyState::default();
+        let first = Region::point(0, 1, 1);
+        let second = Region::point(0, 2, 2);
+        dirty.record_region(first);
+        let stale = dirty.lease();
+        dirty.record_region(second);
+        let current = dirty.lease();
+        assert!(!dirty.ack(stale));
+        assert_eq!(dirty.pending_event_count(), 2);
+        assert!(dirty.ack(current));
+        assert_eq!(dirty.pending_event_count(), 0);
+    }
+
+    #[test]
+    fn graph_owned_dirty_authority_source_audit() {
+        let authority = include_str!("../../formula_plane/authority.rs");
+        let evaluator = include_str!("../eval.rs");
+        let graph = include_str!("mod.rs");
+        assert!(!authority.contains("pending_changed_regions"));
+        assert!(!authority.contains("record_changed_region"));
+        assert!(!evaluator.contains("SpanSeedMode"));
+        assert!(!graph.contains("dirty_vertices: FxHashSet"));
+        assert!(graph.contains("formula_dirty: FormulaDirtyState"));
+    }
+
+    #[test]
+    fn abandoned_lease_retains_exact_retry_work() {
+        let mut dirty = FormulaDirtyState::default();
+        let first = Region::point(0, 1, 1);
+        let later = Region::point(0, 2, 2);
+        dirty.record_region(first);
+        let abandoned = dirty.lease();
+        dirty.record_region(later);
+        drop(abandoned);
+        let retry = dirty.lease();
+        assert_eq!(retry.regions().collect::<Vec<_>>(), vec![first, later]);
+    }
+}

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -25,6 +25,7 @@ pub struct GraphInstrumentation {
 mod ast_utils;
 pub mod editor;
 mod formula_analysis;
+mod formula_dirty;
 mod names;
 pub(crate) mod prepared_legacy_graph;
 mod range_deps;
@@ -46,6 +47,8 @@ use crate::engine::topo::{
 };
 use crate::reference::{CellRef, Coord, SharedRangeRef, SharedRef, SharedSheetLocator};
 use formualizer_common::Coord as AbsCoord;
+use formula_dirty::FormulaDirtyState;
+pub(crate) use formula_dirty::{FormulaDirtyLease, FormulaDirtyStats, WholeSpanDirtyReason};
 // topo::pk wiring will be integrated behind config.use_dynamic_topo in a follow-up step
 
 struct RegistryFunctionProvider;
@@ -183,8 +186,9 @@ pub struct DependencyGraph {
     cell_to_vertex: std::collections::HashMap<CellRef, VertexId, CoordBuildHasher>,
     load_packed_to_vertex: std::collections::HashMap<PackedSheetCell, VertexId, CoordBuildHasher>,
 
-    // Scheduling state - using HashSet for O(1) operations
-    dirty_vertices: FxHashSet<VertexId>,
+    // Graph-owned formula dirtiness. Legacy vertices retain their sparse bits
+    // and set representation behind this single authority.
+    formula_dirty: FormulaDirtyState,
     volatile_vertices: FxHashSet<VertexId>,
 
     /// Monotonic count of vertices processed by dirty-propagation BFS loops
@@ -336,6 +340,66 @@ impl DependencyGraph {
         &mut self.formula_authority
     }
 
+    pub(crate) fn mark_formula_region_dirty(
+        &mut self,
+        region: crate::formula_plane::region_index::Region,
+    ) {
+        self.formula_dirty.record_region(region);
+    }
+
+    pub(crate) fn mark_formula_spans_dirty(
+        &mut self,
+        spans: impl IntoIterator<Item = crate::formula_plane::runtime::FormulaSpanRef>,
+        reason: WholeSpanDirtyReason,
+    ) {
+        self.formula_dirty.record_whole_spans(spans, reason);
+    }
+
+    pub(crate) fn mark_all_formula_spans_dirty(&mut self, reason: WholeSpanDirtyReason) {
+        let spans = self.formula_authority.active_span_refs();
+        self.formula_dirty.record_whole_spans(spans, reason);
+    }
+
+    pub(crate) fn lease_formula_dirty(&mut self) -> FormulaDirtyLease {
+        self.formula_dirty.lease()
+    }
+
+    pub(crate) fn extend_formula_dirty_lease(
+        &mut self,
+        lease: FormulaDirtyLease,
+    ) -> Option<FormulaDirtyLease> {
+        self.formula_dirty.extend(lease)
+    }
+
+    pub(crate) fn ack_formula_dirty(&mut self, lease: FormulaDirtyLease) -> bool {
+        self.formula_dirty.ack(lease)
+    }
+
+    pub(crate) fn pending_formula_dirty_regions(
+        &self,
+    ) -> impl Iterator<Item = crate::formula_plane::region_index::Region> + '_ {
+        self.formula_dirty.pending_regions()
+    }
+
+    pub(crate) fn pending_formula_dirty_whole_spans(
+        &self,
+    ) -> impl Iterator<Item = crate::formula_plane::runtime::FormulaSpanRef> + '_ {
+        self.formula_dirty.pending_whole_spans()
+    }
+
+    pub(crate) fn pending_formula_dirty_event_count(&self) -> usize {
+        self.formula_dirty.pending_event_count()
+    }
+
+    pub(crate) fn formula_dirty_stats(&self) -> FormulaDirtyStats {
+        self.formula_dirty.stats()
+    }
+
+    pub(crate) fn clear_formula_vertex_dirty(&mut self, vertex_id: VertexId) {
+        self.store.set_dirty(vertex_id, false);
+        self.formula_dirty.legacy_remove(&vertex_id);
+    }
+
     /// Return read-only baseline counters for FormulaPlane/dispatch benchmarking.
     pub fn baseline_stats(&self) -> GraphBaselineStats {
         let data_stats = self.data_store.memory_usage();
@@ -343,7 +407,7 @@ impl DependencyGraph {
             graph_vertex_count: self.store.len(),
             graph_formula_vertex_count: self.vertex_formulas.len(),
             graph_edge_count: self.edges.num_edges_exact(),
-            dirty_vertex_count: self.dirty_vertices.len(),
+            dirty_vertex_count: self.formula_dirty.legacy_len(),
             evaluation_vertex_count: self.get_evaluation_vertices().len(),
             formula_ast_root_count: self.vertex_formulas.len(),
             formula_ast_node_count: data_stats.total_ast_nodes,
@@ -818,7 +882,7 @@ impl DependencyGraph {
     /// Reserve metadata structures for upcoming formula assignments during bulk load.
     pub fn reserve_formula_metadata(&mut self, additional: usize) {
         self.vertex_formulas.reserve(additional);
-        self.dirty_vertices.reserve(additional);
+        self.formula_dirty.legacy_reserve(additional);
         self.volatile_vertices.reserve(additional);
     }
 
@@ -1088,7 +1152,7 @@ impl DependencyGraph {
             graph_value_read_attempts: AtomicU64::new(0),
             cell_to_vertex: std::collections::HashMap::with_hasher(CoordBuildHasher),
             load_packed_to_vertex: std::collections::HashMap::with_hasher(CoordBuildHasher),
-            dirty_vertices: FxHashSet::default(),
+            formula_dirty: FormulaDirtyState::default(),
             dirty_propagation_visits: 0,
             deferred_dirty_depth: 0,
             deferred_dirty_pending: Vec::new(),
@@ -2240,7 +2304,7 @@ impl DependencyGraph {
         }
 
         // Add to dirty set
-        self.dirty_vertices.extend(&affected);
+        self.formula_dirty.legacy_extend(affected.iter().copied());
 
         // Return as Vec for compatibility
         affected.into_iter().collect()
@@ -2311,7 +2375,7 @@ impl DependencyGraph {
     /// Get all vertices that need evaluation
     pub fn get_evaluation_vertices(&self) -> Vec<VertexId> {
         let mut combined = FxHashSet::default();
-        combined.extend(&self.dirty_vertices);
+        combined.extend(self.formula_dirty.legacy_iter().copied());
         combined.extend(&self.volatile_vertices);
 
         let mut result: Vec<VertexId> = combined
@@ -2337,7 +2401,7 @@ impl DependencyGraph {
     pub fn clear_dirty_flags(&mut self, vertices: &[VertexId]) {
         for &vertex_id in vertices {
             self.store.set_dirty(vertex_id, false);
-            self.dirty_vertices.remove(&vertex_id);
+            self.formula_dirty.legacy_remove(&vertex_id);
         }
     }
 
@@ -2591,7 +2655,8 @@ impl DependencyGraph {
             self.mark_volatile(tvid, planned[i].3.volatile);
             self.store.set_dynamic(tvid, planned[i].3.dynamic);
         }
-        self.dirty_vertices.extend(target_vids.iter().copied());
+        self.formula_dirty
+            .legacy_extend(target_vids.iter().copied());
 
         self.edges.begin_batch();
         for (i, tvid) in target_vids.iter().copied().enumerate() {
@@ -2680,7 +2745,7 @@ impl DependencyGraph {
         }
         self.edges.add_edge(dependent, dependency);
         self.store.set_dirty(dependent, true);
-        self.dirty_vertices.insert(dependent);
+        self.formula_dirty.legacy_insert(dependent);
     }
 
     fn remove_dependent_edges(&mut self, vertex: VertexId) {
@@ -3151,7 +3216,7 @@ impl DependencyGraph {
                 self.vertex_values.remove(&vid);
             }
             self.store.set_dirty(vid, false);
-            self.dirty_vertices.remove(&vid);
+            self.formula_dirty.legacy_remove(&vid);
             changed_vertices.push(vid);
         }
 
@@ -3240,7 +3305,7 @@ impl DependencyGraph {
             to_visit.extend(self.collect_range_dependents_for_vertex(id));
         }
 
-        self.dirty_vertices.extend(&affected);
+        self.formula_dirty.legacy_extend(affected.iter().copied());
         affected.into_iter().collect()
     }
 
@@ -3630,7 +3695,7 @@ impl DependencyGraph {
         let dependents = self.get_dependents(id);
         for dep_id in dependents {
             self.store.set_dirty(dep_id, true);
-            self.dirty_vertices.insert(dep_id);
+            self.formula_dirty.legacy_insert(dep_id);
         }
     }
 
@@ -3674,9 +3739,9 @@ impl DependencyGraph {
     pub fn set_dirty(&mut self, id: VertexId, dirty: bool) {
         self.store.set_dirty(id, dirty);
         if dirty {
-            self.dirty_vertices.insert(id);
+            self.formula_dirty.legacy_insert(id);
         } else {
-            self.dirty_vertices.remove(&id);
+            self.formula_dirty.legacy_remove(&id);
         }
     }
 
@@ -3811,16 +3876,16 @@ impl DependencyGraph {
     /// Mark a vertex as dirty without propagation (for VertexEditor)
     pub fn mark_vertex_dirty(&mut self, vertex_id: VertexId) {
         self.store.set_dirty(vertex_id, true);
-        self.dirty_vertices.insert(vertex_id);
+        self.formula_dirty.legacy_insert(vertex_id);
     }
 
     /// Batch-mark vertices dirty without propagation.
     pub fn mark_vertices_dirty_batch(&mut self, vertices: &[VertexId]) {
-        self.dirty_vertices.reserve(vertices.len());
+        self.formula_dirty.legacy_reserve(vertices.len());
         for &vertex_id in vertices {
             self.store.set_dirty(vertex_id, true);
         }
-        self.dirty_vertices.extend(vertices.iter().copied());
+        self.formula_dirty.legacy_extend(vertices.iter().copied());
     }
 
     /// Update cell mapping for a vertex (for VertexEditor)

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -141,9 +141,8 @@ impl DependencyGraph {
         };
         let vertex_id = self.store.allocate(coord, sheet_id, 0x01);
         self.store.set_kind(vertex_id, VertexKind::NamedScalar);
-        self.store.set_dirty(vertex_id, true);
+        self.mark_vertex_dirty(vertex_id);
         self.edges.add_vertex(coord, vertex_id.0);
-        self.dirty_vertices.insert(vertex_id);
         vertex_id
     }
 
@@ -358,8 +357,7 @@ impl DependencyGraph {
                 } else {
                     self.store.set_kind(vertex, VertexKind::NamedScalar);
                 }
-                self.store.set_dirty(vertex, true);
-                self.dirty_vertices.insert(vertex);
+                self.mark_vertex_dirty(vertex);
 
                 let referenced_names =
                     self.rebuild_name_dependencies(vertex, &definition_snapshot, scope_value);
@@ -735,7 +733,7 @@ impl DependencyGraph {
         self.store.mark_deleted(named_range.vertex, true);
         self.vertex_values.remove(&named_range.vertex);
         self.vertex_formulas.remove(&named_range.vertex);
-        self.dirty_vertices.remove(&named_range.vertex);
+        self.clear_formula_vertex_dirty(named_range.vertex);
         self.volatile_vertices.remove(&named_range.vertex);
         self.vertex_to_names.remove(&named_range.vertex);
         self.name_vertex_lookup.remove(&named_range.vertex);

--- a/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
+++ b/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
@@ -506,8 +506,7 @@ impl DependencyGraph {
             && !self.vertex_formulas.contains_key(&id)
             && !self.vertex_values.contains_key(&id)
             && !self.ref_error_vertices.contains(&id)
-            && !self.store.is_dirty(id)
-            && !self.dirty_vertices.contains(&id)
+            && !self.is_dirty(id)
             && !self.store.is_volatile(id)
             && !self.volatile_vertices.contains(&id)
             && !self.store.is_dynamic(id)
@@ -814,7 +813,7 @@ mod tests {
         let a1_id = graph.get_vertex_for_cell(&a1).unwrap();
         graph.clear_dirty_flags(&[a1_id]);
         assert!(!graph.store.is_dirty(a1_id));
-        assert!(!graph.dirty_vertices.contains(&a1_id));
+        assert!(!graph.get_evaluation_vertices().contains(&a1_id));
         let rebuilds = graph.edges_rebuild_count();
 
         let addition = planned(&mut graph, sheet, 1, 2, "=C1", &[(1, 3)]);
@@ -825,7 +824,7 @@ mod tests {
         assert_eq!(graph.baseline_stats().graph_formula_vertex_count, 2);
         assert_eq!(graph.baseline_stats().graph_edge_count, 2);
         assert!(graph.store.is_dirty(a1_id));
-        assert!(graph.dirty_vertices.contains(&a1_id));
+        assert!(graph.get_evaluation_vertices().contains(&a1_id));
         assert_eq!(graph.edges_rebuild_count(), rebuilds);
     }
 

--- a/crates/formualizer-eval/src/engine/graph/tables.rs
+++ b/crates/formualizer-eval/src/engine/graph/tables.rs
@@ -171,7 +171,7 @@ impl DependencyGraph {
         self.store.mark_deleted(vertex, true);
         self.vertex_values.remove(&vertex);
         self.vertex_formulas.remove(&vertex);
-        self.dirty_vertices.remove(&vertex);
+        self.clear_formula_vertex_dirty(vertex);
         self.volatile_vertices.remove(&vertex);
 
         Ok(())

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
@@ -183,6 +183,40 @@ fn span_member_in_runtime_cycle_is_demoted_and_circ() {
     assert_eq!(num(&engine, "Sheet1", 120, 5), 240.0);
 }
 
+#[test]
+fn cycle_retry_lease_extension_preserves_later_identical_span_event() {
+    let mut engine = build_workbook(CycleDetection::Static);
+    engine.rerecord_cycle_retry_span_after_lease_extension_for_test();
+
+    engine
+        .evaluate_all()
+        .expect("cycle evaluation must succeed");
+
+    let surviving_span = active_span_refs_by_sheet(&engine);
+    assert_eq!(surviving_span.len(), 1);
+    assert_eq!(
+        engine
+            .graph
+            .pending_formula_dirty_whole_spans()
+            .collect::<Vec<_>>(),
+        surviving_span,
+        "an identical event recorded after renewal must remain pending"
+    );
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 1);
+
+    engine
+        .evaluate_all()
+        .expect("retained event must be consumable on retry");
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
+    assert_eq!(
+        engine
+            .last_formula_plane_span_eval_report()
+            .expect("retained whole-span event must schedule the survivor")
+            .span_eval_placement_count,
+        120
+    );
+}
+
 /// A phantom (guarded, live-acyclic) cycle through a span member must not stamp
 /// `#CIRC` under `CycleDetection::Runtime`: the span is still demoted (its
 /// member is a *static* SCC candidate), but live-edge evaluation resolves the
@@ -497,15 +531,18 @@ fn two_sheet_cyclic_demotion_is_one_atomic_batch() {
     let refs = failed.graph.formula_authority().active_span_refs();
     let pending = failed
         .graph
-        .formula_authority()
-        .pending_changed_regions()
+        .pending_formula_dirty_regions()
+        .collect::<Vec<_>>()
         .to_vec();
     let before = failed.baseline_stats();
     failed.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
     assert!(failed.evaluate_all().is_err());
     assert_eq!(failed.graph.formula_authority().active_span_refs(), refs);
     assert_eq!(
-        failed.graph.formula_authority().pending_changed_regions(),
+        failed
+            .graph
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>(),
         pending
     );
     let after = failed.baseline_stats();
@@ -536,8 +573,8 @@ fn two_sheet_cyclic_demotion_is_one_atomic_batch() {
     assert!(
         committed
             .graph
-            .formula_authority()
-            .pending_changed_regions()
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>()
             .is_empty(),
         "successful cyclic demotion plus legacy completion acknowledges the lease"
     );
@@ -553,10 +590,7 @@ fn prepared_span_demotion_rejects_stale_authority_before_graph_mutation() {
     let mut engine = build_workbook(CycleDetection::Static);
     let refs = engine.graph.formula_authority().active_span_refs();
     let prepared = engine.prepare_formula_span_demotion(&refs).unwrap();
-    engine
-        .graph
-        .formula_authority_mut()
-        .mark_all_active_spans_dirty();
+    engine.graph.formula_authority_mut().rebuild_indexes();
     let before = engine.baseline_stats();
     let live_refs = engine.graph.formula_authority().active_span_refs();
 

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_literal_param_memo.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_literal_param_memo.rs
@@ -685,10 +685,18 @@ fn formula_plane_memo_cache_is_per_evaluate_task() {
         .last_formula_plane_span_eval_report()
         .unwrap()
         .memo_eval_count;
-    engine
-        .graph
-        .formula_authority_mut()
-        .mark_all_active_spans_dirty();
+    let global_before = engine
+        .baseline_stats()
+        .formula_plane_dirty_global_invalidations;
+    engine.graph.mark_all_formula_spans_dirty(
+        crate::engine::graph::WholeSpanDirtyReason::GlobalInvalidation,
+    );
+    assert_eq!(
+        engine
+            .baseline_stats()
+            .formula_plane_dirty_global_invalidations,
+        global_before + 1
+    );
     engine.evaluate_all().unwrap();
     let second = engine
         .last_formula_plane_span_eval_report()

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -172,6 +172,9 @@ fn cached_mixed_topology_matches_off_first_warm_and_post_edit() {
     let build = |mode| build_mixed_engine(mode, |row| format!("=SUM($A{row}:$B${ROWS})"));
     let mut off = build(FormulaPlaneMode::Off);
     let mut authoritative = build(FormulaPlaneMode::AuthoritativeExperimental);
+    let pre_eval_dirty = authoritative.baseline_stats();
+    assert!(pre_eval_dirty.formula_plane_dirty_pending_events > 0);
+    assert!(pre_eval_dirty.formula_plane_dirty_whole_span_seeds_recorded > 0);
 
     let default_fallback_cap = authoritative
         .workbook_load_limits()
@@ -189,6 +192,7 @@ fn cached_mixed_topology_matches_off_first_warm_and_post_edit() {
     assert_eq!(first_stats.formula_plane_active_span_count, 1);
     assert_eq!(first_stats.formula_plane_mixed_topology_cache_builds, 1);
     assert_eq!(first_stats.formula_plane_mixed_topology_cache_hits, 0);
+    assert_eq!(first_stats.formula_plane_dirty_pending_events, 0);
     assert_full_capacity_corpus_parity(&off, &authoritative);
 
     off.evaluate_all().unwrap();
@@ -203,6 +207,9 @@ fn cached_mixed_topology_matches_off_first_warm_and_post_edit() {
     );
     assert_full_capacity_corpus_parity(&off, &authoritative);
 
+    let region_events_before_edit = authoritative
+        .baseline_stats()
+        .formula_plane_dirty_region_events_recorded;
     for engine in [&mut off, &mut authoritative] {
         engine
             .set_cell_value(SHEET, ROWS / 2, 1, LiteralValue::Number(10_000.0))
@@ -213,6 +220,8 @@ fn cached_mixed_topology_matches_off_first_warm_and_post_edit() {
     let edited_stats = authoritative.baseline_stats();
     assert_eq!(edited_stats.formula_plane_mixed_topology_cache_builds, 1);
     assert_eq!(edited_stats.formula_plane_mixed_topology_cache_hits, 1);
+    assert_eq!(edited_stats.formula_plane_dirty_pending_events, 0);
+    assert!(edited_stats.formula_plane_dirty_region_events_recorded > region_events_before_edit);
     assert_full_capacity_corpus_parity(&off, &authoritative);
 }
 
@@ -325,8 +334,8 @@ fn fallback_cap_failure_retains_exact_state_and_pending_lease_for_retry() {
     let refs = engine.graph.formula_authority().active_span_refs();
     let pending = engine
         .graph
-        .formula_authority()
-        .pending_changed_regions()
+        .pending_formula_dirty_regions()
+        .collect::<Vec<_>>()
         .to_vec();
     let epochs = (
         engine.graph.formula_authority().plane.epoch(),
@@ -343,7 +352,10 @@ fn fallback_cap_failure_retains_exact_state_and_pending_lease_for_retry() {
     assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
     assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
     assert_eq!(
-        engine.graph.formula_authority().pending_changed_regions(),
+        engine
+            .graph
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>(),
         pending
     );
     assert_eq!(
@@ -375,8 +387,8 @@ fn fallback_cap_failure_retains_exact_state_and_pending_lease_for_retry() {
     assert!(
         engine
             .graph
-            .formula_authority()
-            .pending_changed_regions()
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>()
             .is_empty()
     );
     assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
@@ -403,8 +415,8 @@ fn capacity_faults_retain_pending_lease_and_count_only_successful_retry() {
         let refs = engine.graph.formula_authority().active_span_refs();
         let pending = engine
             .graph
-            .formula_authority()
-            .pending_changed_regions()
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>()
             .to_vec();
         let epochs = (
             engine.graph.formula_authority().plane.epoch(),
@@ -420,7 +432,10 @@ fn capacity_faults_retain_pending_lease_and_count_only_successful_retry() {
         assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
         assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
         assert_eq!(
-            engine.graph.formula_authority().pending_changed_regions(),
+            engine
+                .graph
+                .pending_formula_dirty_regions()
+                .collect::<Vec<_>>(),
             pending
         );
         assert_eq!(
@@ -440,8 +455,8 @@ fn capacity_faults_retain_pending_lease_and_count_only_successful_retry() {
         assert!(
             engine
                 .graph
-                .formula_authority()
-                .pending_changed_regions()
+                .pending_formula_dirty_regions()
+                .collect::<Vec<_>>()
                 .is_empty()
         );
     }
@@ -525,8 +540,8 @@ fn capacity_fallback_demotes_only_scheduled_dirty_span() {
     assert!(
         engine
             .graph
-            .formula_authority()
-            .pending_changed_regions()
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>()
             .is_empty()
     );
 }
@@ -545,8 +560,8 @@ fn clean_spans_remain_authoritative_when_only_legacy_work_is_dirty() {
     assert!(
         engine
             .graph
-            .formula_authority()
-            .pending_changed_regions()
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>()
             .is_empty()
     );
 }
@@ -575,6 +590,18 @@ fn assert_mutation_invalidates_cache_once(
         "{label} must bump graph topology revision once",
     );
     assert!(!engine.mixed_topology_cache_present_for_test());
+    if label == "sheet" {
+        assert_eq!(
+            engine.graph.pending_formula_dirty_event_count(),
+            0,
+            "metadata-only sheet addition must not invent dirty work"
+        );
+    } else {
+        assert!(
+            engine.graph.pending_formula_dirty_event_count() > 0,
+            "{label} must publish graph-owned formula dirtiness"
+        );
+    }
     engine
         .set_cell_value(SHEET, 1, 1, LiteralValue::Number(10_001.0))
         .unwrap();

--- a/crates/formualizer-eval/src/engine/tests/fragmented_source_transaction.rs
+++ b/crates/formualizer-eval/src/engine/tests/fragmented_source_transaction.rs
@@ -1405,6 +1405,8 @@ fn every_pre_mutation_fault_replays_without_publication_or_state_change() {
     for (index, fault) in faults.into_iter().enumerate() {
         let (mut engine, source, disposition, prepared, _) = transaction(Shape::Row, 10 + index);
         let before = state(&engine);
+        let dirty_before = engine.graph.formula_dirty_stats();
+        let revision_before = engine.graph.topology_revision();
         let disposition_before = disposition.clone();
         let decision = engine.commit_fragmented_source_transaction_with_fault_for_test(
             prepared,
@@ -1419,6 +1421,8 @@ fn every_pre_mutation_fault_replays_without_publication_or_state_change() {
             } if source_id == source.source_id && actual == fault
         ));
         assert_eq!(state(&engine), before, "fault {fault:?} mutated state");
+        assert_eq!(engine.graph.formula_dirty_stats(), dirty_before);
+        assert_eq!(engine.graph.topology_revision(), revision_before);
         assert_eq!(disposition, disposition_before);
         assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
         assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 0);
@@ -1711,6 +1715,19 @@ fn row_column_and_rect_success_commit_graph_then_plane_and_return_local_deltas()
         assert_eq!(engine.baseline_stats().graph_formula_vertex_count, 2);
         assert_eq!(engine.baseline_stats().graph_edge_count, 2);
         assert_eq!(
+            engine
+                .graph
+                .pending_formula_dirty_whole_spans()
+                .collect::<Vec<_>>(),
+            success.plane.spans
+        );
+        assert_eq!(
+            engine
+                .baseline_stats()
+                .formula_plane_dirty_whole_span_seeds_recorded,
+            source.fragments.len() as u64
+        );
+        assert_eq!(
             (
                 engine.last_formula_ingest_report().cloned(),
                 engine.formula_ingest_report_total().clone(),
@@ -1729,6 +1746,7 @@ fn row_column_and_rect_success_commit_graph_then_plane_and_return_local_deltas()
             assert!(engine.graph.get_formula_id(vertex).is_some());
         }
         engine.evaluate_all().unwrap();
+        assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
         let hole = match shape {
             Shape::Row | Shape::Column => source.declared.end,
             Shape::Rect => SourceCoord { row: 3, col: 4 },

--- a/crates/formualizer-eval/src/formula_plane/authority.rs
+++ b/crates/formualizer-eval/src/formula_plane/authority.rs
@@ -5,10 +5,8 @@
 //! for opt-in authoritative FormulaPlane evaluation. Unsupported or demoted
 //! formulas remain on the legacy dependency graph.
 
-use rustc_hash::FxHashSet;
-
 use super::producer::{FormulaConsumerReadIndex, FormulaProducerId, FormulaProducerResultIndex};
-use super::region_index::{FormulaOverlayIndex, Region, SpanDomainIndex};
+use super::region_index::{FormulaOverlayIndex, SpanDomainIndex};
 use super::runtime::{FormulaPlane, FormulaSpanRef};
 
 #[derive(Debug, Default)]
@@ -22,30 +20,6 @@ pub(crate) struct FormulaAuthority {
     pub(crate) indexed_plane_epoch: u64,
     #[cfg(test)]
     pub(crate) prepared_append_failure_for_test: bool,
-    /// Externally-observed changed regions accumulated since the last
-    /// successful evaluation acknowledgement. Edits that intersect span read
-    /// regions drive bounded span dirty work via `compute_dirty_closure`.
-    pending_changed_regions: Vec<Region>,
-    pending_seen: FxHashSet<Region>,
-    pending_lease_generation: u64,
-    active_pending_lease_generation: Option<u64>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct PendingChangedRegionsLease {
-    generation: u64,
-    prefix_len: usize,
-    regions: Vec<Region>,
-}
-
-impl PendingChangedRegionsLease {
-    pub(crate) fn regions(&self) -> &[Region] {
-        &self.regions
-    }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.regions.is_empty()
-    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -83,70 +57,6 @@ impl FormulaAuthority {
                 version: span.version,
             })
             .collect()
-    }
-
-    pub(crate) fn record_changed_region(&mut self, region: Region) {
-        if self.pending_seen.insert(region) {
-            self.pending_changed_regions.push(region);
-        }
-    }
-
-    pub(crate) fn lease_pending_changed_regions(&mut self) -> PendingChangedRegionsLease {
-        self.pending_lease_generation = self.pending_lease_generation.wrapping_add(1);
-        let generation = self.pending_lease_generation;
-        self.active_pending_lease_generation = Some(generation);
-        let lease = PendingChangedRegionsLease {
-            generation,
-            prefix_len: self.pending_changed_regions.len(),
-            regions: self.pending_changed_regions.clone(),
-        };
-        // The leased prefix remains queued but no longer participates in
-        // dedupe. Identical post-lease changes therefore append as new work,
-        // while this set dedupes only within the new generation.
-        self.pending_seen.clear();
-        lease
-    }
-
-    pub(crate) fn ack_pending_changed_regions(&mut self, lease: PendingChangedRegionsLease) {
-        if self.active_pending_lease_generation != Some(lease.generation) {
-            return;
-        }
-        let prefix_len = lease.prefix_len.min(self.pending_changed_regions.len());
-        self.pending_changed_regions.drain(..prefix_len);
-        self.active_pending_lease_generation = None;
-    }
-
-    pub(crate) fn pending_changed_regions(&self) -> &[Region] {
-        &self.pending_changed_regions
-    }
-
-    pub(crate) fn pending_changed_region_count(&self) -> usize {
-        self.pending_changed_regions.len()
-    }
-
-    pub(crate) fn mark_all_active_spans_dirty(&mut self) {
-        // Conservative escape hatch: invalidate every span by bumping the
-        // authority index epoch. The FormulaPlane coordinator treats an unseen
-        // epoch as `WholeAll`, which is the only representation that guarantees
-        // self-dirtying for spans whose result region (rather than read region)
-        // was structurally affected.
-        if self.active_span_count() == 0 {
-            return;
-        }
-        self.indexes_epoch = self.indexes_epoch.saturating_add(1);
-
-        // Also publish result regions as changed regions so downstream span
-        // consumers can be discovered through the normal dirty-closure path if
-        // the caller evaluates before another epoch-bumping rebuild.
-        let regions: Vec<Region> = self
-            .plane
-            .spans
-            .active_spans()
-            .map(|span| Region::from_domain(span.result_region.domain()))
-            .collect();
-        for region in regions {
-            self.record_changed_region(region);
-        }
     }
 
     pub(crate) fn rebuild_indexes(&mut self) -> FormulaAuthorityIndexReport {
@@ -490,81 +400,5 @@ mod tests {
         assert_eq!(second.producer_result_entries, 0);
         assert_eq!(authority.producer_results.len(), 0);
         assert!(authority.indexes_epoch() > first.indexes_epoch);
-    }
-
-    #[test]
-    fn pending_lease_ack_preserves_identical_region_recorded_after_lease() {
-        let mut authority = FormulaAuthority::default();
-        let region = Region::point(0, 1, 1);
-        authority.record_changed_region(region);
-        let lease = authority.lease_pending_changed_regions();
-        authority.record_changed_region(region);
-        authority.record_changed_region(region);
-        assert_eq!(authority.pending_changed_regions(), &[region, region]);
-
-        authority.ack_pending_changed_regions(lease);
-
-        assert_eq!(authority.pending_changed_regions(), &[region]);
-    }
-
-    #[test]
-    fn pending_lease_ack_preserves_different_later_regions_in_order() {
-        let mut authority = FormulaAuthority::default();
-        let leased_region = Region::point(0, 1, 1);
-        let later_a = Region::point(0, 2, 2);
-        let later_b = Region::point(0, 3, 3);
-        authority.record_changed_region(leased_region);
-        let lease = authority.lease_pending_changed_regions();
-        authority.record_changed_region(later_a);
-        authority.record_changed_region(later_b);
-        authority.record_changed_region(later_a);
-
-        authority.ack_pending_changed_regions(lease);
-
-        assert_eq!(authority.pending_changed_regions(), &[later_a, later_b]);
-    }
-
-    #[test]
-    fn pending_lease_multiple_ack_cycles_keep_generation_local_dedupe() {
-        let mut authority = FormulaAuthority::default();
-        let first = Region::point(0, 1, 1);
-        let second = Region::point(0, 2, 2);
-        authority.record_changed_region(first);
-        let first_lease = authority.lease_pending_changed_regions();
-        authority.record_changed_region(second);
-        authority.record_changed_region(second);
-        authority.ack_pending_changed_regions(first_lease);
-        assert_eq!(authority.pending_changed_regions(), &[second]);
-
-        let second_lease = authority.lease_pending_changed_regions();
-        authority.record_changed_region(first);
-        authority.record_changed_region(first);
-        authority.ack_pending_changed_regions(second_lease);
-        assert_eq!(authority.pending_changed_regions(), &[first]);
-
-        let final_lease = authority.lease_pending_changed_regions();
-        authority.ack_pending_changed_regions(final_lease);
-        assert!(authority.pending_changed_regions().is_empty());
-    }
-
-    #[test]
-    fn abandoned_pending_lease_retains_original_work_for_failed_evaluation_retry() {
-        let mut authority = FormulaAuthority::default();
-        let original = Region::point(0, 1, 1);
-        let during_failed_evaluation = Region::point(0, 2, 2);
-        authority.record_changed_region(original);
-        let abandoned = authority.lease_pending_changed_regions();
-        authority.record_changed_region(during_failed_evaluation);
-        drop(abandoned);
-        assert_eq!(
-            authority.pending_changed_regions(),
-            &[original, during_failed_evaluation]
-        );
-
-        let retry = authority.lease_pending_changed_regions();
-        assert_eq!(retry.regions(), &[original, during_failed_evaluation]);
-        authority.record_changed_region(original);
-        authority.ack_pending_changed_regions(retry);
-        assert_eq!(authority.pending_changed_regions(), &[original]);
     }
 }

--- a/docs/architecture/adaptive-formula-partition.md
+++ b/docs/architecture/adaptive-formula-partition.md
@@ -57,7 +57,7 @@ An accurate inventory matters because the distance to the end state is shorter t
 | Concern | State |
 | --- | --- |
 | Evaluation loop | **Already one loop.** `evaluate_authoritative_formula_plane_all` builds a `MixedSchedule` whose layers interleave span producers and legacy vertices, evaluating both per layer with a per-layer computed-write flush (eval.rs, scheduler.rs). There is no global legacy-pass/span-pass boundary. |
-| Authority ownership | **Already graph-owned.** `FormulaAuthority` (spans, producer/consumer indexes, pending changed regions) is a field of `DependencyGraph`. |
+| Authority ownership | **Graph-owned.** `FormulaAuthority` owns spans and producer/consumer indexes; `FormulaDirtyState` separately owns all formula dirtiness inside `DependencyGraph`. |
 | Cross-span cycles | **Detected and demoted.** Mixed-schedule toposort detects producer-level cycles, demotes the cyclic spans to legacy vertices, and resolves via the legacy cycle prepass. Intra-family self-reads reject at placement (`InternalDependency`). |
 | Structural ops | **Span-aware.** Insert/delete rows/cols classify each span: uniform shift mutates domain geometry in place; straddling demotes (structural_shift.rs). |
 | Result storage | **Already columnar.** Span results stage in a `ComputedWriteBuffer` and flush as coalesced fragments into the sheet's computed overlay (Arrow-side), consulted at read time. |
@@ -67,12 +67,12 @@ What remains dual — the actual gap:
 
 | Concern | State |
 | --- | --- |
-| Dirty tracking | Graph per-vertex dirty flags vs. `FormulaAuthority::pending_changed_regions` + plane epoch. Epoch bumps escalate to `SpanSeedMode::WholeAll` — every active span re-evaluates whole. |
+| Dirty tracking | **Unified in T1.2.** `FormulaDirtyState` owns sparse legacy vertex dirtiness plus generation-leased region and exact-span events. `FormulaAuthority` has no dirty queue, and `SpanSeedMode` is retired. |
 | Per-cell overrides | **No punchouts.** Editing one cell inside a span (value or different formula) demotes the whole span. `PlacementDomain` is contiguous (`RowRun`/`ColRun`/`Rect`); holes are unrepresentable. |
 | Iterative calculation | Legacy-only. Iterative members are `VertexId`s; spans are excluded from SCC analysis. |
 | Demand-driven evaluation | Legacy-only. `build_demand_subgraph` walks graph vertices; span producers are invisible to it. |
-| Edit notification | Dual: edits must reach both per-vertex `mark_dirty` and `record_changed_region`, and lifecycle events (names, tables, sheets) must remember FP hooks per path. |
-| Schedule/dirty cost model | Mixed-schedule construction and producer indexes are rebuilt/maintained per cycle with cost sensitive to legacy range mass (the warm tax above). |
+| Edit notification | Engine APIs, editor journals, undo/redo, formulas, values, names, tables, sheets, structural operations, span appends, and prepared commits publish through the graph dirty API. Failed preparation publishes nothing. |
+| Schedule/dirty cost model | T1.1 caches immutable mixed topology. T1.2 consumes graph-owned leased dirty events per request while warm no-op and span-free work remain on the sparse legacy floor. |
 
 ## 3. Target Model
 
@@ -291,11 +291,15 @@ side exit without waiting for topology unification:
   edge, and retained-memory budgets stop atomically and route overflow through T1.0b; no
   partial topology is cached. Value-only edits reuse the cache, dependency mutations rebuild
   it, and span-free workbooks perform zero mixed-topology builds.
+- **T1.2 — Graph-owned dirty authority.** `FormulaDirtyState` is the only owner/API for
+  sparse legacy dirty vertices, changed regions, and exact whole-span seeds. Generation leases
+  retain the exact prefix across faults and retries, including same-value post-lease events.
+  Successful evaluation acknowledges only its leased prefix. Global invalidations may seed all
+  active spans explicitly and are telemetered; authority epochs no longer hide whole-span work.
 
-1. **T1 — Single dirty authority (T1.2–T1.3 remaining).** Move region dirtiness into the graph: `mark_dirty`
-   probes the region index natively; `pending_changed_regions` and the FP-side dirty
-   seeding retire; replace `WholeAll` epoch escalation with translated interval
-   dirtiness for shifts. Profile and eliminate the warm tax (§1) — the per-cycle
+1. **T1 — Single dirty authority (T1.3 remaining).** Translate structural shifts into precise
+   interval dirtiness and remove remaining explicit global whole-span invalidations. Profile and
+   eliminate the warm tax (§1) — the per-cycle
    schedule/index rebuild becomes incremental (rebuild only on partition mutation, not
    per eval). **Closes #144 structurally** (capacity bail becomes a node-refinement,
    ordered by the one schedule, not a side exit) and closes the warm-tax family.


### PR DESCRIPTION
## Summary
- add graph-owned `FormulaDirtyState` as the single owner of sparse legacy dirtiness, region events, explicit whole-span seeds, leases, and telemetry
- remove FormulaAuthority pending-region/dirty-dedupe state and retire `SpanSeedMode`
- migrate evaluator, transaction, editor, journal/undo, name, table, sheet, span, and demotion paths to the graph API
- preserve exact generation/prefix acknowledgement, including cycle-retry lease extension without consuming later identical events

## Correctness
- failed/rejected/faulted preparations publish no dirty state or topology revision
- successful prepared commits dirty and invalidate exactly once
- cached mixed topology consumes graph-owned dirty work directly
- explicit global whole-span invalidation remains graph-owned and telemetered for T1.3 refinement

## Validation
- independent blocker/high review: PASS
- default evaluator: 2,220 passed, 12 ignored
- all-feature evaluator: 2,221 passed, 12 ignored
- strict all-target/all-feature Clippy passed
- focused dirty lease, cycle, capacity fallback, fragmented transaction, structural W0, sparse-domain, undo/redo, and mutation suites passed
- formatting and diff checks passed

Stacked on #186; retarget to `main` after #186 merges.
