### PR TITLE
perf(eval): track precise structural dirtiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Formualizer will be documented in this file.
 - Added registry-owned function semantic contracts so safe current and future ordinary functions can use FormulaPlane authority without a secondary supported-name list, while exceptional and untrusted functions continue to replay conservatively.
 - Added bounded fragmented shared-formula evidence, exact coordinate-disposition replay, one-analysis Shadow preparation, and typed ordinary-exception ownership as the replay-only foundation for transactional fragmented authority.
 - Added graph-owned FormulaPlane dirty authority with generation-leased region and exact-span work, unified sparse legacy dirty tracking, explicit global-invalidation telemetry, and retry-safe prefix acknowledgement.
+- Added exact span-region structural dirty events so row and column shifts schedule only moved or cleared placement intervals while preserving post-lease retry identity.
 
 ### Improved
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -733,6 +733,8 @@ pub struct Engine<R> {
     /// legacy completion pass succeeds; failed attempts are not counted.
     /// Observational only.
     formula_plane_capacity_bailouts: u64,
+    /// Exact span candidates classified across structural mutations.
+    formula_plane_structural_span_candidates: u64,
     /// Transient cancellation flag used during evaluation
     active_cancel_flag: Option<Arc<AtomicBool>>,
 
@@ -894,7 +896,7 @@ where
                     old_value.clone(),
                     old_formula.clone(),
                 );
