### PR TITLE
perf(bench): add target locality calibration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,7 @@ dependencies = [
  "formualizer-common",
  "formualizer-eval",
  "formualizer-parse",
+ "formualizer-sheetport",
  "formualizer-testkit",
  "formualizer-workbook",
  "ironcalc",
@@ -1427,6 +1428,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "sheetport-spec",
  "umya-spreadsheet",
  "zip 7.2.0",
 ]

--- a/crates/formualizer-bench-core/Cargo.toml
+++ b/crates/formualizer-bench-core/Cargo.toml
@@ -13,6 +13,11 @@ publish = false
 default = []
 xlsx = ["dep:formualizer-testkit", "dep:umya-spreadsheet"]
 formualizer_runner = ["xlsx", "dep:formualizer-workbook", "formualizer-workbook/benchmark_internal"]
+c6_calibration = [
+  "formualizer_runner",
+  "dep:formualizer-sheetport",
+  "dep:sheetport-spec",
+]
 dhat-heap = ["dep:dhat"]
 perf_instrumentation = ["formualizer-workbook/perf_instrumentation"]
 ironcalc_runner = ["dep:ironcalc"]
@@ -29,6 +34,8 @@ sha2 = "0.10"
 zip = { version = "7.2", default-features = false, features = ["deflate"] }
 formualizer-testkit = { path = "../formualizer-testkit", optional = true }
 formualizer-workbook = { path = "../formualizer-workbook", optional = true, default-features = false, features = ["umya", "calamine"] }
+formualizer-sheetport = { path = "../formualizer-sheetport", optional = true, features = ["benchmark_internal"] }
+sheetport-spec = { path = "../sheetport-spec", optional = true }
 umya-spreadsheet = { version = "=2.3.2", optional = true }
 formualizer-parse = { workspace = true }
 formualizer-common = { workspace = true }

