### PR TITLE
Render #REF sheet-sentinel references as the #REF! literal

### DIFF
--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1008,6 +1008,13 @@ impl Display for ReferenceType {
                     row_abs,
                     col_abs,
                 } => {
+                    // A reference invalidated by a structural delete carries the
+                    // "#REF" sheet sentinel; render it as the Excel #REF! literal
+                    // rather than a quoted sheet with a bogus address.
+                    if sheet.as_deref() == Some("#REF") {
+                        return write!(f, "#REF!");
+                    }
+
                     let col_str = Self::format_col(*col, *col_abs);
                     let row_str = Self::format_row(*row, *row_abs);
 
@@ -1034,6 +1041,12 @@ impl Display for ReferenceType {
                     end_row_abs,
                     end_col_abs,
                 } => {
+                    // A range invalidated by a structural delete carries the
+                    // "#REF" sheet sentinel; render it as the Excel #REF! literal.
+                    if sheet.as_deref() == Some("#REF") {
+                        return write!(f, "#REF!");
+                    }
+
                     // Format start reference
                     let start_ref = match (start_col, start_row) {
                         (Some(col), Some(row)) => format!(

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -322,6 +322,45 @@ mod tests {
     }
 
     #[test]
+    fn test_pretty_print_ref_error_sentinel() {
+        use crate::parser::ReferenceType;
+        // A reference invalidated by a structural delete carries the "#REF"
+        // sheet sentinel and must render as the Excel #REF! literal (it used to
+        // render as '#REF'!0 / '#REF'!$$0).
+        let cell = ReferenceType::Cell {
+            sheet: Some("#REF".to_string()),
+            row: 0,
+            col: 0,
+            row_abs: false,
+            col_abs: false,
+        };
+        assert_eq!(cell.normalise(), "#REF!");
+
+        // Absolute flags on the sentinel must not leak into the rendering.
+        let cell_abs = ReferenceType::Cell {
+            sheet: Some("#REF".to_string()),
+            row: 0,
+            col: 0,
+            row_abs: true,
+            col_abs: true,
+        };
+        assert_eq!(cell_abs.normalise(), "#REF!");
+
+        let range = ReferenceType::Range {
+            sheet: Some("#REF".to_string()),
+            start_row: Some(0),
+            start_col: Some(0),
+            end_row: Some(0),
+            end_col: Some(0),
+            start_row_abs: false,
+            start_col_abs: false,
+            end_row_abs: false,
+            end_col_abs: false,
+        };
+        assert_eq!(range.normalise(), "#REF!");
+    }
+
+    #[test]
     fn test_pretty_print_text_literals_in_functions() {
         // Should preserve quotes around text literals
         let formula = "=SUMIFS(A:A, B:B, \"*Parking*\")";


### PR DESCRIPTION
HI,
I am not a Rust programmer but I was doing some experimentation with formualizer via Claude Code and noticed some discrepancies wrt some Python-based Excel formula-parsing. Most of these appear to be fixed on main: I  was going against the published crate and encountered more errors but all but one went away when I tested against main. The one remaining one is described in the paragraph below, authored by Claude code, which also wrote the fix and the test-cases. So I hope that even if the fix is not appropriate, then at least the problem is described in sufficient detail. I am doing some experimentation with Office.js addins (most of my experience is with PyXLL (Python) and ExcelDNA(C#)) and wanted a formula parser that could be compiled to WASM easily and this is where I encountered your library for the first time. I am looking forward to working with it more on as part of an addin that does Excel formula "linting".

A reference invalidated by a structural delete carries a Cell/Range with sheet == "#REF". ReferenceType's Display did not special-case this, so it rendered as a quoted sheet plus a bogus address (e.g. '#REF'!0, or '#REF'!$$0 when the original had absolute flags). Render it as the Excel #REF! literal instead, in both the Cell and Range arms. Adds a regression test.