-            });
+            })?;
             self.engine
                 .record_formula_plane_structural_change(StructuralScope::Cell {
                     sheet: addr.sheet_id,
@@ -967,7 +969,7 @@ where
             let log = unsafe { &mut *log_ptr };
             self.engine.edit_with_logger(log, |editor| {
                 editor.set_cell_formula_with_old_state(addr, ast.clone(), old_value, old_formula);
-            });
+            })?;
             self.engine
                 .record_formula_plane_structural_change(StructuralScope::Cell {
                     sheet: addr.sheet_id,
@@ -1098,6 +1100,9 @@ where
         before: u32,
         count: u32,
     ) -> Result<crate::engine::ShiftSummary, crate::engine::EditorError> {
+        if count == 0 {
+            return Ok(crate::engine::ShiftSummary::default());
+        }
         if self.log.is_some() {
             let Some(log_ptr) = self.log else {
                 return Err(crate::engine::EditorError::TransactionFailed {
@@ -1107,15 +1112,12 @@ where
 
             let sheet_id = self.engine.graph.sheet_id_mut(sheet);
             let before0 = before.saturating_sub(1);
-            let op = StructuralOp::InsertRows {
-                sheet_id,
-                before: before0,
-                count,
-            };
-            self.engine.demote_spans_for_structural_op(
-                op,
-                Engine::<R>::structural_row_region(sheet_id, before0),
-            )?;
+            let affected_region = Engine::<R>::structural_row_region(sheet_id, before0);
+            // Authority geometry is not journaled. Materialize affected spans
+            // before the logged graph shift so undo/redo remains exact instead
+            // of leaving an unlogged shifted span behind.
+            self.engine
+                .demote_spans_preserving_computed_overlays(sheet_id, affected_region)?;
 
             // Graph structural insert (logged) - no snapshot bump.
             let summary = {
@@ -1124,7 +1126,7 @@ where
                     Ok(crate::engine::ShiftSummary::default());
                 self.engine.edit_with_logger(log, |editor| {
                     out = editor.insert_rows(sheet_id, before0, count);
-                });
+                })?;
                 out?
             };
 
@@ -1135,6 +1137,12 @@ where
             }
             self.engine
                 .shift_row_visibility_insert(sheet_id, before0, count);
+            self.engine.mark_moved_formula_vertices_dirty(&summary);
+            self.engine
+                .clear_computed_overlay_after_row(sheet, before0 as usize);
+            self.engine
+                .record_formula_plane_structural_change(StructuralScope::Region(affected_region));
+            self.engine.mark_topology_edited();
             if let Some(undo_ptr) = self.arrow_undo {
                 unsafe { &mut *undo_ptr }.record_insert_rows(sheet_id, before0, count);
             }
@@ -1151,6 +1159,9 @@ where
         start: u32,
         count: u32,
     ) -> Result<crate::engine::ShiftSummary, crate::engine::EditorError> {
+        if count == 0 {
+            return Ok(crate::engine::ShiftSummary::default());
+        }
         if self.atomic_policy {
             return Err(crate::engine::EditorError::TransactionUnsupported {
                 reason:
@@ -1168,6 +1179,9 @@ where
         before: u32,
         count: u32,
     ) -> Result<crate::engine::ShiftSummary, crate::engine::EditorError> {
+        if count == 0 {
+            return Ok(crate::engine::ShiftSummary::default());
+        }
         if self.log.is_some() {
             let Some(log_ptr) = self.log else {
                 return Err(crate::engine::EditorError::TransactionFailed {
@@ -1177,15 +1191,9 @@ where
 
             let sheet_id = self.engine.graph.sheet_id_mut(sheet);
             let before0 = before.saturating_sub(1);
-            let op = StructuralOp::InsertColumns {
-                sheet_id,
-                before: before0,
-                count,
-            };
-            self.engine.demote_spans_for_structural_op(
-                op,
-                Engine::<R>::structural_col_region(sheet_id, before0),
-            )?;
+            let affected_region = Engine::<R>::structural_col_region(sheet_id, before0);
+            self.engine
+                .demote_spans_preserving_computed_overlays(sheet_id, affected_region)?;
 
             let summary = {
                 let log = unsafe { &mut *log_ptr };
@@ -1193,7 +1201,7 @@ where
                     Ok(crate::engine::ShiftSummary::default());
                 self.engine.edit_with_logger(log, |editor| {
                     out = editor.insert_columns(sheet_id, before0, count);
-                });
+                })?;
                 out?
             };
 
@@ -1201,6 +1209,12 @@ where
             if let Some(asheet) = self.engine.arrow_sheets.sheet_mut(sheet) {
                 asheet.insert_columns(before0 as usize, count as usize);
             }
+            self.engine.mark_moved_formula_vertices_dirty(&summary);
+            self.engine
+                .clear_computed_overlay_after_col(sheet, before0 as usize);
+            self.engine
+                .record_formula_plane_structural_change(StructuralScope::Region(affected_region));
+            self.engine.mark_topology_edited();
             if let Some(undo_ptr) = self.arrow_undo {
                 unsafe { &mut *undo_ptr }.record_insert_cols(sheet_id, before0, count);
             }
@@ -1217,6 +1231,9 @@ where
         start: u32,
         count: u32,
     ) -> Result<crate::engine::ShiftSummary, crate::engine::EditorError> {
+        if count == 0 {
+            return Ok(crate::engine::ShiftSummary::default());
+        }
         if self.atomic_policy {
             return Err(crate::engine::EditorError::TransactionUnsupported {
                 reason:
@@ -1278,6 +1295,7 @@ enum StructuralScope {
     Region(Region),
     Sheet(SheetId),
     RemovedSheet(SheetId),
+    OpaqueGlobal,
     AllSheets,
 }
 
@@ -1322,8 +1340,10 @@ pub struct EngineBaselineStats {
     pub formula_plane_mixed_topology_cache_overflows: u64,
     pub formula_plane_dirty_pending_events: usize,
     pub formula_plane_dirty_region_events_recorded: u64,
+    pub formula_plane_dirty_span_region_events_recorded: u64,
     pub formula_plane_dirty_whole_span_seeds_recorded: u64,
     pub formula_plane_dirty_global_invalidations: u64,
+    pub formula_plane_structural_span_candidates: u64,
     /// Number of spans demoted to legacy because a member participated in a
     /// statically-cyclic SCC (gotcha G8, refs #112).
     pub formula_plane_cycle_member_span_demotions: u64,
@@ -1830,6 +1850,7 @@ where
             formula_ingest_report_total: FormulaIngestReport::default(),
             formula_plane_cycle_member_span_demotions: 0,
             formula_plane_capacity_bailouts: 0,
+            formula_plane_structural_span_candidates: 0,
             active_cancel_flag: None,
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
@@ -1929,6 +1950,7 @@ where
             formula_ingest_report_total: FormulaIngestReport::default(),
             formula_plane_cycle_member_span_demotions: 0,
             formula_plane_capacity_bailouts: 0,
+            formula_plane_structural_span_candidates: 0,
             active_cancel_flag: None,
             action_depth: 0,
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
@@ -2394,6 +2416,13 @@ where
         let source_id = self.graph.sheet_id(source).ok_or_else(|| {
             ExcelError::new(ExcelErrorKind::Value).with_message("Source sheet does not exist")
         })?;
+        if new_name.is_empty() || new_name.len() > 255 {
+            return Err(ExcelError::new(ExcelErrorKind::Value).with_message("Invalid sheet name"));
+        }
+        if self.graph.sheet_id(new_name).is_some() {
+            return Err(ExcelError::new(ExcelErrorKind::Value)
+                .with_message(format!("Sheet '{new_name}' already exists")));
+        }
         // Materialize only spans on the source sheet so graph duplication sees
         // the formulas being copied. Spans on unrelated sheets remain active.
         self.demote_spans_preserving_computed_overlays(source_id, Region::whole_sheet(source_id))
@@ -2408,10 +2437,17 @@ where
             self.ensure_arrow_sheet(new_name);
         }
 
-        self.clear_all_computed_overlays();
-        self.mark_all_formula_vertices_dirty();
-        self.graph
-            .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
+        let duplicated_formulas = self
+            .graph
+            .formula_vertices()
+            .into_iter()
+            .filter(|vertex| {
+                self.graph
+                    .get_cell_ref(*vertex)
+                    .is_some_and(|cell| cell.sheet_id == new_id)
+            })
+            .collect::<Vec<_>>();
+        self.graph.mark_vertices_dirty_batch(&duplicated_formulas);
         self.mark_topology_edited();
         Ok(new_id)
     }
@@ -2440,6 +2476,9 @@ where
             .map_err(Self::editor_error_to_excel)?;
         self.graph.remove_sheet(sheet_id)?;
         self.arrow_sheets.sheets.retain(|s| s.name.as_ref() != name);
+        // Sheet removal can change cross-sheet refs, names, and default-sheet
+        // resolution. Until those domains have a complete exact dependency
+        // proof, retain the documented graph-owned global invalidation.
         self.clear_all_computed_overlays();
         self.mark_all_formula_vertices_dirty();
         self.staged_formulas.remove(&name);
@@ -2572,10 +2611,24 @@ where
         // shadowing a workbook-scoped one). Demote those spans BEFORE the
         // registry changes so their cells re-ingest and re-resolve through
         // the normal legacy path.
-        self.invalidate_formula_plane_spans_for_name(name)?;
+        self.graph.validate_define_name(name, scope)?;
+        let has_dependent_spans = !self.exact_name_dependent_span_refs([name]).is_empty();
+        if has_dependent_spans && matches!(definition, NamedDefinition::Formula { .. }) {
+            return Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(
+                "formula-name shadowing with active FormulaPlane dependents is not supported",
+            ));
+        }
+        let prepared = self
+            .prepare_name_dependent_span_demotion([name])
+            .map_err(Self::editor_error_to_excel)?;
+        let demoted = self
+            .commit_name_dependent_span_demotion(prepared)
+            .map_err(Self::editor_error_to_excel)?;
         self.graph.define_name(name, definition, scope)?;
         self.record_formula_plane_structural_change(StructuralScope::AllSheets);
-        self.mark_topology_edited();
+        if !demoted {
+            self.mark_topology_edited();
+        }
         Ok(())
     }
 
@@ -2590,10 +2643,18 @@ where
         // (via their resolved-name dep plans), so the registry update's
         // dependent dirtying reaches them exactly like long-lived legacy
         // formulas.
-        self.invalidate_formula_plane_spans_for_name(name)?;
+        self.graph.validate_existing_name(name, scope)?;
+        let prepared = self
+            .prepare_name_dependent_span_demotion([name])
+            .map_err(Self::editor_error_to_excel)?;
+        let demoted = self
+            .commit_name_dependent_span_demotion(prepared)
+            .map_err(Self::editor_error_to_excel)?;
         self.graph.update_name(name, definition, scope)?;
         self.record_formula_plane_structural_change(StructuralScope::AllSheets);
-        self.mark_topology_edited();
+        if !demoted {
+            self.mark_topology_edited();
+        }
         Ok(())
     }
 
@@ -2601,38 +2662,102 @@ where
         // Demote first (see update_name): the demoted legacy vertices become
         // dependents of the name vertex, so delete_name dirties them and they
         // re-evaluate to #NAME? exactly as legacy formulas do.
-        self.invalidate_formula_plane_spans_for_name(name)?;
+        self.graph.validate_existing_name(name, scope)?;
+        let prepared = self
+            .prepare_name_dependent_span_demotion([name])
+            .map_err(Self::editor_error_to_excel)?;
+        let demoted = self
+            .commit_name_dependent_span_demotion(prepared)
+            .map_err(Self::editor_error_to_excel)?;
         self.graph.delete_name(name, scope)?;
         self.record_formula_plane_structural_change(StructuralScope::AllSheets);
-        self.mark_topology_edited();
+        if !demoted {
+            self.mark_topology_edited();
+        }
         Ok(())
     }
 
-    /// Demote every FormulaPlane span whose ingest-time read projections
-    /// resolved `name` (any scope; see the FormulaPlane name-dependents map
-    /// for the conservative keying contract). Demotion materializes the span
-    /// placements as legacy graph formulas through the existing demotion
-    /// machinery, preserving computed values; the subsequent registry change
-    /// then dirties them through the legacy name-dependents path.
-    fn invalidate_formula_plane_spans_for_name(&mut self, name: &str) -> Result<(), ExcelError> {
+    fn exact_name_dependent_span_refs<'a>(
+        &self,
+        names: impl IntoIterator<Item = &'a str>,
+    ) -> Vec<FormulaSpanRef> {
+        let authority = self.graph.formula_authority();
+        let mut refs = names
+            .into_iter()
+            .flat_map(|name| authority.plane.name_dependent_span_refs(name))
+            .collect::<Vec<_>>();
+        refs.sort_unstable_by_key(|span_ref| {
+            (span_ref.id.0, span_ref.generation, span_ref.version)
+        });
+        refs.dedup();
+        refs
+    }
+
+    fn name_event_names(events: &[ChangeEvent]) -> Vec<String> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                ChangeEvent::DefineName { name, .. }
+                | ChangeEvent::UpdateName { name, .. }
+                | ChangeEvent::DeleteName { name, .. }
+                | ChangeEvent::NamedRangeAdjusted { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn prepare_name_dependent_span_demotion<'a>(
+        &mut self,
+        names: impl IntoIterator<Item = &'a str>,
+    ) -> Result<Option<(PreparedFormulaSpanDemotion, Vec<CellRef>)>, crate::engine::EditorError>
+    {
         if self.config.formula_plane_mode == FormulaPlaneMode::Off {
-            return Ok(());
+            return Ok(None);
         }
-        let regions: Vec<Region> = {
+        let refs = self.exact_name_dependent_span_refs(names);
+        if refs.is_empty() {
+            return Ok(None);
+        }
+
+        // Exact demotion creates dirty legacy vertices. Preserve the old
+        // span's clean/dirty state so the following name mutation remains the
+        // sole authority that dirties formulas whose resolution changed.
+        let dirty_coords = self.compute_current_formula_plane_dirty_result_coords()?;
+        let clean_cells = {
             let authority = self.graph.formula_authority();
-            authority
-                .plane
-                .name_dependent_span_refs(name)
-                .into_iter()
-                .filter_map(|span_ref| authority.plane.spans.get(span_ref))
-                .map(|span| Region::from_domain(span.result_region.domain()))
-                .collect()
+            refs.iter()
+                .filter_map(|span_ref| authority.plane.spans.get(*span_ref))
+                .flat_map(|span| span.domain.iter())
+                .filter(|coord| !dirty_coords.contains(&(coord.sheet_id, coord.row, coord.col)))
+                .map(|coord| {
+                    CellRef::new(coord.sheet_id, Coord::new(coord.row, coord.col, true, true))
+                })
+                .collect::<Vec<_>>()
         };
-        for region in regions {
-            self.demote_spans_preserving_computed_overlays(region.sheet_id(), region)
-                .map_err(Self::editor_error_to_excel)?;
+        self.prepare_formula_span_demotion(&refs)
+            .map(|prepared| Some((prepared, clean_cells)))
+            .map_err(|error| crate::engine::EditorError::TransactionFailed {
+                reason: format!("FormulaPlane name-dependent demotion preparation failed: {error}"),
+            })
+    }
+
+    fn commit_name_dependent_span_demotion(
+        &mut self,
+        prepared: Option<(PreparedFormulaSpanDemotion, Vec<CellRef>)>,
+    ) -> Result<bool, crate::engine::EditorError> {
+        let Some((prepared, clean_cells)) = prepared else {
+            return Ok(false);
+        };
+        self.commit_prepared_formula_span_demotion(prepared)
+            .map_err(|error| crate::engine::EditorError::TransactionFailed {
+                reason: format!("FormulaPlane name-dependent demotion commit failed: {error}"),
+            })?;
+        for cell in clean_cells {
+            if let Some(&vertex_id) = self.graph.get_vertex_id_for_address(&cell) {
+                self.graph.set_dirty(vertex_id, false);
+            }
         }
-        Ok(())
+        Ok(true)
     }
 
     pub fn define_table(
@@ -2656,7 +2781,7 @@ where
         version: Option<u64>,
     ) -> Result<(), ExcelError> {
         self.graph.define_source_scalar(name, version)?;
-        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        self.record_formula_plane_structural_change(StructuralScope::OpaqueGlobal);
         self.mark_topology_edited();
         Ok(())
     }
@@ -2667,7 +2792,7 @@ where
         version: Option<u64>,
     ) -> Result<(), ExcelError> {
         self.graph.define_source_table(name, version)?;
-        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        self.record_formula_plane_structural_change(StructuralScope::OpaqueGlobal);
         self.mark_topology_edited();
         Ok(())
     }
@@ -2678,7 +2803,7 @@ where
         version: Option<u64>,
     ) -> Result<(), ExcelError> {
         self.graph.set_source_scalar_version(name, version)?;
-        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        self.record_formula_plane_structural_change(StructuralScope::OpaqueGlobal);
         Ok(())
     }
 
@@ -2688,13 +2813,13 @@ where
         version: Option<u64>,
     ) -> Result<(), ExcelError> {
         self.graph.set_source_table_version(name, version)?;
-        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        self.record_formula_plane_structural_change(StructuralScope::OpaqueGlobal);
         Ok(())
     }
 
     pub fn invalidate_source(&mut self, name: &str) -> Result<(), ExcelError> {
         self.graph.invalidate_source(name)?;
-        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        self.record_formula_plane_structural_change(StructuralScope::OpaqueGlobal);
         Ok(())
     }
 
@@ -2736,8 +2861,11 @@ where
             formula_plane_mixed_topology_cache_overflows: self.mixed_topology_cache_overflows,
             formula_plane_dirty_pending_events: formula_dirty.pending_events,
             formula_plane_dirty_region_events_recorded: formula_dirty.region_events_recorded,
+            formula_plane_dirty_span_region_events_recorded: formula_dirty
+                .span_region_events_recorded,
             formula_plane_dirty_whole_span_seeds_recorded: formula_dirty.whole_span_seeds_recorded,
             formula_plane_dirty_global_invalidations: formula_dirty.global_whole_span_invalidations,
+            formula_plane_structural_span_candidates: self.formula_plane_structural_span_candidates,
             formula_plane_cycle_member_span_demotions: self
                 .formula_plane_cycle_member_span_demotions,
         }
@@ -3028,11 +3156,86 @@ where
             .retrieve_ast(ast_id, self.graph.sheet_reg())
     }
 
+    pub fn define_name_with_logger(
+        &mut self,
+        log: &mut crate::engine::ChangeLog,
+        name: &str,
+        definition: NamedDefinition,
+        scope: NameScope,
+    ) -> Result<(), crate::engine::EditorError> {
+        self.graph
+            .validate_define_name(name, scope)
+            .map_err(crate::engine::EditorError::Excel)?;
+        let has_dependent_spans = !self.exact_name_dependent_span_refs([name]).is_empty();
+        if has_dependent_spans && matches!(definition, NamedDefinition::Formula { .. }) {
+            return Err(crate::engine::EditorError::TransactionUnsupported {
+                reason: "logged formula-name shadowing with active FormulaPlane dependents is not supported"
+                    .to_string(),
+            });
+        }
+        let prepared = self.prepare_name_dependent_span_demotion([name])?;
+        let demoted = self.commit_name_dependent_span_demotion(prepared)?;
+        {
+            let mut editor = crate::engine::VertexEditor::with_logger(&mut self.graph, log);
+            editor.define_name(name, definition, scope)?;
+        }
+        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        if !demoted {
+            self.mark_topology_edited();
+        }
+        Ok(())
+    }
+
+    pub fn update_name_with_logger(
+        &mut self,
+        log: &mut crate::engine::ChangeLog,
+        name: &str,
+        definition: NamedDefinition,
+        scope: NameScope,
+    ) -> Result<(), crate::engine::EditorError> {
+        self.graph
+            .validate_existing_name(name, scope)
+            .map_err(crate::engine::EditorError::Excel)?;
+        let prepared = self.prepare_name_dependent_span_demotion([name])?;
+        let demoted = self.commit_name_dependent_span_demotion(prepared)?;
+        {
+            let mut editor = crate::engine::VertexEditor::with_logger(&mut self.graph, log);
+            editor.update_name(name, definition, scope)?;
+        }
+        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        if !demoted {
+            self.mark_topology_edited();
+        }
+        Ok(())
+    }
+
+    pub fn delete_name_with_logger(
+        &mut self,
+        log: &mut crate::engine::ChangeLog,
+        name: &str,
+        scope: NameScope,
+    ) -> Result<(), crate::engine::EditorError> {
+        self.graph
+            .validate_existing_name(name, scope)
+            .map_err(crate::engine::EditorError::Excel)?;
+        let prepared = self.prepare_name_dependent_span_demotion([name])?;
+        let demoted = self.commit_name_dependent_span_demotion(prepared)?;
+        {
+            let mut editor = crate::engine::VertexEditor::with_logger(&mut self.graph, log);
+            editor.delete_name(name, scope)?;
+        }
+        self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+        if !demoted {
+            self.mark_topology_edited();
+        }
+        Ok(())
+    }
+
     pub fn edit_with_logger<T>(
         &mut self,
         log: &mut crate::engine::ChangeLog,
         f: impl FnOnce(&mut crate::engine::VertexEditor) -> T,
-    ) -> T {
+    ) -> Result<T, crate::engine::EditorError> {
         // Record starting log length so we can mirror only newly-recorded events.
         let start_len = log.len();
 
@@ -3073,16 +3276,32 @@ where
             f(&mut editor)
         };
 
+        let new_events = log.events()[start_len..].to_vec();
+        if new_events.iter().any(|event| {
+            matches!(
+                event,
+                ChangeEvent::DefineName { .. }
+                    | ChangeEvent::UpdateName { .. }
+                    | ChangeEvent::DeleteName { .. }
+            )
+        }) {
+            self.rollback_from_change_events(&new_events)?;
+            log.truncate(start_len);
+            return Err(crate::engine::EditorError::TransactionUnsupported {
+                reason: "name mutations must use Engine's prepared logged-name APIs".to_string(),
+            });
+        }
+
         // Mirror value-impacting graph events to Arrow for forward edits.
         // This keeps Arrow overlays (delta + computed) consistent when edits clear/commit spills.
-        for ev in &log.events()[start_len..] {
+        for ev in &new_events {
             self.mirror_forward_change_to_arrow(ev);
         }
-        for ev in &log.events()[start_len..] {
+        for ev in &new_events {
             self.record_formula_plane_change_for_event(ev);
         }
 
-        ret
+        Ok(ret)
     }
 
     pub fn undo_logged(
@@ -3090,6 +3309,15 @@ where
         undo: &mut crate::engine::graph::editor::undo_engine::UndoEngine,
         log: &mut crate::engine::ChangeLog,
     ) -> Result<(), crate::engine::EditorError> {
+        let pending_events = log
+            .last_group_indices()
+            .into_iter()
+            .map(|index| log.events()[index].clone())
+            .collect::<Vec<_>>();
+        let names = Self::name_event_names(&pending_events);
+        let prepared =
+            self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str))?;
+        let demoted = self.commit_name_dependent_span_demotion(prepared)?;
         let batch = undo.undo(&mut self.graph, log)?;
         for item in batch.iter().rev() {
             self.apply_inverse_row_visibility_event(&item.event);
@@ -3100,6 +3328,9 @@ where
             for item in &batch {
                 self.record_formula_plane_change_for_event(&item.event);
             }
+            if !demoted && !names.is_empty() {
+                self.mark_topology_edited();
+            }
         }
         Ok(())
     }
@@ -3109,6 +3340,11 @@ where
         undo: &mut crate::engine::graph::editor::undo_engine::UndoEngine,
         log: &mut crate::engine::ChangeLog,
     ) -> Result<(), crate::engine::EditorError> {
+        let pending_events = undo.pending_redo_events();
+        let names = Self::name_event_names(&pending_events);
+        let prepared =
+            self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str))?;
+        let demoted = self.commit_name_dependent_span_demotion(prepared)?;
         let batch = undo.redo(&mut self.graph, log)?;
         for item in &batch {
             self.apply_forward_row_visibility_event(&item.event);
@@ -3118,6 +3354,9 @@ where
         if !batch.is_empty() {
             for item in &batch {
                 self.record_formula_plane_change_for_event(&item.event);
+            }
+            if !demoted && !names.is_empty() {
+                self.mark_topology_edited();
             }
         }
         Ok(())
@@ -3133,6 +3372,22 @@ where
         let Some(journal) = undo.pop_undo_action() else {
             return Ok(());
         };
+        let names = Self::name_event_names(&journal.graph.events);
+        let prepared =
+            match self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str)) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    undo.push_done_action(journal);
+                    return Err(error);
+                }
+            };
+        let demoted = match self.commit_name_dependent_span_demotion(prepared) {
+            Ok(demoted) => demoted,
+            Err(error) => {
+                undo.push_done_action(journal);
+                return Err(error);
+            }
+        };
 
         journal.graph.undo(&mut self.graph)?;
         self.apply_inverse_row_visibility_events(&journal.graph.events);
@@ -3141,7 +3396,11 @@ where
             for event in &journal.graph.events {
                 self.record_formula_plane_change_for_event(event);
             }
-            self.mark_data_edited();
+            if !demoted && !names.is_empty() {
+                self.mark_topology_edited();
+            } else {
+                self.mark_data_edited();
+            }
         }
 
         undo.push_redo_action(journal);
