### PR TITLE
fix(eval): prepare cross-sheet delta dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Fixed deferred `evaluate_cells_with_delta` requests missing transitive formula precedents staged on non-target sheets.
 - Fixed experimental FormulaPlane capacity fallbacks evaluating legacy readers before required span results were available. Unsafe requests now transactionally demote exactly their scheduled spans, retain pending dirty regions across failed attempts, and fail closed behind a finite materialization limit.
 
 ### Performance

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -14224,12 +14224,11 @@ where
         if targets.is_empty() {
             return Ok((Vec::new(), EvalDelta::default()));
         }
+        // A target formula can depend transitively on a formula staged on any
+        // sheet. Preparing only target sheets can leave those precedents as
+        // empty placeholders and produce stale values and incomplete deltas.
         if self.config.defer_graph_building {
-            let mut sheets: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
-            for (s, _, _) in targets.iter() {
-                sheets.insert(*s);
-            }
-            self.build_graph_for_sheets(sheets.iter().cloned())?;
+            self.build_graph_all()?;
         }
         if self.graph.formula_authority().active_span_count() > 0 {
             let _ = self.evaluate_authoritative_formula_plane_all()?;

--- a/crates/formualizer-eval/src/engine/tests/cross_sheet_named_range_first_cell.rs
+++ b/crates/formualizer-eval/src/engine/tests/cross_sheet_named_range_first_cell.rs
@@ -150,3 +150,86 @@ fn cross_sheet_evaluate_cell_drains_all_staged_sheets() {
         v
     );
 }
+
+fn build_delta_cross_sheet_engine(deferred: bool) -> Engine<TestWorkbook> {
+    let cfg = EvalConfig {
+        defer_graph_building: deferred,
+        ..Default::default()
+    };
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    engine.graph.add_sheet("Schedule").unwrap();
+    engine.graph.add_sheet("Model").unwrap();
+    for row in 2..=5u32 {
+        engine
+            .set_cell_value("Schedule", row, 1, LiteralValue::Number(row as f64 * 100.0))
+            .unwrap();
+    }
+
+    let formulas = [
+        ("Schedule", 2, 3, "=$A$2"),
+        ("Schedule", 3, 3, "=$A$3"),
+        ("Schedule", 4, 3, "=$A$4"),
+        ("Schedule", 5, 3, "=$A$5"),
+        ("Schedule", 6, 3, "=SUM(C2:C5)"),
+        ("Model", 7, 4, "='Schedule'!C6"),
+    ];
+    for (sheet, row, col, formula) in formulas {
+        if deferred {
+            engine.stage_formula_text(sheet, row, col, formula.to_string());
+        } else {
+            engine
+                .set_cell_formula(sheet, row, col, parse(formula).unwrap())
+                .unwrap();
+        }
+    }
+    engine
+}
+
+#[test]
+fn cross_sheet_evaluate_cells_with_delta_drains_all_staged_sheets() {
+    let mut deferred = build_delta_cross_sheet_engine(true);
+    let mut oracle = build_delta_cross_sheet_engine(false);
+
+    assert_eq!(deferred.staged_formula_count(), 6);
+    let (deferred_values, deferred_delta) = deferred
+        .evaluate_cells_with_delta(&[("Model", 7, 4)])
+        .unwrap();
+    let (oracle_values, oracle_delta) = oracle
+        .evaluate_cells_with_delta(&[("Model", 7, 4)])
+        .unwrap();
+
+    assert_eq!(deferred_values, vec![Some(LiteralValue::Number(1400.0))]);
+    assert_eq!(deferred_values, oracle_values);
+    assert_eq!(deferred_delta, oracle_delta);
+    assert_eq!(deferred_delta.changed_cells.len(), 6);
+    assert_eq!(deferred.staged_formula_count(), 0);
+}
+
+#[test]
+fn cross_sheet_evaluate_cells_with_delta_parse_failure_restores_all_staged_formulas() {
+    let cfg = EvalConfig {
+        defer_graph_building: true,
+        ..Default::default()
+    };
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+    engine.graph.add_sheet("Schedule").unwrap();
+    engine.graph.add_sheet("Model").unwrap();
+    engine.stage_formula_text("Schedule", 1, 1, "=1+".to_string());
+    engine.stage_formula_text("Model", 1, 1, "=Schedule!A1+1".to_string());
+
+    let before = engine.baseline_stats();
+    assert!(
+        engine
+            .evaluate_cells_with_delta(&[("Model", 1, 1)])
+            .is_err()
+    );
+    let after = engine.baseline_stats();
+
+    assert_eq!(after.staged_formula_count, before.staged_formula_count);
+    assert_eq!(
+        after.graph_formula_vertex_count,
+        before.graph_formula_vertex_count
+    );
+    assert_eq!(engine.get_cell_value("Model", 1, 1), None);
+}


### PR DESCRIPTION
## Summary
- make deferred `evaluate_cells_with_delta` prepare all staged sheets, matching sibling cell-evaluation APIs
- prevent target-sheet formulas from observing empty placeholders when transitive precedents remain staged elsewhere
- add cross-sheet value/delta parity and strict-parse rollback coverage

## Validation
- independent blocker/high review: PASS
- focused cross-sheet/deferred regressions passed
- default evaluator: 2,245 passed, 12 ignored
- strict evaluator Clippy passed
- wasm32 evaluator check passed
- formatting and diff checks passed

This is the Fable-required C0-pre correctness hotfix before target-driven graph preparation.
