### PR TITLE
feat(eval): observe evaluation resource usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Added
 
+- Added observational evaluation-resource telemetry with monotonic request IDs, typed cap reasons, FormulaPlane topology/cache/materialization/dirty-lease counters, staged preparation and phase timings, replay-spool storage counters, and cold-process load-envelope JSON reporting. Defaults, fallback strategies, errors, and evaluation behavior are unchanged.
 - Added Calamine-backed in-memory XLSX loading to the native Python binding and made it the default for `Workbook.from_bytes` and `load_workbook_bytes`; Pyodide retains its Umya fallback.
 - Added backend-neutral source-family ingest with anchor-once FormulaPlane authority for proven complete domains. Calamine supplies bounded XLSX evidence and exact replay for eager and deferred loading, with structural-edit, cycle-demotion, and source-family telemetry support.
 - Added registry-owned function semantic contracts so safe current and future ordinary functions can use FormulaPlane authority without a secondary supported-name list, while exceptional and untrusted functions continue to replay conservatively.

--- a/crates/formualizer-bench-core/src/bin/probe-load-envelope-matrix.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-load-envelope-matrix.rs
@@ -59,6 +59,13 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = BackendKind::Umya)]
     backend: BackendKind,
 
+    #[arg(long, value_enum, default_value_t = FormulaPlaneProbeMode::Off)]
+    formula_plane_mode: FormulaPlaneProbeMode,
+
+    /// Fresh child-process samples per case.
+    #[arg(long, default_value_t = 1)]
+    samples: usize,
+
     /// Hard timeout applied to generation and load/eval subprocesses independently.
     #[arg(long, default_value_t = 60)]
     timeout_seconds: u64,
@@ -121,6 +128,14 @@ enum BackendKind {
 }
 
 #[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum FormulaPlaneProbeMode {