--- a/crates/formualizer-bench-core/src/bin/probe-c6-target-locality-matrix.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-c6-target-locality-matrix.rs
@@ -1,0 +1,905 @@
+#[cfg(feature = "c6_calibration")]
+use std::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "c6_calibration")]
+use std::fs;
+#[cfg(feature = "c6_calibration")]
+use std::io::Read;
+#[cfg(feature = "c6_calibration")]
+use std::path::{Path, PathBuf};
+#[cfg(feature = "c6_calibration")]
+use std::process::{Command, Stdio};
+#[cfg(feature = "c6_calibration")]
+use std::thread;
+#[cfg(feature = "c6_calibration")]
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "c6_calibration")]
+use anyhow::{Context, Result, bail};
+#[cfg(feature = "c6_calibration")]
+use clap::Parser;
+#[cfg(feature = "c6_calibration")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "c6_calibration")]
+use formualizer_bench_core::c6_calibration::{
+    CalibrationPath, ChildReport, Distribution, TargetScope, distribution, sha256_file,
+};
+
+#[cfg(not(feature = "c6_calibration"))]
+fn main() {
+    eprintln!("This binary requires feature `c6_calibration`");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Parser)]
+#[command(about = "Run randomized fresh-process C6 target-locality samples")]
+struct Cli {
+    /// Total formula count across the deterministic independent branches.
+    #[arg(long, default_value_t = 50_000)]
+    formulas: u32,
+
+    /// Fresh child-process samples for every path/scope case.
+    #[arg(long, default_value_t = 7)]
+    samples: usize,
+
+    #[arg(
+        long,
+        value_enum,
+        value_delimiter = ',',
+        default_values_t = [CalibrationPath::Full, CalibrationPath::Cells, CalibrationPath::Plan, CalibrationPath::Sheetport]
+    )]
+    paths: Vec<CalibrationPath>,
+
+    #[arg(
+        long,
+        value_enum,
+        value_delimiter = ',',
+        default_values_t = [TargetScope::Tiny, TargetScope::Medium, TargetScope::Full]
+    )]
+    scopes: Vec<TargetScope>,
+
+    #[arg(long, default_value_t = 3)]
+    warm_repeats: usize,
+
+    /// Hard timeout for each generation/sample child process.
+    #[arg(long, default_value_t = 600)]
+    timeout_seconds: u64,
+
+    /// Deterministic randomization seed recorded in raw output.
+    #[arg(long, default_value_t = 0xc6ca_1b7a_u64)]
+    seed: u64,
+
+    #[arg(long, default_value = "target/c6-calibration")]
+    output_dir: PathBuf,
+
+    /// Reuse an already built release child probe.
+    #[arg(long)]
+    skip_build: bool,
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RunIdentity {
+    commit: String,
+    dirty: bool,
+    rustc: String,
+    host: String,
+    os: String,
+    architecture: String,
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+struct Job {
+    path: CalibrationPath,
+    scope: TargetScope,
+    sample: usize,
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SampleResult {
+    job: Job,
+    status: String,
+    child: Option<ChildReport>,
+    external_max_rss_bytes: Option<u64>,
+    wall_milliseconds: f64,
+    error: Option<String>,
+    stderr_log: String,
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CaseSummary {
+    path: CalibrationPath,
+    scope: TargetScope,
+    successful_samples: usize,
+    cold_total_ms: Option<Distribution>,
+    load_ms: Option<Distribution>,
+    bind_resolution_ms: Option<Distribution>,
+    preparation_plan_ms: Option<Distribution>,
+    first_evaluation_ms: Option<Distribution>,
+    output_read_ms: Option<Distribution>,
+    edit_ms: Option<Distribution>,
+    warm_evaluation_ms: Option<Distribution>,
+    batch_restore_ms: Option<Distribution>,
+    sheetport_batch_plan_telemetry_ms: Option<Distribution>,
+    sheetport_batch_execution_telemetry_ms: Option<Distribution>,
+    peak_rss_bytes: Option<Distribution>,
+    max_prepared_formula_delta: Option<u64>,
+    max_staged_selected: Option<u64>,
+    max_target_actual_work: Option<u64>,
+    locality_oracle_all_passed: bool,
+    analytical_output_oracle_all_passed: bool,
+    exact_fixture_counts_all_passed: bool,
+    exact_locality_counts_all_passed: bool,
+    unrelated_staged_all_retained: bool,
+    unrelated_dirty_all_retained: bool,
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MatrixReport {
+    schema_version: u32,
+    identity: RunIdentity,
+    formulas: u32,
+    samples_per_case: usize,
+    warm_repeats: usize,
+    timeout_seconds: u64,
+    random_seed: u64,
+    fixture_path: String,
+    fixture_sha256: String,
+    randomized_jobs: Vec<Job>,
+    results: Vec<SampleResult>,
+    summaries: Vec<CaseSummary>,
+    parity_by_scope: BTreeMap<String, bool>,
+}
+
+#[cfg(feature = "c6_calibration")]
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    run(cli)
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run(mut cli: Cli) -> Result<()> {
+    if cli.formulas >= 50_000 {
+        cli.timeout_seconds = cli.timeout_seconds.max(600);
+    }
+    if cli.samples == 0 {
+        bail!("--samples must be greater than zero");
+    }
+    if cli.paths.is_empty() || cli.scopes.is_empty() {
+        bail!("--paths and --scopes must not be empty");
+    }
+    let root = repo_root();
+    fs::create_dir_all(&cli.output_dir)?;
+    if !cli.skip_build {
+        build_child(&root)?;
+    }
+    let probe = child_path(&root);
+    if !probe.is_file() {
+        bail!(
+            "child probe not found at {}; omit --skip-build",
+            probe.display()
+        );
+    }
+
+    let fixture = cli
+        .output_dir
+        .join(format!("fixture-{}.xlsx", cli.formulas));
+    let generation_log = cli.output_dir.join("fixture-generation.stderr.log");
+    let generation = run_process(
+        command_for_generate(&probe, &fixture, cli.formulas),
+        Duration::from_secs(cli.timeout_seconds),
+        &generation_log,
+    )?;
+    if !generation.success {
+        bail!("fixture generation failed: {}", generation.error);
+    }
+    let fixture_sha256 = sha256_file(&fixture)?;
+
+    let mut jobs = Vec::new();
+    for sample in 1..=cli.samples {
+        for &scope in &cli.scopes {
+            for &path in &cli.paths {
+                jobs.push(Job {
+                    path,
+                    scope,
+                    sample,
+                });
+            }
+        }
+    }
+    shuffle(&mut jobs, cli.seed);
+
+    let mut results = Vec::with_capacity(jobs.len());
+    for (order, job) in jobs.iter().copied().enumerate() {
+        eprintln!(
+            "[c6] {}/{} path={} scope={} sample={}",
+            order + 1,
+            jobs.len(),
+            job.path.label(),
+            job.scope.label(),
+            job.sample
+        );
+        let stderr_log = cli.output_dir.join(format!(
+            "{:03}-{}-{}-sample{}.stderr.log",
+            order + 1,
+            job.path.label(),
+            job.scope.label(),
+            job.sample
+        ));
+        let time_log = cli.output_dir.join(format!(
+            "{:03}-{}-{}-sample{}.time.log",
+            order + 1,
+            job.path.label(),
+            job.scope.label(),
+            job.sample
+        ));
+        results.push(run_job(&probe, &fixture, job, &cli, &stderr_log, &time_log));
+    }
+
+    let summaries = summarize(&results, &cli);
+    let parity_by_scope = parity(&results, &cli.scopes);
+    let report = MatrixReport {
+        schema_version: 1,
+        identity: identity(&root),
+        formulas: cli.formulas,
+        samples_per_case: cli.samples,
+        warm_repeats: cli.warm_repeats,
+        timeout_seconds: cli.timeout_seconds,
+        random_seed: cli.seed,
+        fixture_path: fixture.display().to_string(),
+        fixture_sha256,
+        randomized_jobs: jobs,
+        results,
+        summaries,
+        parity_by_scope,
+    };
+    let raw_path = cli.output_dir.join("matrix-raw.json");
+    let markdown_path = cli.output_dir.join("matrix-summary.md");
+    fs::write(&raw_path, serde_json::to_string_pretty(&report)? + "\n")?;
+    fs::write(&markdown_path, render_markdown(&report))?;
+    println!("{}", render_markdown(&report));
+    eprintln!(
+        "[c6] raw={} summary={}",
+        raw_path.display(),
+        markdown_path.display()
+    );
+
+    if report.results.iter().any(|result| result.status != "ok") {
+        bail!("one or more child samples failed; inspect raw JSON and stderr logs");
+    }
+    if report.parity_by_scope.values().any(|parity| !parity) {
+        bail!("output/error parity failed");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+#[cfg(feature = "c6_calibration")]
+fn target_dir(root: &Path) -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| root.join("target"))
+}
+
+#[cfg(feature = "c6_calibration")]
+fn child_path(root: &Path) -> PathBuf {
+    target_dir(root).join("release").join(if cfg!(windows) {
+        "probe-c6-target-locality.exe"
+    } else {
+        "probe-c6-target-locality"
+    })
+}
+
+#[cfg(feature = "c6_calibration")]
+fn build_child(root: &Path) -> Result<()> {
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "formualizer-bench-core",
+            "--features",
+            "c6_calibration",
+            "--bin",
+            "probe-c6-target-locality",
+        ])
+        .current_dir(root)
+        .status()
+        .context("build release child probe")?;
+    if !status.success() {
+        bail!("release child probe build failed with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn command_for_generate(probe: &Path, fixture: &Path, formulas: u32) -> Command {
+    let mut command = Command::new(probe);
+    command
+        .arg("generate")
+        .arg("--fixture")
+        .arg(fixture)
+        .arg("--formulas")
+        .arg(formulas.to_string());
+    command
+}
+
+#[cfg(feature = "c6_calibration")]
+fn sample_args(fixture: &Path, job: Job, cli: &Cli) -> Vec<String> {
+    vec![
+        "sample".to_string(),
+        "--fixture".to_string(),
+        fixture.display().to_string(),
+        "--formulas".to_string(),
+        cli.formulas.to_string(),
+        "--path".to_string(),
+        job.path.label().to_string(),
+        "--scope".to_string(),
+        match job.scope {
+            TargetScope::Tiny => "tiny",
+            TargetScope::Medium => "medium",
+            TargetScope::Full => "full",
+        }
+        .to_string(),
+        "--warm-repeats".to_string(),
+        cli.warm_repeats.to_string(),
+    ]
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run_job(
+    probe: &Path,
+    fixture: &Path,
+    job: Job,
+    cli: &Cli,
+    stderr_log: &Path,
+    time_log: &Path,
+) -> SampleResult {
+    let args = sample_args(fixture, job, cli);
+    let command = if Path::new("/usr/bin/time").is_file() {
+        let mut command = Command::new("/usr/bin/time");
+        command.arg("-v").arg("-o").arg(time_log).arg(probe);
+        command.args(&args);
+        command
+    } else {
+        let mut command = Command::new(probe);
+        command.args(&args);
+        command
+    };
+    let process = run_process(
+        command,
+        Duration::from_secs(cli.timeout_seconds),
+        stderr_log,
+    );
+    match process {
+        Ok(process) if process.success => {
+            match serde_json::from_slice::<ChildReport>(&process.stdout) {
+                Ok(child) => SampleResult {
+                    job,
+                    status: child.status.clone(),
+                    child: Some(child),
+                    external_max_rss_bytes: parse_time_max_rss(time_log),
+                    wall_milliseconds: process.wall_milliseconds,
+                    error: None,
+                    stderr_log: stderr_log.display().to_string(),
+                },
+                Err(error) => SampleResult {
+                    job,
+                    status: "invalid_json".to_string(),
+                    child: None,
+                    external_max_rss_bytes: parse_time_max_rss(time_log),
+                    wall_milliseconds: process.wall_milliseconds,
+                    error: Some(error.to_string()),
+                    stderr_log: stderr_log.display().to_string(),
+                },
+            }
+        }
+        Ok(process) => SampleResult {
+            job,
+            status: if process.timed_out {
+                "timeout"
+            } else {
+                "child_error"
+            }
+            .to_string(),
+            child: None,
+            external_max_rss_bytes: parse_time_max_rss(time_log),
+            wall_milliseconds: process.wall_milliseconds,
+            error: Some(process.error),
+            stderr_log: stderr_log.display().to_string(),
+        },
+        Err(error) => SampleResult {
+            job,
+            status: "spawn_error".to_string(),
+            child: None,
+            external_max_rss_bytes: None,
+            wall_milliseconds: 0.0,
+            error: Some(error.to_string()),
+            stderr_log: stderr_log.display().to_string(),
+        },
+    }
+}
+
+#[cfg(feature = "c6_calibration")]
+struct ProcessResult {
+    success: bool,
+    timed_out: bool,
+    stdout: Vec<u8>,
+    wall_milliseconds: f64,
+    error: String,
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run_process(
+    mut command: Command,
+    timeout: Duration,
+    stderr_log: &Path,
+) -> Result<ProcessResult> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let started = Instant::now();
+    let mut child = command.spawn().context("spawn child process")?;
+    let stdout = child.stdout.take().context("capture child stdout")?;
+    let stderr = child.stderr.take().context("capture child stderr")?;
+    let stdout_drain = thread::spawn(move || drain_pipe(stdout));
+    let stderr_drain = thread::spawn(move || drain_pipe(stderr));
+    let mut timed_out = false;
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if started.elapsed() >= timeout {
+            timed_out = true;
+            kill_process_group(&mut child).context("kill timed-out child process group")?;
+            break child.wait()?;
+        }
+        thread::sleep(Duration::from_millis(20));
+    };
+    let stdout = stdout_drain
+        .join()
+        .map_err(|_| anyhow::anyhow!("stdout drain thread panicked"))??;
+    let stderr = stderr_drain
+        .join()
+        .map_err(|_| anyhow::anyhow!("stderr drain thread panicked"))??;
+    if let Some(parent) = stderr_log.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(stderr_log, &stderr)?;
+    Ok(ProcessResult {
+        success: status.success() && !timed_out,
+        timed_out,
+        stdout,
+        wall_milliseconds: started.elapsed().as_secs_f64() * 1000.0,
+        error: String::from_utf8_lossy(&stderr).trim().to_string(),
+    })
+}
+
+#[cfg(feature = "c6_calibration")]
+fn drain_pipe(mut pipe: impl Read) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    pipe.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(all(feature = "c6_calibration", unix))]
+fn kill_process_group(child: &mut std::process::Child) -> Result<()> {
+    let status = Command::new("kill")
+        .arg("-KILL")
+        .arg(format!("-{}", child.id()))
+        .status()
+        .context("invoke kill for child process group")?;
+    if !status.success() {
+        child.kill().context("fallback kill of child process")?;
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "c6_calibration", not(unix)))]
+fn kill_process_group(child: &mut std::process::Child) -> Result<()> {
+    child.kill().context("kill child process")
+}
+
+#[cfg(feature = "c6_calibration")]
+fn parse_time_max_rss(path: &Path) -> Option<u64> {
+    let text = fs::read_to_string(path).ok()?;
+    text.lines().find_map(|line| {
+        let value = line
+            .trim()
+            .strip_prefix("Maximum resident set size (kbytes):")?
+            .trim()
+            .parse::<u64>()
+            .ok()?;
+        value.checked_mul(1024)
+    })
+}
+
+#[cfg(feature = "c6_calibration")]
+fn shuffle<T>(values: &mut [T], seed: u64) {
+    let mut state = seed.max(1);
+    for index in (1..values.len()).rev() {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        values.swap(index, (state as usize) % (index + 1));
+    }
+}
+
+#[cfg(feature = "c6_calibration")]
+fn summarize(results: &[SampleResult], cli: &Cli) -> Vec<CaseSummary> {
+    let mut summaries = Vec::new();
+    for &scope in &cli.scopes {
+        for &path in &cli.paths {
+            let children = results
+                .iter()
+                .filter(|result| result.job.path == path && result.job.scope == scope)
+                .filter_map(|result| result.child.as_ref())
+                .filter(|child| child.status == "ok")
+                .collect::<Vec<_>>();
+            let phase = |extract: fn(&ChildReport) -> Option<f64>| {
+                distribution(
+                    &children
+                        .iter()
+                        .filter_map(|child| extract(child))
+                        .collect::<Vec<_>>(),
+                )
+            };
+            let flattened = |extract: fn(&ChildReport) -> Vec<f64>| {
+                distribution(
+                    &children
+                        .iter()
+                        .flat_map(|child| extract(child))
+                        .collect::<Vec<_>>(),
+                )
+            };
+            let cold_total_ms = distribution(
+                &children
+                    .iter()
+                    .map(|child| {
+                        [
+                            child.phases.load.as_ref(),
+                            child.phases.unrelated_dirty_setup.as_ref(),
+                            child.phases.bind_target_resolution.as_ref(),
+                            if path == CalibrationPath::Sheetport {
+                                None
+                            } else {
+                                child.phases.preparation_plan_build.as_ref()
+                            },
+                            child.phases.first_evaluation.as_ref(),
+                            child.phases.output_read.as_ref(),
+                        ]
+                        .into_iter()
+                        .flatten()
+                        .map(|phase| phase.milliseconds)
+                        .sum()
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            let rss = results
+                .iter()
+                .filter(|result| {
+                    result.job.path == path
+                        && result.job.scope == scope
+                        && result.status == "ok"
+                        && result
+                            .child
+                            .as_ref()
+                            .is_some_and(|child| child.status == "ok")
+                })
+                .filter_map(|result| {
+                    result
+                        .external_max_rss_bytes
+                        .or_else(|| result.child.as_ref()?.peak_rss_bytes)
+                })
+                .map(|bytes| bytes as f64)
+                .collect::<Vec<_>>();
+            let prepared = children
+                .iter()
+                .filter_map(|child| {
+                    Some(
+                        child
+                            .graph_after_run
+                            .as_ref()?
+                            .graph_formula_vertices
+                            .saturating_sub(
+                                child.graph_after_setup.as_ref()?.graph_formula_vertices,
+                            ) as u64,
+                    )
+                })
+                .max();
+            let max_telemetry =
+                |extract: fn(&formualizer_bench_core::c6_calibration::EngineTelemetry) -> u64| {
+                    children
+                        .iter()
+                        .flat_map(|child| child.telemetry.values())
+                        .map(extract)
+                        .max()
+                };
+            let telemetry_phase = |key: &str| {
+                distribution(
+                    &children
+                        .iter()
+                        .filter_map(|child| child.telemetry.get(key))
+                        .map(|telemetry| telemetry.request_total_ms)
+                        .collect::<Vec<_>>(),
+                )
+            };
+            summaries.push(CaseSummary {
+                path,
+                scope,
+                successful_samples: children.len(),
+                cold_total_ms,
+                load_ms: phase(|child| child.phases.load.as_ref().map(|p| p.milliseconds)),
+                bind_resolution_ms: phase(|child| {
+                    child
+                        .phases
+                        .bind_target_resolution
+                        .as_ref()
+                        .map(|p| p.milliseconds)
+                }),
+                preparation_plan_ms: phase(|child| {
+                    child
+                        .phases
+                        .preparation_plan_build
+                        .as_ref()
+                        .map(|p| p.milliseconds)
+                }),
+                first_evaluation_ms: phase(|child| {
+                    child
+                        .phases
+                        .first_evaluation
+                        .as_ref()
+                        .map(|p| p.milliseconds)
+                }),
+                output_read_ms: phase(|child| {
+                    child.phases.output_read.as_ref().map(|p| p.milliseconds)
+                }),
+                edit_ms: flattened(|child| {
+                    child.phases.edit.iter().map(|p| p.milliseconds).collect()
+                }),
+                warm_evaluation_ms: flattened(|child| {
+                    child
+                        .phases
+                        .warm_evaluation
+                        .iter()
+                        .map(|p| p.milliseconds)
+                        .collect()
+                }),
+                batch_restore_ms: phase(|child| {
+                    child.phases.batch_restore.as_ref().map(|p| p.milliseconds)
+                }),
+                sheetport_batch_plan_telemetry_ms: telemetry_phase("sheetport_batch_plan_build"),
+                sheetport_batch_execution_telemetry_ms: telemetry_phase(
+                    "sheetport_batch_execution",
+                ),
+                peak_rss_bytes: distribution(&rss),
+                max_prepared_formula_delta: prepared,
+                max_staged_selected: max_telemetry(|stats| stats.staged_selected),
+                max_target_actual_work: max_telemetry(|stats| stats.target_commit_actual_work),
+                locality_oracle_all_passed: children
+                    .iter()
+                    .all(|child| child.oracle_within_one_percent.unwrap_or(true)),
+                analytical_output_oracle_all_passed: children
+                    .iter()
+                    .all(|child| child.analytical_output_oracle_passed.unwrap_or(false)),
+                exact_fixture_counts_all_passed: children
+                    .iter()
+                    .all(|child| child.exact_fixture_counts_passed.unwrap_or(false)),
+                exact_locality_counts_all_passed: children
+                    .iter()
+                    .all(|child| child.exact_locality_counts_passed.unwrap_or(false)),
+                unrelated_staged_all_retained: children
+                    .iter()
+                    .all(|child| child.unrelated_staged_retained.unwrap_or(true)),
+                unrelated_dirty_all_retained: children
+                    .iter()
+                    .all(|child| child.unrelated_dirty_retained.unwrap_or(true)),
+            });
+        }
+    }
+    summaries
+}
+
+#[cfg(feature = "c6_calibration")]
+fn parity(results: &[SampleResult], scopes: &[TargetScope]) -> BTreeMap<String, bool> {
+    let mut parity = BTreeMap::new();
+    for &scope in scopes {
+        let outcomes = results
+            .iter()
+            .filter(|result| result.job.scope == scope && result.status == "ok")
+            .filter_map(|result| result.child.as_ref())
+            .filter(|child| child.status == "ok")
+            .map(|child| {
+                child
+                    .typed_error
+                    .clone()
+                    .unwrap_or_else(|| child.output_checksum.clone().unwrap_or_default())
+            })
+            .collect::<BTreeSet<_>>();
+        parity.insert(scope.label().to_string(), outcomes.len() == 1);
+    }
+    parity
+}
+
+#[cfg(feature = "c6_calibration")]
+fn identity(root: &Path) -> RunIdentity {
+    let output = |program: &str, args: &[&str]| {
+        Command::new(program)
+            .args(args)
+            .current_dir(root)
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    };
+    RunIdentity {
+        commit: output("git", &["rev-parse", "HEAD"]),
+        dirty: !output("git", &["status", "--porcelain"]).is_empty(),
+        rustc: output("rustc", &["--version", "--verbose"]),
+        host: output("hostname", &[]),
+        os: output("uname", &["-srv"]),
+        architecture: output("uname", &["-m"]),
+    }
+}
+
+#[cfg(feature = "c6_calibration")]
+fn fmt_stat(value: Option<Distribution>) -> String {
+    value.map_or_else(
+        || "n/a".to_string(),
+        |stats| {
+            format!(
+                "{:.2} / {:.2} / {:.2} / {:.2}",
+                stats.median, stats.p95, stats.mad, stats.max
+            )
+        },
+    )
+}
+
+#[cfg(feature = "c6_calibration")]
+fn render_markdown(report: &MatrixReport) -> String {
+    let mut out = format!(
+        "# C6 target-locality calibration\n\n- Commit: `{}`{}\n- Fixture: `{}` formulas, SHA-256 `{}`\n- Samples: {} per case; randomized seed `{:#x}`; child timeout {}s\n- Rust: `{}`\n- Host: `{}` / `{}` / `{}`\n\n",
+        report.identity.commit,
+        if report.identity.dirty {
+            " (dirty)"
+        } else {
+            ""
+        },
+        report.formulas,
+        report.fixture_sha256,
+        report.samples_per_case,
+        report.random_seed,
+        report.timeout_seconds,
+        report.identity.rustc.lines().next().unwrap_or("unknown"),
+        report.identity.host,
+        report.identity.os,
+        report.identity.architecture,
+    );
+    out.push_str("All timing cells are `median / p95 / MAD / max` in milliseconds, using nearest-rank p95. With seven per-child samples, per-child p95 is the maximum; pooled warm calls contain 21 observations. `cold` is process-cold but normally OS-page-cache-warm and includes load, the explicitly reported unrelated-dirty setup, binding/resolution, first evaluation, and preparation/plan plus separate output read where those precede the first evaluation. SheetPort cold is its one-shot path; its subsequent batch-plan build is shown only in `prepare/plan`. Cells and SheetPort retain combined phases when their public APIs do not expose a split.\n\n");
+    out.push_str("| scope | path | n | cold | prepare/plan | first eval | warm API cost | batch restore | peak RSS MiB | prepared formulas | staged selected | actual target work | gates |\n");
+    out.push_str("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n");
+    for summary in &report.summaries {
+        let rss = summary.peak_rss_bytes.map(|mut stats| {
+            stats.median /= 1_048_576.0;
+            stats.p95 /= 1_048_576.0;
+            stats.mad /= 1_048_576.0;
+            stats.max /= 1_048_576.0;
+            stats
+        });
+        let gates = if summary.locality_oracle_all_passed
+            && summary.analytical_output_oracle_all_passed
+            && summary.exact_fixture_counts_all_passed
+            && summary.exact_locality_counts_all_passed
+            && summary.unrelated_staged_all_retained
+            && summary.unrelated_dirty_all_retained
+        {
+            "pass"
+        } else {
+            "FAIL"
+        };
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+            summary.scope.label(),
+            summary.path.label(),
+            summary.successful_samples,
+            fmt_stat(summary.cold_total_ms),
+            fmt_stat(summary.preparation_plan_ms),
+            fmt_stat(summary.first_evaluation_ms),
+            fmt_stat(summary.warm_evaluation_ms),
+            fmt_stat(summary.batch_restore_ms),
+            fmt_stat(rss),
+            summary
+                .max_prepared_formula_delta
+                .map_or_else(|| "n/a".to_string(), |v| v.to_string()),
+            summary
+                .max_staged_selected
+                .map_or_else(|| "n/a".to_string(), |v| v.to_string()),
+            summary
+                .max_target_actual_work
+                .map_or_else(|| "n/a".to_string(), |v| v.to_string()),
+            gates,
+        ));
+    }
+    out.push_str("\n## SheetPort telemetry snapshots\n\nThe raw telemetry keys `first_evaluation`, `sheetport_batch_plan_build`, and `sheetport_batch_execution` are distinct and never overwrite one another. The last key is captured after `batch.run`, so its request ledger describes the final baseline-restoration evaluation. Values are engine request-total milliseconds.\n\n");
+    out.push_str("| scope | after batch-plan construction | after batch execution/restoration |\n|---|---:|---:|\n");
+    for summary in report
+        .summaries
+        .iter()
+        .filter(|summary| summary.path == CalibrationPath::Sheetport)
+    {
+        out.push_str(&format!(
+            "| {} | {} | {} |\n",
+            summary.scope.label(),
+            fmt_stat(summary.sheetport_batch_plan_telemetry_ms),
+            fmt_stat(summary.sheetport_batch_execution_telemetry_ms),
+        ));
+    }
+    out.push_str("\n## Correctness\n\n");
+    out.push_str("- Every successful sample passes a closed-form finance-chain output oracle for the initial evaluation and every repeated edit, independent of engine/path parity.\n");
+    out.push_str("- Exact deferred/staged/prepared/dirty fixture assertions are included in the table gate.\n");
+    for (scope, passed) in &report.parity_by_scope {
+        out.push_str(&format!(
+            "- `{scope}` output/error parity: {}\n",
+            if *passed { "pass" } else { "FAIL" }
+        ));
+    }
+    out.push_str("\n## Interpretation limits\n\n- `warm API cost` means the public API latency after one selected-branch input edit; it is not a claim that 100% of formulas are dirty or recomputed. In `full_100pct`, the fixed edit is `Tiny!A1`, a 0.5% branch, while all terminal outputs are requested.\n- `cells` first/warm timings combine target preparation, ephemeral plan construction, evaluation, and returned output because `evaluate_cells` exposes one public call.\n- SheetPort one-shot combines selector resolution, target preparation, evaluation, and runtime output read; batch iterations combine input edit, plan evaluation, and runtime output read. Checked baseline-restoration accounting is reported separately.\n- SheetPort batch creation follows its one-shot evaluation on the already prepared workbook. Its separately reported batch-plan build is not a second cold latency and is not setup-equivalent to the direct plan build on deferred staging.\n- Prepared formula deltas and public request telemetry prove locality; no allocator-specific counter is available, so RSS/HWM and ledger retained/scratch accounting are reported instead.\n");
+    out
+}
+
+#[cfg(all(test, feature = "c6_calibration"))]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parses_smoke_command() {
+        let cli = Cli::try_parse_from([
+            "matrix",
+            "--formulas",
+            "500",
+            "--samples",
+            "1",
+            "--paths",
+            "full,cells",
+            "--scopes",
+            "tiny,full",
+            "--timeout-seconds",
+            "10",
+        ])
+        .unwrap();
+        assert_eq!(cli.formulas, 500);
+        assert_eq!(
+            cli.paths,
+            vec![CalibrationPath::Full, CalibrationPath::Cells]
+        );
+        assert_eq!(cli.scopes, vec![TargetScope::Tiny, TargetScope::Full]);
+    }
+
+    #[test]
+    fn shuffle_is_reproducible() {
+        let mut left = (0..20).collect::<Vec<_>>();
+        let mut right = left.clone();
+        shuffle(&mut left, 42);
+        shuffle(&mut right, 42);
+        assert_eq!(left, right);
+        assert_ne!(left, (0..20).collect::<Vec<_>>());
+    }
+}

--- a/crates/formualizer-bench-core/src/bin/probe-c6-target-locality.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-c6-target-locality.rs
@@ -1,0 +1,831 @@
+#[cfg(feature = "c6_calibration")]
+use std::collections::BTreeMap;
+#[cfg(feature = "c6_calibration")]
+use std::path::PathBuf;
+#[cfg(feature = "c6_calibration")]
+use std::sync::{Arc, Mutex};
+#[cfg(feature = "c6_calibration")]
+use std::time::Instant;
+
+#[cfg(feature = "c6_calibration")]
+use anyhow::{Context, Result};
+#[cfg(feature = "c6_calibration")]
+use clap::{Parser, Subcommand};
+#[cfg(feature = "c6_calibration")]
+use formualizer_bench_core::c6_calibration::{
+    CalibrationPath, ChildReport, EngineTelemetry, FixtureShape, GraphSnapshot, PhaseTimings,
+    TargetScope, TimedPhase, allowed_oracle, analytical_expected_outputs, checksum_values,
+    generate_fixture, manifest_yaml, sha256_file,
+};
+#[cfg(feature = "c6_calibration")]
+use formualizer_common::LiteralValue;
+#[cfg(feature = "c6_calibration")]
+use formualizer_sheetport::{
+    BatchInput, BatchOptions, EvalOptions, InputUpdate, PortValue, SheetPort,
+};
+#[cfg(feature = "c6_calibration")]
+use formualizer_workbook::{
+    CalamineAdapter, LoadStrategy, SpreadsheetReader, Workbook, WorkbookConfig,
+};
+#[cfg(feature = "c6_calibration")]
+use sheetport_spec::Manifest;
+
+#[cfg(not(feature = "c6_calibration"))]
+fn main() {
+    eprintln!("This binary requires feature `c6_calibration`");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Parser)]
+#[command(about = "C6 target-locality fixture generator and fresh-process child probe")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Subcommand)]
+enum Command {
+    Generate {
+        #[arg(long)]
+        fixture: PathBuf,
+        #[arg(long)]
+        formulas: u32,
+    },
+    Sample {
+        #[arg(long)]
+        fixture: PathBuf,
+        #[arg(long)]
+        formulas: u32,
+        #[arg(long, value_enum)]
+        path: CalibrationPath,
+        #[arg(long, value_enum)]
+        scope: TargetScope,
+        #[arg(long, default_value_t = 3)]
+        warm_repeats: usize,
+    },
+}
+
+#[cfg(feature = "c6_calibration")]
+fn main() -> Result<()> {
+    match Cli::parse().command {
+        Command::Generate { fixture, formulas } => {
+            let shape = generate_fixture(&fixture, formulas)?;
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({
+                    "fixture": fixture,
+                    "shape": shape,
+                    "sha256": sha256_file(&fixture)?,
+                }))?
+            );
+        }
+        Command::Sample {
+            fixture,
+            formulas,
+            path,
+            scope,
+            warm_repeats,
+        } => println!(
+            "{}",
+            serde_json::to_string(&run_sample(&fixture, formulas, path, scope, warm_repeats)?)?
+        ),
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run_sample(
+    fixture: &std::path::Path,
+    formulas: u32,
+    path: CalibrationPath,
+    scope: TargetScope,
+    warm_repeats: usize,
+) -> Result<ChildReport> {
+    let shape = FixtureShape::new(formulas)?;
+    let fixture_sha256 = sha256_file(fixture)?;
+    let mut phases = PhaseTimings::default();
+    let mut telemetry = BTreeMap::new();
+
+    let load_started = Instant::now();
+    let reader = CalamineAdapter::open_path(fixture).context("open fixture with Calamine")?;
+    let mut workbook = Workbook::from_reader(
+        reader,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .context("interactive deferred workbook load")?;
+    phases.load = Some(TimedPhase::new(
+        elapsed_ms(load_started),
+        &["xlsx_open", "load"],
+    ));
+    let graph_after_load = graph_snapshot(&workbook);
+
+    // Establish a genuinely prepared and dirty branch while leaving all other branches staged.
+    // This setup is identical for every path and is reported rather than hidden in load/evaluation.
+    let setup_started = Instant::now();
+    workbook
+        .prepare_graph_for_cells(&[("Dirty", shape.dirty_formulas, 2)])
+        .context("prepare unrelated dirty branch")?;
+    workbook
+        .evaluate_cell("Dirty", shape.dirty_formulas, 2)
+        .context("evaluate unrelated dirty branch")?;
+    workbook
+        .set_value("Dirty", 1, 1, LiteralValue::Number(40.0))
+        .context("dirty unrelated branch")?;
+    phases.unrelated_dirty_setup = Some(TimedPhase::new(
+        elapsed_ms(setup_started),
+        &[
+            "target_resolution",
+            "preparation",
+            "evaluation",
+            "unrelated_edit",
+        ],
+    ));
+    let graph_after_setup = graph_snapshot(&workbook);
+
+    let mut outputs = Vec::new();
+    let path_result = match path {
+        CalibrationPath::Full => run_full(
+            &mut workbook,
+            shape,
+            scope,
+            warm_repeats,
+            &mut phases,
+            &mut telemetry,
+            &mut outputs,
+        ),
+        CalibrationPath::Cells => run_cells(
+            &mut workbook,
+            shape,
+            scope,
+            warm_repeats,
+            &mut phases,
+            &mut telemetry,
+            &mut outputs,
+        ),
+        CalibrationPath::Plan => run_plan(
+            &mut workbook,
+            shape,
+            scope,
+            warm_repeats,
+            &mut phases,
+            &mut telemetry,
+            &mut outputs,
+        ),
+        CalibrationPath::Sheetport => run_sheetport(
+            &mut workbook,
+            shape,
+            scope,
+            warm_repeats,
+            &mut phases,
+            &mut telemetry,
+            &mut outputs,
+        ),
+    };
+    let mut typed_error = path_result.err().map(|error| format!("{error:#}"));
+
+    let graph_after_run = graph_snapshot(&workbook);
+    let target_path = path != CalibrationPath::Full;
+    let locality_scope = scope != TargetScope::Full;
+    let expected_prepared = if target_path {
+        let already_prepared = if scope == TargetScope::Full {
+            shape.dirty_formulas
+        } else {
+            0
+        };
+        u64::from(shape.oracle(scope)) - u64::from(already_prepared)
+    } else {
+        u64::from(shape.formulas - shape.dirty_formulas)
+    };
+    let expected_staged = if target_path && locality_scope {
+        u64::from(shape.formulas - shape.dirty_formulas - shape.oracle(scope))
+    } else {
+        0
+    };
+    let expected_dirty = match (target_path && locality_scope, warm_repeats > 0) {
+        (true, true) => 10,
+        (true, false) => 9,
+        (false, true) => 2,
+        (false, false) => 0,
+    };
+    let unrelated_staged_retained = (target_path && locality_scope)
+        .then_some(graph_after_run.staged_formulas as u64 == expected_staged);
+    let unrelated_dirty_retained =
+        (target_path && locality_scope).then_some(graph_after_run.dirty_vertices == expected_dirty);
+    let prepared_delta = graph_after_run
+        .graph_formula_vertices
+        .saturating_sub(graph_after_setup.graph_formula_vertices) as u64;
+    let max_staged_selected = telemetry
+        .values()
+        .map(|stats| stats.staged_selected)
+        .max()
+        .unwrap_or(0);
+    let oracle_within_one_percent = target_path.then_some(
+        prepared_delta <= allowed_oracle(shape.oracle(scope))
+            && telemetry
+                .values()
+                .all(|stats| stats.staged_selected <= allowed_oracle(shape.oracle(scope))),
+    );
+    let exact_fixture_counts_passed = graph_after_load.graph_formula_vertices == 0
+        && graph_after_load.staged_formulas == shape.formulas as usize
+        && graph_after_load.dirty_vertices == 0
+        && graph_after_setup.graph_formula_vertices == shape.dirty_formulas as usize
+        && graph_after_setup.staged_formulas == (shape.formulas - shape.dirty_formulas) as usize
+        && graph_after_setup.dirty_vertices == 9;
+    let exact_locality_counts_passed = prepared_delta == expected_prepared
+        && graph_after_run.staged_formulas as u64 == expected_staged
+        && graph_after_run.dirty_vertices == expected_dirty
+        && max_staged_selected == if target_path { expected_prepared } else { 0 };
+
+    let analytical_expected_outputs = analytical_expected_outputs(shape, scope, warm_repeats);
+    let analytical_output_oracle_passed = if typed_error.is_none() {
+        match validate_analytical_outputs(&outputs, &analytical_expected_outputs) {
+            Ok(()) => Some(true),
+            Err(error) => {
+                typed_error = Some(format!("analytical output oracle mismatch: {error:#}"));
+                Some(false)
+            }
+        }
+    } else {
+        None
+    };
+    if typed_error.is_none() && (!exact_fixture_counts_passed || !exact_locality_counts_passed) {
+        typed_error = Some(format!(
+            "exact fixture/locality assertion failed: fixture={exact_fixture_counts_passed}, locality={exact_locality_counts_passed}, prepared={prepared_delta}/{expected_prepared}, staged={}/{expected_staged}, dirty={}/{expected_dirty}, staged_selected={max_staged_selected}",
+            graph_after_run.staged_formulas, graph_after_run.dirty_vertices
+        ));
+    }
+    let flat_outputs = outputs.iter().flatten().cloned().collect::<Vec<_>>();
+    let (current_rss_bytes, peak_rss_bytes) = process_memory_bytes();
+
+    Ok(ChildReport {
+        schema_version: 2,
+        path,
+        scope,
+        formulas,
+        reachable_oracle: shape.oracle(scope),
+        fixture_sha256,
+        status: if typed_error.is_some() {
+            "path_error"
+        } else {
+            "ok"
+        }
+        .to_string(),
+        phases,
+        output_checksum: typed_error
+            .is_none()
+            .then(|| checksum_values(&flat_outputs)),
+        outputs,
+        analytical_expected_outputs,
+        analytical_output_oracle_passed,
+        typed_error,
+        telemetry,
+        graph_after_load: Some(graph_after_load),
+        graph_after_setup: Some(graph_after_setup),
+        graph_after_run: Some(graph_after_run),
+        unrelated_staged_retained,
+        unrelated_dirty_retained,
+        oracle_within_one_percent,
+        exact_fixture_counts_passed: Some(exact_fixture_counts_passed),
+        exact_locality_counts_passed: Some(exact_locality_counts_passed),
+        current_rss_bytes,
+        peak_rss_bytes,
+    })
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run_full(
+    workbook: &mut Workbook,
+    shape: FixtureShape,
+    scope: TargetScope,
+    warm_repeats: usize,
+    phases: &mut PhaseTimings,
+    telemetry: &mut BTreeMap<String, EngineTelemetry>,
+    outputs: &mut Vec<Vec<String>>,
+) -> Result<()> {
+    let resolve = Instant::now();
+    let cells = shape.output_cells(scope);
+    phases.bind_target_resolution = Some(TimedPhase::new(
+        elapsed_ms(resolve),
+        &["target_address_construction"],
+    ));
+    let prepare = Instant::now();
+    workbook.prepare_graph_all()?;
+    phases.preparation_plan_build =
+        Some(TimedPhase::new(elapsed_ms(prepare), &["prepare_graph_all"]));
+    let evaluate = Instant::now();
+    workbook.evaluate_all()?;
+    phases.first_evaluation = Some(TimedPhase::new(elapsed_ms(evaluate), &["evaluate_all"]));
+    telemetry.insert("first_evaluation".to_string(), collect_telemetry(workbook));
+    let read = Instant::now();
+    outputs.push(read_cells(workbook, &cells));
+    phases.output_read = Some(TimedPhase::new(elapsed_ms(read), &["get_value"]));
+
+    for repeat in 0..warm_repeats {
+        edit_input(workbook, shape, scope, repeat, phases)?;
+        let evaluate = Instant::now();
+        workbook.evaluate_all()?;
+        phases
+            .warm_evaluation
+            .push(TimedPhase::new(elapsed_ms(evaluate), &["evaluate_all"]));
+        telemetry.insert(format!("warm_{repeat}"), collect_telemetry(workbook));
+        let read = Instant::now();
+        outputs.push(read_cells(workbook, &cells));
+        phases
+            .warm_output_read
+            .push(TimedPhase::new(elapsed_ms(read), &["get_value"]));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run_cells(
+    workbook: &mut Workbook,
+    shape: FixtureShape,
+    scope: TargetScope,
+    warm_repeats: usize,
+    phases: &mut PhaseTimings,
+    telemetry: &mut BTreeMap<String, EngineTelemetry>,
+    outputs: &mut Vec<Vec<String>>,
+) -> Result<()> {
+    let resolve = Instant::now();
+    let cells = shape.cell_targets(scope);
+    phases.bind_target_resolution = Some(TimedPhase::new(
+        elapsed_ms(resolve),
+        &["cell_target_construction"],
+    ));
+    let evaluate = Instant::now();
+    outputs.push(literals(workbook.evaluate_cells(&cells)?));
+    phases.first_evaluation = Some(TimedPhase::new(
+        elapsed_ms(evaluate),
+        &[
+            "target_preparation",
+            "ephemeral_plan_build",
+            "evaluation",
+            "output_return",
+        ],
+    ));
+    telemetry.insert("first_evaluation".to_string(), collect_telemetry(workbook));
+
+    for repeat in 0..warm_repeats {
+        edit_input(workbook, shape, scope, repeat, phases)?;
+        let evaluate = Instant::now();
+        outputs.push(literals(workbook.evaluate_cells(&cells)?));
+        phases.warm_evaluation.push(TimedPhase::new(
+            elapsed_ms(evaluate),
+            &[
+                "target_preparation",
+                "ephemeral_plan_build",
+                "evaluation",
+                "output_return",
+            ],
+        ));
+        telemetry.insert(format!("warm_{repeat}"), collect_telemetry(workbook));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run_plan(
+    workbook: &mut Workbook,
+    shape: FixtureShape,
+    scope: TargetScope,
+    warm_repeats: usize,
+    phases: &mut PhaseTimings,
+    telemetry: &mut BTreeMap<String, EngineTelemetry>,
+    outputs: &mut Vec<Vec<String>>,
+) -> Result<()> {
+    let resolve = Instant::now();
+    let targets = shape.targets(scope);
+    let cells = shape.output_cells(scope);
+    phases.bind_target_resolution = Some(TimedPhase::new(
+        elapsed_ms(resolve),
+        &["typed_target_construction"],
+    ));
+    let prepare = Instant::now();
+    let plan = workbook.build_recalc_plan_for_targets(&targets)?;
+    phases.preparation_plan_build = Some(TimedPhase::new(
+        elapsed_ms(prepare),
+        &["target_preparation", "revision_bound_plan_build"],
+    ));
+    telemetry.insert("plan_build".to_string(), collect_telemetry(workbook));
+    let evaluate = Instant::now();
+    workbook.evaluate_with_plan(&plan)?;
+    phases.first_evaluation = Some(TimedPhase::new(
+        elapsed_ms(evaluate),
+        &["evaluate_with_plan"],
+    ));
+    telemetry.insert("first_evaluation".to_string(), collect_telemetry(workbook));
+    let read = Instant::now();
+    outputs.push(read_cells(workbook, &cells));
+    phases.output_read = Some(TimedPhase::new(elapsed_ms(read), &["get_value"]));
+
+    for repeat in 0..warm_repeats {
+        edit_input(workbook, shape, scope, repeat, phases)?;
+        let evaluate = Instant::now();
+        workbook.evaluate_with_plan(&plan)?;
+        phases.warm_evaluation.push(TimedPhase::new(
+            elapsed_ms(evaluate),
+            &["evaluate_with_plan"],
+        ));
+        telemetry.insert(format!("warm_{repeat}"), collect_telemetry(workbook));
+        let read = Instant::now();
+        outputs.push(read_cells(workbook, &cells));
+        phases
+            .warm_output_read
+            .push(TimedPhase::new(elapsed_ms(read), &["get_value"]));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn run_sheetport(
+    workbook: &mut Workbook,
+    shape: FixtureShape,
+    scope: TargetScope,
+    warm_repeats: usize,
+    phases: &mut PhaseTimings,
+    telemetry: &mut BTreeMap<String, EngineTelemetry>,
+    outputs: &mut Vec<Vec<String>>,
+) -> Result<()> {
+    let bind = Instant::now();
+    let manifest = Manifest::from_yaml_str(&manifest_yaml(shape, scope))?;
+    let mut sheetport = SheetPort::new(workbook, manifest)?;
+    phases.bind_target_resolution = Some(TimedPhase::new(
+        elapsed_ms(bind),
+        &[
+            "manifest_parse",
+            "manifest_bind",
+            "workbook_selector_validation",
+        ],
+    ));
+
+    let first = Instant::now();
+    let first_output = sheetport.evaluate_once(EvalOptions::default())?;
+    phases.first_evaluation = Some(TimedPhase::new(
+        elapsed_ms(first),
+        &[
+            "selector_resolution",
+            "target_preparation",
+            "evaluation",
+            "sheetport_output_read",
+        ],
+    ));
+    outputs.push(sheetport_values(&first_output, shape, scope));
+    telemetry.insert(
+        "first_evaluation".to_string(),
+        collect_telemetry(sheetport.workbook()),
+    );
+
+    let completion_ms = Arc::new(Mutex::new(Vec::new()));
+    let last = Arc::new(Mutex::new(Instant::now()));
+    let completion_capture = Arc::clone(&completion_ms);
+    let last_capture = Arc::clone(&last);
+    let plan_started = Instant::now();
+    let batch_options = BatchOptions {
+        progress: Some(Box::new(move |_| {
+            let now = Instant::now();
+            let mut previous = last_capture.lock().expect("progress clock lock");
+            completion_capture
+                .lock()
+                .expect("progress samples lock")
+                .push(now.duration_since(*previous).as_secs_f64() * 1000.0);
+            *previous = now;
+        })),
+        ..BatchOptions::default()
+    };
+    let (batch_results, batch_total_ms) = {
+        let mut batch = sheetport.batch(batch_options)?;
+        phases.preparation_plan_build = Some(TimedPhase::new(
+            elapsed_ms(plan_started),
+            &[
+                "input_baseline_read",
+                "selector_resolution",
+                "target_preparation",
+                "revision_bound_plan_build",
+            ],
+        ));
+        telemetry.insert(
+            "sheetport_batch_plan_build".to_string(),
+            collect_telemetry(batch.workbook_for_benchmark()),
+        );
+        let cases = (0..warm_repeats)
+            .map(|repeat| {
+                let mut update = InputUpdate::new();
+                update.insert(
+                    "input",
+                    PortValue::Scalar(LiteralValue::Number(2.0 + repeat as f64)),
+                );
+                BatchInput::new(format!("warm_{repeat}"), update)
+            })
+            .collect::<Vec<_>>();
+        let run_started = Instant::now();
+        *last.lock().expect("progress clock lock") = run_started;
+        let results = batch.run(cases)?;
+        let total_ms = elapsed_ms(run_started);
+        telemetry.insert(
+            "sheetport_batch_execution".to_string(),
+            collect_telemetry(batch.workbook_for_benchmark()),
+        );
+        (results, total_ms)
+    };
+    let samples = completion_ms.lock().expect("progress samples lock").clone();
+    for duration in &samples {
+        phases.warm_evaluation.push(TimedPhase::new(
+            *duration,
+            &["input_edit", "plan_evaluation", "sheetport_output_read"],
+        ));
+    }
+    let samples_total_ms = samples.iter().sum::<f64>();
+    anyhow::ensure!(
+        batch_total_ms >= samples_total_ms,
+        "SheetPort batch timing accounting is negative: total={batch_total_ms:.6}ms, iterations={samples_total_ms:.6}ms"
+    );
+    let restore_ms = batch_total_ms - samples_total_ms;
+    phases.batch_restore = Some(TimedPhase::new(
+        restore_ms,
+        &[
+            "baseline_restore_edit",
+            "plan_evaluation",
+            "sheetport_output_read",
+        ],
+    ));
+    for result in batch_results {
+        outputs.push(sheetport_values(&result.outputs, shape, scope));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn edit_input(
+    workbook: &mut Workbook,
+    shape: FixtureShape,
+    scope: TargetScope,
+    repeat: usize,
+    phases: &mut PhaseTimings,
+) -> Result<()> {
+    let edit = Instant::now();
+    workbook.set_value(
+        shape.edit_sheet(scope),
+        1,
+        1,
+        LiteralValue::Number(2.0 + repeat as f64),
+    )?;
+    phases.edit.push(TimedPhase::new(
+        elapsed_ms(edit),
+        &["value_edit_inside_selected_closure"],
+    ));
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn validate_analytical_outputs(outputs: &[Vec<String>], expected: &[Vec<f64>]) -> Result<()> {
+    anyhow::ensure!(
+        outputs.len() == expected.len(),
+        "evaluation count: actual {}, expected {}",
+        outputs.len(),
+        expected.len()
+    );
+    for (evaluation, (actual_values, expected_values)) in outputs.iter().zip(expected).enumerate() {
+        anyhow::ensure!(
+            actual_values.len() == expected_values.len(),
+            "evaluation {evaluation} output count: actual {}, expected {}",
+            actual_values.len(),
+            expected_values.len()
+        );
+        for (output, (actual, expected)) in actual_values.iter().zip(expected_values).enumerate() {
+            let actual = parse_numeric_literal(actual).with_context(|| {
+                format!("evaluation {evaluation} output {output} is not numeric: {actual}")
+            })?;
+            let tolerance = 1e-9 * expected.abs().max(1.0);
+            anyhow::ensure!(
+                (actual - expected).abs() <= tolerance,
+                "evaluation {evaluation} output {output}: actual {actual:.17}, analytical {expected:.17}, tolerance {tolerance:.3e}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn parse_numeric_literal(value: &str) -> Result<f64> {
+    let number = value
+        .strip_prefix("Number(")
+        .and_then(|value| value.strip_suffix(')'))
+        .or_else(|| {
+            value
+                .strip_prefix("Int(")
+                .and_then(|value| value.strip_suffix(')'))
+        })
+        .context("LiteralValue debug representation")?;
+    number.parse().context("numeric LiteralValue payload")
+}
+
+#[cfg(feature = "c6_calibration")]
+fn literals(values: Vec<LiteralValue>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| format!("{value:?}"))
+        .collect()
+}
+
+#[cfg(feature = "c6_calibration")]
+fn read_cells(workbook: &Workbook, cells: &[(&str, u32, u32)]) -> Vec<String> {
+    cells
+        .iter()
+        .map(|(sheet, row, col)| {
+            format!(
+                "{:?}",
+                workbook
+                    .get_value(sheet, *row, *col)
+                    .unwrap_or(LiteralValue::Empty)
+            )
+        })
+        .collect()
+}
+
+#[cfg(feature = "c6_calibration")]
+fn sheetport_values(
+    snapshot: &formualizer_sheetport::OutputSnapshot,
+    shape: FixtureShape,
+    scope: TargetScope,
+) -> Vec<String> {
+    (0..shape.output_cells(scope).len())
+        .map(|index| match snapshot.get(&format!("output_{index}")) {
+            Some(PortValue::Scalar(value)) => format!("{value:?}"),
+            other => format!("{other:?}"),
+        })
+        .collect()
+}
+
+#[cfg(feature = "c6_calibration")]
+fn graph_snapshot(workbook: &Workbook) -> GraphSnapshot {
+    let stats = workbook.engine().baseline_stats();
+    GraphSnapshot {
+        graph_vertices: stats.graph_vertex_count,
+        graph_formula_vertices: stats.graph_formula_vertex_count,
+        graph_edges: stats.graph_edge_count,
+        dirty_vertices: stats.dirty_vertex_count,
+        evaluation_vertices: stats.evaluation_vertex_count,
+        staged_formulas: stats.staged_formula_count,
+        active_spans: stats.formula_plane_active_span_count,
+    }
+}
+
+#[cfg(feature = "c6_calibration")]
+fn collect_telemetry(workbook: &Workbook) -> EngineTelemetry {
+    let baseline = workbook.engine().baseline_stats();
+    let Some(request) = workbook.engine().last_evaluation_resource_request_stats() else {
+        return EngineTelemetry {
+            graph_vertices: baseline.graph_vertex_count,
+            graph_formula_vertices: baseline.graph_formula_vertex_count,
+            graph_edges: baseline.graph_edge_count,
+            dirty_vertices: baseline.dirty_vertex_count,
+            staged_formulas: baseline.staged_formula_count,
+            active_spans: baseline.formula_plane_active_span_count,
+            ..EngineTelemetry::default()
+        };
+    };
+    EngineTelemetry {
+        request_id: request.request_id,
+        request_kind: request.kind.as_str().to_string(),
+        request_outcome: request.outcome.as_str().to_string(),
+        graph_vertices: baseline.graph_vertex_count,
+        graph_formula_vertices: baseline.graph_formula_vertex_count,
+        graph_edges: baseline.graph_edge_count,
+        dirty_vertices: baseline.dirty_vertex_count,
+        staged_formulas: baseline.staged_formula_count,
+        active_spans: baseline.formula_plane_active_span_count,
+        target_requested: request.target_requested,
+        target_normalized_regions: request.target_normalized_regions,
+        staged_selected: request.staged_selected,
+        staged_retained: request.staged_retained,
+        preparation_scope_level: request.target_scope_level,
+        widening_reason_bits: request.target_widening_reason_bits,
+        target_commit_estimated_work: request.target_commit_estimated_work,
+        target_commit_actual_work: request.target_commit_actual_work,
+        work_charged: request.ledger.work_charged,
+        topology_strategy: request.topology.strategy.as_str().to_string(),
+        topology_cache_outcome: request.topology.cache_outcome.as_str().to_string(),
+        topology_producers: request.topology.producers_observed,
+        topology_candidates: request.topology.candidates_observed,
+        topology_edges: request.topology.edges_observed,
+        topology_retained_bytes: request.topology.retained_bytes_observed,
+        exact_pass_count: request.topology.exact_pass_count,
+        native_topology_disk_bytes: request.topology.native_topology_disk_bytes,
+        fallback_materialized_cells: request.fallback_materialized_cells,
+        cycle_materialized_cells: request.cycle_materialized_cells,
+        dirty_lease_outcome: request.dirty_lease.as_str().to_string(),
+        retained_current: request.ledger.retained_current,
+        retained_peak: request.ledger.retained_peak,
+        scratch_current: request.ledger.scratch_current,
+        scratch_peak: request.ledger.scratch_peak,
+        graph_source_scratch_estimated: request.graph_source_scratch_estimated,
+        graph_source_scratch_observed: request.graph_source_scratch_observed,
+        request_total_ms: request.phases.total_ns as f64 / 1_000_000.0,
+        graph_prepare_ms: request.phases.staged_prepare_ns as f64 / 1_000_000.0,
+        topology_ms: request.phases.topology_ns as f64 / 1_000_000.0,
+        materialization_ms: request.phases.materialization_ns as f64 / 1_000_000.0,
+        evaluation_ms: request.phases.evaluation_ns as f64 / 1_000_000.0,
+    }
+}
+
+#[cfg(feature = "c6_calibration")]
+fn process_memory_bytes() -> (Option<u64>, Option<u64>) {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return (None, None);
+    };
+    let parse = |prefix: &str| {
+        status.lines().find_map(|line| {
+            line.strip_prefix(prefix)?
+                .split_whitespace()
+                .next()?
+                .parse::<u64>()
+                .ok()?
+                .checked_mul(1024)
+        })
+    };
+    (parse("VmRSS:"), parse("VmHWM:"))
+}
+
+#[cfg(all(test, feature = "c6_calibration"))]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn temp_fixture(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "formualizer-c6-{label}-{}-{}.xlsx",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ))
+    }
+
+    #[test]
+    fn parses_sample_command() {
+        let cli = Cli::try_parse_from([
+            "probe",
+            "sample",
+            "--fixture",
+            "fixture.xlsx",
+            "--formulas",
+            "500",
+            "--path",
+            "sheetport",
+            "--scope",
+            "medium",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Sample {
+                path: CalibrationPath::Sheetport,
+                scope: TargetScope::Medium,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn fixture_bytes_are_deterministic() {
+        let first = temp_fixture("determinism-a");
+        let second = temp_fixture("determinism-b");
+        generate_fixture(&first, 200).unwrap();
+        generate_fixture(&second, 200).unwrap();
+        assert_eq!(sha256_file(&first).unwrap(), sha256_file(&second).unwrap());
+        let _ = std::fs::remove_file(first);
+        let _ = std::fs::remove_file(second);
+    }
+
+    #[test]
+    fn smoke_paths_have_output_parity_and_target_locality() {
+        let fixture = temp_fixture("path-parity");
+        generate_fixture(&fixture, 200).unwrap();
+        let reports = CalibrationPath::ALL
+            .into_iter()
+            .map(|path| run_sample(&fixture, 200, path, TargetScope::Tiny, 1).unwrap())
+            .collect::<Vec<_>>();
+        let expected = &reports[0].outputs;
+        assert!(reports.iter().all(|report| report.outputs == *expected));
+        assert!(
+            reports
+                .iter()
+                .filter(|report| report.path != CalibrationPath::Full)
+                .all(|report| report.oracle_within_one_percent == Some(true))
+        );
+        assert!(
+            reports
+                .iter()
+                .filter(|report| report.path != CalibrationPath::Full)
+                .all(|report| report.unrelated_staged_retained == Some(true))
+        );
+        let _ = std::fs::remove_file(fixture);
+    }
+}

--- a/crates/formualizer-bench-core/src/c6_calibration.rs
+++ b/crates/formualizer-bench-core/src/c6_calibration.rs
@@ -1,0 +1,432 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use formualizer_eval::engine::EvaluationTarget;
+use formualizer_testkit::write_workbook;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationPath {
+    Full,
+    Cells,
+    Plan,
+    Sheetport,
+}
+
+impl CalibrationPath {
+    pub const ALL: [Self; 4] = [Self::Full, Self::Cells, Self::Plan, Self::Sheetport];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Cells => "cells",
+            Self::Plan => "plan",
+            Self::Sheetport => "sheetport",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetScope {
+    Tiny,
+    Medium,
+    Full,
+}
+
+impl TargetScope {
+    pub const ALL: [Self; 3] = [Self::Tiny, Self::Medium, Self::Full];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Tiny => "tiny_lt_1pct",
+            Self::Medium => "medium_approx_10pct",
+            Self::Full => "full_100pct",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FixtureShape {
+    pub formulas: u32,
+    pub tiny_formulas: u32,
+    pub medium_formulas: u32,
+    pub large_formulas: u32,
+    pub dirty_formulas: u32,
+}
+
+impl FixtureShape {
+    pub fn new(formulas: u32) -> Result<Self> {
+        if formulas < 200 {
+            bail!("--formulas must be at least 200");
+        }
+        let tiny_formulas = (formulas / 200).max(1); // 0.5%
+        let medium_formulas = (formulas / 10).max(1); // 10%
+        let dirty_formulas = 8;
+        let large_formulas = formulas
+            .checked_sub(tiny_formulas + medium_formulas + dirty_formulas)
+            .ok_or_else(|| anyhow::anyhow!("fixture branch allocation overflow"))?;
+        Ok(Self {
+            formulas,
+            tiny_formulas,
+            medium_formulas,
+            large_formulas,
+            dirty_formulas,
+        })
+    }
+
+    pub const fn oracle(self, scope: TargetScope) -> u32 {
+        match scope {
+            TargetScope::Tiny => self.tiny_formulas,
+            TargetScope::Medium => self.medium_formulas,
+            TargetScope::Full => self.formulas,
+        }
+    }
+
+    pub const fn edit_sheet(self, scope: TargetScope) -> &'static str {
+        match scope {
+            TargetScope::Tiny | TargetScope::Full => "Tiny",
+            TargetScope::Medium => "Medium",
+        }
+    }
+
+    pub fn targets(self, scope: TargetScope) -> Vec<EvaluationTarget> {
+        let cell = |sheet: &str, row| EvaluationTarget::Cell {
+            sheet: sheet.to_string(),
+            row,
+            col: 2,
+        };
+        match scope {
+            TargetScope::Tiny => vec![cell("Tiny", self.tiny_formulas)],
+            TargetScope::Medium => vec![cell("Medium", self.medium_formulas)],
+            TargetScope::Full => vec![
+                cell("Tiny", self.tiny_formulas),
+                cell("Medium", self.medium_formulas),
+                cell("Large", self.large_formulas),
+                cell("Dirty", self.dirty_formulas),
+            ],
+        }
+    }
+
+    pub fn cell_targets(self, scope: TargetScope) -> Vec<(&'static str, u32, u32)> {
+        match scope {
+            TargetScope::Tiny => vec![("Tiny", self.tiny_formulas, 2)],
+            TargetScope::Medium => vec![("Medium", self.medium_formulas, 2)],
+            TargetScope::Full => vec![
+                ("Tiny", self.tiny_formulas, 2),
+                ("Medium", self.medium_formulas, 2),
+                ("Large", self.large_formulas, 2),
+                ("Dirty", self.dirty_formulas, 2),
+            ],
+        }
+    }
+
+    pub fn output_cells(self, scope: TargetScope) -> Vec<(&'static str, u32, u32)> {
+        self.cell_targets(scope)
+    }
+}
+
+pub fn generate_fixture(path: &Path, formulas: u32) -> Result<FixtureShape> {
+    let shape = FixtureShape::new(formulas)?;
+    write_workbook(path, |book| {
+        book.get_sheet_by_name_mut("Sheet1")
+            .expect("default sheet")
+            .set_name("Tiny");
+        book.new_sheet("Medium").expect("Medium sheet");
+        book.new_sheet("Large").expect("Large sheet");
+        book.new_sheet("Dirty").expect("Dirty sheet");
+        populate_finance_branch(book, "Tiny", shape.tiny_formulas, 1.0);
+        populate_finance_branch(book, "Medium", shape.medium_formulas, 2.0);
+        populate_finance_branch(book, "Large", shape.large_formulas, 3.0);
+        populate_finance_branch(book, "Dirty", shape.dirty_formulas, 4.0);
+    });
+    Ok(shape)
+}
+
+fn populate_finance_branch(
+    book: &mut umya_spreadsheet::Spreadsheet,
+    sheet_name: &str,
+    formulas: u32,
+    seed: f64,
+) {
+    let sheet = book
+        .get_sheet_by_name_mut(sheet_name)
+        .expect("fixture sheet exists");
+    sheet.get_cell_mut((1, 1)).set_value_number(seed);
+    sheet.get_cell_mut((2, 1)).set_formula("=A1*1.015-0.25");
+    for row in 2..=formulas {
+        sheet
+            .get_cell_mut((2, row))
+            .set_formula(format!("=B{}*1.0001+$A$1*0.00001", row - 1));
+    }
+}
+
+pub fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = fs::read(path)?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
+}
+
+pub fn checksum_values(values: &[String]) -> String {
+    let mut digest = Sha256::new();
+    for value in values {
+        digest.update((value.len() as u64).to_le_bytes());
+        digest.update(value.as_bytes());
+    }
+    format!("{:x}", digest.finalize())
+}
+
+pub fn analytical_terminal(seed: f64, formulas: u32) -> f64 {
+    let first = seed * 1.015 - 0.25;
+    if formulas == 1 {
+        return first;
+    }
+    let ratio = 1.0001_f64;
+    let power = ratio.powi((formulas - 1) as i32);
+    first * power + seed * 0.00001 * (power - 1.0) / (ratio - 1.0)
+}
+
+pub fn analytical_expected_outputs(
+    shape: FixtureShape,
+    scope: TargetScope,
+    warm_repeats: usize,
+) -> Vec<Vec<f64>> {
+    (0..=warm_repeats)
+        .map(|evaluation| {
+            let repeat_seed = (evaluation > 0).then_some(1.0 + evaluation as f64);
+            shape
+                .output_cells(scope)
+                .into_iter()
+                .map(|(sheet, formulas, _)| {
+                    let seed = match sheet {
+                        "Tiny" => repeat_seed
+                            .filter(|_| shape.edit_sheet(scope) == "Tiny")
+                            .unwrap_or(1.0),
+                        "Medium" => repeat_seed
+                            .filter(|_| shape.edit_sheet(scope) == "Medium")
+                            .unwrap_or(2.0),
+                        "Large" => 3.0,
+                        "Dirty" => 40.0,
+                        _ => unreachable!("fixture output sheet"),
+                    };
+                    analytical_terminal(seed, formulas)
+                })
+                .collect()
+        })
+        .collect()
+}
+
+pub fn manifest_yaml(shape: FixtureShape, scope: TargetScope) -> String {
+    let mut yaml = String::from(
+        "spec: fio\nspec_version: \"0.3.0\"\nmanifest:\n  id: c6-target-locality\n  name: C6 Target Locality\n  workbook:\n    uri: fixture://c6.xlsx\n    locale: en-US\n    date_system: 1900\nports:\n",
+    );
+    yaml.push_str(&format!(
+        "  - id: input\n    dir: in\n    shape: scalar\n    location: {{ a1: {}!A1 }}\n    schema: {{ type: number }}\n",
+        shape.edit_sheet(scope)
+    ));
+    for (index, (sheet, row, _)) in shape.output_cells(scope).iter().enumerate() {
+        yaml.push_str(&format!(
+            "  - id: output_{index}\n    dir: out\n    shape: scalar\n    location: {{ a1: {sheet}!B{row} }}\n    schema: {{ type: number }}\n"
+        ));
+    }
+    yaml
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TimedPhase {
+    pub milliseconds: f64,
+    pub includes: Vec<String>,
+}
+
+impl TimedPhase {
+    pub fn new(milliseconds: f64, includes: &[&str]) -> Self {
+        Self {
+            milliseconds,
+            includes: includes.iter().map(|part| (*part).to_string()).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PhaseTimings {
+    pub load: Option<TimedPhase>,
+    pub unrelated_dirty_setup: Option<TimedPhase>,
+    pub bind_target_resolution: Option<TimedPhase>,
+    pub preparation_plan_build: Option<TimedPhase>,
+    pub first_evaluation: Option<TimedPhase>,
+    pub output_read: Option<TimedPhase>,
+    pub edit: Vec<TimedPhase>,
+    pub warm_evaluation: Vec<TimedPhase>,
+    pub warm_output_read: Vec<TimedPhase>,
+    pub batch_restore: Option<TimedPhase>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EngineTelemetry {
+    pub request_id: u64,
+    pub request_kind: String,
+    pub request_outcome: String,
+    pub graph_vertices: usize,
+    pub graph_formula_vertices: usize,
+    pub graph_edges: usize,
+    pub dirty_vertices: usize,
+    pub staged_formulas: usize,
+    pub active_spans: usize,
+    pub target_requested: u64,
+    pub target_normalized_regions: u64,
+    pub staged_selected: u64,
+    pub staged_retained: u64,
+    pub preparation_scope_level: u8,
+    pub widening_reason_bits: u64,
+    pub target_commit_estimated_work: u64,
+    pub target_commit_actual_work: u64,
+    pub work_charged: u64,
+    pub topology_strategy: String,
+    pub topology_cache_outcome: String,
+    pub topology_producers: u64,
+    pub topology_candidates: u64,
+    pub topology_edges: u64,
+    pub topology_retained_bytes: u64,
+    pub exact_pass_count: u64,
+    pub native_topology_disk_bytes: u64,
+    pub fallback_materialized_cells: u64,
+    pub cycle_materialized_cells: u64,
+    pub dirty_lease_outcome: String,
+    pub retained_current: u64,
+    pub retained_peak: u64,
+    pub scratch_current: u64,
+    pub scratch_peak: u64,
+    pub graph_source_scratch_estimated: u64,
+    pub graph_source_scratch_observed: u64,
+    pub request_total_ms: f64,
+    pub graph_prepare_ms: f64,
+    pub topology_ms: f64,
+    pub materialization_ms: f64,
+    pub evaluation_ms: f64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GraphSnapshot {
+    pub graph_vertices: usize,
+    pub graph_formula_vertices: usize,
+    pub graph_edges: usize,
+    pub dirty_vertices: usize,
+    pub evaluation_vertices: usize,
+    pub staged_formulas: usize,
+    pub active_spans: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChildReport {
+    pub schema_version: u32,
+    pub path: CalibrationPath,
+    pub scope: TargetScope,
+    pub formulas: u32,
+    pub reachable_oracle: u32,
+    pub fixture_sha256: String,
+    pub status: String,
+    pub phases: PhaseTimings,
+    pub outputs: Vec<Vec<String>>,
+    pub analytical_expected_outputs: Vec<Vec<f64>>,
+    pub analytical_output_oracle_passed: Option<bool>,
+    pub output_checksum: Option<String>,
+    pub typed_error: Option<String>,
+    pub telemetry: BTreeMap<String, EngineTelemetry>,
+    pub graph_after_load: Option<GraphSnapshot>,
+    pub graph_after_setup: Option<GraphSnapshot>,
+    pub graph_after_run: Option<GraphSnapshot>,
+    pub unrelated_staged_retained: Option<bool>,
+    pub unrelated_dirty_retained: Option<bool>,
+    pub oracle_within_one_percent: Option<bool>,
+    pub exact_fixture_counts_passed: Option<bool>,
+    pub exact_locality_counts_passed: Option<bool>,
+    pub current_rss_bytes: Option<u64>,
+    pub peak_rss_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct Distribution {
+    pub median: f64,
+    pub p95: f64,
+    pub mad: f64,
+    pub max: f64,
+}
+
+pub fn distribution(values: &[f64]) -> Option<Distribution> {
+    if values.is_empty() || values.iter().any(|value| !value.is_finite()) {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let median = percentile_sorted(&sorted, 0.5);
+    let p95 = percentile_sorted(&sorted, 0.95);
+    let mut deviations = sorted
+        .iter()
+        .map(|value| (value - median).abs())
+        .collect::<Vec<_>>();
+    deviations.sort_by(f64::total_cmp);
+    Some(Distribution {
+        median,
+        p95,
+        mad: percentile_sorted(&deviations, 0.5),
+        max: *sorted.last().expect("nonempty distribution"),
+    })
+}
+
+fn percentile_sorted(sorted: &[f64], percentile: f64) -> f64 {
+    let rank = (percentile * sorted.len() as f64).ceil() as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+pub fn allowed_oracle(oracle: u32) -> u64 {
+    u64::from(oracle).saturating_add(u64::from(oracle).div_ceil(100))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_uses_nearest_rank_and_median_absolute_deviation() {
+        let stats = distribution(&[7.0, 1.0, 3.0, 2.0, 100.0, 5.0, 4.0]).unwrap();
+        assert_eq!(stats.median, 4.0);
+        assert_eq!(stats.p95, 100.0);
+        assert_eq!(stats.mad, 2.0);
+        assert_eq!(stats.max, 100.0);
+    }
+
+    #[test]
+    fn target_scope_allocations_are_bounded() {
+        let shape = FixtureShape::new(50_000).unwrap();
+        assert!(shape.tiny_formulas < shape.formulas / 100);
+        assert_eq!(shape.medium_formulas, shape.formulas / 10);
+        assert_eq!(shape.oracle(TargetScope::Full), 50_000);
+        assert_eq!(
+            shape.tiny_formulas
+                + shape.medium_formulas
+                + shape.large_formulas
+                + shape.dirty_formulas,
+            shape.formulas
+        );
+    }
+
+    #[test]
+    fn analytical_oracle_covers_initial_and_repeated_edits() {
+        let shape = FixtureShape::new(1_000).unwrap();
+        let expected = analytical_expected_outputs(shape, TargetScope::Full, 2);
+        assert_eq!(expected.len(), 3);
+        assert_eq!(expected[0].len(), 4);
+        assert_ne!(expected[0][0], expected[1][0]);
+        assert_ne!(expected[1][0], expected[2][0]);
+        assert_eq!(expected[0][1], expected[2][1]);
+        assert_eq!(
+            expected[0][3],
+            analytical_terminal(40.0, shape.dirty_formulas)
+        );
+    }
+}

--- a/crates/formualizer-bench-core/src/lib.rs
+++ b/crates/formualizer-bench-core/src/lib.rs
@@ -4,6 +4,9 @@ pub mod scenario;
 #[cfg(feature = "xlsx")]
 pub mod corpus;
 
+#[cfg(feature = "c6_calibration")]
+pub mod c6_calibration;
+
 #[cfg(feature = "formualizer_runner")]
 pub mod instrumentation;
 #[cfg(feature = "formualizer_runner")]

--- a/crates/formualizer-sheetport/Cargo.toml
+++ b/crates/formualizer-sheetport/Cargo.toml
@@ -21,6 +21,8 @@ system-clock = ["formualizer-eval/system-clock", "formualizer-workbook/system-cl
 js-runtime = ["formualizer-eval/js-runtime", "formualizer-workbook/js-runtime"]
 # umya: opt-in umya-spreadsheet I/O adapters in the workbook layer.
 umya = ["formualizer-workbook/umya_integration"]
+# Internal telemetry access for repository benchmarks; not a supported public API.
+benchmark_internal = []
 
 [dependencies]
 sheetport-spec = { path = "../sheetport-spec", version = "0.3.0" }

--- a/crates/formualizer-sheetport/src/batch.rs
+++ b/crates/formualizer-sheetport/src/batch.rs
@@ -256,6 +256,13 @@ impl<'a> BatchExecutor<'a> {
         }
     }
 
+    #[cfg(feature = "benchmark_internal")]
+    #[doc(hidden)]
+    /// Read-only access used to snapshot engine telemetry without affecting batch execution.
+    pub fn workbook_for_benchmark(&self) -> &formualizer_workbook::Workbook {
+        self.sheetport.workbook()
+    }
+
     fn is_plan_stale(error: &SheetPortError) -> bool {
         let excel = match error {
             SheetPortError::Engine { source } => Some(source),

--- a/docs/architecture/evaluation-c6-calibration.md
+++ b/docs/architecture/evaluation-c6-calibration.md
@@ -1,0 +1,90 @@
+# C6 Target-Locality Calibration
+
+Status: focused Phase A harness; measurement only
+
+This harness compares four native public evaluation paths in fresh processes:
+
+- `full`: interactive/deferred XLSX load, explicit `prepare_graph_all`, `evaluate_all`, and direct output reads.
+- `cells`: ordinary `evaluate_cells`; its public call necessarily combines target preparation, ephemeral target-plan construction, evaluation, and returned outputs.
+- `plan`: a revision-bound target plan built once with `build_recalc_plan_for_targets`, followed by `evaluate_with_plan` and direct output reads.
+- `sheetport`: a parsed and validated FIO manifest bound with `SheetPort::new`; one-shot output is read by `evaluate_once`, then warm edits use a SheetPort batch and its reusable target plan.
+
+The child probe and matrix runner require the `c6_calibration` feature. Fixtures are generated before timed child samples. Every sample loads the same immutable XLSX in a new process using `WorkbookConfig::interactive()`, so graph preparation remains deferred and request-time locality is visible.
+
+## Fixture
+
+The deterministic fixture contains exactly the requested formula count split across independent finance-shaped chains:
+
+- `Tiny`: 0.5% of formulas, providing the less-than-1% target.
+- `Medium`: 10% of formulas.
+- `Large`: the remaining primary formulas.
+- `Dirty`: eight formulas used to establish an unrelated prepared and dirty branch.
+
+A target is the terminal balance in a branch. The 100% scope requests every terminal balance. Before the measured path, every child prepares and evaluates `Dirty`, edits its input, and reports that common setup separately. Tiny and medium runs therefore begin with both unrelated staged formulas and unrelated dirty prepared work. Target-local runs must retain both. The prepared-formula locality gate subtracts the eight-formula common setup and allows at most the reachable oracle plus 1%.
+
+Repeated value edits change `A1` inside the selected closure. These rows report public API cost after that edit, not a claim that the full requested scope is dirty or recomputed. In particular, `full_100pct` always edits the fixed 0.5% `Tiny` branch while requesting all four terminals. Direct plan runs reuse the same revision-bound plan. SheetPort repeated runs go through `BatchExecutor`; its progress clock is reset immediately before `batch.run`, each edit/evaluate/output iteration is separated, and checked nonnegative baseline-restoration accounting is reported independently.
+
+## Commands
+
+Build and run the focused tests:
+
+```bash
+cargo test -p formualizer-bench-core --features c6_calibration \
+  --lib \
+  --bin probe-c6-target-locality \
+  --bin probe-c6-target-locality-matrix
+cargo check -p formualizer-bench-core --features c6_calibration --bins
+cargo clippy -p formualizer-bench-core --features c6_calibration --bins --tests -- -D warnings
+```
+
+Run a one-sample native smoke matrix:
+
+```bash
+cargo run --release -p formualizer-bench-core --features c6_calibration \
+  --bin probe-c6-target-locality-matrix -- \
+  --formulas 1000 --samples 1 --warm-repeats 1 --timeout-seconds 60 \
+  --output-dir target/c6-calibration/smoke
+```
+
+Run the required randomized seven-sample 50k matrix. The runner builds the release child once; use `--skip-build` only when that exact child is already built:
+
+```bash
+cargo run --release -p formualizer-bench-core --features c6_calibration \
+  --bin probe-c6-target-locality-matrix -- \
+  --formulas 50000 --samples 7 --warm-repeats 3 --timeout-seconds 600 \
+  --output-dir target/c6-calibration/native-50k
+```
+
+The child can also generate and inspect one case directly:
+
+```bash
+cargo run --release -p formualizer-bench-core --features c6_calibration \
+  --bin probe-c6-target-locality -- generate \
+  --fixture target/c6-calibration/manual-50000.xlsx --formulas 50000
+cargo run --release -p formualizer-bench-core --features c6_calibration \
+  --bin probe-c6-target-locality -- sample \
+  --fixture target/c6-calibration/manual-50000.xlsx --formulas 50000 \
+  --path plan --scope tiny --warm-repeats 3
+```
+
+## Outputs and interpretation
+
+The output directory contains:
+
+- `matrix-raw.json`: identity, randomized job order, per-child raw phase data, typed output/error fields, graph snapshots, request telemetry, RSS/HWM, and `/usr/bin/time -v` maximum RSS where available.
+- `matrix-summary.md`: median, nearest-rank p95, median absolute deviation, and maximum over successful samples.
+- the immutable fixture and its SHA-256 plus stderr and external-time logs.
+
+Machine-specific output stays under `target/c6-calibration/` and is not committed. Sample summaries include only `status: ok` children. The runner drains child stdout and stderr concurrently; on timeout it kills the complete child process group, including the `/usr/bin/time` wrapper and probe. Runs at 50,000 formulas or above enforce at least a 600-second per-child timeout.
+
+A summary timing cell is `median / p95 / MAD / max`. Percentiles use nearest rank; with seven values a per-child p95 equals the maximum, while the pooled repeated-API cells contain 21 observations. Every child is process-cold, but fixture reads are normally OS-page-cache-warm. Cold total includes XLSX open/load, the common dirty-branch setup, binding/target resolution, first evaluation, and preparation/plan build plus output read when those precede the first evaluation. SheetPort cold total is its one-shot path; the subsequent reusable batch-plan build is reported separately in the `prepare/plan` column and raw phases rather than double-counted into one-shot cold latency. The raw `includes` list is authoritative when a public API combines phases. In particular, `cells` cannot split preparation from evaluation/output, and SheetPort one-shot and batch calls cannot split all selector, edit, evaluation, restoration, and output-read subphases.
+
+Correctness does not rely only on agreement between APIs. For the finance recurrence, the harness computes every requested terminal after the initial seeds and every repeated edit from the closed form `B_n = B_1*r^(n-1) + A1*0.00001*(r^(n-1)-1)/(r-1)`, independently of the engine, and fails a sample on mismatch. It also asserts exact deferred, staged, prepared, and dirty counts for this deterministic fixture. Path shape is supported by the preparation scope/widening bits, requested/normalized targets, selected/retained staging, graph formula/edge deltas, target commit work, charged work, topology strategy/candidates/edges, materialization counts, dirty-lease outcome, and retained/scratch accounting. Formula count and target commit work are different units and are reported separately; the locality tolerance gate uses prepared formula deltas and selected staged formula counts only.
+
+SheetPort records three non-overwriting telemetry stages: `first_evaluation` immediately after one-shot evaluation, `sheetport_batch_plan_build` immediately after batch construction, and `sheetport_batch_execution` immediately after `batch.run` completes restoration. The summary identifies the latter two snapshots explicitly.
+
+## Current limitations
+
+This focused first deliverable covers deterministic independent scalar finance branches with Calamine native loading and the current default FormulaPlane mode. The SheetPort sample deliberately records both public modes in sequence: one-shot first, then batch creation/reuse on the already prepared workbook. Its separately reported batch-plan build is therefore not a second cold-path latency and is not directly setup-equivalent to the direct plan build on deferred staging. It does not yet add the remaining Phase A cross-sheet, name, bounded-layout, native-table, or dynamic/opaque widening fixture families. It also does not run 250k/largest-safe tiers, historical pre-C5 binaries, the broader native mode/budget matrix, WASM/no-disk, or recommend defaults. No algorithm, semantic behavior, cap, or default changes are part of this harness.
+
+The engine does not expose a stable allocator-specific counter. The harness therefore records process RSS/HWM, external maximum RSS, and existing request-ledger retained/scratch values. Failed child processes are preserved as typed matrix statuses with stderr; successful engine/SheetPort errors have a raw `typed_error` slot for parity, but the initial scalar fixture is expected to succeed and is not an error-injection suite.


### PR DESCRIPTION
## Summary

- add a feature-gated cold-process C6 target-locality child probe and randomized matrix runner
- compare full evaluation, ordinary `evaluate_cells`, reusable target plans, and actual SheetPort one-shot/batch paths
- generate deterministic independent finance chains at 0.5%, 10%, and 100% target scopes
- record phase timings, RSS/HWM, preparation/evaluation telemetry, exact staged/prepared counts, topology/resource evidence, fixture checksums, compiler/host identity, and raw per-sample output
- validate outputs against an analytical recurrence oracle independent of API parity
- document exact commands, interpretation limits, and generated-output policy

## Corrected 50k result

All 84 fresh-process samples passed analytical output parity, exact locality assertions, unrelated staged/dirty retention, and cross-path parity.

Median cold latency in milliseconds (`full / cells / plan / SheetPort`):

- 0.5% target: `861 / 100 / 100 / 101`
- 10% target: `882 / 513 / 517 / 514`
- 100% target: `860 / 4870 / 4820 / 4740`

Median warm API cost after one selected-branch edit:

- 0.5%: `full 0.16 / cells 21.23 / plan 0.23 / SheetPort 0.27`
- 10%: `full 3.37 / cells 1116 / plan 4.73 / SheetPort 5.44`
- 100% requested, 0.5% dirty: `full 0.16 / cells 76896 / plan 5.16 / SheetPort 4.99`

The harness exposed a genuine engine pathology: warm target discovery through ordinary `evaluate_cells` and SheetPort batch-plan construction is quadratic over populated point indexes. At 100% requested scope, cells warm cost is 76.9s median and SheetPort plan construction is 73.0s median, while retained-plan execution remains about 5ms. The harness does not change the algorithm or defaults.

## Validation

- 8 focused benchmark unit/smoke tests
- 12/12 smoke matrix samples
- 84/84 corrected 50k matrix samples
- strict affected-package Clippy
- default SheetPort check
- `cargo fmt --all -- --check`
- `git diff --check`
- fresh read-only review: `BENCHMARK_VALID: YES`, `MERGEABLE_HARNESS: YES`

Generated machine-specific JSON/Markdown/logs remain under ignored `target/c6-calibration/` and are not committed.

## Follow-up

A separate semantics-preserving optimization tranche should fix exact point lookup and warm target discovery before extending C6 to 250k, historical, mode/budget, and WASM/no-disk matrices.