@@ -3158,6 +3417,22 @@ where
         let Some(journal) = undo.pop_redo_action() else {
             return Ok(());
         };
+        let names = Self::name_event_names(&journal.graph.events);
+        let prepared =
+            match self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str)) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    undo.push_redo_action(journal);
+                    return Err(error);
+                }
+            };
+        let demoted = match self.commit_name_dependent_span_demotion(prepared) {
+            Ok(demoted) => demoted,
+            Err(error) => {
+                undo.push_redo_action(journal);
+                return Err(error);
+            }
+        };
 
         journal.graph.redo(&mut self.graph)?;
         self.apply_forward_row_visibility_events(&journal.graph.events);
@@ -3166,7 +3441,11 @@ where
             for event in &journal.graph.events {
                 self.record_formula_plane_change_for_event(event);
             }
-            self.mark_data_edited();
+            if !demoted && !names.is_empty() {
+                self.mark_topology_edited();
+            } else {
+                self.mark_data_edited();
+            }
         }
 
         undo.push_done_action(journal);
@@ -7425,6 +7704,80 @@ where
         Region::cols_from(sheet_id, start_col0)
     }
 
+    fn structural_dirty_region_for_domain(
+        domain: &PlacementDomain,
+        op: StructuralOp,
+    ) -> Option<Region> {
+        let (sheet_id, row_start, row_end, col_start, col_end) = match domain {
+            PlacementDomain::RowRun {
+                sheet_id,
+                row_start,
+                row_end,
+                col,
+            } => (*sheet_id, *row_start, *row_end, *col, *col),
+            PlacementDomain::ColRun {
+                sheet_id,
+                row,
+                col_start,
+                col_end,
+            } => (*sheet_id, *row, *row, *col_start, *col_end),
+            PlacementDomain::Rect {
+                sheet_id,
+                row_start,
+                row_end,
+                col_start,
+                col_end,
+            } => (*sheet_id, *row_start, *row_end, *col_start, *col_end),
+        };
+        match op {
+            StructuralOp::InsertRows {
+                sheet_id: edited,
+                before,
+                ..
+            } if sheet_id == edited && row_end >= before => Some(Region::rect(
+                sheet_id,
+                row_start.max(before),
+                row_end,
+                col_start,
+                col_end,
+            )),
+            StructuralOp::DeleteRows {
+                sheet_id: edited,
+                start,
+                ..
+            } if sheet_id == edited && row_end >= start => Some(Region::rect(
+                sheet_id,
+                row_start.max(start),
+                row_end,
+                col_start,
+                col_end,
+            )),
+            StructuralOp::InsertColumns {
+                sheet_id: edited,
+                before,
+                ..
+            } if sheet_id == edited && col_end >= before => Some(Region::rect(
+                sheet_id,
+                row_start,
+                row_end,
+                col_start.max(before),
+                col_end,
+            )),
+            StructuralOp::DeleteColumns {
+                sheet_id: edited,
+                start,
+                ..
+            } if sheet_id == edited && col_end >= start => Some(Region::rect(
+                sheet_id,
+                row_start,
+                row_end,
+                col_start.max(start),
+                col_end,
+            )),
+            _ => None,
+        }
+    }
+
     fn span_result_region_intersects_affected(
         span: &crate::formula_plane::runtime::FormulaSpan,
         affected_region: &Region,
@@ -7510,6 +7863,15 @@ where
                 )?;
             }
         }
+        for (span_ref, region) in self.graph.pending_formula_dirty_span_regions() {
+            if span_refs_by_id.get(&span_ref.id) == Some(&span_ref) {
+                self.insert_formula_plane_dirty_coords_for_span(
+                    span_ref,
+                    ProducerDirtyDomain::Regions(vec![region]),
+                    &mut dirty_coords,
+                )?;
+            }
+        }
 
         let pending_changed_regions = self
             .graph
@@ -7572,6 +7934,90 @@ where
             return Ok(());
         }
         self.demote_spans_for_structural_op_impl(Some(op), affected_region, true)
+    }
+
+    fn indexed_structural_candidate_span_refs(
+        &self,
+        affected_region: Region,
+    ) -> Result<Vec<FormulaSpanRef>, crate::engine::EditorError> {
+        use crate::formula_plane::region_index::BoundedRegionQueryResult;
+
+        let authority = self.graph.formula_authority();
+        if authority.indexed_plane_epoch() != authority.plane.epoch().0 {
+            return Err(ExcelError::new(ExcelErrorKind::NImpl)
+                .with_message("FormulaPlane structural candidate indexes are stale")
+                .into());
+        }
+        let indexed_region = match affected_region.axis_ranges() {
+            (
+                crate::formula_plane::region_index::AxisRange::From(start),
+                crate::formula_plane::region_index::AxisRange::All,
+            ) => Region {
+                sheet_id: affected_region.sheet_id(),
+                rows: crate::formula_plane::region_index::AxisRange::Span(start, u32::MAX),
+                cols: crate::formula_plane::region_index::AxisRange::All,
+            },
+            (
+                crate::formula_plane::region_index::AxisRange::All,
+                crate::formula_plane::region_index::AxisRange::From(start),
+            ) => Region {
+                sheet_id: affected_region.sheet_id(),
+                rows: crate::formula_plane::region_index::AxisRange::All,
+                cols: crate::formula_plane::region_index::AxisRange::Span(start, u32::MAX),
+            },
+            _ => affected_region,
+        };
+        let max_candidates = self.config.max_formula_plane_cache_candidates;
+        let result_query = match authority
+            .producer_results
+            .query_bounded(indexed_region, max_candidates)
+        {
+            BoundedRegionQueryResult::Complete(result) => result,
+            BoundedRegionQueryResult::Incomplete {
+                observed_candidates,
+            } => {
+                return Err(ExcelError::new(ExcelErrorKind::NImpl)
+                    .with_message(format!(
+                        "FormulaPlane structural result candidate limit exceeded: observed {observed_candidates}, limit {max_candidates}"
+                    ))
+                    .into());
+            }
+        };
+        let remaining = max_candidates.saturating_sub(result_query.matches.len());
+        let read_query = match authority
+            .consumer_reads
+            .query_changed_region_bounded(indexed_region, remaining)
+        {
+            BoundedRegionQueryResult::Complete(result) => result,
+            BoundedRegionQueryResult::Incomplete { .. } => {
+                return Err(ExcelError::new(ExcelErrorKind::NImpl)
+                    .with_message("FormulaPlane structural read candidate limit exceeded")
+                    .into());
+            }
+        };
+
+        let mut ids = BTreeSet::new();
+        for matched in result_query.matches {
+            if let FormulaProducerId::Span(id) = matched.value.producer {
+                ids.insert(id);
+            }
+        }
+        for matched in read_query.matches {
+            if let FormulaProducerId::Span(id) = matched.value.consumer {
+                ids.insert(id);
+            }
+        }
+
+        ids.into_iter()
+            .map(|id| {
+                authority.plane.spans.current_ref(id).ok_or_else(|| {
+                    crate::engine::EditorError::Excel(
+                        ExcelError::new(ExcelErrorKind::NImpl)
+                            .with_message("FormulaPlane structural index referenced a stale span"),
+                    )
+                })
+            })
+            .collect()
     }
 
     fn demote_spans_for_structural_op_impl(
@@ -7653,7 +8099,10 @@ where
             clone_with_slots(ast, binding, &mut next, false)
         }
 
-        let span_refs = self.graph.formula_authority().active_span_refs();
+        let span_refs = self.indexed_structural_candidate_span_refs(affected_region)?;
+        self.formula_plane_structural_span_candidates = self
+            .formula_plane_structural_span_candidates
+            .saturating_add(span_refs.len() as u64);
         if span_refs.is_empty() {
             return Ok(());
         }
@@ -7693,6 +8142,7 @@ where
             binding_set_id: Option<crate::formula_plane::runtime::SpanBindingSetId>,
             force_binding_residual_axes: bool,
             rewrite: Option<SpanTemplateRewrite>,
+            dirty_region: Option<Region>,
         }
 
         /// StructuralOp and ShiftOperation are field-for-field identical
@@ -7759,6 +8209,8 @@ where
             lower_new_read_summary: Option<SpanReadSummary>,
             lower_force_binding_residual_axes: bool,
             lower_overlay_refs: Vec<crate::formula_plane::runtime::FormulaOverlayRef>,
+            upper_dirty_region: Option<Region>,
+            lower_dirty_region: Option<Region>,
         }
 
         fn checked_shift_u32(value: u32, delta: i64) -> Option<u32> {
@@ -8163,6 +8615,8 @@ where
                 lower_new_read_summary,
                 lower_force_binding_residual_axes,
                 lower_overlay_refs,
+                upper_dirty_region: None,
+                lower_dirty_region: None,
             })
         }
 
@@ -8288,6 +8742,8 @@ where
                                         && (new_origin_row != template.origin_row
                                             || new_origin_col != template.origin_col)
                                 });
+                            let dirty_region =
+                                Self::structural_dirty_region_for_domain(&new_domain, op);
                             shift_plans.push(ShiftPlan {
                                 span_ref,
                                 template_id: span.template_id,
@@ -8298,6 +8754,7 @@ where
                                 binding_set_id: span.binding_set_id,
                                 force_binding_residual_axes,
                                 rewrite: None,
+                                dirty_region,
                             });
                         } else {
                             demote_refs.push(span_ref);
@@ -8311,7 +8768,15 @@ where
                 }
                 SpanShiftPlan::Split => {
                     match plan_span_split(authority, span, span_ref, read_summary, op) {
-                        Some(plan) => split_plans.push(plan),
+                        Some(mut plan) => {
+                            plan.upper_dirty_region =
+                                Self::structural_dirty_region_for_domain(&plan.upper_domain, op);
+                            plan.lower_dirty_region = Self::structural_dirty_region_for_domain(
+                                &plan.lower_new_domain,
+                                op,
+                            );
+                            split_plans.push(plan);
+                        }
                         // Not provably clean: demote the whole span (the
                         // pre-split conservative path).
                         None => demote_refs.push(span_ref),
@@ -8518,6 +8983,7 @@ where
                             (None, new_read_summary)
                         }
                     };
+                    let dirty_region = Self::structural_dirty_region_for_domain(&new_domain, op);
                     shift_plans.push(ShiftPlan {
                         span_ref,
                         template_id: span.template_id,
@@ -8528,12 +8994,14 @@ where
                         binding_set_id: span.binding_set_id,
                         force_binding_residual_axes,
                         rewrite,
+                        dirty_region,
                     });
                 }
             }
         }
         let span_geometry_changed =
             !shift_plans.is_empty() || !split_plans.is_empty() || !remove_refs.is_empty();
+        let mut span_dirty_deltas = Vec::new();
         if span_geometry_changed {
             // Rewritten template ASTs must be interned into the graph's AST
             // arena before the authority is borrowed mutably; the literal
@@ -8558,6 +9026,7 @@ where
                 authority.plane.remove_span(span_ref);
             }
             for (plan, rewrite_prepared) in prepared_shift_plans {
+                let dirty_region = plan.dirty_region;
                 let (template_id, rewrite_slots) = if let Some(rewrite) = plan.rewrite {
                     let Some((ast_id, template_slot_map)) = rewrite_prepared else {
                         return Err(ExcelError::new(ExcelErrorKind::Ref)
@@ -8632,6 +9101,9 @@ where
                         .with_message("FormulaPlane shift could not update span geometry")
                         .into());
                 }
+                if let Some(region) = dirty_region {
+                    span_dirty_deltas.push((plan.span_ref, region));
+                }
                 if plan.force_binding_residual_axes
                     && let Some(binding_set_id) = plan.binding_set_id
                 {
@@ -8647,6 +9119,8 @@ where
                 }
             }
             for plan in split_plans {
+                let upper_dirty_region = plan.upper_dirty_region;
+                let lower_dirty_region = plan.lower_dirty_region;
                 let Some(split_relocation) = authority
                     .plane
                     .spans
@@ -8719,6 +9193,9 @@ where
                         anchor_col: plan.lower_new_origin_col,
                     },
                 );
+                if let Some(region) = lower_dirty_region {
+                    span_dirty_deltas.push((lower_ref, region));
+                }
                 if let Some(binding_set_id) = lower_binding_set_id {
                     authority
                         .plane
@@ -8769,12 +9246,14 @@ where
                         .with_message("FormulaPlane split could not update span geometry")
                         .into());
                 }
+                if let Some(region) = upper_dirty_region {
+                    span_dirty_deltas.push((plan.span_ref, region));
+                }
             }
             authority.rebuild_indexes();
         }