+    Off,
+    Shadow,
+    Authoritative,
+}
+
+#[cfg(feature = "formualizer_runner")]
 #[derive(Debug, Clone, Copy)]
 struct Case {
     scenario: &'static str,
@@ -132,9 +147,51 @@ struct Case {
 
 #[cfg(feature = "formualizer_runner")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct EngineTelemetry {
+    graph_vertices: usize,
+    graph_formula_vertices: usize,
+    graph_edges: usize,
+    active_spans: usize,
+    request_id: u64,
+    request_kind: String,
+    request_outcome: String,
+    staged_selected: u64,
+    staged_retained: u64,
+    request_total_ms: f64,
+    graph_prepare_ms: f64,
+    topology_ms: f64,
+    materialization_ms: f64,
+    evaluation_ms: f64,
+    topology_strategy: String,
+    topology_cache_outcome: String,
+    topology_cache_hit_events: u64,
+    topology_cache_build_events: u64,
+    topology_cache_skip_events: u64,
+    topology_overflow_reason: Option<String>,
+    topology_producers_observed: u64,
+    topology_candidates_observed: u64,
+    topology_edges_observed: u64,
+    topology_retained_bytes_observed: u64,
+    topology_candidate_cap_hits: u64,
+    topology_edge_cap_hits: u64,
+    topology_byte_cap_hits: u64,
+    fallback_materialized_cells: u64,
+    cycle_materialized_cells: u64,
+    dirty_lease_outcome: String,
+    spool_records: u64,
+    spool_encoded_bytes: u64,
+    spool_peak_memory_bytes: u64,
+    spool_spilled_bytes: u64,
+    spool_spill_files: u64,
+    spool_replays: u64,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ProbeReport {
     backend: String,
     scenario: String,
+    formula_plane_mode: String,
     workbook_path: String,
     logical_rows: u32,
     logical_cols: u32,
@@ -145,6 +202,10 @@ struct ProbeReport {
     generation_ms: f64,
     load_ms: Option<f64>,
     evaluate_ms: Option<f64>,
+    output_read_ms: Option<f64>,
+    current_rss_bytes: Option<u64>,
+    peak_rss_bytes: Option<u64>,
+    engine: Option<EngineTelemetry>,
     load_within_budget: Option<bool>,
     evaluate_within_budget: Option<bool>,
     error: Option<String>,
@@ -155,6 +216,8 @@ struct ProbeReport {
 struct MatrixResult {
     backend: String,
     scenario: String,
+    formula_plane_mode: String,
+    sample: usize,
     workbook_path: String,
     logical_rows: u32,
     logical_cols: u32,
@@ -165,6 +228,10 @@ struct MatrixResult {
     generation_ms: Option<f64>,
     load_ms: Option<f64>,
     evaluate_ms: Option<f64>,
+    output_read_ms: Option<f64>,
+    current_rss_bytes: Option<u64>,
+    peak_rss_bytes: Option<u64>,
+    engine: Option<EngineTelemetry>,
     load_within_budget: Option<bool>,
     evaluate_within_budget: Option<bool>,
     generate_log_path: String,
@@ -407,6 +474,17 @@ impl BackendKind {
 }
 
 #[cfg(feature = "formualizer_runner")]
+impl FormulaPlaneProbeMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Shadow => "shadow",
+            Self::Authoritative => "authoritative",
+        }
+    }
+}
+
+#[cfg(feature = "formualizer_runner")]
 fn workbook_path(output_dir: &Path, case: Case) -> PathBuf {
     output_dir.join(format!(
         "{}-{}x{}.xlsx",
@@ -415,13 +493,22 @@ fn workbook_path(output_dir: &Path, case: Case) -> PathBuf {
 }
 
 #[cfg(feature = "formualizer_runner")]
-fn log_path(output_dir: &Path, backend: BackendKind, case: Case, phase: &str) -> PathBuf {
+fn log_path(
+    output_dir: &Path,
+    backend: BackendKind,
+    mode: FormulaPlaneProbeMode,
+    case: Case,
+    sample: usize,
+    phase: &str,
+) -> PathBuf {
     output_dir.join(format!(
-        "{}-{}-{}x{}-{}.log",
+        "{}-{}-{}-{}x{}-sample{}-{}.log",
         backend.label(),
+        mode.label(),
         case.scenario,
         case.rows,
         case.logical_cols,
+        sample,
         phase,
     ))
 }
@@ -437,7 +524,9 @@ fn run_matrix(root: &Path, cli: &Cli) -> Result<Vec<MatrixResult>> {
     let probe = probe_binary_path(root);
     let mut results = Vec::new();
     for case in cases_for_preset(cli.preset) {
-        results.push(run_case(root, &probe, &output_dir, *case, cli)?);
+        for sample in 1..=cli.samples.max(1) {
+            results.push(run_case(root, &probe, &output_dir, *case, sample, cli)?);
+        }
     }
     Ok(results)
 }
@@ -448,11 +537,26 @@ fn run_case(
     probe: &Path,
     output_dir: &Path,
     case: Case,
+    sample: usize,
     cli: &Cli,
 ) -> Result<MatrixResult> {
     let workbook = workbook_path(output_dir, case);
-    let generate_log_path = log_path(output_dir, cli.backend, case, "generate");
-    let measure_log_path = log_path(output_dir, cli.backend, case, "measure");
+    let generate_log_path = log_path(
+        output_dir,
+        cli.backend,
+        cli.formula_plane_mode,
+        case,
+        sample,
+        "generate",
+    );
+    let measure_log_path = log_path(
+        output_dir,
+        cli.backend,
+        cli.formula_plane_mode,
+        case,
+        sample,
+        "measure",
+    );
 
     let generate_args = probe_args(case, cli, &workbook, true);
     let generated = run_probe_subprocess(
@@ -479,6 +583,8 @@ fn run_case(
             return Ok(MatrixResult {
                 backend: cli.backend.label().to_string(),
                 scenario: case.scenario.to_string(),
+                formula_plane_mode: cli.formula_plane_mode.label().to_string(),
+                sample,
                 workbook_path: workbook.display().to_string(),
                 logical_rows: case.rows,
                 logical_cols: case.logical_cols,
@@ -489,6 +595,10 @@ fn run_case(
                 generation_ms: None,
                 load_ms: None,
                 evaluate_ms: None,
+                output_read_ms: None,
+                current_rss_bytes: None,
+                peak_rss_bytes: None,
+                engine: None,
                 load_within_budget: None,
                 evaluate_within_budget: None,
                 generate_log_path: generate_log_path.display().to_string(),
@@ -521,6 +631,8 @@ fn run_case(
         Ok(result) => MatrixResult {
             backend: result.backend,
             scenario: result.scenario,
+            formula_plane_mode: result.formula_plane_mode,
+            sample,
             workbook_path: result.workbook_path,
             logical_rows: result.logical_rows,
             logical_cols: result.logical_cols,
@@ -531,6 +643,10 @@ fn run_case(
             generation_ms: Some(generated.generation_ms),
             load_ms: result.load_ms,
             evaluate_ms: result.evaluate_ms,
+            output_read_ms: result.output_read_ms,
+            current_rss_bytes: result.current_rss_bytes,
+            peak_rss_bytes: result.peak_rss_bytes,
+            engine: result.engine,
             load_within_budget: result.load_within_budget,
             evaluate_within_budget: result.evaluate_within_budget,
             generate_log_path: generate_log_path.display().to_string(),
@@ -540,6 +656,8 @@ fn run_case(
         Err(err) => MatrixResult {
             backend: cli.backend.label().to_string(),
             scenario: case.scenario.to_string(),
+            formula_plane_mode: cli.formula_plane_mode.label().to_string(),
+            sample,
             workbook_path: workbook.display().to_string(),
             logical_rows: case.rows,
             logical_cols: case.logical_cols,
@@ -550,6 +668,10 @@ fn run_case(
             generation_ms: Some(generated.generation_ms),
             load_ms: None,
             evaluate_ms: None,
+            output_read_ms: None,
+            current_rss_bytes: None,
+            peak_rss_bytes: None,
+            engine: None,
             load_within_budget: Some(false),
             evaluate_within_budget: Some(false),
             generate_log_path: generate_log_path.display().to_string(),
@@ -579,6 +701,8 @@ fn probe_args(case: Case, cli: &Cli, workbook: &Path, generate_only: bool) -> Ve
         case.scenario.to_string(),
         "--backend".to_string(),
         cli.backend.label().to_string(),
+        "--formula-plane-mode".to_string(),
+        cli.formula_plane_mode.label().to_string(),
         "--rows".to_string(),
         case.rows.to_string(),
         "--logical-cols".to_string(),
@@ -730,33 +854,40 @@ fn fmt_ms(value: Option<f64>) -> String {
 }
 
 #[cfg(feature = "formualizer_runner")]
-fn fmt_bool(value: Option<bool>) -> &'static str {
-    match value {
-        Some(true) => "yes",
-        Some(false) => "no",
-        None => "-",
-    }
-}
-
-#[cfg(feature = "formualizer_runner")]
 fn render_markdown(results: &[MatrixResult]) -> String {
     let mut out = String::from(
-        "| Backend | Scenario | Shape | Logical cells | Status | Gen ms | Load ms | Eval ms | Load <=60s | Eval <=60s |\n|---|---|---:|---:|---|---:|---:|---:|---|---|\n",
+        "| Backend | Mode | Sample | Scenario | Shape | Status | Load ms | Eval ms | Output ms | Peak MiB | Topology | Materialized |\n|---|---|---:|---|---:|---|---:|---:|---:|---:|---|---:|\n",
     );
     for item in results {
         let shape = format!("{}x{}", item.logical_rows, item.logical_cols);
+        let topology = item
+            .engine
+            .as_ref()
+            .map(|engine| engine.topology_strategy.as_str())
+            .unwrap_or("-");
+        let materialized = item
+            .engine
+            .as_ref()
+            .map(|engine| engine.fallback_materialized_cells)
+            .unwrap_or(0);
+        let peak_mib = item
+            .peak_rss_bytes
+            .map(|bytes| format!("{:.1}", bytes as f64 / (1024.0 * 1024.0)))
+            .unwrap_or_else(|| "-".to_string());
         out.push_str(&format!(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
             item.backend,
+            item.formula_plane_mode,
+            item.sample,
             item.scenario,
             shape,
-            item.logical_cells,
             item.status,
-            fmt_ms(item.generation_ms),
             fmt_ms(item.load_ms),
             fmt_ms(item.evaluate_ms),
-            fmt_bool(item.load_within_budget),
-            fmt_bool(item.evaluate_within_budget)
+            fmt_ms(item.output_read_ms),
+            peak_mib,
+            topology,
+            materialized,
         ));
     }
     out

--- a/crates/formualizer-bench-core/src/bin/probe-load-envelope.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-load-envelope.rs
@@ -12,6 +12,8 @@ use clap::{Parser, ValueEnum};
 use serde::Serialize;
 
 #[cfg(feature = "formualizer_runner")]
+use formualizer_eval::engine::FormulaPlaneMode;
+#[cfg(feature = "formualizer_runner")]
 use formualizer_testkit::write_workbook;
 #[cfg(feature = "formualizer_runner")]
 use formualizer_workbook::{
@@ -43,6 +45,9 @@ struct Cli {
 
     #[arg(long, value_enum, default_value_t = BackendKind::Umya)]
     backend: BackendKind,
+
+    #[arg(long, value_enum, default_value_t = FormulaPlaneProbeMode::Off)]
+    formula_plane_mode: FormulaPlaneProbeMode,
 
     /// Logical row count for the primary large sheet.
     #[arg(long)]
@@ -109,10 +114,60 @@ enum BackendKind {
 }
 
 #[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum FormulaPlaneProbeMode {
+    Off,
+    Shadow,
+    Authoritative,
+}
+
+#[cfg(feature = "formualizer_runner")]
+#[derive(Debug, Serialize)]
+struct EngineTelemetry {
+    graph_vertices: usize,
+    graph_formula_vertices: usize,
+    graph_edges: usize,
+    active_spans: usize,
+    request_id: u64,
+    request_kind: &'static str,
+    request_outcome: &'static str,
+    staged_selected: u64,
+    staged_retained: u64,
+    request_total_ms: f64,
+    graph_prepare_ms: f64,
+    topology_ms: f64,
+    materialization_ms: f64,
+    evaluation_ms: f64,
+    topology_strategy: &'static str,
+    topology_cache_outcome: &'static str,
+    topology_cache_hit_events: u64,
+    topology_cache_build_events: u64,
+    topology_cache_skip_events: u64,
+    topology_overflow_reason: Option<&'static str>,
+    topology_producers_observed: u64,
+    topology_candidates_observed: u64,
+    topology_edges_observed: u64,
+    topology_retained_bytes_observed: u64,
+    topology_candidate_cap_hits: u64,
+    topology_edge_cap_hits: u64,
+    topology_byte_cap_hits: u64,
+    fallback_materialized_cells: u64,
+    cycle_materialized_cells: u64,
+    dirty_lease_outcome: &'static str,
+    spool_records: u64,
+    spool_encoded_bytes: u64,
+    spool_peak_memory_bytes: u64,
+    spool_spilled_bytes: u64,
+    spool_spill_files: u64,
+    spool_replays: u64,
+}
+
+#[cfg(feature = "formualizer_runner")]
 #[derive(Debug, Serialize)]
 struct ProbeReport {
     backend: &'static str,
     scenario: &'static str,
+    formula_plane_mode: &'static str,
     workbook_path: String,
     logical_rows: u32,
     logical_cols: u32,
@@ -123,6 +178,10 @@ struct ProbeReport {
     generation_ms: f64,
     load_ms: Option<f64>,
     evaluate_ms: Option<f64>,
+    output_read_ms: Option<f64>,
+    current_rss_bytes: Option<u64>,
+    peak_rss_bytes: Option<u64>,
+    engine: Option<EngineTelemetry>,
     load_within_budget: Option<bool>,
     evaluate_within_budget: Option<bool>,
     error: Option<String>,
@@ -169,6 +228,7 @@ fn run(cli: Cli) -> Result<ProbeReport> {
         return Ok(ProbeReport {
             backend: cli.backend.label(),
             scenario: cli.scenario.label(),
+            formula_plane_mode: cli.formula_plane_mode.label(),
             workbook_path: output.display().to_string(),
             logical_rows,
             logical_cols,
@@ -179,6 +239,10 @@ fn run(cli: Cli) -> Result<ProbeReport> {
             generation_ms,
             load_ms: None,
             evaluate_ms: None,
+            output_read_ms: None,
+            current_rss_bytes: None,
+            peak_rss_bytes: None,
+            engine: None,
             load_within_budget: None,
             evaluate_within_budget: None,
             error: None,
@@ -205,6 +269,7 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                     return Ok(ProbeReport {
                         backend: cli.backend.label(),
                         scenario: cli.scenario.label(),
+                        formula_plane_mode: cli.formula_plane_mode.label(),
                         workbook_path: output.display().to_string(),
                         logical_rows,
                         logical_cols,
@@ -215,6 +280,10 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                         generation_ms,
                         load_ms: None,
                         evaluate_ms: None,
+                        output_read_ms: None,
+                        current_rss_bytes: None,
+                        peak_rss_bytes: None,
+                        engine: None,
                         load_within_budget: None,
                         evaluate_within_budget: None,
                         error: Some(err.to_string()),
@@ -227,13 +296,15 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                 backend,
                 LoadStrategy::EagerAll,
                 formualizer_workbook::WorkbookConfig::ephemeral()
-                    .with_ingest_limits(limits.clone()),
+                    .with_ingest_limits(limits.clone())
+                    .with_formula_plane_mode(cli.formula_plane_mode.engine_mode()),
             ) {
                 Ok(wb) => wb,
                 Err(err) => {
                     return Ok(ProbeReport {
                         backend: cli.backend.label(),
                         scenario: cli.scenario.label(),
+                        formula_plane_mode: cli.formula_plane_mode.label(),
                         workbook_path: output.display().to_string(),
                         logical_rows,
                         logical_cols,
@@ -244,6 +315,10 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                         generation_ms,
                         load_ms: Some(load_start.elapsed().as_secs_f64() * 1000.0),
                         evaluate_ms: None,
+                        output_read_ms: None,
+                        current_rss_bytes: None,
+                        peak_rss_bytes: None,
+                        engine: None,
                         load_within_budget: None,
                         evaluate_within_budget: None,
                         error: Some(err.to_string()),
@@ -258,6 +333,7 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                     return Ok(ProbeReport {
                         backend: cli.backend.label(),
                         scenario: cli.scenario.label(),
+                        formula_plane_mode: cli.formula_plane_mode.label(),
                         workbook_path: output.display().to_string(),
                         logical_rows,
                         logical_cols,
@@ -268,6 +344,10 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                         generation_ms,
                         load_ms: None,
                         evaluate_ms: None,
+                        output_read_ms: None,
+                        current_rss_bytes: None,
+                        peak_rss_bytes: None,
+                        engine: None,
                         load_within_budget: None,
                         evaluate_within_budget: None,
                         error: Some(err.to_string()),
@@ -280,13 +360,15 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                 backend,
                 LoadStrategy::EagerAll,
                 formualizer_workbook::WorkbookConfig::ephemeral()
-                    .with_ingest_limits(limits.clone()),
+                    .with_ingest_limits(limits.clone())
+                    .with_formula_plane_mode(cli.formula_plane_mode.engine_mode()),
             ) {
                 Ok(wb) => wb,
                 Err(err) => {
                     return Ok(ProbeReport {
                         backend: cli.backend.label(),
                         scenario: cli.scenario.label(),
+                        formula_plane_mode: cli.formula_plane_mode.label(),
                         workbook_path: output.display().to_string(),
                         logical_rows,
                         logical_cols,
@@ -297,6 +379,10 @@ fn run(cli: Cli) -> Result<ProbeReport> {
                         generation_ms,
                         load_ms: Some(load_start.elapsed().as_secs_f64() * 1000.0),
                         evaluate_ms: None,
+                        output_read_ms: None,
+                        current_rss_bytes: None,
+                        peak_rss_bytes: None,
+                        engine: None,
                         load_within_budget: None,
                         evaluate_within_budget: None,
                         error: Some(err.to_string()),
@@ -310,10 +396,14 @@ fn run(cli: Cli) -> Result<ProbeReport> {
 
     let eval_start = Instant::now();
     eprintln!("[probe] evaluating workbook");
-    if let Err(err) = workbook.evaluate_all() {
+    let evaluation = workbook.evaluate_all();
+    let evaluate_ms = eval_start.elapsed().as_secs_f64() * 1000.0;
+    if let Err(err) = evaluation {
+        let (current_rss_bytes, peak_rss_bytes) = process_memory_bytes();
         return Ok(ProbeReport {
             backend: cli.backend.label(),
             scenario: cli.scenario.label(),
+            formula_plane_mode: cli.formula_plane_mode.label(),
             workbook_path: output.display().to_string(),
             logical_rows,
             logical_cols,
@@ -323,14 +413,22 @@ fn run(cli: Cli) -> Result<ProbeReport> {
             status: "evaluate_error",
             generation_ms,
             load_ms: Some(load_ms),
-            evaluate_ms: Some(eval_start.elapsed().as_secs_f64() * 1000.0),
+            evaluate_ms: Some(evaluate_ms),
+            output_read_ms: None,
+            current_rss_bytes,
+            peak_rss_bytes,
+            engine: collect_engine_telemetry(&workbook),
             load_within_budget: Some(load_ms <= cli.timeout_seconds as f64 * 1000.0),
             evaluate_within_budget: None,
             error: Some(err.to_string()),
         });
     }
-    let evaluate_ms = eval_start.elapsed().as_secs_f64() * 1000.0;
     eprintln!("[probe] evaluation complete in {:.1} ms", evaluate_ms);
+    let output_read_started = Instant::now();
+    read_probe_output(&workbook, &cli);
+    let output_read_ms = output_read_started.elapsed().as_secs_f64() * 1000.0;
+    let engine = collect_engine_telemetry(&workbook);
+    let (current_rss_bytes, peak_rss_bytes) = process_memory_bytes();
 
     if !cli.keep_workbook && using_temp_output {
         let _ = std::fs::remove_file(&output);
@@ -339,6 +437,7 @@ fn run(cli: Cli) -> Result<ProbeReport> {
     Ok(ProbeReport {
         backend: cli.backend.label(),
         scenario: cli.scenario.label(),
+        formula_plane_mode: cli.formula_plane_mode.label(),
         workbook_path: output.display().to_string(),
         logical_rows,
         logical_cols,
@@ -355,6 +454,10 @@ fn run(cli: Cli) -> Result<ProbeReport> {
         generation_ms,
         load_ms: Some(load_ms),
         evaluate_ms: Some(evaluate_ms),
+        output_read_ms: Some(output_read_ms),
+        current_rss_bytes,
+        peak_rss_bytes,
+        engine,
         load_within_budget: Some(load_ms <= cli.timeout_seconds as f64 * 1000.0),
         evaluate_within_budget: Some(evaluate_ms <= cli.timeout_seconds as f64 * 1000.0),
         error: None,
@@ -380,6 +483,108 @@ impl BackendKind {
             BackendKind::Calamine => "calamine",
         }
     }
+}
+
+#[cfg(feature = "formualizer_runner")]
+impl FormulaPlaneProbeMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Shadow => "shadow",
+            Self::Authoritative => "authoritative",
+        }
+    }
+
+    fn engine_mode(self) -> FormulaPlaneMode {
+        match self {
+            Self::Off => FormulaPlaneMode::Off,
+            Self::Shadow => FormulaPlaneMode::Shadow,
+            Self::Authoritative => FormulaPlaneMode::AuthoritativeExperimental,
+        }
+    }
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn ns_to_ms(ns: u64) -> f64 {
+    ns as f64 / 1_000_000.0
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn collect_engine_telemetry(workbook: &Workbook) -> Option<EngineTelemetry> {
+    let request = workbook.engine().last_evaluation_resource_request_stats()?;
+    let baseline = workbook.engine().baseline_stats();
+    let ingest = workbook.formula_ingest_report_total();
+    Some(EngineTelemetry {
+        graph_vertices: baseline.graph_vertex_count,
+        graph_formula_vertices: baseline.graph_formula_vertex_count,
+        graph_edges: baseline.graph_edge_count,
+        active_spans: baseline.formula_plane_active_span_count,
+        request_id: request.request_id,
+        request_kind: request.kind.as_str(),
+        request_outcome: request.outcome.as_str(),
+        staged_selected: request.staged_selected,
+        staged_retained: request.staged_retained,
+        request_total_ms: ns_to_ms(request.phases.total_ns),
+        graph_prepare_ms: ns_to_ms(request.phases.staged_prepare_ns),
+        topology_ms: ns_to_ms(request.phases.topology_ns),
+        materialization_ms: ns_to_ms(request.phases.materialization_ns),
+        evaluation_ms: ns_to_ms(request.phases.evaluation_ns),
+        topology_strategy: request.topology.strategy.as_str(),
+        topology_cache_outcome: request.topology.cache_outcome.as_str(),
+        topology_cache_hit_events: request.topology.cache_hit_events,
+        topology_cache_build_events: request.topology.cache_build_events,
+        topology_cache_skip_events: request.topology.cache_skip_events,
+        topology_overflow_reason: request
+            .topology
+            .overflow_reason
+            .map(|reason| reason.as_str()),
+        topology_producers_observed: request.topology.producers_observed,
+        topology_candidates_observed: request.topology.candidates_observed,
+        topology_edges_observed: request.topology.edges_observed,
+        topology_retained_bytes_observed: request.topology.retained_bytes_observed,
+        topology_candidate_cap_hits: request.topology.candidate_cap_hits,
+        topology_edge_cap_hits: request.topology.edge_cap_hits,
+        topology_byte_cap_hits: request.topology.byte_cap_hits,
+        fallback_materialized_cells: request.fallback_materialized_cells,
+        cycle_materialized_cells: request.cycle_materialized_cells,
+        dirty_lease_outcome: request.dirty_lease.as_str(),
+        spool_records: ingest.source_formula_records_spooled,
+        spool_encoded_bytes: ingest.source_spool_encoded_bytes,
+        spool_peak_memory_bytes: ingest.source_spool_peak_memory_bytes,
+        spool_spilled_bytes: ingest.source_spool_spilled_bytes,
+        spool_spill_files: ingest.source_spool_spill_files,
+        spool_replays: ingest.source_spool_replays,
+    })
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn read_probe_output(workbook: &Workbook, cli: &Cli) {
+    let _ = match cli.scenario {
+        ScenarioKind::LinearRollup => {
+            workbook.get_value("Sheet1", cli.rows.max(1), cli.active_cols.max(2))
+        }
+        ScenarioKind::SumifsReport => {
+            workbook.get_value("Report", cli.report_rows.max(1).saturating_add(1), 4)
+        }
+        ScenarioKind::WholeColumnSummary => {
+            workbook.get_value("Summary", cli.report_rows.max(1).saturating_add(1), 3)
+        }
+    };
+}
+
+#[cfg(feature = "formualizer_runner")]
+fn process_memory_bytes() -> (Option<u64>, Option<u64>) {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return (None, None);
+    };
+    let parse_kib = |name: &str| {
+        status.lines().find_map(|line| {
+            let rest = line.strip_prefix(name)?.trim();
+            let kib = rest.split_whitespace().next()?.parse::<u64>().ok()?;
+            kib.checked_mul(1024)
+        })
+    };
+    (parse_kib("VmRSS:"), parse_kib("VmHWM:"))
 }
 
 #[cfg(feature = "formualizer_runner")]

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -19,10 +19,12 @@ use crate::engine::row_visibility::RowVisibilityState;
 use crate::engine::spill::{RegionLockManager, SpillMeta, SpillShape};
 use crate::engine::virtual_deps::VirtualDepBuilder;
 use crate::engine::{
-    CycleDetection, CyclePolicy, DependencyGraph, EvalConfig, FormulaIngestBatch,
+    CycleDetection, CyclePolicy, DependencyGraph, EvalConfig, EvaluationRequestKind,
+    EvaluationRequestOutcome, EvaluationResourceBaselineStats, EvaluationResourceReason,
+    EvaluationResourceRequestStats, FormulaDirtyLeaseOutcome, FormulaIngestBatch,
     FormulaIngestRecord, FormulaIngestReport, FormulaParseDiagnostic, FormulaParsePolicy,
-    FormulaPlaneMode, RowVisibilitySource, ScheduleUnit, Scheduler, VertexId, VertexKind,
-    VisibilityMaskMode,
+    FormulaPlaneMode, FormulaPlaneTopologyCacheOutcome, FormulaPlaneTopologyStrategy,
+    RowVisibilitySource, ScheduleUnit, Scheduler, VertexId, VertexKind, VisibilityMaskMode,
 };
 use crate::formula_plane::placement::prepare_anchor_once_fragment;
 use crate::formula_plane::placement::{
@@ -40,8 +42,8 @@ use crate::formula_plane::runtime::{
     FormulaPlane, FormulaSpanId, FormulaSpanRef, PlacementCoord, PlacementDomain, ResultRegion,
 };
 use crate::formula_plane::scheduler::{
-    MixedSchedule, MixedScheduleFallbackReason, MixedTopology, MixedTopologyConfig,
-    compile_mixed_topology, schedule_dirty_work,
+    MixedSchedule, MixedScheduleFallbackReason, MixedTopology, MixedTopologyCompileStats,
+    MixedTopologyConfig, compile_mixed_topology, schedule_dirty_work,
 };
 #[cfg(test)]
 use crate::formula_plane::span_eval::SpanEvalReport;
@@ -750,6 +752,14 @@ pub struct Engine<R> {
 
     // Runtime-cycle SCC evaluation telemetry (RFC #112, Stage 2)
     last_cycle_telemetry: CycleTelemetry,
+
+    // C0 evaluation-resource observability. IDs are never reset or reused.
+    next_evaluation_resource_request_id: u64,
+    evaluation_resource_request_depth: usize,
+    active_evaluation_resource_request: Option<EvaluationResourceRequestStats>,
+    last_evaluation_resource_request: Option<EvaluationResourceRequestStats>,
+    evaluation_resource_baseline: EvaluationResourceBaselineStats,
+    evaluation_resource_request_started_at: Option<crate::instant::FzInstant>,
 
     /// SCC members that entered iterative calculation (`CyclePolicy::Iterate`
     /// with a witnessed live cycle) during the current evaluation request.
@@ -1856,6 +1866,12 @@ where
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
             virtual_dep_fallback_activations: 0,
             last_cycle_telemetry: CycleTelemetry::default(),
+            next_evaluation_resource_request_id: 1,
+            evaluation_resource_request_depth: 0,
+            active_evaluation_resource_request: None,
+            last_evaluation_resource_request: None,
+            evaluation_resource_baseline: EvaluationResourceBaselineStats::default(),
+            evaluation_resource_request_started_at: None,
             pending_iterative_redirty: Vec::new(),
             iterative_state_values: FxHashMap::default(),
             function_semantic_epoch_seen: crate::function_registry::semantic_epoch(),
@@ -1956,6 +1972,12 @@ where
             last_virtual_dep_telemetry: VirtualDepTelemetry::default(),
             virtual_dep_fallback_activations: 0,
             last_cycle_telemetry: CycleTelemetry::default(),
+            next_evaluation_resource_request_id: 1,
+            evaluation_resource_request_depth: 0,
+            active_evaluation_resource_request: None,
+            last_evaluation_resource_request: None,
+            evaluation_resource_baseline: EvaluationResourceBaselineStats::default(),
+            evaluation_resource_request_started_at: None,
             pending_iterative_redirty: Vec::new(),
             iterative_state_values: FxHashMap::default(),
             function_semantic_epoch_seen: crate::function_registry::semantic_epoch(),
@@ -2008,6 +2030,243 @@ where
     /// or when `enable_virtual_dep_telemetry` is off).
     pub fn last_cycle_telemetry(&self) -> &CycleTelemetry {
         &self.last_cycle_telemetry
+    }
+
+    /// Resource observations for the most recently completed public evaluation request.
+    pub fn last_evaluation_resource_request_stats(
+        &self,
+    ) -> Option<&EvaluationResourceRequestStats> {
+        self.last_evaluation_resource_request.as_ref()
+    }
+
+    /// Cumulative resource observations since engine creation or the last telemetry reset.
+    pub fn evaluation_resource_baseline_stats(&self) -> EvaluationResourceBaselineStats {
+        self.evaluation_resource_baseline
+    }
+
+    /// Reset accumulated and last-request observations without reusing request IDs.
+    pub fn reset_evaluation_resource_telemetry(&mut self) {
+        self.evaluation_resource_baseline = EvaluationResourceBaselineStats::default();
+        self.last_evaluation_resource_request = None;
+    }
+
+    fn duration_ns(duration: std::time::Duration) -> u64 {
+        u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+    }
+
+    fn observe_evaluation_resource_request<T>(
+        &mut self,
+        kind: EvaluationRequestKind,
+        evaluate: impl FnOnce(&mut Self) -> Result<T, ExcelError>,
+    ) -> Result<T, ExcelError> {
+        let outermost = self.evaluation_resource_request_depth == 0;
+        if outermost {
+            let request_id = self.next_evaluation_resource_request_id;
+            self.next_evaluation_resource_request_id = request_id
+                .checked_add(1)
+                .expect("evaluation resource request ID exhausted");
+            self.active_evaluation_resource_request = Some(EvaluationResourceRequestStats::new(
+                request_id,
+                kind,
+                self.config.formula_plane_mode,
+                self.staged_formula_count(),
+            ));
+            self.evaluation_resource_baseline.record_started(request_id);
+            self.evaluation_resource_request_started_at = Some(crate::instant::FzInstant::now());
+        }
+        self.evaluation_resource_request_depth =
+            self.evaluation_resource_request_depth.saturating_add(1);
+        let result = evaluate(self);
+        self.evaluation_resource_request_depth =
+            self.evaluation_resource_request_depth.saturating_sub(1);
+
+        if outermost {
+            let total_ns = self
+                .evaluation_resource_request_started_at
+                .take()
+                .map(|start| Self::duration_ns(start.elapsed()))
+                .unwrap_or(0);
+            let mut stats = self
+                .active_evaluation_resource_request
+                .take()
+                .expect("outer evaluation resource request has active stats");
+            stats.outcome = match &result {
+                Ok(_) => EvaluationRequestOutcome::Success,
+                Err(error) if error.kind == ExcelErrorKind::Cancelled => {
+                    EvaluationRequestOutcome::Cancelled
+                }
+                Err(_) => EvaluationRequestOutcome::Error,
+            };
+            if stats.dirty_lease == FormulaDirtyLeaseOutcome::Acquired {
+                stats.dirty_lease = if stats.outcome == EvaluationRequestOutcome::Cancelled {
+                    FormulaDirtyLeaseOutcome::RetainedOnCancellation
+                } else {
+                    FormulaDirtyLeaseOutcome::RetainedOnError
+                };
+            }
+            stats.phases.total_ns = total_ns;
+            let attributed = stats
+                .phases
+                .staged_prepare_ns
+                .saturating_add(stats.phases.topology_ns)
+                .saturating_add(stats.phases.materialization_ns);
+            stats.phases.evaluation_ns = total_ns.saturating_sub(attributed);
+            self.evaluation_resource_baseline.record_finished(&stats);
+            self.last_evaluation_resource_request = Some(stats);
+        }
+        result
+    }
+
+    fn observe_staged_preparation(
+        &mut self,
+        selected: usize,
+        retained: usize,
+        elapsed: std::time::Duration,
+    ) {
+        if let Some(stats) = self.active_evaluation_resource_request.as_mut() {
+            stats.staged_selected = stats.staged_selected.saturating_add(selected as u64);
+            stats.staged_retained = retained as u64;
+            stats.phases.staged_prepare_ns = stats
+                .phases
+                .staged_prepare_ns
+                .saturating_add(Self::duration_ns(elapsed));
+        }
+    }
+
+    fn observe_topology(
+        &mut self,
+        outcome: FormulaPlaneTopologyCacheOutcome,
+        strategy: FormulaPlaneTopologyStrategy,
+        observed: &MixedTopologyCompileStats,
+        elapsed: std::time::Duration,
+    ) {
+        if let Some(stats) = self.active_evaluation_resource_request.as_mut() {
+            if outcome.severity() > stats.topology.cache_outcome.severity() {
+                stats.topology.cache_outcome = outcome;
+            }
+            if strategy.severity() > stats.topology.strategy.severity() {
+                stats.topology.strategy = strategy;
+            }
+            match outcome {
+                FormulaPlaneTopologyCacheOutcome::Hit => {
+                    stats.topology.cache_hit_events =
+                        stats.topology.cache_hit_events.saturating_add(1);
+                }
+                FormulaPlaneTopologyCacheOutcome::Built => {
+                    stats.topology.cache_build_events =
+                        stats.topology.cache_build_events.saturating_add(1);
+                }
+                FormulaPlaneTopologyCacheOutcome::SkippedOverflow => {
+                    stats.topology.cache_build_events =
+                        stats.topology.cache_build_events.saturating_add(1);
+                    stats.topology.cache_skip_events =
+                        stats.topology.cache_skip_events.saturating_add(1);
+                }
+                FormulaPlaneTopologyCacheOutcome::NotUsed => {}
+            }
+            if matches!(
+                outcome,
+                FormulaPlaneTopologyCacheOutcome::Built
+                    | FormulaPlaneTopologyCacheOutcome::SkippedOverflow
+            ) {
+                stats.topology.producers_observed = stats
+                    .topology
+                    .producers_observed
+                    .saturating_add(observed.producers as u64);
+                stats.topology.candidates_observed = stats
+                    .topology
+                    .candidates_observed
+                    .saturating_add(observed.candidates as u64);
+                stats.topology.edges_observed = stats
+                    .topology
+                    .edges_observed
+                    .saturating_add(observed.relationships as u64);
+                stats.topology.candidate_cap_hits = stats
+                    .topology
+                    .candidate_cap_hits
+                    .saturating_add(observed.candidate_overflow_count as u64);
+                stats.topology.edge_cap_hits = stats
+                    .topology
+                    .edge_cap_hits
+                    .saturating_add(observed.edge_overflow_count as u64);
+                stats.topology.byte_cap_hits = stats
+                    .topology
+                    .byte_cap_hits
+                    .saturating_add(observed.memory_overflow_count as u64);
+                stats.topology.overflow_reason = if stats.topology.byte_cap_hits > 0 {
+                    Some(EvaluationResourceReason::FormulaPlaneTopologyRetainedBytes)
+                } else if stats.topology.edge_cap_hits > 0 {
+                    Some(EvaluationResourceReason::FormulaPlaneTopologyEdges)
+                } else if stats.topology.candidate_cap_hits > 0 {
+                    Some(EvaluationResourceReason::FormulaPlaneTopologyCandidates)
+                } else {
+                    None
+                };
+            }
+            stats.topology.retained_bytes_observed = stats
+                .topology
+                .retained_bytes_observed
+                .max(observed.estimated_memory_bytes as u64);
+            stats.phases.topology_ns = stats
+                .phases
+                .topology_ns
+                .saturating_add(Self::duration_ns(elapsed));
+        }
+    }
+
+    fn observe_topology_strategy(&mut self, strategy: FormulaPlaneTopologyStrategy) {
+        if let Some(stats) = self.active_evaluation_resource_request.as_mut()
+            && strategy.severity() > stats.topology.strategy.severity()
+        {
+            stats.topology.strategy = strategy;
+        }
+    }
+
+    fn observe_materialization(
+        &mut self,
+        placements: usize,
+        cycle: bool,
+        elapsed: std::time::Duration,
+    ) {
+        if let Some(stats) = self.active_evaluation_resource_request.as_mut() {
+            if cycle {
+                stats.cycle_materialized_cells = stats
+                    .cycle_materialized_cells
+                    .saturating_add(placements as u64);
+            } else {
+                stats.fallback_materialized_cells = stats
+                    .fallback_materialized_cells
+                    .saturating_add(placements as u64);
+                stats.topology.strategy =
+                    FormulaPlaneTopologyStrategy::CapacityFallbackMaterialization;
+            }
+            stats.phases.materialization_ns = stats
+                .phases
+                .materialization_ns
+                .saturating_add(Self::duration_ns(elapsed));
+        }
+    }
+
+    fn observe_dirty_lease_acquired(&mut self, empty: bool) {
+        if let Some(stats) = self.active_evaluation_resource_request.as_mut() {
+            stats.dirty_lease = if empty {
+                FormulaDirtyLeaseOutcome::Empty
+            } else {
+                FormulaDirtyLeaseOutcome::Acquired
+            };
+        }
+    }
+
+    fn ack_formula_dirty_observed(&mut self, lease: FormulaDirtyLease) {
+        let empty = lease.is_empty();
+        let _ = self.graph.ack_formula_dirty(lease);
+        if let Some(stats) = self.active_evaluation_resource_request.as_mut() {
+            stats.dirty_lease = if empty {
+                FormulaDirtyLeaseOutcome::AcknowledgedEmpty
+            } else {
+                FormulaDirtyLeaseOutcome::Acknowledged
+            };
+        }
     }
 
     /// Begin a new evaluation request: reset per-recalc cycle telemetry and
@@ -6623,7 +6882,7 @@ where
         )>,
         publish_report: bool,
     ) -> Result<FormulaIngestReport, ExcelError> {
-        let mut source_counts = [0_u64; 10];
+        let mut source_counts = [0_u64; 11];
         let mut source_report = crate::engine::FormulaCompressedSourceReport::default();
         let mut formula_batches = Vec::with_capacity(batches.len());
         let mut compressed_families = Vec::new();
@@ -6651,7 +6910,8 @@ where
             source_counts[7] = source_counts[7].max(compressed.source_spool_peak_memory_bytes);
             source_counts[8] =
                 source_counts[8].saturating_add(compressed.source_spool_spilled_bytes);
-            source_counts[9] = source_counts[9].saturating_add(compressed.source_spool_replays);
+            source_counts[9] = source_counts[9].saturating_add(compressed.source_spool_spill_files);
+            source_counts[10] = source_counts[10].saturating_add(compressed.source_spool_replays);
             source_report.families_seen = source_report
                 .families_seen
                 .saturating_add(compressed.families_seen);
@@ -6722,7 +6982,7 @@ where
         let has_formulas = batches.iter().any(|batch| !batch.formulas.is_empty());
         let report = self.ingest_formula_batches_inner(
             batches,
-            [0; 10],
+            [0; 11],
             None,
             Vec::new(),
             Vec::new(),
@@ -6738,13 +6998,13 @@ where
         &mut self,
         batches: Vec<FormulaIngestBatch>,
     ) -> Result<FormulaIngestReport, ExcelError> {
-        self.ingest_formula_batches_inner(batches, [0; 10], None, Vec::new(), Vec::new(), false)
+        self.ingest_formula_batches_inner(batches, [0; 11], None, Vec::new(), Vec::new(), false)
     }
 
     fn ingest_formula_batches_inner(
         &mut self,
         batches: Vec<FormulaIngestBatch>,
-        source_counts: [u64; 10],
+        source_counts: [u64; 11],
         source_report: Option<crate::engine::FormulaCompressedSourceReport>,
         compressed_families: Vec<(String, Vec<crate::engine::SourceFormulaFamily>)>,
         partitioned_families: Vec<(String, Vec<crate::engine::PartitionedSourceFormulaFamily>)>,
@@ -6814,7 +7074,8 @@ where
         report.source_spool_encoded_bytes = source_counts[6];
         report.source_spool_peak_memory_bytes = source_counts[7];
         report.source_spool_spilled_bytes = source_counts[8];
-        report.source_spool_replays = source_counts[9];
+        report.source_spool_spill_files = source_counts[9];
+        report.source_spool_replays = source_counts[10];
         if let Some(source) = source_report {
             report.source_families_seen = source.families_seen;
             report.source_family_cells_seen = source.family_cells_seen;
@@ -6922,10 +7183,14 @@ where
 
     /// Build graph for all staged formulas.
     pub fn build_graph_all(&mut self) -> Result<(), formualizer_parse::ExcelError> {
+        let selected = self.staged_formula_count();
+        let started = crate::instant::FzInstant::now();
         let collected = std::mem::take(&mut self.staged_formulas)
             .into_iter()
             .collect();
-        self.build_graph_from_staged_batches(collected, false)
+        let result = self.build_graph_from_staged_batches(collected, false);
+        self.observe_staged_preparation(selected, self.staged_formula_count(), started.elapsed());
+        result
     }
 
     /// Build graph for specific sheets (consuming only those staged entries).
@@ -6933,13 +7198,20 @@ where
         &mut self,
         sheets: I,
     ) -> Result<(), formualizer_parse::ExcelError> {
+        let started = crate::instant::FzInstant::now();
         let mut collected = Vec::new();
         for sheet in sheets {
             if let Some(staged) = self.staged_formulas.remove(sheet) {
                 collected.push((sheet.to_string(), staged));
             }
         }
-        self.build_graph_from_staged_batches(collected, true)
+        let selected = collected
+            .iter()
+            .map(|(_, staged)| staged.len())
+            .sum::<usize>();
+        let result = self.build_graph_from_staged_batches(collected, true);
+        self.observe_staged_preparation(selected, self.staged_formula_count(), started.elapsed());
+        result
     }
 
     fn build_graph_from_staged_batches(
@@ -9774,6 +10046,7 @@ where
     /// the first graph/authority mutation, so a multi-span or multi-sheet cycle
     /// cannot publish only an earlier subset.
     fn demote_cyclic_spans(&mut self, span_refs: &[FormulaSpanRef]) -> Result<(), ExcelError> {
+        let materialization_started = crate::instant::FzInstant::now();
         let prepared = self
             .prepare_formula_span_demotion(span_refs)
             .map_err(|error| {
@@ -9788,6 +10061,11 @@ where
                     "FormulaPlane cycle-member span demotion commit failed: {error}"
                 ))
             })?;
+        self.observe_materialization(
+            report.placements_materialized,
+            true,
+            materialization_started.elapsed(),
+        );
         self.formula_plane_cycle_member_span_demotions = self
             .formula_plane_cycle_member_span_demotions
             .saturating_add(report.spans_demoted as u64);
@@ -12257,11 +12535,13 @@ where
     }
 
     pub fn evaluate_vertex(&mut self, vertex_id: VertexId) -> Result<LiteralValue, ExcelError> {
-        self.observe_function_semantic_epoch()?;
-        if self.graph.formula_authority().active_span_count() > 0 {
-            let _ = self.evaluate_authoritative_formula_plane_all()?;
-        }
-        self.evaluate_vertex_impl(vertex_id, None)
+        self.observe_evaluation_resource_request(EvaluationRequestKind::Vertex, |engine| {
+            engine.observe_function_semantic_epoch()?;
+            if engine.graph.formula_authority().active_span_count() > 0 {
+                let _ = engine.evaluate_authoritative_formula_plane_all()?;
+            }
+            engine.evaluate_vertex_impl(vertex_id, None)
+        })
     }
 
     fn evaluate_vertex_impl(
@@ -12905,6 +13185,15 @@ where
         &mut self,
         targets: &[(&str, u32, u32)],
     ) -> Result<EvalResult, ExcelError> {
+        self.observe_evaluation_resource_request(EvaluationRequestKind::Targeted, |engine| {
+            engine.evaluate_until_unobserved(targets)
+        })
+    }
+
+    fn evaluate_until_unobserved(
+        &mut self,
+        targets: &[(&str, u32, u32)],
+    ) -> Result<EvalResult, ExcelError> {
         self.observe_function_semantic_epoch()?;
         #[cfg(feature = "tracing")]
         let _span_eval = tracing::info_span!("evaluate_until", targets = targets.len()).entered();
@@ -13112,6 +13401,15 @@ where
 
     /// Evaluate using a previously constructed plan. This avoids rebuilding layer schedules for each run.
     pub fn evaluate_recalc_plan(&mut self, plan: &RecalcPlan) -> Result<EvalResult, ExcelError> {
+        self.observe_evaluation_resource_request(EvaluationRequestKind::RecalcPlan, |engine| {
+            engine.evaluate_recalc_plan_unobserved(plan)
+        })
+    }
+
+    fn evaluate_recalc_plan_unobserved(
+        &mut self,
+        plan: &RecalcPlan,
+    ) -> Result<EvalResult, ExcelError> {
         if self.observe_function_semantic_epoch()? {
             return self.evaluate_all();
         }
@@ -13200,7 +13498,7 @@ where
         formula_dirty: FormulaDirtyLease,
     ) -> Result<EvalResult, ExcelError> {
         let result = self.evaluate_all_legacy_impl()?;
-        self.graph.ack_formula_dirty(formula_dirty);
+        self.ack_formula_dirty_observed(formula_dirty);
         Ok(result)
     }
 
@@ -13213,10 +13511,12 @@ where
         // counts survive into the final telemetry.
         self.begin_evaluation_request();
         let mut formula_dirty = self.graph.lease_formula_dirty();
+        self.observe_dirty_lease_acquired(formula_dirty.is_empty());
 
         // SingletonUnique formulas intentionally remain legacy graph vertices;
         // when no spans are active, execute through the private legacy primitive.
         if self.graph.formula_authority().active_span_count() == 0 {
+            self.observe_topology_strategy(FormulaPlaneTopologyStrategy::SkippedNoActiveSpans);
             #[cfg(test)]
             {
                 self.last_formula_plane_span_eval_report = None;
@@ -13227,6 +13527,7 @@ where
         // With no graph-owned span/region dirtiness, only sparse legacy work
         // (including volatiles) can remain. Preserve the warm no-op fast path.
         if formula_dirty.is_empty() {
+            self.observe_topology_strategy(FormulaPlaneTopologyStrategy::SkippedNoDirtyWork);
             #[cfg(test)]
             {
                 self.last_formula_plane_span_eval_report = None;
@@ -13275,6 +13576,7 @@ where
                     .collect::<Vec<_>>();
 
                 if !selected_span_refs.is_empty() {
+                    let materialization_started = crate::instant::FzInstant::now();
                     let prepared = self
                         .prepare_formula_span_demotion(&selected_span_refs)
                         .map_err(|error| {
@@ -13282,12 +13584,18 @@ where
                                 "FormulaPlane capacity fallback demotion preparation failed: {error}"
                             ))
                         })?;
-                    self.commit_prepared_formula_span_demotion(prepared)
+                    let report = self
+                        .commit_prepared_formula_span_demotion(prepared)
                         .map_err(|error| {
                             ExcelError::new(ExcelErrorKind::NImpl).with_message(format!(
                                 "FormulaPlane capacity fallback demotion commit failed: {error}"
                             ))
                         })?;
+                    self.observe_materialization(
+                        report.placements_materialized,
+                        false,
+                        materialization_started.elapsed(),
+                    );
                 }
 
                 #[cfg(test)]
@@ -13295,7 +13603,7 @@ where
                     self.last_formula_plane_span_eval_report = None;
                 }
                 let result = self.evaluate_all_legacy_impl()?;
-                self.graph.ack_formula_dirty(formula_dirty);
+                self.ack_formula_dirty_observed(formula_dirty);
                 self.formula_plane_capacity_bailouts =
                     self.formula_plane_capacity_bailouts.saturating_add(1);
                 return Ok(result);
@@ -13490,7 +13798,7 @@ where
         // vertices weren't in the dirty subset (e.g. recently-introduced span
         // result cells); legacy clear_dirty_flags is safe over the full set.
         self.redirty_for_next_recalc();
-        self.graph.ack_formula_dirty(formula_dirty);
+        self.ack_formula_dirty_observed(formula_dirty);
         self.recalc_epoch = self.recalc_epoch.wrapping_add(1);
         Ok(EvalResult {
             computed_vertices,
@@ -13680,19 +13988,49 @@ where
             .as_ref()
             .is_some_and(|cached| cached.key == key && cached.span_refs_by_id == active_refs);
         let mut uncached_topology = None;
-        if cache_hit {
+        let topology_started = crate::instant::FzInstant::now();
+        let (cache_outcome, strategy, compile_stats) = if cache_hit {
             self.mixed_topology_cache_hits = self.mixed_topology_cache_hits.saturating_add(1);
+            let stats = self
+                .cached_mixed_topology
+                .as_ref()
+                .expect("cache hit has topology")
+                .topology
+                .stats
+                .clone();
+            (
+                FormulaPlaneTopologyCacheOutcome::Hit,
+                FormulaPlaneTopologyStrategy::Cached,
+                stats,
+            )
         } else {
             let compiled = self.compile_formula_plane_mixed_topology(key)?;
             self.mixed_topology_cache_builds = self.mixed_topology_cache_builds.saturating_add(1);
+            let stats = compiled.topology.stats.clone();
             if compiled.topology.is_complete() {
                 self.cached_mixed_topology = Some(compiled);
+                (
+                    FormulaPlaneTopologyCacheOutcome::Built,
+                    FormulaPlaneTopologyStrategy::CompiledAndCached,
+                    stats,
+                )
             } else {
                 self.mixed_topology_cache_overflows =
                     self.mixed_topology_cache_overflows.saturating_add(1);
                 uncached_topology = Some(compiled);
+                (
+                    FormulaPlaneTopologyCacheOutcome::SkippedOverflow,
+                    FormulaPlaneTopologyStrategy::CapacityFallbackMaterialization,
+                    stats,
+                )
             }
-        }
+        };
+        self.observe_topology(
+            cache_outcome,
+            strategy,
+            &compile_stats,
+            topology_started.elapsed(),
+        );
 
         let cached = uncached_topology
             .as_ref()
@@ -13813,6 +14151,12 @@ where
 
     /// Evaluate all dirty/volatile vertices
     pub fn evaluate_all(&mut self) -> Result<EvalResult, ExcelError> {
+        self.observe_evaluation_resource_request(EvaluationRequestKind::Full, |engine| {
+            engine.evaluate_all_unobserved()
+        })
+    }
+
+    fn evaluate_all_unobserved(&mut self) -> Result<EvalResult, ExcelError> {
         debug_assert!(
             !self.graph.deferred_dirty_active(),
             "deferred-dirty scope leaked into evaluate_all: a begin_deferred_dirty \
@@ -13963,10 +14307,12 @@ where
     }
 
     pub fn evaluate_all_with_delta(&mut self) -> Result<(EvalResult, EvalDelta), ExcelError> {
-        self.observe_function_semantic_epoch()?;
-        let mut collector = DeltaCollector::new(DeltaMode::Cells);
-        let result = self.evaluate_all_with_delta_collector(&mut collector)?;
-        Ok((result, collector.finish()))
+        self.observe_evaluation_resource_request(EvaluationRequestKind::FullWithDelta, |engine| {
+            engine.observe_function_semantic_epoch()?;
+            let mut collector = DeltaCollector::new(DeltaMode::Cells);
+            let result = engine.evaluate_all_with_delta_collector(&mut collector)?;
+            Ok((result, collector.finish()))
+        })
     }
 
     fn evaluate_all_with_delta_collector(
@@ -14092,6 +14438,17 @@ where
         row: u32,
         col: u32,
     ) -> Result<Option<LiteralValue>, ExcelError> {
+        self.observe_evaluation_resource_request(EvaluationRequestKind::Cell, |engine| {
+            engine.evaluate_cell_unobserved(sheet, row, col)
+        })
+    }
+
+    fn evaluate_cell_unobserved(
+        &mut self,
+        sheet: &str,
+        row: u32,
+        col: u32,
+    ) -> Result<Option<LiteralValue>, ExcelError> {
         if row == 0 || col == 0 {
             return Err(ExcelError::new(ExcelErrorKind::Ref)
                 .with_message("Row and column must be >= 1".to_string()));
@@ -14130,6 +14487,15 @@ where
         &mut self,
         targets: &[(&str, u32, u32)],
     ) -> Result<Vec<Option<LiteralValue>>, ExcelError> {
+        self.observe_evaluation_resource_request(EvaluationRequestKind::Cells, |engine| {
+            engine.evaluate_cells_unobserved(targets)
+        })
+    }
+
+    fn evaluate_cells_unobserved(
+        &mut self,
+        targets: &[(&str, u32, u32)],
+    ) -> Result<Vec<Option<LiteralValue>>, ExcelError> {
         self.observe_function_semantic_epoch()?;
         debug_assert!(
             !self.graph.deferred_dirty_active(),
@@ -14162,11 +14528,16 @@ where
         targets: &[(&str, u32, u32)],
         cancel_flag: Arc<AtomicBool>,
     ) -> Result<Vec<Option<LiteralValue>>, ExcelError> {
-        self.observe_function_semantic_epoch()?;
-        self.active_cancel_flag = Some(cancel_flag.clone());
-        let res = self.evaluate_cells_cancellable_impl(targets, &cancel_flag);
-        self.active_cancel_flag = None;
-        res
+        self.observe_evaluation_resource_request(
+            EvaluationRequestKind::CellsCancellable,
+            |engine| {
+                engine.observe_function_semantic_epoch()?;
+                engine.active_cancel_flag = Some(cancel_flag.clone());
+                let res = engine.evaluate_cells_cancellable_impl(targets, &cancel_flag);
+                engine.active_cancel_flag = None;
+                res
+            },
+        )
     }
 
     fn evaluate_cells_cancellable_impl(
@@ -14216,6 +14587,15 @@ where
     }
 
     pub fn evaluate_cells_with_delta(
+        &mut self,
+        targets: &[(&str, u32, u32)],
+    ) -> Result<(Vec<Option<LiteralValue>>, EvalDelta), ExcelError> {
+        self.observe_evaluation_resource_request(EvaluationRequestKind::CellsWithDelta, |engine| {
+            engine.evaluate_cells_with_delta_unobserved(targets)
+        })
+    }
+
+    fn evaluate_cells_with_delta_unobserved(
         &mut self,
         targets: &[(&str, u32, u32)],
     ) -> Result<(Vec<Option<LiteralValue>>, EvalDelta), ExcelError> {
@@ -14645,11 +15025,13 @@ where
         &mut self,
         cancel_flag: Arc<AtomicBool>,
     ) -> Result<EvalResult, ExcelError> {
-        self.observe_function_semantic_epoch()?;
-        self.active_cancel_flag = Some(cancel_flag.clone());
-        let res = self.evaluate_all_cancellable_impl(&cancel_flag);
-        self.active_cancel_flag = None;
-        res
+        self.observe_evaluation_resource_request(EvaluationRequestKind::FullCancellable, |engine| {
+            engine.observe_function_semantic_epoch()?;
+            engine.active_cancel_flag = Some(cancel_flag.clone());
+            let res = engine.evaluate_all_cancellable_impl(&cancel_flag);
+            engine.active_cancel_flag = None;
+            res
+        })
     }
 
     fn evaluate_all_cancellable_impl(
@@ -14806,11 +15188,16 @@ where
         targets: &[&str],
         cancel_flag: Arc<AtomicBool>,
     ) -> Result<EvalResult, ExcelError> {
-        self.observe_function_semantic_epoch()?;
-        self.active_cancel_flag = Some(cancel_flag.clone());
-        let res = self.evaluate_until_cancellable_impl(targets, &cancel_flag);
-        self.active_cancel_flag = None;
-        res
+        self.observe_evaluation_resource_request(
+            EvaluationRequestKind::TargetedCancellable,
+            |engine| {
+                engine.observe_function_semantic_epoch()?;
+                engine.active_cancel_flag = Some(cancel_flag.clone());
+                let res = engine.evaluate_until_cancellable_impl(targets, &cancel_flag);
+                engine.active_cancel_flag = None;
+                res
+            },
+        )
     }
 
     fn evaluate_until_cancellable_impl(
@@ -19171,6 +19558,15 @@ where
     /// This is the same flow as `evaluate_all` but threads a ChangeLog through
     /// every effect application so that spill commits/clears are captured.
     pub fn evaluate_all_logged(&mut self, log: &mut ChangeLog) -> Result<EvalResult, ExcelError> {
+        self.observe_evaluation_resource_request(EvaluationRequestKind::FullLogged, |engine| {
+            engine.evaluate_all_logged_unobserved(log)
+        })
+    }
+
+    fn evaluate_all_logged_unobserved(
+        &mut self,
+        log: &mut ChangeLog,
+    ) -> Result<EvalResult, ExcelError> {
         self.observe_function_semantic_epoch()?;
         self.begin_evaluation_request();
         let _source_cache = self.source_cache_session();

--- a/crates/formualizer-eval/src/engine/formula_ingest.rs
+++ b/crates/formualizer-eval/src/engine/formula_ingest.rs
@@ -89,6 +89,7 @@ pub struct FormulaIngestReport {
     pub source_spool_encoded_bytes: u64,
     pub source_spool_peak_memory_bytes: u64,
     pub source_spool_spilled_bytes: u64,
+    pub source_spool_spill_files: u64,
     pub source_spool_replays: u64,
     pub source_ordinary_events: u64,
     pub source_shared_anchor_events: u64,
@@ -150,6 +151,7 @@ impl Default for FormulaIngestReport {
             source_spool_encoded_bytes: 0,
             source_spool_peak_memory_bytes: 0,
             source_spool_spilled_bytes: 0,
+            source_spool_spill_files: 0,
             source_spool_replays: 0,
             source_ordinary_events: 0,
             source_shared_anchor_events: 0,
@@ -251,6 +253,9 @@ impl FormulaIngestReport {
         self.source_spool_spilled_bytes = self
             .source_spool_spilled_bytes
             .saturating_add(other.source_spool_spilled_bytes);
+        self.source_spool_spill_files = self
+            .source_spool_spill_files
+            .saturating_add(other.source_spool_spill_files);
         self.source_spool_replays = self
             .source_spool_replays
             .saturating_add(other.source_spool_replays);

--- a/crates/formualizer-eval/src/engine/formula_source.rs
+++ b/crates/formualizer-eval/src/engine/formula_source.rs
@@ -912,6 +912,7 @@ pub struct FormulaCompressedSourceReport {
     pub source_spool_encoded_bytes: u64,
     pub source_spool_peak_memory_bytes: u64,
     pub source_spool_spilled_bytes: u64,
+    pub source_spool_spill_files: u64,
     pub source_spool_replays: u64,
     pub source_ordinary_events: u64,
     pub source_shared_anchor_events: u64,

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -20,6 +20,7 @@ pub mod live_graph;
 pub mod lookup_index_cache;
 pub mod plan;
 pub mod range_view;
+pub mod resource_observability;
 pub mod row_visibility;
 pub mod scheduler;
 pub mod spill;
@@ -70,6 +71,12 @@ pub use graph::snapshot::VertexSnapshot;
 pub use graph::{
     ChangeEvent, DependencyGraph, DependencyRef, GraphBaselineStats, OperationSummary, StripeKey,
     StripeType, block_index,
+};
+pub use resource_observability::{
+    EvaluationRequestKind, EvaluationRequestOutcome, EvaluationRequestPhaseTimings,
+    EvaluationResourceBaselineStats, EvaluationResourceClass, EvaluationResourceReason,
+    EvaluationResourceRequestStats, FormulaDirtyLeaseOutcome, FormulaPlaneTopologyCacheOutcome,
+    FormulaPlaneTopologyRequestStats, FormulaPlaneTopologyStrategy,
 };
 pub use row_visibility::{RowVisibilitySource, VisibilityMaskMode};
 pub use scheduler::{Layer, Schedule, ScheduleUnit, Scheduler};

--- a/crates/formualizer-eval/src/engine/resource_observability.rs
+++ b/crates/formualizer-eval/src/engine/resource_observability.rs
@@ -1,0 +1,411 @@
+use super::FormulaPlaneMode;
+
+/// Stable classification for evaluation limits. C0 is observational only: these classes do not
+/// alter limit enforcement or fallback selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EvaluationResourceClass {
+    SemanticFormat,
+    Admission,
+    RetainedMemory,
+    ScratchMemory,
+    WorkTime,
+    Optimization,
+}
+
+/// Stable reason vocabulary for observed evaluation-resource boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EvaluationResourceReason {
+    FormulaPlaneTopologyCandidates,
+    FormulaPlaneTopologyEdges,
+    FormulaPlaneTopologyRetainedBytes,
+    FormulaPlaneMaterializationCells,
+    FormulaReplayEncodedBytes,
+    FormulaReplayMemoryBytes,
+    FormulaReplayDiskBytes,
+    FormulaReplayFiles,
+    EvaluationCancelled,
+    EvaluationError,
+}
+
+impl EvaluationResourceClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SemanticFormat => "semantic_format",
+            Self::Admission => "admission",
+            Self::RetainedMemory => "retained_memory",
+            Self::ScratchMemory => "scratch_memory",
+            Self::WorkTime => "work_time",
+            Self::Optimization => "optimization",
+        }
+    }
+}
+
+impl EvaluationResourceReason {
+    pub const fn class(self) -> EvaluationResourceClass {
+        match self {
+            Self::FormulaPlaneTopologyCandidates | Self::FormulaPlaneTopologyEdges => {
+                EvaluationResourceClass::Optimization
+            }
+            Self::FormulaPlaneTopologyRetainedBytes => EvaluationResourceClass::RetainedMemory,
+            Self::FormulaPlaneMaterializationCells
+            | Self::FormulaReplayEncodedBytes
+            | Self::FormulaReplayDiskBytes
+            | Self::FormulaReplayFiles => EvaluationResourceClass::Admission,
+            Self::FormulaReplayMemoryBytes => EvaluationResourceClass::ScratchMemory,
+            Self::EvaluationCancelled | Self::EvaluationError => EvaluationResourceClass::WorkTime,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::FormulaPlaneTopologyCandidates => "formula_plane_topology_candidates",
+            Self::FormulaPlaneTopologyEdges => "formula_plane_topology_edges",
+            Self::FormulaPlaneTopologyRetainedBytes => "formula_plane_topology_retained_bytes",
+            Self::FormulaPlaneMaterializationCells => "formula_plane_materialization_cells",
+            Self::FormulaReplayEncodedBytes => "formula_replay_encoded_bytes",
+            Self::FormulaReplayMemoryBytes => "formula_replay_memory_bytes",
+            Self::FormulaReplayDiskBytes => "formula_replay_disk_bytes",
+            Self::FormulaReplayFiles => "formula_replay_files",
+            Self::EvaluationCancelled => "evaluation_cancelled",
+            Self::EvaluationError => "evaluation_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum EvaluationRequestKind {
+    Vertex,
+    Targeted,
+    RecalcPlan,
+    #[default]
+    Full,
+    FullWithDelta,
+    Cell,
+    Cells,
+    CellsCancellable,
+    CellsWithDelta,
+    FullCancellable,
+    TargetedCancellable,
+    FullLogged,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum EvaluationRequestOutcome {
+    #[default]
+    InProgress,
+    Success,
+    Cancelled,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum FormulaPlaneTopologyStrategy {
+    #[default]
+    NotUsed,
+    Legacy,
+    SkippedNoActiveSpans,
+    SkippedNoDirtyWork,
+    Cached,
+    CompiledAndCached,
+    CapacityFallbackMaterialization,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum FormulaPlaneTopologyCacheOutcome {
+    #[default]
+    NotUsed,
+    Hit,
+    Built,
+    SkippedOverflow,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum FormulaDirtyLeaseOutcome {
+    #[default]
+    NotAcquired,
+    Acquired,
+    Empty,
+    Acknowledged,
+    AcknowledgedEmpty,
+    RetainedOnCancellation,
+    RetainedOnError,
+}
+
+impl EvaluationRequestKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Vertex => "vertex",
+            Self::Targeted => "targeted",
+            Self::RecalcPlan => "recalc_plan",
+            Self::Full => "full",
+            Self::FullWithDelta => "full_with_delta",
+            Self::Cell => "cell",
+            Self::Cells => "cells",
+            Self::CellsCancellable => "cells_cancellable",
+            Self::CellsWithDelta => "cells_with_delta",
+            Self::FullCancellable => "full_cancellable",
+            Self::TargetedCancellable => "targeted_cancellable",
+            Self::FullLogged => "full_logged",
+        }
+    }
+}
+
+impl EvaluationRequestOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InProgress => "in_progress",
+            Self::Success => "success",
+            Self::Cancelled => "cancelled",
+            Self::Error => "error",
+        }
+    }
+}
+
+impl FormulaPlaneTopologyStrategy {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotUsed => "not_used",
+            Self::Legacy => "legacy",
+            Self::SkippedNoActiveSpans => "skipped_no_active_spans",
+            Self::SkippedNoDirtyWork => "skipped_no_dirty_work",
+            Self::Cached => "cached",
+            Self::CompiledAndCached => "compiled_and_cached",
+            Self::CapacityFallbackMaterialization => "capacity_fallback_materialization",
+        }
+    }
+
+    pub(crate) const fn severity(self) -> u8 {
+        match self {
+            Self::NotUsed => 0,
+            Self::Legacy => 1,
+            Self::SkippedNoActiveSpans => 2,
+            Self::SkippedNoDirtyWork => 3,
+            Self::Cached => 4,
+            Self::CompiledAndCached => 5,
+            Self::CapacityFallbackMaterialization => 6,
+        }
+    }
+}
+
+impl FormulaPlaneTopologyCacheOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotUsed => "not_used",
+            Self::Hit => "hit",
+            Self::Built => "built",
+            Self::SkippedOverflow => "skipped_overflow",
+        }
+    }
+
+    pub(crate) const fn severity(self) -> u8 {
+        match self {
+            Self::NotUsed => 0,
+            Self::Hit => 1,
+            Self::Built => 2,
+            Self::SkippedOverflow => 3,
+        }
+    }
+}
+
+impl FormulaDirtyLeaseOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotAcquired => "not_acquired",
+            Self::Acquired => "acquired",
+            Self::Empty => "empty",
+            Self::Acknowledged => "acknowledged",
+            Self::AcknowledgedEmpty => "acknowledged_empty",
+            Self::RetainedOnCancellation => "retained_on_cancellation",
+            Self::RetainedOnError => "retained_on_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FormulaPlaneTopologyRequestStats {
+    /// Most severe strategy observed during the request.
+    pub strategy: FormulaPlaneTopologyStrategy,
+    /// Most severe cache outcome observed during the request.
+    pub cache_outcome: FormulaPlaneTopologyCacheOutcome,
+    pub cache_hit_events: u64,
+    pub cache_build_events: u64,
+    pub cache_skip_events: u64,
+    /// Sum across topology build attempts; cache hits do not replay prior build work.
+    pub producers_observed: u64,
+    pub candidates_observed: u64,
+    pub edges_observed: u64,
+    pub retained_bytes_observed: u64,
+    pub candidate_cap_hits: u64,
+    pub edge_cap_hits: u64,
+    pub byte_cap_hits: u64,
+    pub overflow_reason: Option<EvaluationResourceReason>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EvaluationRequestPhaseTimings {
+    pub total_ns: u64,
+    pub staged_prepare_ns: u64,
+    pub topology_ns: u64,
+    pub materialization_ns: u64,
+    pub evaluation_ns: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvaluationResourceRequestStats {
+    pub request_id: u64,
+    pub kind: EvaluationRequestKind,
+    pub formula_plane_mode: FormulaPlaneMode,
+    pub outcome: EvaluationRequestOutcome,
+    pub staged_selected: u64,
+    pub staged_retained: u64,
+    pub topology: FormulaPlaneTopologyRequestStats,
+    pub fallback_materialized_cells: u64,
+    pub cycle_materialized_cells: u64,
+    pub dirty_lease: FormulaDirtyLeaseOutcome,
+    pub phases: EvaluationRequestPhaseTimings,
+}
+
+impl EvaluationResourceRequestStats {
+    pub(crate) fn new(
+        request_id: u64,
+        kind: EvaluationRequestKind,
+        formula_plane_mode: FormulaPlaneMode,
+        staged_retained: usize,
+    ) -> Self {
+        Self {
+            request_id,
+            kind,
+            formula_plane_mode,
+            outcome: EvaluationRequestOutcome::InProgress,
+            staged_selected: 0,
+            staged_retained: staged_retained as u64,
+            topology: FormulaPlaneTopologyRequestStats {
+                strategy: if formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental {
+                    FormulaPlaneTopologyStrategy::NotUsed
+                } else {
+                    FormulaPlaneTopologyStrategy::Legacy
+                },
+                ..FormulaPlaneTopologyRequestStats::default()
+            },
+            fallback_materialized_cells: 0,
+            cycle_materialized_cells: 0,
+            dirty_lease: FormulaDirtyLeaseOutcome::NotAcquired,
+            phases: EvaluationRequestPhaseTimings::default(),
+        }
+    }
+}
+
+/// Cumulative observational counters since engine creation or the last explicit telemetry reset.
+/// Resetting these counters never resets the monotonic request ID sequence.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EvaluationResourceBaselineStats {
+    pub last_request_id: u64,
+    pub requests_started: u64,
+    pub requests_succeeded: u64,
+    pub requests_cancelled: u64,
+    pub requests_errored: u64,
+    pub staged_selected_total: u64,
+    pub topology_cache_hits: u64,
+    pub topology_cache_builds: u64,
+    pub topology_cache_skips: u64,
+    pub topology_candidate_cap_hits: u64,
+    pub topology_edge_cap_hits: u64,
+    pub topology_byte_cap_hits: u64,
+    pub topology_candidates_observed_total: u64,
+    pub topology_edges_observed_total: u64,
+    pub topology_retained_bytes_observed_max: u64,
+    pub fallback_materialized_cells_total: u64,
+    pub cycle_materialized_cells_total: u64,
+    pub dirty_leases_acknowledged: u64,
+    pub dirty_leases_retained_on_cancel: u64,
+    pub dirty_leases_retained_on_error: u64,
+    pub total_request_ns: u64,
+    pub staged_prepare_ns: u64,
+    pub topology_ns: u64,
+    pub materialization_ns: u64,
+    pub evaluation_ns: u64,
+}
+
+impl EvaluationResourceBaselineStats {
+    pub(crate) fn record_started(&mut self, request_id: u64) {
+        self.last_request_id = request_id;
+        self.requests_started = self.requests_started.saturating_add(1);
+    }
+
+    pub(crate) fn record_finished(&mut self, stats: &EvaluationResourceRequestStats) {
+        match stats.outcome {
+            EvaluationRequestOutcome::Success => {
+                self.requests_succeeded = self.requests_succeeded.saturating_add(1)
+            }
+            EvaluationRequestOutcome::Cancelled => {
+                self.requests_cancelled = self.requests_cancelled.saturating_add(1)
+            }
+            EvaluationRequestOutcome::Error => {
+                self.requests_errored = self.requests_errored.saturating_add(1)
+            }
+            EvaluationRequestOutcome::InProgress => {}
+        }
+        self.staged_selected_total = self
+            .staged_selected_total
+            .saturating_add(stats.staged_selected);
+        self.topology_cache_hits = self
+            .topology_cache_hits
+            .saturating_add(stats.topology.cache_hit_events);
+        self.topology_cache_builds = self
+            .topology_cache_builds
+            .saturating_add(stats.topology.cache_build_events);
+        self.topology_cache_skips = self
+            .topology_cache_skips
+            .saturating_add(stats.topology.cache_skip_events);
+        self.topology_candidate_cap_hits = self
+            .topology_candidate_cap_hits
+            .saturating_add(stats.topology.candidate_cap_hits);
+        self.topology_edge_cap_hits = self
+            .topology_edge_cap_hits
+            .saturating_add(stats.topology.edge_cap_hits);
+        self.topology_byte_cap_hits = self
+            .topology_byte_cap_hits
+            .saturating_add(stats.topology.byte_cap_hits);
+        self.topology_candidates_observed_total = self
+            .topology_candidates_observed_total
+            .saturating_add(stats.topology.candidates_observed);
+        self.topology_edges_observed_total = self
+            .topology_edges_observed_total
+            .saturating_add(stats.topology.edges_observed);
+        self.topology_retained_bytes_observed_max = self
+            .topology_retained_bytes_observed_max
+            .max(stats.topology.retained_bytes_observed);
+        self.fallback_materialized_cells_total = self
+            .fallback_materialized_cells_total
+            .saturating_add(stats.fallback_materialized_cells);
+        self.cycle_materialized_cells_total = self
+            .cycle_materialized_cells_total
+            .saturating_add(stats.cycle_materialized_cells);
+        match stats.dirty_lease {
+            FormulaDirtyLeaseOutcome::Acknowledged
+            | FormulaDirtyLeaseOutcome::AcknowledgedEmpty => {
+                self.dirty_leases_acknowledged = self.dirty_leases_acknowledged.saturating_add(1)
+            }
+            FormulaDirtyLeaseOutcome::RetainedOnCancellation => {
+                self.dirty_leases_retained_on_cancel =
+                    self.dirty_leases_retained_on_cancel.saturating_add(1)
+            }
+            FormulaDirtyLeaseOutcome::RetainedOnError => {
+                self.dirty_leases_retained_on_error =
+                    self.dirty_leases_retained_on_error.saturating_add(1)
+            }
+            _ => {}
+        }
+        self.total_request_ns = self.total_request_ns.saturating_add(stats.phases.total_ns);
+        self.staged_prepare_ns = self
+            .staged_prepare_ns
+            .saturating_add(stats.phases.staged_prepare_ns);
+        self.topology_ns = self.topology_ns.saturating_add(stats.phases.topology_ns);
+        self.materialization_ns = self
+            .materialization_ns
+            .saturating_add(stats.phases.materialization_ns);
+        self.evaluation_ns = self
+            .evaluation_ns
+            .saturating_add(stats.phases.evaluation_ns);
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/evaluation_resource_observability.rs
+++ b/crates/formualizer-eval/src/engine/tests/evaluation_resource_observability.rs
@@ -1,0 +1,274 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use formualizer_common::LiteralValue;
+use formualizer_parse::ExcelErrorKind;
+use formualizer_parse::parser::parse;
+
+use crate::engine::{
+    Engine, EvalConfig, EvaluationRequestKind, EvaluationRequestOutcome, EvaluationResourceClass,
+    EvaluationResourceReason, FormulaDirtyLeaseOutcome, FormulaIngestBatch, FormulaIngestRecord,
+    FormulaPlaneMode, FormulaPlaneTopologyCacheOutcome, FormulaPlaneTopologyStrategy,
+};
+use crate::test_workbook::TestWorkbook;
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    let ast = parse(formula).unwrap();
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn build_mode_engine(mode: FormulaPlaneMode, cache_bytes: Option<usize>) -> Engine<TestWorkbook> {
+    let mut config = EvalConfig::default().with_formula_plane_mode(mode);
+    if let Some(cache_bytes) = cache_bytes {
+        config.max_formula_plane_cache_bytes = cache_bytes;
+    }
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    let mut formulas = Vec::new();
+    for row in 1..=100 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}*2")));
+    }
+    formulas.push(record(&mut engine, 1, 3, "=B100+1"));
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    engine
+}
+
+#[test]
+fn resource_taxonomy_is_stable_and_observational() {
+    assert_eq!(
+        EvaluationResourceReason::FormulaPlaneTopologyCandidates.class(),
+        EvaluationResourceClass::Optimization
+    );
+    assert_eq!(
+        EvaluationResourceReason::FormulaPlaneTopologyRetainedBytes.class(),
+        EvaluationResourceClass::RetainedMemory
+    );
+    assert_eq!(
+        EvaluationResourceReason::FormulaPlaneMaterializationCells.class(),
+        EvaluationResourceClass::Admission
+    );
+    assert_eq!(
+        EvaluationResourceReason::FormulaPlaneTopologyEdges.as_str(),
+        "formula_plane_topology_edges"
+    );
+}
+
+#[test]
+fn request_ids_accumulate_and_reset_without_reuse() {
+    let mut engine = Engine::new(TestWorkbook::default(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=1+1").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+    let first = *engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(first.request_id, 1);
+    assert_eq!(first.kind, EvaluationRequestKind::Full);
+    assert_eq!(first.outcome, EvaluationRequestOutcome::Success);
+    assert_eq!(
+        first.topology.strategy,
+        FormulaPlaneTopologyStrategy::Legacy
+    );
+
+    engine.evaluate_cell("Sheet1", 1, 1).unwrap();
+    let second = *engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(second.request_id, 2);
+    assert_eq!(second.kind, EvaluationRequestKind::Cell);
+    assert_eq!(second.outcome, EvaluationRequestOutcome::Success);
+
+    let total = engine.evaluation_resource_baseline_stats();
+    assert_eq!(total.last_request_id, 2);
+    assert_eq!(total.requests_started, 2);
+    assert_eq!(total.requests_succeeded, 2);
+    assert_eq!(total.requests_cancelled, 0);
+    assert_eq!(total.requests_errored, 0);
+
+    engine.reset_evaluation_resource_telemetry();
+    assert_eq!(
+        engine.evaluation_resource_baseline_stats(),
+        Default::default()
+    );
+    assert!(engine.last_evaluation_resource_request_stats().is_none());
+
+    engine.evaluate_all().unwrap();
+    let third = *engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(third.request_id, 3, "reset must not reuse request IDs");
+    let total = engine.evaluation_resource_baseline_stats();
+    assert_eq!(total.requests_started, 1);
+    assert_eq!(total.requests_succeeded, 1);
+}
+
+#[test]
+fn cancellation_and_error_outcomes_accumulate_deterministically() {
+    let mut engine = Engine::new(TestWorkbook::default(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=1+1").unwrap())
+        .unwrap();
+
+    let cancel = Arc::new(AtomicBool::new(true));
+    let error = engine.evaluate_all_cancellable(cancel).unwrap_err();
+    assert_eq!(error.kind, ExcelErrorKind::Cancelled);
+    let cancelled = engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(cancelled.outcome, EvaluationRequestOutcome::Cancelled);
+
+    let error = engine.evaluate_cell("Sheet1", 0, 1).unwrap_err();
+    assert_eq!(error.kind, ExcelErrorKind::Ref);
+    let failed = engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(failed.outcome, EvaluationRequestOutcome::Error);
+
+    let total = engine.evaluation_resource_baseline_stats();
+    assert_eq!(total.requests_started, 2);
+    assert_eq!(total.requests_cancelled, 1);
+    assert_eq!(total.requests_errored, 1);
+}
+
+#[test]
+fn deferred_preparation_records_selected_and_restored_staging() {
+    let config = EvalConfig {
+        defer_graph_building: true,
+        ..EvalConfig::default()
+    };
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    engine.graph.add_sheet("Other").unwrap();
+    engine.stage_formula_text("Sheet1", 1, 1, "=1+1".to_string());
+    engine.stage_formula_text("Other", 1, 1, "=2+2".to_string());
+
+    engine.evaluate_cell("Sheet1", 1, 1).unwrap();
+    let request = engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(request.staged_selected, 2);
+    assert_eq!(request.staged_retained, 0);
+
+    let mut failed = Engine::new(
+        TestWorkbook::default(),
+        EvalConfig {
+            defer_graph_building: true,
+            ..EvalConfig::default()
+        },
+    );
+    failed.graph.add_sheet("Other").unwrap();
+    failed.stage_formula_text("Sheet1", 1, 1, "=1+".to_string());
+    failed.stage_formula_text("Other", 1, 1, "=2+2".to_string());
+    assert!(failed.evaluate_all().is_err());
+    let request = failed.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(request.outcome, EvaluationRequestOutcome::Error);
+    assert_eq!(request.staged_selected, 2);
+    assert_eq!(request.staged_retained, 2);
+    assert_eq!(failed.staged_formula_count(), 2);
+}
+
+#[test]
+fn topology_build_hit_and_overflow_materialization_are_exactly_observed() {
+    let mut cached = build_mode_engine(FormulaPlaneMode::AuthoritativeExperimental, None);
+    assert_eq!(cached.baseline_stats().formula_plane_active_span_count, 1);
+    cached.evaluate_all().unwrap();
+    let built = cached.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(
+        built.topology.cache_outcome,
+        FormulaPlaneTopologyCacheOutcome::Built
+    );
+    assert_eq!(
+        built.topology.strategy,
+        FormulaPlaneTopologyStrategy::CompiledAndCached
+    );
+    assert!(built.topology.producers_observed >= 2);
+    assert!(built.topology.retained_bytes_observed > 0);
+    assert_eq!(built.topology.cache_build_events, 1);
+    assert_eq!(built.topology.cache_hit_events, 0);
+    assert_eq!(built.topology.cache_skip_events, 0);
+    assert_eq!(built.fallback_materialized_cells, 0);
+    assert_eq!(built.dirty_lease, FormulaDirtyLeaseOutcome::Acknowledged);
+
+    cached
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(9.0))
+        .unwrap();
+    cached.evaluate_all().unwrap();
+    let hit = cached.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(
+        hit.topology.cache_outcome,
+        FormulaPlaneTopologyCacheOutcome::Hit
+    );
+    assert_eq!(hit.topology.strategy, FormulaPlaneTopologyStrategy::Cached);
+    assert_eq!(hit.topology.cache_hit_events, 1);
+    assert_eq!(hit.topology.cache_build_events, 0);
+    assert_eq!(hit.topology.cache_skip_events, 0);
+    assert_eq!(hit.topology.producers_observed, 0);
+    assert_eq!(hit.topology.candidates_observed, 0);
+    assert_eq!(hit.topology.edges_observed, 0);
+    let totals = cached.evaluation_resource_baseline_stats();
+    assert_eq!(totals.topology_cache_builds, 1);
+    assert_eq!(totals.topology_cache_hits, 1);
+
+    let mut overflow = build_mode_engine(FormulaPlaneMode::AuthoritativeExperimental, Some(0));
+    overflow.evaluate_all().unwrap();
+    let request = overflow.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(
+        request.topology.cache_outcome,
+        FormulaPlaneTopologyCacheOutcome::SkippedOverflow
+    );
+    assert_eq!(
+        request.topology.overflow_reason,
+        Some(EvaluationResourceReason::FormulaPlaneTopologyRetainedBytes)
+    );
+    assert_eq!(request.topology.cache_build_events, 1);
+    assert_eq!(request.topology.cache_skip_events, 1);
+    assert!(request.topology.byte_cap_hits > 0);
+    assert!(request.topology.retained_bytes_observed > 0);
+    assert_eq!(request.fallback_materialized_cells, 100);
+    assert_eq!(overflow.baseline_stats().formula_plane_active_span_count, 0);
+    let totals = overflow.evaluation_resource_baseline_stats();
+    assert_eq!(totals.topology_cache_skips, 1);
+    assert_eq!(totals.topology_byte_cap_hits, 1);
+    assert_eq!(totals.fallback_materialized_cells_total, 100);
+
+    let mut candidate = build_mode_engine(FormulaPlaneMode::AuthoritativeExperimental, None);
+    candidate.config.max_formula_plane_cache_candidates = 0;
+    candidate.evaluate_all().unwrap();
+    let request = candidate.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(
+        request.topology.overflow_reason,
+        Some(EvaluationResourceReason::FormulaPlaneTopologyCandidates)
+    );
+    assert!(request.topology.candidate_cap_hits > 0);
+    assert!(request.topology.candidates_observed > 0);
+
+    let mut edge = build_mode_engine(FormulaPlaneMode::AuthoritativeExperimental, None);
+    edge.config.max_formula_plane_cache_edges = 0;
+    edge.evaluate_all().unwrap();
+    let request = edge.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(
+        request.topology.overflow_reason,
+        Some(EvaluationResourceReason::FormulaPlaneTopologyEdges)
+    );
+    assert!(request.topology.edge_cap_hits > 0);
+    assert!(request.topology.edges_observed > 0);
+}
+
+#[test]
+fn off_shadow_and_authoritative_values_remain_equal() {
+    let run = |mode| {
+        let mut engine = build_mode_engine(mode, None);
+        engine.evaluate_all().unwrap();
+        (
+            engine.get_cell_value("Sheet1", 100, 2),
+            engine.get_cell_value("Sheet1", 1, 3),
+        )
+    };
+
+    let off = run(FormulaPlaneMode::Off);
+    let shadow = run(FormulaPlaneMode::Shadow);
+    let authoritative = run(FormulaPlaneMode::AuthoritativeExperimental);
+    assert_eq!(off, shadow);
+    assert_eq!(off, authoritative);
+    assert_eq!(off.0, Some(LiteralValue::Number(200.0)));
+    assert_eq!(off.1, Some(LiteralValue::Number(201.0)));
+}

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
@@ -107,6 +107,26 @@ fn span_member_in_static_cycle_is_demoted_and_circ() {
 
     // (a) the cyclic span family was demoted to legacy.
     let stats = engine.baseline_stats();
+    let resource_baseline = engine.evaluation_resource_baseline_stats();
+    let request = engine
+        .last_evaluation_resource_request_stats()
+        .expect("evaluation publishes resource telemetry");
+    assert_eq!(request.topology.cache_build_events, 2);
+    assert_eq!(request.topology.cache_hit_events, 0);
+    assert_eq!(request.topology.cache_skip_events, 0);
+    assert_eq!(request.topology.producers_observed, 125);
+    assert_eq!(request.topology.candidates_observed, 4);
+    assert_eq!(request.topology.edges_observed, 4);
+    assert_eq!(
+        resource_baseline.topology_cache_builds,
+        stats.formula_plane_mixed_topology_cache_builds,
+    );
+    assert_eq!(resource_baseline.topology_candidates_observed_total, 4);
+    assert_eq!(resource_baseline.topology_edges_observed_total, 4);
+    assert_eq!(
+        resource_baseline.topology_retained_bytes_observed_max,
+        request.topology.retained_bytes_observed,
+    );
     assert_eq!(
         stats.formula_plane_cycle_member_span_demotions, 1,
         "the column-B span must be demoted for cycle membership"

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -14,6 +14,7 @@ mod deterministic_clock;
 mod dirty_propagation;
 mod dirty_propagation_precision;
 mod evaluation;
+mod evaluation_resource_observability;
 mod graph_basic;
 mod graph_internal_helpers;
 mod layer_evaluation;

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -680,6 +680,7 @@ impl CalamineAdapter {
         } else {
             0
         };
+        formula_source_report.source_spool_spill_files = u64::from(formula_spool_spilled);
         let _formula_spool_storage = formula_spool.storage_kind();
         debug_assert!(formula_count == 0 || formula_spool_bytes >= 5);
         let mut formula_spool = Some(formula_spool);

--- a/docs/architecture/evaluation-resource-target-driven-cutover.md
+++ b/docs/architecture/evaluation-resource-target-driven-cutover.md
@@ -1,6 +1,6 @@
 # Evaluation Resources and Target-Driven Cutover
 
-Status: Approved implementation contract
+Status: Approved implementation contract; C0 observability implemented
 
 This document defines the staged cutover from workbook-wide preparation and mixed evaluation to
 resource-accounted, target-driven preparation and evaluation. It complements
@@ -626,6 +626,17 @@ includes cross-sheet transitive value/delta parity and strict parse-failure rest
 span empty-delta limitation remains documented until C4.
 
 ### C0 - contract, telemetry, and cold harness
+
+Status: Implemented observationally. Engine request IDs are monotonic and are not reset with
+telemetry counters. Stable request/baseline stats expose staged preparation, mixed topology
+cache/overflow observations, exact fallback materialization, dirty-lease outcome, phase timings, and
+success/cancellation/error outcome. Requests aggregate every topology build, hit, skip, and cap event;
+build-attempt producer/candidate/edge work is summed and retained bytes preserve the request peak.
+The load-envelope probe reports these with process RSS/HWM, output-read time, replay spool
+memory/disk/file counts, FormulaPlane mode, and fresh-child sample
+identity. Eager loader graph preparation remains part of `load_ms`; request-time deferred graph
+preparation is reported separately. Allocator-specific byte counters remain omitted because no stable
+global allocator observer exists; no allocator or evaluation behavior was changed to obtain them.
 
 - Land cap classes, typed reason vocabulary, request IDs, closure definitions, and observational
   counters without behavior changes.


### PR DESCRIPTION
## Summary
- add typed, observational evaluation resource classes/reasons and monotonic request telemetry
- expose per-request and cumulative Engine stats for staged preparation, topology strategy/cache work, cap events, materialization, dirty leases, outcomes, and phase timings
- extend the existing load-envelope probes with fresh-child-per-sample cold-process JSON, RSS/HWM, phase, topology, fallback, and spool fields
- preserve all cap defaults, strategy decisions, error kinds, modes, admission, and evaluation semantics

## Correctness
- all public evaluation entry points share one outer request record; nested calls fold into it
- telemetry reset clears reports without reusing request IDs
- topology rebuild attempts aggregate exact hit/build/skip and cap events, summed work, and peak retained bytes
- cancellation and errors retain dirty/staged state and publish typed outcomes

## Validation
- default evaluator: 2,250 passed, 12 ignored; integration/doctests passed
- all-feature evaluator passed
- strict Clippy, WASM, formatting, and diff checks passed
- cold-process smoke: 3 cases, fresh child per sample, JSON sanity passed
- independent blocker/high review: PASS after fixing multi-compile aggregation

C0 is observational only. ResourceLedger and non-materializing cache-overflow routing remain C1.