-        if span_geometry_changed {
-            self.graph
-                .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
+        for (span_ref, region) in span_dirty_deltas {
+            self.graph.mark_formula_span_region_dirty(span_ref, region);
         }
 
         let mut span_plans = Vec::new();
@@ -9382,6 +9861,9 @@ where
         count: u32,
     ) -> Result<crate::engine::graph::editor::vertex_editor::ShiftSummary, crate::engine::EditorError>
     {
+        if count == 0 {
+            return Ok(crate::engine::graph::editor::vertex_editor::ShiftSummary::default());
+        }
         self.observe_function_semantic_epoch()
             .map_err(crate::engine::EditorError::Excel)?;
         use crate::engine::graph::editor::vertex_editor::VertexEditor;
@@ -9419,6 +9901,9 @@ where
         count: u32,
     ) -> Result<crate::engine::graph::editor::vertex_editor::ShiftSummary, crate::engine::EditorError>
     {
+        if count == 0 {
+            return Ok(crate::engine::graph::editor::vertex_editor::ShiftSummary::default());
+        }
         self.observe_function_semantic_epoch()
             .map_err(crate::engine::EditorError::Excel)?;
         use crate::engine::graph::editor::vertex_editor::VertexEditor;
@@ -9456,6 +9941,9 @@ where
         count: u32,
     ) -> Result<crate::engine::graph::editor::vertex_editor::ShiftSummary, crate::engine::EditorError>
     {
+        if count == 0 {
+            return Ok(crate::engine::graph::editor::vertex_editor::ShiftSummary::default());
+        }
         self.observe_function_semantic_epoch()
             .map_err(crate::engine::EditorError::Excel)?;
         use crate::engine::graph::editor::vertex_editor::VertexEditor;
@@ -9497,6 +9985,9 @@ where
         count: u32,
     ) -> Result<crate::engine::graph::editor::vertex_editor::ShiftSummary, crate::engine::EditorError>
     {
+        if count == 0 {
+            return Ok(crate::engine::graph::editor::vertex_editor::ShiftSummary::default());
+        }
         self.observe_function_semantic_epoch()
             .map_err(crate::engine::EditorError::Excel)?;
         use crate::engine::graph::editor::vertex_editor::VertexEditor;
@@ -11305,10 +11796,15 @@ where
             ChangeEvent::DefineName { .. }
             | ChangeEvent::UpdateName { .. }
             | ChangeEvent::DeleteName { .. }
-            | ChangeEvent::VertexMoved { .. }
-            | ChangeEvent::FormulaAdjusted { .. }
             | ChangeEvent::NamedRangeAdjusted { .. } => {
+                // Direct name events are preflighted by the logged-name APIs.
+                // Structural entry points preflight spans before emitting a
+                // NamedRangeAdjusted event. Epoch changes only rebuild caches.
                 self.record_formula_plane_structural_change(StructuralScope::AllSheets);
+            }
+            ChangeEvent::VertexMoved { .. } | ChangeEvent::FormulaAdjusted { .. } => {
+                // Structural entry points publish their axis delta once after
+                // graph, Arrow, and span geometry commits.
             }
             ChangeEvent::SetRowVisibility { sheet_id, row0, .. } => {
                 self.record_formula_plane_structural_change(StructuralScope::Region(
@@ -11369,10 +11865,16 @@ where
                 self.graph
                     .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
             }
-            StructuralScope::AllSheets => {
+            StructuralScope::OpaqueGlobal => {
                 let _ = self.graph.formula_authority_mut().rebuild_indexes();
                 self.graph
                     .mark_all_formula_spans_dirty(WholeSpanDirtyReason::GlobalInvalidation);
+            }
+            StructuralScope::AllSheets => {
+                // Name/table mutations dirty their exact graph dependents,
+                // and name-dependent spans are demoted by the name invalidation
+                // registry. A topology rebuild is cache invalidation only.
+                let _ = self.graph.formula_authority_mut().rebuild_indexes();
             }
         }
     }
@@ -11381,7 +11883,7 @@ where
         let first = cells.first()?;
         let sheet_id = first.sheet_id;
         if cells.iter().any(|cell| cell.sheet_id != sheet_id) {
-            return Some(StructuralScope::AllSheets);
+            return Some(StructuralScope::OpaqueGlobal);
         }
         let mut row_start = first.coord.row();
         let mut row_end = row_start;
@@ -13199,6 +13701,14 @@ where
         let dirty_legacy = self.graph.get_evaluation_vertices();
         let mut work = Vec::new();
         let mut scheduled_legacy_vertices = Vec::new();
+        for (span_ref, region) in formula_dirty.span_regions() {
+            if cached.span_refs_by_id.get(&span_ref.id) == Some(&span_ref) {
+                work.push(FormulaProducerWork {
+                    producer: FormulaProducerId::Span(span_ref.id),
+                    dirty: ProducerDirtyDomain::Regions(vec![region]),
+                });
+            }
+        }
         for span_ref in formula_dirty
             .whole_spans()
             .chain(retry_whole_spans.iter().copied())
@@ -13225,7 +13735,10 @@ where
             }
         }
 
-        let pending_changed_regions = formula_dirty.regions().collect::<Vec<_>>();
+        let pending_changed_regions = formula_dirty
+            .regions()
+            .chain(formula_dirty.span_regions().map(|(_, region)| region))
+            .collect::<Vec<_>>();
         if include_dirty_regions && !pending_changed_regions.is_empty() {
             use crate::formula_plane::producer::compute_dirty_closure;
             let closure = compute_dirty_closure(

--- a/crates/formualizer-eval/src/engine/graph/editor/undo_engine.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/undo_engine.rs
@@ -87,6 +87,14 @@ impl UndoEngine {
         Ok(batch)
     }
 
+    pub(crate) fn pending_redo_events(&self) -> Vec<ChangeEvent> {
+        self.undone
+            .last()
+            .into_iter()
+            .flat_map(|batch| batch.iter().map(|item| item.event.clone()))
+            .collect()
+    }
+
     pub fn redo(
         &mut self,
         graph: &mut DependencyGraph,

--- a/crates/formualizer-eval/src/engine/graph/formula_dirty.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_dirty.rs
@@ -14,6 +14,10 @@ pub(crate) enum WholeSpanDirtyReason {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum FormulaDirtyEvent {
     Region(Region),
+    SpanRegion {
+        span_ref: FormulaSpanRef,
+        region: Region,
+    },
     WholeSpan(FormulaSpanRef),
 }
 
@@ -32,13 +36,20 @@ impl FormulaDirtyLease {
     pub(crate) fn regions(&self) -> impl Iterator<Item = Region> + '_ {
         self.events.iter().filter_map(|event| match event {
             FormulaDirtyEvent::Region(region) => Some(*region),
-            FormulaDirtyEvent::WholeSpan(_) => None,
+            FormulaDirtyEvent::SpanRegion { .. } | FormulaDirtyEvent::WholeSpan(_) => None,
+        })
+    }
+
+    pub(crate) fn span_regions(&self) -> impl Iterator<Item = (FormulaSpanRef, Region)> + '_ {
+        self.events.iter().filter_map(|event| match event {
+            FormulaDirtyEvent::SpanRegion { span_ref, region } => Some((*span_ref, *region)),
+            FormulaDirtyEvent::Region(_) | FormulaDirtyEvent::WholeSpan(_) => None,
         })
     }
 
     pub(crate) fn whole_spans(&self) -> impl Iterator<Item = FormulaSpanRef> + '_ {
         self.events.iter().filter_map(|event| match event {
-            FormulaDirtyEvent::Region(_) => None,
+            FormulaDirtyEvent::Region(_) | FormulaDirtyEvent::SpanRegion { .. } => None,
             FormulaDirtyEvent::WholeSpan(span_ref) => Some(*span_ref),
         })
     }
@@ -48,6 +59,7 @@ impl FormulaDirtyLease {
 pub(crate) struct FormulaDirtyStats {
     pub(crate) pending_events: usize,
     pub(crate) region_events_recorded: u64,
+    pub(crate) span_region_events_recorded: u64,
     pub(crate) whole_span_seeds_recorded: u64,
     pub(crate) global_whole_span_invalidations: u64,
 }
@@ -57,10 +69,12 @@ pub(super) struct FormulaDirtyState {
     legacy_vertices: FxHashSet<VertexId>,
     events: Vec<FormulaDirtyEvent>,
     pending_regions_seen: FxHashSet<Region>,
+    pending_span_regions_seen: FxHashSet<(FormulaSpanRef, Region)>,
     pending_spans_seen: FxHashSet<FormulaSpanRef>,
     lease_generation: u64,
     active_lease: Option<ActiveFormulaDirtyLease>,
     region_events_recorded: u64,
+    span_region_events_recorded: u64,
     whole_span_seeds_recorded: u64,
     global_whole_span_invalidations: u64,
 }
@@ -108,6 +122,14 @@ impl FormulaDirtyState {
         }
     }
 
+    pub(super) fn record_span_region(&mut self, span_ref: FormulaSpanRef, region: Region) {
+        if self.pending_span_regions_seen.insert((span_ref, region)) {
+            self.events
+                .push(FormulaDirtyEvent::SpanRegion { span_ref, region });
+            self.span_region_events_recorded = self.span_region_events_recorded.saturating_add(1);
+        }
+    }
+
     pub(super) fn record_whole_spans(
         &mut self,
         spans: impl IntoIterator<Item = FormulaSpanRef>,
@@ -144,6 +166,7 @@ impl FormulaDirtyState {
             events: self.events.clone(),
         };
         self.pending_regions_seen.clear();
+        self.pending_span_regions_seen.clear();
         self.pending_spans_seen.clear();
         lease
     }
@@ -169,6 +192,7 @@ impl FormulaDirtyState {
             events: self.events[..prefix_len].to_vec(),
         };
         self.pending_regions_seen.clear();
+        self.pending_span_regions_seen.clear();
         self.pending_spans_seen.clear();
         Some(lease)
     }
@@ -189,13 +213,22 @@ impl FormulaDirtyState {
     pub(super) fn pending_regions(&self) -> impl Iterator<Item = Region> + '_ {
         self.events.iter().filter_map(|event| match event {
             FormulaDirtyEvent::Region(region) => Some(*region),
-            FormulaDirtyEvent::WholeSpan(_) => None,
+            FormulaDirtyEvent::SpanRegion { .. } | FormulaDirtyEvent::WholeSpan(_) => None,
+        })
+    }
+
+    pub(super) fn pending_span_regions(
+        &self,
+    ) -> impl Iterator<Item = (FormulaSpanRef, Region)> + '_ {
+        self.events.iter().filter_map(|event| match event {
+            FormulaDirtyEvent::SpanRegion { span_ref, region } => Some((*span_ref, *region)),
+            FormulaDirtyEvent::Region(_) | FormulaDirtyEvent::WholeSpan(_) => None,
         })
     }
 
     pub(super) fn pending_whole_spans(&self) -> impl Iterator<Item = FormulaSpanRef> + '_ {
         self.events.iter().filter_map(|event| match event {
-            FormulaDirtyEvent::Region(_) => None,
+            FormulaDirtyEvent::Region(_) | FormulaDirtyEvent::SpanRegion { .. } => None,
             FormulaDirtyEvent::WholeSpan(span_ref) => Some(*span_ref),
         })
     }
@@ -208,6 +241,7 @@ impl FormulaDirtyState {
         FormulaDirtyStats {
             pending_events: self.events.len(),
             region_events_recorded: self.region_events_recorded,
+            span_region_events_recorded: self.span_region_events_recorded,
             whole_span_seeds_recorded: self.whole_span_seeds_recorded,
             global_whole_span_invalidations: self.global_whole_span_invalidations,
         }
@@ -242,6 +276,25 @@ mod tests {
         assert_eq!(
             dirty.pending_whole_spans().collect::<Vec<_>>(),
             vec![span(1)]
+        );
+    }
+
+    #[test]
+    fn span_region_lease_preserves_exact_ref_region_and_post_lease_rerecord() {
+        let mut dirty = FormulaDirtyState::default();
+        let span_ref = span(1);
+        let region = Region::rect(0, 10, 20, 2, 2);
+        dirty.record_span_region(span_ref, region);
+        let lease = dirty.lease();
+        assert_eq!(
+            lease.span_regions().collect::<Vec<_>>(),
+            vec![(span_ref, region)]
+        );
+        dirty.record_span_region(span_ref, region);
+        assert!(dirty.ack(lease));
+        assert_eq!(
+            dirty.pending_span_regions().collect::<Vec<_>>(),
+            vec![(span_ref, region)]
         );
     }
 

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -347,6 +347,14 @@ impl DependencyGraph {
         self.formula_dirty.record_region(region);
     }
 
+    pub(crate) fn mark_formula_span_region_dirty(
+        &mut self,
+        span_ref: crate::formula_plane::runtime::FormulaSpanRef,
+        region: crate::formula_plane::region_index::Region,
+    ) {
+        self.formula_dirty.record_span_region(span_ref, region);
+    }
+
     pub(crate) fn mark_formula_spans_dirty(
         &mut self,
         spans: impl IntoIterator<Item = crate::formula_plane::runtime::FormulaSpanRef>,
@@ -379,6 +387,17 @@ impl DependencyGraph {
         &self,
     ) -> impl Iterator<Item = crate::formula_plane::region_index::Region> + '_ {
         self.formula_dirty.pending_regions()
+    }
+
+    pub(crate) fn pending_formula_dirty_span_regions(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            crate::formula_plane::runtime::FormulaSpanRef,
+            crate::formula_plane::region_index::Region,
+        ),
+    > + '_ {
+        self.formula_dirty.pending_span_regions()
     }
 
     pub(crate) fn pending_formula_dirty_whole_spans(

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -148,21 +148,17 @@ impl DependencyGraph {
 
     // Named Range Methods
 
-    /// Define a new named range
-    pub fn define_name(
-        &mut self,
+    pub(crate) fn validate_define_name(
+        &self,
         name: &str,
-        definition: NamedDefinition,
         scope: NameScope,
     ) -> Result<(), ExcelError> {
-        // Validate name
         if !is_valid_excel_name(name) {
             return Err(
                 ExcelError::new(ExcelErrorKind::Name).with_message(format!("Invalid name: {name}"))
             );
         }
 
-        // Check for duplicates / collisions (respect case-sensitivity config)
         let lookup_key = self.name_lookup_key(name);
         match scope {
             NameScope::Workbook => {
@@ -173,9 +169,7 @@ impl DependencyGraph {
                 }
             }
             NameScope::Sheet(sheet_id) => {
-                if let Some(existing) = self
-                    .sheet_named_ranges_lookup
-                    .get(&(sheet_id, lookup_key.clone()))
+                if let Some(existing) = self.sheet_named_ranges_lookup.get(&(sheet_id, lookup_key))
                 {
                     return Err(ExcelError::new(ExcelErrorKind::Name).with_message(format!(
                         "Name collision under normalization in sheet: '{name}' conflicts with '{existing}'"
@@ -183,6 +177,30 @@ impl DependencyGraph {
                 }
             }
         }
+        Ok(())
+    }
+
+    pub(crate) fn validate_existing_name(
+        &self,
+        name: &str,
+        scope: NameScope,
+    ) -> Result<(), ExcelError> {
+        self.canonical_name_in_scope(scope, name)
+            .map(|_| ())
+            .ok_or_else(|| {
+                ExcelError::new(ExcelErrorKind::Name)
+                    .with_message(format!("Name not found: {name}"))
+            })
+    }
+
+    /// Define a new named range
+    pub fn define_name(
+        &mut self,
+        name: &str,
+        definition: NamedDefinition,
+        scope: NameScope,
+    ) -> Result<(), ExcelError> {
+        self.validate_define_name(name, scope)?;
 
         let mut final_definition = definition;
         // Extract dependencies if formula

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_ingest_shadow.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_ingest_shadow.rs
@@ -936,7 +936,7 @@ fn formula_plane_row_visibility_change_redirties_absolute_anchor_span() {
 }
 
 #[test]
-fn formula_plane_insert_rows_conservatively_redirties_sheet_spans() {
+fn formula_plane_insert_rows_dirties_only_shifted_span_interval() {
     let cfg =
         EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
     let mut engine = Engine::new(TestWorkbook::default(), cfg);
@@ -952,11 +952,32 @@ fn formula_plane_insert_rows_conservatively_redirties_sheet_spans() {
     engine.ingest_formula_batches(batches).unwrap();
     engine.evaluate_all().unwrap();
 
+    let sheet_id = engine.graph.sheet_id("Sheet1").unwrap();
+    let globals_before = engine
+        .baseline_stats()
+        .formula_plane_dirty_global_invalidations;
     engine.insert_rows("Sheet1", 10, 1).unwrap();
+    assert_eq!(
+        engine
+            .graph
+            .pending_formula_dirty_span_regions()
+            .map(|(_, region)| region)
+            .collect::<Vec<_>>(),
+        vec![crate::formula_plane::region_index::Region::rect(
+            sheet_id, 10, 100, 1, 1
+        )]
+    );
     let result = engine.evaluate_all().unwrap();
-    assert!(
-        result.computed_vertices >= 100,
-        "expected sheet structural notification to re-evaluate span, got {result:?}"
+    assert_eq!(result.computed_vertices, 91, "result={result:?}");
+    assert_eq!(
+        engine
+            .baseline_stats()
+            .formula_plane_dirty_global_invalidations,
+        globals_before
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 11, 2),
+        Some(LiteralValue::Number(6.0))
     );
 }
 

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -590,11 +590,11 @@ fn assert_mutation_invalidates_cache_once(
         "{label} must bump graph topology revision once",
     );
     assert!(!engine.mixed_topology_cache_present_for_test());
-    if label == "sheet" {
+    if matches!(label, "sheet" | "name" | "table") {
         assert_eq!(
             engine.graph.pending_formula_dirty_event_count(),
             0,
-            "metadata-only sheet addition must not invent dirty work"
+            "metadata-only topology mutation must not invent dirty work"
         );
     } else {
         assert!(
@@ -685,6 +685,39 @@ fn mixed_topology_cache_rejects_stale_span_ref_even_without_epoch_change() {
             .formula_plane_mixed_topology_cache_builds,
         before.formula_plane_mixed_topology_cache_builds + 1
     );
+}
+
+#[test]
+fn stale_exact_span_region_event_is_ignored_after_generation_change() {
+    let mut engine = cached_topology_engine();
+    engine.evaluate_all().unwrap();
+    let span_ref = engine.graph.formula_authority().active_span_refs()[0];
+    let result_region = {
+        let span = engine
+            .graph
+            .formula_authority()
+            .plane
+            .spans
+            .get(span_ref)
+            .unwrap();
+        crate::formula_plane::region_index::Region::from_domain(&span.domain)
+    };
+    engine
+        .graph
+        .mark_formula_span_region_dirty(span_ref, result_region);
+    engine
+        .graph
+        .formula_authority_mut()
+        .plane
+        .spans
+        .get_mut_for_test(span_ref)
+        .unwrap()
+        .version = span_ref.version.wrapping_add(1);
+
+    engine.evaluate_all().unwrap();
+
+    assert!(engine.last_formula_plane_span_eval_report().is_none());
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
@@ -596,3 +596,368 @@ fn literal_and_undefined_names_fall_back_with_precise_reason() {
         other => panic!("expected #NAME? ground truth for undefined name, got {other:?}"),
     }
 }
+
+#[test]
+fn logged_name_update_forward_undo_redo_preserves_value_parity() {
+    use crate::engine::ChangeLog;
+    use crate::engine::graph::editor::undo_engine::UndoEngine;
+
+    let mut auth = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut off = engine_with_mode(FormulaPlaneMode::Off);
+    for engine in [&mut auth, &mut off] {
+        seed_named_workbook(engine);
+        for row in FIRST_ROW..=LAST_ROW {
+            engine
+                .set_cell_value(SHEET, row, 4, LiteralValue::Number(1_000.0 + row as f64))
+                .unwrap();
+        }
+    }
+    ingest_column(&mut auth, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    ingest_column(&mut off, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+
+    let old_definition = range_def(&mut off, SHEET, FIRST_ROW, 2, LAST_ROW, 2);
+    let new_definition_auth = range_def(&mut auth, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+    let new_definition_off = range_def(&mut off, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+    let mut log = ChangeLog::new();
+    auth.update_name_with_logger(&mut log, "Data", new_definition_auth, NameScope::Workbook)
+        .unwrap();
+    off.update_name("Data", new_definition_off.clone(), NameScope::Workbook)
+        .unwrap();
+    assert_eq!(auth.baseline_stats().formula_plane_active_span_count, 0);
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("logged update", SHEET, 3, &auth, &off);
+
+    let mut undo = UndoEngine::new();
+    auth.undo_logged(&mut undo, &mut log).unwrap();
+    off.update_name("Data", old_definition, NameScope::Workbook)
+        .unwrap();
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("logged update undo", SHEET, 3, &auth, &off);
+
+    auth.redo_logged(&mut undo, &mut log).unwrap();
+    off.update_name("Data", new_definition_off, NameScope::Workbook)
+        .unwrap();
+    auth.evaluate_all().unwrap();
+    off.evaluate_all().unwrap();
+    assert_column_parity("logged update redo", SHEET, 3, &auth, &off);
+}
+
+#[test]
+fn logged_name_define_and_delete_demote_exact_dependents() {
+    use crate::engine::ChangeLog;
+
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    for row in FIRST_ROW..=LAST_ROW {
+        engine
+            .set_cell_value(SHEET, row, 4, LiteralValue::Number(2_000.0 + row as f64))
+            .unwrap();
+    }
+    ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    engine.evaluate_all().unwrap();
+
+    let sheet_id = engine.graph.sheet_id_mut(SHEET);
+    let shadow = range_def(&mut engine, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+    let mut log = ChangeLog::new();
+    engine
+        .define_name_with_logger(&mut log, "Data", shadow, NameScope::Sheet(sheet_id))
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    engine.evaluate_all().unwrap();
+
+    ingest_column(&mut engine, SHEET, 5, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    engine
+        .delete_name_with_logger(&mut log, "Data", NameScope::Sheet(sheet_id))
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    engine.evaluate_all().unwrap();
+    assert!(matches!(
+        engine.get_cell_value(SHEET, FIRST_ROW, 5),
+        Some(LiteralValue::Number(_))
+    ));
+}
+
+#[test]
+fn logged_name_demotion_limit_and_fault_are_atomic_and_retryable() {
+    use crate::engine::ChangeLog;
+    use crate::engine::eval::FormulaSpanDemotionFault;
+
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    for row in FIRST_ROW..=LAST_ROW {
+        engine
+            .set_cell_value(SHEET, row, 4, LiteralValue::Number(3_000.0 + row as f64))
+            .unwrap();
+    }
+    ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    engine.evaluate_all().unwrap();
+    let refs = engine.graph.formula_authority().active_span_refs();
+    let old_definition = engine
+        .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+        .unwrap()
+        .definition
+        .clone();
+    let new_definition = range_def(&mut engine, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+    let mut log = ChangeLog::new();
+
+    let original_limits = engine.workbook_load_limits().clone();
+    let mut limited = original_limits.clone();
+    limited.max_formula_plane_fallback_cells = 0;
+    engine.set_workbook_load_limits(limited);
+    assert!(
+        engine
+            .update_name_with_logger(
+                &mut log,
+                "Data",
+                new_definition.clone(),
+                NameScope::Workbook,
+            )
+            .is_err()
+    );
+    assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        old_definition
+    );
+    assert!(log.is_empty());
+
+    engine.set_workbook_load_limits(original_limits);
+    engine.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
+    assert!(
+        engine
+            .update_name_with_logger(
+                &mut log,
+                "Data",
+                new_definition.clone(),
+                NameScope::Workbook,
+            )
+            .is_err()
+    );
+    assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        old_definition
+    );
+    assert!(log.is_empty());
+
+    engine
+        .update_name_with_logger(&mut log, "Data", new_definition, NameScope::Workbook)
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(log.len(), 1);
+}
+
+#[test]
+fn generic_edit_with_logger_rejects_and_rolls_back_name_mutations() {
+    use crate::engine::ChangeLog;
+
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    engine.evaluate_all().unwrap();
+    let refs = engine.graph.formula_authority().active_span_refs();
+    let old_definition = engine
+        .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+        .unwrap()
+        .definition
+        .clone();
+    let new_definition = range_def(&mut engine, SHEET, FIRST_ROW, 1, LAST_ROW, 1);
+    let mut log = ChangeLog::new();
+    let result = engine.edit_with_logger(&mut log, |editor| {
+        editor.update_name("Data", new_definition, NameScope::Workbook)
+    });
+    assert!(result.is_err());
+    assert!(log.is_empty());
+    assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        old_definition
+    );
+}
+
+#[test]
+fn logged_name_undo_redo_faults_leave_history_and_authority_retryable() {
+    use crate::engine::ChangeLog;
+    use crate::engine::eval::FormulaSpanDemotionFault;
+    use crate::engine::graph::editor::undo_engine::UndoEngine;
+
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    for row in FIRST_ROW..=LAST_ROW {
+        engine
+            .set_cell_value(SHEET, row, 4, LiteralValue::Number(4_000.0 + row as f64))
+            .unwrap();
+    }
+    ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    engine.evaluate_all().unwrap();
+
+    let old_definition = engine
+        .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+        .unwrap()
+        .definition
+        .clone();
+    let new_definition = range_def(&mut engine, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+    let mut log = ChangeLog::new();
+    engine
+        .update_name_with_logger(
+            &mut log,
+            "Data",
+            new_definition.clone(),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    ingest_column(&mut engine, SHEET, 5, |r| format!("=SUM(Data)+A{r}"));
+    engine.evaluate_all().unwrap();
+    let undo_refs = engine.graph.formula_authority().active_span_refs();
+    let undo_log_len = log.len();
+    let mut undo = UndoEngine::new();
+    engine.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
+    assert!(engine.undo_logged(&mut undo, &mut log).is_err());
+    assert_eq!(log.len(), undo_log_len);
+    assert_eq!(
+        engine.graph.formula_authority().active_span_refs(),
+        undo_refs
+    );
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        new_definition
+    );
+
+    engine.undo_logged(&mut undo, &mut log).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        old_definition
+    );
+    engine.evaluate_all().unwrap();
+
+    ingest_column(&mut engine, SHEET, 6, |r| format!("=SUM(Data)+A{r}"));
+    engine.evaluate_all().unwrap();
+    let redo_refs = engine.graph.formula_authority().active_span_refs();
+    let redo_log_len = log.len();
+    engine.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
+    assert!(engine.redo_logged(&mut undo, &mut log).is_err());
+    assert_eq!(log.len(), redo_log_len);
+    assert_eq!(
+        engine.graph.formula_authority().active_span_refs(),
+        redo_refs
+    );
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        old_definition
+    );
+
+    engine.redo_logged(&mut undo, &mut log).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        new_definition
+    );
+    engine.evaluate_all().unwrap();
+    assert!(matches!(
+        engine.get_cell_value(SHEET, FIRST_ROW, 6),
+        Some(LiteralValue::Number(_))
+    ));
+}
+
+#[test]
+fn direct_name_update_demotes_disjoint_spans_as_one_retryable_batch() {
+    use crate::engine::eval::FormulaSpanDemotionFault;
+
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    for row in FIRST_ROW..=LAST_ROW {
+        engine
+            .set_cell_value(SHEET, row, 4, LiteralValue::Number(6_000.0 + row as f64))
+            .unwrap();
+    }
+    ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    ingest_column(&mut engine, SHEET, 5, |r| format!("=SUM(Data)+A{r}"));
+    engine.evaluate_all().unwrap();
+
+    let refs_before = engine.graph.formula_authority().active_span_refs();
+    assert_eq!(refs_before.len(), 2);
+    let old_definition = engine
+        .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+        .unwrap()
+        .definition
+        .clone();
+    let new_definition = range_def(&mut engine, SHEET, FIRST_ROW, 4, LAST_ROW, 4);
+    let topology_before = engine.topology_epoch_for_test();
+    let graph_revision_before = engine.graph_topology_revision_for_test();
+    let dirty_before = engine.graph.formula_dirty_stats();
+
+    engine.set_formula_span_demotion_fault_for_test(FormulaSpanDemotionFault::BeforeFirstMutation);
+    assert!(
+        engine
+            .update_name("Data", new_definition.clone(), NameScope::Workbook,)
+            .is_err()
+    );
+    assert_eq!(
+        engine.graph.formula_authority().active_span_refs(),
+        refs_before
+    );
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+    assert_eq!(
+        engine.graph_topology_revision_for_test(),
+        graph_revision_before
+    );
+    assert_eq!(engine.graph.formula_dirty_stats(), dirty_before);
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        old_definition
+    );
+
+    engine
+        .update_name("Data", new_definition.clone(), NameScope::Workbook)
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(
+        engine
+            .resolve_name_entry("Data", engine.graph.sheet_id(SHEET).unwrap())
+            .unwrap()
+            .definition,
+        new_definition
+    );
+    engine.evaluate_all().unwrap();
+    assert!(matches!(
+        engine.get_cell_value(SHEET, FIRST_ROW, 3),
+        Some(LiteralValue::Number(_))
+    ));
+    assert!(matches!(
+        engine.get_cell_value(SHEET, FIRST_ROW, 5),
+        Some(LiteralValue::Number(_))
+    ));
+}

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -828,13 +828,24 @@ fn formula_plane_duplicate_sheet_only_demotes_source_sheet_spans() {
 #[test]
 fn formula_plane_zero_count_structural_ops_are_noops() {
     let mut engine = build_single_formula_column_family(100);
+    engine.evaluate_all().unwrap();
+    let before = engine.baseline_stats();
+    let topology_before = engine.topology_epoch_for_test();
 
     engine.insert_rows("Sheet1", 3, 0).unwrap();
     engine.delete_rows("Sheet1", 3, 0).unwrap();
     engine.insert_columns("Sheet1", 2, 0).unwrap();
     engine.delete_columns("Sheet1", 2, 0).unwrap();
     assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
     engine.evaluate_all().unwrap();
+    let after = engine.baseline_stats();
+    assert_eq!(
+        after.formula_plane_mixed_topology_cache_builds,
+        before.formula_plane_mixed_topology_cache_builds
+    );
+    assert!(engine.last_formula_plane_span_eval_report().is_none());
 
     assert_eq!(
         engine.get_cell_value("Sheet1", 50, 2),
@@ -876,7 +887,7 @@ fn formula_plane_origin_shift_with_stationary_value_ref_does_not_memo_broadcast_
 /// plane. Engine batch ingest groups families per column (so it only ever
 /// produces RowRun spans); this helper lets structural tests exercise ColRun
 /// and Rect domains through the real engine insert path.
-fn seed_absolute_read_span(
+pub(super) fn seed_absolute_read_span(
     engine: &mut Engine<TestWorkbook>,
     formula: &str,
     domain: crate::formula_plane::runtime::PlacementDomain,

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural_tail_precision.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural_tail_precision.rs
@@ -105,3 +105,479 @@ fn column_insert_outside_span_region_with_dirty_closure_no_recompute() {
         assert_number(&engine, 654, col, 654.0 + f64::from(col - 1));
     }
 }
+
+fn build_row_run(rows: u32) -> Engine<TestWorkbook> {
+    let mut engine = authoritative_engine();
+    let mut formulas = Vec::with_capacity(rows as usize);
+    for row in 1..=rows {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}+1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(active_span_count(&engine), 1);
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+fn build_col_run(cols: u32) -> Engine<TestWorkbook> {
+    let mut engine = authoritative_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(21.0))
+        .unwrap();
+    super::formula_plane_structural::seed_absolute_read_span(
+        &mut engine,
+        "=$A$1*2",
+        crate::formula_plane::runtime::PlacementDomain::col_run(0, 0, 1, cols),
+    );
+    assert_eq!(active_span_count(&engine), 1);
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+#[test]
+fn row_structural_before_inside_after_publish_exact_bounded_span_regions() {
+    let mut inside = build_row_run(1000);
+    let sheet_id = inside.graph.sheet_id("Sheet1").unwrap();
+    let globals_before = inside
+        .baseline_stats()
+        .formula_plane_dirty_global_invalidations;
+    inside.insert_rows("Sheet1", 901, 1).unwrap();
+    let exact = inside
+        .graph
+        .pending_formula_dirty_span_regions()
+        .collect::<Vec<_>>();
+    assert_eq!(exact.len(), 1, "only the shifted lower split is dirty");
+    assert_eq!(
+        exact[0].1,
+        crate::formula_plane::region_index::Region::rect(sheet_id, 901, 1000, 1, 1)
+    );
+    assert_eq!(
+        inside
+            .graph
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>(),
+        vec![crate::formula_plane::region_index::Region::rows_from(
+            sheet_id, 900
+        )]
+    );
+    inside.evaluate_all().unwrap();
+    assert_eq!(
+        inside
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        100
+    );
+    assert_eq!(
+        inside
+            .baseline_stats()
+            .formula_plane_dirty_global_invalidations,
+        globals_before,
+        "structural geometry must not use global WholeAll-equivalent dirtiness"
+    );
+
+    let mut before = build_row_run(1000);
+    before.insert_rows("Sheet1", 1, 1).unwrap();
+    before.evaluate_all().unwrap();
+    assert_eq!(
+        before
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        1000
+    );
+
+    let mut after = build_row_run(1000);
+    after.insert_rows("Sheet1", 1002, 1).unwrap();
+    after.evaluate_all().unwrap();
+    assert!(after.last_formula_plane_span_eval_report().is_none());
+}
+
+#[test]
+fn row_delete_tail_recomputes_only_compacted_interval() {
+    let mut engine = build_row_run(1000);
+    let sheet_id = engine.graph.sheet_id("Sheet1").unwrap();
+    engine.delete_rows("Sheet1", 901, 50).unwrap();
+    assert_eq!(
+        engine
+            .graph
+            .pending_formula_dirty_span_regions()
+            .map(|(_, region)| region)
+            .collect::<Vec<_>>(),
+        vec![crate::formula_plane::region_index::Region::rect(
+            sheet_id, 900, 949, 1, 1
+        )]
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        50
+    );
+}
+
+#[test]
+fn column_structural_inside_and_after_are_precise() {
+    let mut inside = build_col_run(1000);
+    let sheet_id = inside.graph.sheet_id("Sheet1").unwrap();
+    inside.insert_columns("Sheet1", 902, 1).unwrap();
+    assert_eq!(
+        inside
+            .graph
+            .pending_formula_dirty_span_regions()
+            .map(|(_, region)| region)
+            .collect::<Vec<_>>(),
+        vec![crate::formula_plane::region_index::Region::rect(
+            sheet_id, 0, 0, 902, 1001
+        )]
+    );
+    inside.evaluate_all().unwrap();
+    assert_eq!(
+        inside
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        100
+    );
+
+    let mut after = build_col_run(1000);
+    after.insert_columns("Sheet1", 1003, 1).unwrap();
+    after.evaluate_all().unwrap();
+    assert!(after.last_formula_plane_span_eval_report().is_none());
+}
+
+#[test]
+fn failed_duplicate_validation_publishes_no_structural_dirty_delta() {
+    let mut engine = build_row_run(120);
+    let refs = engine.graph.formula_authority().active_span_refs();
+    let before = engine.baseline_stats();
+    assert!(engine.duplicate_sheet("Sheet1", "Sheet1").is_err());
+    assert_eq!(engine.graph.formula_authority().active_span_refs(), refs);
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
+    let after = engine.baseline_stats();
+    assert_eq!(
+        after.formula_plane_dirty_span_region_events_recorded,
+        before.formula_plane_dirty_span_region_events_recorded
+    );
+    assert_eq!(
+        after.formula_plane_dirty_region_events_recorded,
+        before.formula_plane_dirty_region_events_recorded
+    );
+}
+
+fn ingest_row_run_on_sheet(
+    engine: &mut Engine<TestWorkbook>,
+    sheet: &str,
+    rows: u32,
+    formula_col: u32,
+) {
+    let mut formulas = Vec::with_capacity(rows as usize);
+    for row in 1..=rows {
+        engine
+            .set_cell_value(sheet, row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(engine, row, formula_col, &format!("=A{row}+1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(sheet, formulas)])
+        .unwrap();
+}
+
+#[test]
+fn structural_span_region_isolated_to_edited_sheet() {
+    let mut engine = authoritative_engine();
+    engine.add_sheet("Sheet2").unwrap();
+    ingest_row_run_on_sheet(&mut engine, "Sheet1", 1000, 2);
+    ingest_row_run_on_sheet(&mut engine, "Sheet2", 1000, 2);
+    assert_eq!(active_span_count(&engine), 2);
+    engine.evaluate_all().unwrap();
+
+    let sheet1_id = engine.graph.sheet_id("Sheet1").unwrap();
+    let sheet2_id = engine.graph.sheet_id("Sheet2").unwrap();
+    engine.insert_rows("Sheet1", 901, 1).unwrap();
+    let exact = engine
+        .graph
+        .pending_formula_dirty_span_regions()
+        .collect::<Vec<_>>();
+    assert_eq!(exact.len(), 1);
+    assert_eq!(exact[0].1.sheet_id(), sheet1_id);
+    let authority = engine.graph.formula_authority();
+    assert_eq!(
+        authority.plane.spans.get(exact[0].0).unwrap().sheet_id,
+        sheet1_id
+    );
+    assert!(
+        authority
+            .active_span_refs()
+            .into_iter()
+            .any(|span_ref| authority.plane.spans.get(span_ref).unwrap().sheet_id == sheet2_id)
+    );
+
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        100
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet2", 999, 2),
+        Some(LiteralValue::Number(1000.0))
+    );
+}
+
+#[test]
+fn sheet_and_unrelated_name_table_lifecycle_do_not_dirty_surviving_spans() {
+    use crate::engine::named_range::{NameScope, NamedDefinition};
+    use crate::reference::{CellRef, Coord, RangeRef};
+
+    let mut engine = authoritative_engine();
+    engine.add_sheet("Sheet2").unwrap();
+    ingest_row_run_on_sheet(&mut engine, "Sheet1", 120, 2);
+    ingest_row_run_on_sheet(&mut engine, "Sheet2", 120, 2);
+    engine.evaluate_all().unwrap();
+
+    engine
+        .rename_sheet(engine.graph.sheet_id("Sheet2").unwrap(), "Renamed")
+        .unwrap();
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
+
+    engine
+        .define_name(
+            "Unrelated",
+            NamedDefinition::Literal(LiteralValue::Number(7.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
+
+    let sheet1_id = engine.graph.sheet_id("Sheet1").unwrap();
+    engine
+        .define_table(
+            "UnrelatedTable",
+            RangeRef::new(
+                CellRef::new(sheet1_id, Coord::from_excel(1, 10, true, true)),
+                CellRef::new(sheet1_id, Coord::from_excel(2, 10, true, true)),
+            ),
+            true,
+            vec!["Value".into()],
+            false,
+        )
+        .unwrap();
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
+
+    let refs_before_duplicate = engine.graph.formula_authority().active_span_refs();
+    engine.duplicate_sheet("Sheet1", "Copy").unwrap();
+    let surviving = engine.graph.formula_authority().active_span_refs();
+    assert_eq!(surviving.len(), 1, "only the source-sheet span is demoted");
+    assert!(refs_before_duplicate.contains(&surviving[0]));
+    assert_eq!(engine.graph.pending_formula_dirty_event_count(), 0);
+    engine.evaluate_all().unwrap();
+    assert!(engine.last_formula_plane_span_eval_report().is_none());
+
+    engine.add_sheet("Empty").unwrap();
+    let empty_id = engine.graph.sheet_id("Empty").unwrap();
+    let globals_before = engine
+        .baseline_stats()
+        .formula_plane_dirty_global_invalidations;
+    engine.remove_sheet(empty_id).unwrap();
+    assert_eq!(
+        engine.graph.formula_authority().active_span_refs(),
+        surviving
+    );
+    assert_eq!(
+        engine
+            .graph
+            .pending_formula_dirty_whole_spans()
+            .collect::<Vec<_>>(),
+        surviving
+    );
+    assert_eq!(
+        engine
+            .baseline_stats()
+            .formula_plane_dirty_global_invalidations,
+        globals_before + 1
+    );
+}
+
+#[test]
+fn structural_insert_action_undo_redo_preserves_values_without_unlogged_span_geometry() {
+    use crate::engine::graph::editor::undo_engine::UndoEngine;
+
+    let mut engine = build_row_run(120);
+    let mut undo = UndoEngine::new();
+    let (_value, journal) = engine
+        .action_atomic_journal("insert row".to_string(), |tx| {
+            tx.insert_rows("Sheet1", 61, 1)?;
+            Ok(())
+        })
+        .unwrap();
+    undo.push_action(journal);
+    assert_eq!(
+        active_span_count(&engine),
+        0,
+        "journaled geometry is materialized"
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 62, 2),
+        Some(LiteralValue::Number(62.0))
+    );
+
+    engine.undo_action(&mut undo).unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 61, 2),
+        Some(LiteralValue::Number(62.0))
+    );
+
+    engine.redo_action(&mut undo).unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 62, 2),
+        Some(LiteralValue::Number(62.0))
+    );
+}
+
+#[test]
+fn structural_candidate_overflow_is_atomic_and_retryable() {
+    let mut engine = build_row_run(120);
+    let refs_before = engine.graph.formula_authority().active_span_refs();
+    let topology_before = engine.topology_epoch_for_test();
+    let graph_revision_before = engine.graph_topology_revision_for_test();
+    let (plane_epoch_before, indexes_epoch_before) = {
+        let authority = engine.graph.formula_authority();
+        (authority.plane.epoch(), authority.indexes_epoch())
+    };
+    let dirty_stats_before = engine.graph.formula_dirty_stats();
+    let dirty_regions_before = engine
+        .graph
+        .pending_formula_dirty_regions()
+        .collect::<Vec<_>>();
+    let dirty_span_regions_before = engine
+        .graph
+        .pending_formula_dirty_span_regions()
+        .collect::<Vec<_>>();
+    let dirty_spans_before = engine
+        .graph
+        .pending_formula_dirty_whole_spans()
+        .collect::<Vec<_>>();
+    let candidates_before = engine
+        .baseline_stats()
+        .formula_plane_structural_span_candidates;
+
+    engine.config.max_formula_plane_cache_candidates = 0;
+    assert!(engine.insert_rows("Sheet1", 111, 1).is_err());
+
+    assert_eq!(
+        engine.graph.formula_authority().active_span_refs(),
+        refs_before
+    );
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+    assert_eq!(
+        engine.graph_topology_revision_for_test(),
+        graph_revision_before
+    );
+    {
+        let authority = engine.graph.formula_authority();
+        assert_eq!(authority.plane.epoch(), plane_epoch_before);
+        assert_eq!(authority.indexes_epoch(), indexes_epoch_before);
+    }
+    assert_eq!(engine.graph.formula_dirty_stats(), dirty_stats_before);
+    assert_eq!(
+        engine
+            .graph
+            .pending_formula_dirty_regions()
+            .collect::<Vec<_>>(),
+        dirty_regions_before
+    );
+    assert_eq!(
+        engine
+            .graph
+            .pending_formula_dirty_span_regions()
+            .collect::<Vec<_>>(),
+        dirty_span_regions_before
+    );
+    assert_eq!(
+        engine
+            .graph
+            .pending_formula_dirty_whole_spans()
+            .collect::<Vec<_>>(),
+        dirty_spans_before
+    );
+    assert_eq!(
+        engine
+            .baseline_stats()
+            .formula_plane_structural_span_candidates,
+        candidates_before
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 111, 1),
+        Some(LiteralValue::Number(111.0))
+    );
+    assert_eq!(engine.get_cell_value("Sheet1", 121, 1), None);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 120, 2),
+        Some(LiteralValue::Number(121.0))
+    );
+
+    engine.config.max_formula_plane_cache_candidates = 100_000;
+    engine.insert_rows("Sheet1", 111, 1).unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 121, 2),
+        Some(LiteralValue::Number(121.0))
+    );
+}
+
+#[test]
+fn indexed_structural_selection_classifies_only_affected_candidate_among_many_sheets() {
+    const SHEETS: u32 = 24;
+    let mut engine = authoritative_engine();
+    for index in 0..SHEETS {
+        let sheet = if index == 0 {
+            "Sheet1".to_string()
+        } else {
+            let name = format!("Unrelated{index}");
+            engine.add_sheet(&name).unwrap();
+            name
+        };
+        ingest_row_run_on_sheet(&mut engine, &sheet, 120, 2);
+    }
+    assert_eq!(active_span_count(&engine), SHEETS as usize);
+    engine.evaluate_all().unwrap();
+    let candidates_before = engine
+        .baseline_stats()
+        .formula_plane_structural_span_candidates;
+
+    engine.insert_rows("Sheet1", 111, 1).unwrap();
+
+    let candidates_after = engine
+        .baseline_stats()
+        .formula_plane_structural_span_candidates;
+    assert_eq!(
+        candidates_after - candidates_before,
+        1,
+        "result/read indexes must select only the edited sheet's span"
+    );
+    assert_eq!(engine.graph.pending_formula_dirty_span_regions().count(), 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        10
+    );
+    assert_eq!(
+        engine.get_cell_value("Unrelated23", 120, 2),
+        Some(LiteralValue::Number(121.0))
+    );
+}

--- a/crates/formualizer-eval/src/formula_plane/producer.rs
+++ b/crates/formualizer-eval/src/formula_plane/producer.rs
@@ -188,6 +188,33 @@ impl FormulaProducerResultIndex {
         }
     }
 
+    pub(crate) fn query_bounded(
+        &self,
+        read_region: Region,
+        max_candidates: usize,
+    ) -> BoundedRegionQueryResult<FormulaProducerResultEntry> {
+        match self.index.query_bounded(read_region, max_candidates) {
+            BoundedRegionQueryResult::Incomplete {
+                observed_candidates,
+            } => BoundedRegionQueryResult::Incomplete {
+                observed_candidates,
+            },
+            BoundedRegionQueryResult::Complete(result) => {
+                BoundedRegionQueryResult::Complete(RegionQueryResult {
+                    matches: result
+                        .matches
+                        .into_iter()
+                        .map(|matched| RegionMatch {
+                            value: self.entries[matched.value.0].clone(),
+                            indexed_region: matched.indexed_region,
+                        })
+                        .collect(),
+                    stats: result.stats,
+                })
+            }
+        }
+    }
+
     pub(crate) fn producer_result_region(&self, producer: FormulaProducerId) -> Option<Region> {
         self.by_producer.get(&producer).copied()
     }

--- a/crates/formualizer-eval/src/formula_plane/region_index.rs
+++ b/crates/formualizer-eval/src/formula_plane/region_index.rs
@@ -556,6 +556,7 @@ pub(crate) struct SheetRegionIndex<T: Clone> {
     col_intervals: BTreeMap<(SheetId, u32), IntervalTree<usize>>,
     row_intervals: BTreeMap<(SheetId, u32), IntervalTree<usize>>,
     rect_buckets: BTreeMap<(SheetId, u32, u32), Vec<usize>>,
+    rect_buckets_by_col: BTreeMap<(SheetId, u32, u32), Vec<usize>>,
     rows_from: FxHashMap<SheetId, BTreeMap<u32, Vec<usize>>>,
     cols_from: FxHashMap<SheetId, BTreeMap<u32, Vec<usize>>>,
     whole_rows: BTreeMap<(SheetId, u32), Vec<usize>>,
@@ -595,6 +596,7 @@ impl<T: Clone> SheetRegionIndex<T> {
             col_intervals: BTreeMap::new(),
             row_intervals: BTreeMap::new(),
             rect_buckets: BTreeMap::new(),
+            rect_buckets_by_col: BTreeMap::new(),
             rows_from: FxHashMap::default(),
             cols_from: FxHashMap::default(),
             whole_rows: BTreeMap::new(),
@@ -628,6 +630,7 @@ impl<T: Clone> SheetRegionIndex<T> {
         self.col_intervals.clear();
         self.row_intervals.clear();
         self.rect_buckets.clear();
+        self.rect_buckets_by_col.clear();
         self.rows_from.clear();
         self.cols_from.clear();
         self.whole_rows.clear();
@@ -734,6 +737,7 @@ impl<T: Clone> SheetRegionIndex<T> {
         bytes = bytes.checked_add(estimate_interval_map(&self.col_intervals)?)?;
         bytes = bytes.checked_add(estimate_interval_map(&self.row_intervals)?)?;
         bytes = bytes.checked_add(estimate_btree_vec_map(&self.rect_buckets)?)?;
+        bytes = bytes.checked_add(estimate_btree_vec_map(&self.rect_buckets_by_col)?)?;
         bytes = bytes.checked_add(estimate_nested_btree_vec_map(&self.rows_from)?)?;
         bytes = bytes.checked_add(estimate_nested_btree_vec_map(&self.cols_from)?)?;
         bytes = bytes.checked_add(estimate_btree_vec_map(&self.whole_rows)?)?;
@@ -942,6 +946,86 @@ impl<T: Clone> SheetRegionIndex<T> {
                     visitor,
                 )
             }
+            (AxisRange::Span(row_start, row_end), AxisRange::All) => {
+                for ids in self
+                    .points_by_row
+                    .range((sheet_id, row_start, 0)..=(sheet_id, row_end, u32::MAX))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                for tree in self
+                    .col_intervals
+                    .range((sheet_id, 0)..=(sheet_id, u32::MAX))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, row_start, row_end, visitor)?;
+                }
+                for tree in self
+                    .row_intervals
+                    .range((sheet_id, row_start)..=(sheet_id, row_end))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, 0, u32::MAX, visitor)?;
+                }
+                for ids in self
+                    .rect_buckets
+                    .range(
+                        (sheet_id, self.row_bucket(row_start), 0)
+                            ..=(sheet_id, self.row_bucket(row_end), u32::MAX),
+                    )
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                visit_common(
+                    row_end,
+                    u32::MAX,
+                    Some((row_start, row_end)),
+                    Some((0, u32::MAX)),
+                    visitor,
+                )
+            }
+            (AxisRange::All, AxisRange::Span(col_start, col_end)) => {
+                for ids in self
+                    .points_by_col
+                    .range((sheet_id, col_start, 0)..=(sheet_id, col_end, u32::MAX))
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                for tree in self
+                    .col_intervals
+                    .range((sheet_id, col_start)..=(sheet_id, col_end))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, 0, u32::MAX, visitor)?;
+                }
+                for tree in self
+                    .row_intervals
+                    .range((sheet_id, 0)..=(sheet_id, u32::MAX))
+                    .map(|(_, tree)| tree)
+                {
+                    visit_tree(tree, col_start, col_end, visitor)?;
+                }
+                for ids in self
+                    .rect_buckets_by_col
+                    .range(
+                        (sheet_id, self.col_bucket(col_start), 0)
+                            ..=(sheet_id, self.col_bucket(col_end), u32::MAX),
+                    )
+                    .map(|(_, ids)| ids)
+                {
+                    visit_ids(ids, visitor)?;
+                }
+                visit_common(
+                    u32::MAX,
+                    col_end,
+                    Some((0, u32::MAX)),
+                    Some((col_start, col_end)),
+                    visitor,
+                )
+            }
             (AxisRange::All, AxisRange::All) => {
                 for ids in self
                     .points_by_row
@@ -1027,8 +1111,13 @@ impl<T: Clone> SheetRegionIndex<T> {
                     unreachable!()
                 };
                 let rect = RectRegion::new(sheet_id, row_start, row_end, col_start, col_end);
-                for bucket in self.rect_buckets_for_rect(rect) {
+                for bucket @ (sheet_id, row_bucket, col_bucket) in self.rect_buckets_for_rect(rect)
+                {
                     self.rect_buckets.entry(bucket).or_default().push(id);
+                    self.rect_buckets_by_col
+                        .entry((sheet_id, col_bucket, row_bucket))
+                        .or_default()
+                        .push(id);
                 }
             }
             (AxisKind::From, AxisKind::All) => {
@@ -2717,5 +2806,56 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![0, 1, 2, 3]
         );
+    }
+}
+
+#[cfg(test)]
+mod structural_stripe_tests {
+    use super::*;
+
+    #[test]
+    fn bounded_column_stripe_uses_mirrored_rect_buckets() {
+        let mut index = SheetRegionIndex::with_rect_bucket_size(8, 8);
+        for item in 0..2_000u32 {
+            let col = item.saturating_mul(16);
+            index.insert(Region::rect(0, 10, 11, col, col + 1), item);
+        }
+        let target = 1_234u32.saturating_mul(16);
+        let query = Region {
+            sheet_id: 0,
+            rows: AxisRange::All,
+            cols: AxisRange::Span(target, target + 1),
+        };
+        let BoundedRegionQueryResult::Complete(result) = index.query_bounded(query, 8) else {
+            panic!("narrow column stripe must remain bounded");
+        };
+        assert_eq!(
+            result.matches.iter().map(|m| m.value).collect::<Vec<_>>(),
+            vec![1_234]
+        );
+        assert!(result.stats.visited_index_entries <= 2, "{result:?}");
+    }
+
+    #[test]
+    fn bounded_row_stripe_uses_row_major_rect_buckets() {
+        let mut index = SheetRegionIndex::with_rect_bucket_size(8, 8);
+        for item in 0..2_000u32 {
+            let row = item.saturating_mul(16);
+            index.insert(Region::rect(0, row, row + 1, 10, 11), item);
+        }
+        let target = 1_234u32.saturating_mul(16);
+        let query = Region {
+            sheet_id: 0,
+            rows: AxisRange::Span(target, target + 1),
+            cols: AxisRange::All,
+        };
+        let BoundedRegionQueryResult::Complete(result) = index.query_bounded(query, 8) else {
+            panic!("narrow row stripe must remain bounded");
+        };
+        assert_eq!(
+            result.matches.iter().map(|m| m.value).collect::<Vec<_>>(),
+            vec![1_234]
+        );
+        assert!(result.stats.visited_index_entries <= 2, "{result:?}");
     }
 }

--- a/crates/formualizer-eval/src/formula_plane/runtime.rs
+++ b/crates/formualizer-eval/src/formula_plane/runtime.rs
@@ -1028,6 +1028,16 @@ impl SpanStore {
         (span.version == span_ref.version).then_some(span)
     }
 
+    pub(crate) fn current_ref(&self, id: FormulaSpanId) -> Option<FormulaSpanRef> {
+        let slot = self.slots.get(id.0 as usize)?;
+        let span = slot.span.as_ref()?;
+        (span.state == SpanState::Active).then_some(FormulaSpanRef {
+            id,
+            generation: slot.generation,
+            version: span.version,
+        })
+    }
+
     #[cfg(test)]
     pub(crate) fn get_mut_for_test(
         &mut self,

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -2179,9 +2179,16 @@ impl Workbook {
                 .get_cell(sheet, row, col)
                 .and_then(|(ast, _)| ast);
 
-            self.engine.edit_with_logger(&mut self.log, |editor| {
-                editor.set_cell_value_with_old_state(cell, value.clone(), old_value, old_formula);
-            });
+            self.engine
+                .edit_with_logger(&mut self.log, |editor| {
+                    editor.set_cell_value_with_old_state(
+                        cell,
+                        value.clone(),
+                        old_value,
+                        old_formula,
+                    );
+                })
+                .map_err(|e| IoError::from_backend("editor", e))?;
 
             self.mirror_value_to_overlay(sheet, row, col, &value);
             self.engine.clear_staged_formula_text(sheet, row, col);
@@ -2232,9 +2239,16 @@ impl Workbook {
                     let old_value = self.engine.get_cell_value(sheet, row, col);
                     let old_formula = self.engine.get_cell(sheet, row, col).and_then(|(a, _)| a);
 
-                    self.engine.edit_with_logger(&mut self.log, |editor| {
-                        editor.set_cell_formula_with_old_state(cell, ast, old_value, old_formula);
-                    });
+                    self.engine
+                        .edit_with_logger(&mut self.log, |editor| {
+                            editor.set_cell_formula_with_old_state(
+                                cell,
+                                ast,
+                                old_value,
+                                old_formula,
+                            );
+                        })
+                        .map_err(|e| IoError::from_backend("editor", e))?;
 
                     self.engine.clear_staged_formula_text(sheet, row, col);
                     if let Some(before) = staged_before {
@@ -2275,9 +2289,11 @@ impl Workbook {
                     sheet_id,
                     formualizer_eval::reference::Coord::from_excel(row, col, true, true),
                 );
-                self.engine.edit_with_logger(&mut self.log, |editor| {
-                    editor.set_cell_formula(cell, ast);
-                });
+                self.engine
+                    .edit_with_logger(&mut self.log, |editor| {
+                        editor.set_cell_formula(cell, ast);
+                    })
+                    .map_err(|e| IoError::from_backend("editor", e))?;
                 self.engine.clear_staged_formula_text(sheet, row, col);
                 if let Some(before) = staged_before {
                     self.record_staged_formula_cell_change(sheet, row, col, before, None);
@@ -2478,7 +2494,8 @@ impl Workbook {
                         }
                     }
                     Ok(())
-                })?;
+                })
+                .map_err(|e| IoError::from_backend("editor", e))??;
 
             for (r, c, v) in overlay_ops {
                 self.mirror_value_to_overlay(sheet, r, c, &v);
@@ -2600,18 +2617,20 @@ impl Workbook {
                 }
             }
 
-            self.engine.edit_with_logger(&mut self.log, |editor| {
-                for (_r, _c, v, cell, old_value, old_formula, _staged_before) in items.iter() {
-                    // Old state captured from Arrow truth rides directly on the
-                    // event (graph-captured state wins; this only fills `None`).
-                    editor.set_cell_value_with_old_state(
-                        *cell,
-                        v.clone(),
-                        old_value.clone(),
-                        old_formula.clone(),
-                    );
-                }
-            });
+            self.engine
+                .edit_with_logger(&mut self.log, |editor| {
+                    for (_r, _c, v, cell, old_value, old_formula, _staged_before) in items.iter() {
+                        // Old state captured from Arrow truth rides directly on the
+                        // event (graph-captured state wins; this only fills `None`).
+                        editor.set_cell_value_with_old_state(
+                            *cell,
+                            v.clone(),
+                            old_value.clone(),
+                            old_formula.clone(),
+                        );
+                    }
+                })
+                .map_err(|e| IoError::from_backend("editor", e))?;
 
             for (r, c, v, _cell, _old_value, _old_formula, staged_before) in items {
                 self.mirror_value_to_overlay(sheet, r, c, &v);
@@ -2728,7 +2747,8 @@ impl Workbook {
                         }
                     }
                     Ok(())
-                })?;
+                })
+                .map_err(|e| IoError::from_backend("editor", e))??;
 
             for (ri, rforms) in rows.iter().enumerate() {
                 let r = start_row + ri as u32;
@@ -2872,10 +2892,9 @@ impl Workbook {
     ) -> Result<(), IoError> {
         let (definition, scope) = self.named_definition_with_scope(address, scope)?;
         if self.enable_changelog {
-            let result = self.engine.edit_with_logger(&mut self.log, |editor| {
-                editor.define_name(name, definition, scope)
-            });
-            result.map_err(|e| IoError::from_backend("editor", e))
+            self.engine
+                .define_name_with_logger(&mut self.log, name, definition, scope)
+                .map_err(|e| IoError::from_backend("editor", e))
         } else {
             self.engine
                 .define_name(name, definition, scope)
@@ -2891,10 +2910,9 @@ impl Workbook {
     ) -> Result<(), IoError> {
         let (definition, scope) = self.named_definition_with_scope(address, scope)?;
         if self.enable_changelog {
-            let result = self.engine.edit_with_logger(&mut self.log, |editor| {
-                editor.update_name(name, definition, scope)
-            });
-            result.map_err(|e| IoError::from_backend("editor", e))
+            self.engine
+                .update_name_with_logger(&mut self.log, name, definition, scope)
+                .map_err(|e| IoError::from_backend("editor", e))
         } else {
             self.engine
                 .update_name(name, definition, scope)
@@ -2910,10 +2928,9 @@ impl Workbook {
     ) -> Result<(), IoError> {
         let scope = self.name_scope_from_hint(scope, sheet)?;
         if self.enable_changelog {
-            let result = self
-                .engine
-                .edit_with_logger(&mut self.log, |editor| editor.delete_name(name, scope));
-            result.map_err(|e| IoError::from_backend("editor", e))
+            self.engine
+                .delete_name_with_logger(&mut self.log, name, scope)
+                .map_err(|e| IoError::from_backend("editor", e))
         } else {
             self.engine
                 .delete_name(name, scope)

--- a/docs/architecture/adaptive-formula-partition.md
+++ b/docs/architecture/adaptive-formula-partition.md
@@ -59,7 +59,7 @@ An accurate inventory matters because the distance to the end state is shorter t
 | Evaluation loop | **Already one loop.** `evaluate_authoritative_formula_plane_all` builds a `MixedSchedule` whose layers interleave span producers and legacy vertices, evaluating both per layer with a per-layer computed-write flush (eval.rs, scheduler.rs). There is no global legacy-pass/span-pass boundary. |
 | Authority ownership | **Graph-owned.** `FormulaAuthority` owns spans and producer/consumer indexes; `FormulaDirtyState` separately owns all formula dirtiness inside `DependencyGraph`. |
 | Cross-span cycles | **Detected and demoted.** Mixed-schedule toposort detects producer-level cycles, demotes the cyclic spans to legacy vertices, and resolves via the legacy cycle prepass. Intra-family self-reads reject at placement (`InternalDependency`). |
-| Structural ops | **Span-aware.** Insert/delete rows/cols classify each span: uniform shift mutates domain geometry in place; straddling demotes (structural_shift.rs). |
+| Structural ops | **Precisely dirty.** Insert/delete rows/cols classify each span, mutate proven-safe geometry, and publish exact `(span ref, result interval)` dirtiness only for moved or cleared placements. Demotions transfer work to sparse legacy vertices; no-op and unrelated-sheet spans publish nothing. |
 | Result storage | **Already columnar.** Span results stage in a `ComputedWriteBuffer` and flush as coalesced fragments into the sheet's computed overlay (Arrow-side), consulted at read time. |
 | Ingest/fingerprinting | **Shared.** One pipeline canonicalizes, fingerprints, and computes per-cell read projections for every formula; placement accepts or falls back per family. Reject-path cost is linear (#146). |
 
@@ -67,12 +67,12 @@ What remains dual — the actual gap:
 
 | Concern | State |
 | --- | --- |
-| Dirty tracking | **Unified in T1.2.** `FormulaDirtyState` owns sparse legacy vertex dirtiness plus generation-leased region and exact-span events. `FormulaAuthority` has no dirty queue, and `SpanSeedMode` is retired. |
+| Dirty tracking | **Unified through T1.3.** `FormulaDirtyState` owns sparse legacy vertex dirtiness plus generation-leased changed-region, exact span-region, and exact whole-span events. `FormulaAuthority` has no dirty queue, and topology epochs never imply value dirtiness. |
 | Per-cell overrides | **No punchouts.** Editing one cell inside a span (value or different formula) demotes the whole span. `PlacementDomain` is contiguous (`RowRun`/`ColRun`/`Rect`); holes are unrepresentable. |
 | Iterative calculation | Legacy-only. Iterative members are `VertexId`s; spans are excluded from SCC analysis. |
 | Demand-driven evaluation | Legacy-only. `build_demand_subgraph` walks graph vertices; span producers are invisible to it. |
-| Edit notification | Engine APIs, editor journals, undo/redo, formulas, values, names, tables, sheets, structural operations, span appends, and prepared commits publish through the graph dirty API. Failed preparation publishes nothing. |
-| Schedule/dirty cost model | T1.1 caches immutable mixed topology. T1.2 consumes graph-owned leased dirty events per request while warm no-op and span-free work remain on the sparse legacy floor. |
+| Edit notification | Engine APIs, editor journals, undo/redo, formulas, values, names, tables, sheets, structural operations, span appends, and prepared commits publish through the graph dirty API. Structural deltas are planned before mutation and published once after committed geometry/index changes; failed validation publishes nothing. |
+| Schedule/dirty cost model | T1.1 caches immutable mixed topology. T1.2 consumes graph-owned leased dirty events per request, and T1.3 seeds structural producer work with bounded span regions. Warm no-op and span-free work remain on the sparse legacy floor. |
 
 ## 3. Target Model
 
@@ -297,12 +297,14 @@ side exit without waiting for topology unification:
   Successful evaluation acknowledges only its leased prefix. Global invalidations may seed all
   active spans explicitly and are telemetered; authority epochs no longer hide whole-span work.
 
-1. **T1 — Single dirty authority (T1.3 remaining).** Translate structural shifts into precise
-   interval dirtiness and remove remaining explicit global whole-span invalidations. Profile and
-   eliminate the warm tax (§1) — the per-cycle
-   schedule/index rebuild becomes incremental (rebuild only on partition mutation, not
-   per eval). **Closes #144 structurally** (capacity bail becomes a node-refinement,
-   ordered by the one schedule, not a side exit) and closes the warm-tax family.
+1. **T1 — Single dirty authority (complete through T1.3).** Structural shifts publish precise
+   span-result intervals; duplicate, rename, unrelated name, and table edits avoid unrelated span
+   work; and topology epochs/revisions invalidate only the compiled cache. Explicit whole-span
+   events remain limited to new spans, cycle retry, or documented opaque invalidations. Source
+   invalidation and sheet removal remain explicit global cases because external-source semantics
+   and cross-sheet/name/default-sheet resolution do not yet have a complete exact closure. Warm
+   no-op and span-free requests bypass mixed schedule construction when no graph-owned formula
+   event is pending.
 2. **T2 — Node lifecycle.** Domain interval sets + punchouts + surgical split
    (§5.1 minus coalescing); single-cell overrides stop demoting spans. Editor-path
    unification: `VertexEditor` mutations flow through the same node-lifecycle API as


### PR DESCRIPTION
## Summary
- translate row and column structural edits into graph-owned changed regions and exact per-span dirty subregions
- keep topology epochs and revisions as cache invalidation only; remove implicit epoch-to-whole-span value dirtiness
- select affected structural spans through bounded producer/read indexes instead of scanning all active spans
- preserve explicit, telemetered whole-span invalidation only for genuinely global or opaque lifecycle changes
- add bounded row/column stripe traversal, including a column-major rectangle-bucket mirror with hard memory accounting
- make direct, logged, workbook, undo, and redo name lifecycle demotion exact-ref, prepared, atomic, and retry-safe

## Correctness
- shifted, split, compacted, demoted, and removed span outcomes publish dirty work after successful geometry mutation
- unrelated sheets and unaffected span prefixes remain clean
- candidate overflow fails before mutation and preserves graph, authority, dirty, overlay, topology, and visible state; retry succeeds
- source invalidation and sheet removal retain explicit global correctness semantics
- name-demotion validation and injected faults preserve definitions, history, exact span refs, and retryability
- Off and Shadow remain replay-only

## Validation
- independent blocker/high review: PASS
- default evaluator: 2,243 passed, 12 ignored
- all-feature evaluator: 2,244 passed, 12 ignored
- strict all-target/all-feature evaluator Clippy passed
- wasm32 all-feature evaluator check passed
- workbook named-range integration passed
- focused structural boundary, split/demotion, multi-sheet isolation, lifecycle, dirty lease, candidate overflow, bounded stripe, direct/logged name, undo/redo, fault, and retry suites passed
- release `self_cumulative,row_arith` probe: 4,000 cells, zero value mismatches, warm Off/auth both 0 ms
- formatting and diff checks passed

Built on merged T1.0a/T1.0b/T1.1/T1.2 tranches (#184–#187).
