### PR TITLE
perf(eval): accelerate target point discovery

### DIFF
--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1804,6 +1804,30 @@ impl DependencyGraph {
             })
     }
 
+    #[cfg(test)]
+    pub(crate) fn reset_sheet_index_query_stats(&self) {
+        for index in self.sheet_indexes.values() {
+            index.reset_query_stats();
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sheet_index_query_stats(
+        &self,
+    ) -> crate::engine::sheet_index::SheetIndexQueryStats {
+        self.sheet_indexes.values().fold(
+            crate::engine::sheet_index::SheetIndexQueryStats::default(),
+            |mut total, index| {
+                let stats = index.query_stats();
+                total.coordinate_nodes_visited = total
+                    .coordinate_nodes_visited
+                    .saturating_add(stats.coordinate_nodes_visited);
+                total.values_visited = total.values_visited.saturating_add(stats.values_visited);
+                total
+            },
+        )
+    }
+
     /// Set a value in a cell, returns affected vertex IDs
     pub fn set_cell_value(
         &mut self,

--- a/crates/formualizer-eval/src/engine/interval_tree.rs
+++ b/crates/formualizer-eval/src/engine/interval_tree.rs
@@ -93,6 +93,67 @@ impl<T: Clone + Eq + std::hash::Hash> IntervalTree<T> {
         results
     }
 
+    /// Returns the values stored at the exact point interval `[point, point]`.
+    ///
+    /// Unlike [`Self::query`], this performs a direct B-tree lookup and therefore
+    /// does not inspect intervals whose lower bound precedes `point`.
+    pub(crate) fn point_values(&self, point: u32) -> Option<&HashSet<T>> {
+        self.map.get(&point).and_then(|nodes| {
+            nodes
+                .iter()
+                .find(|node| node.high == point)
+                .map(|node| &node.values)
+        })
+    }
+
+    /// Visits point intervals whose coordinate is in the inclusive query range.
+    ///
+    /// This is a specialized path for indexes that contain only `[x, x]`
+    /// intervals. General overlapping-range callers must continue to use
+    /// [`Self::query`] or [`Self::visit_query`]. `None` is emitted once for each
+    /// point-interval node inspected so callers can account deterministic visits.
+    pub(crate) fn visit_point_intervals(
+        &self,
+        q_low: u32,
+        q_high: u32,
+        mut visitor: impl FnMut(Option<&T>) -> ControlFlow<()>,
+    ) -> ControlFlow<()> {
+        if q_low > q_high {
+            return ControlFlow::Continue(());
+        }
+        for (&low, nodes) in self.map.range(q_low..=q_high) {
+            for node in nodes {
+                if node.high != low {
+                    continue;
+                }
+                visitor(None)?;
+                for value in &node.values {
+                    visitor(Some(value))?;
+                }
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
+    /// Counts point-interval nodes and values in an inclusive coordinate range.
+    /// This has the same point-only caller contract as [`Self::visit_point_intervals`].
+    pub(crate) fn point_interval_stats(&self, q_low: u32, q_high: u32) -> (usize, usize) {
+        if q_low > q_high {
+            return (0, 0);
+        }
+        let mut node_count = 0usize;
+        let mut value_count = 0usize;
+        for (&low, nodes) in self.map.range(q_low..=q_high) {
+            for node in nodes {
+                if node.high == low {
+                    node_count = node_count.saturating_add(1);
+                    value_count = value_count.saturating_add(node.values.len());
+                }
+            }
+        }
+        (node_count, value_count)
+    }
+
     /// Visits matching values without cloning or materializing the query.
     /// Returning `Break` from the visitor stops traversal immediately.
     pub(crate) fn visit_query(
@@ -256,6 +317,49 @@ mod tests {
         let results = tree.query(35, 45);
         assert_eq!(results.len(), 1);
         assert!(results[0].2.contains(&3));
+    }
+
+    #[test]
+    fn point_interval_visit_does_not_scan_coordinate_prefixes() {
+        let mut tree = IntervalTree::new();
+        for coordinate in 0..10_000 {
+            tree.insert(coordinate, coordinate, coordinate);
+        }
+
+        let mut nodes = 0;
+        let mut values = Vec::new();
+        let result = tree.visit_point_intervals(9_999, 9_999, |entry| {
+            match entry {
+                None => nodes += 1,
+                Some(value) => values.push(*value),
+            }
+            ControlFlow::Continue(())
+        });
+
+        assert_eq!(result, ControlFlow::Continue(()));
+        assert_eq!(nodes, 1);
+        assert_eq!(values, vec![9_999]);
+    }
+
+    #[test]
+    fn point_interval_path_does_not_change_general_overlap_queries() {
+        let mut tree = IntervalTree::new();
+        tree.insert(1, 100, "range");
+        tree.insert(75, 75, "point");
+
+        let general = tree.query(75, 75);
+        assert_eq!(general.len(), 2);
+        assert!(general.iter().any(|entry| entry.2.contains("range")));
+        assert!(general.iter().any(|entry| entry.2.contains("point")));
+
+        let mut point_values = Vec::new();
+        let _ = tree.visit_point_intervals(75, 75, |entry| {
+            if let Some(value) = entry {
+                point_values.push(*value);
+            }
+            ControlFlow::Continue(())
+        });
+        assert_eq!(point_values, vec!["point"]);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/engine/sheet_index.rs
+++ b/crates/formualizer-eval/src/engine/sheet_index.rs
@@ -2,6 +2,16 @@ use super::interval_tree::IntervalTree;
 use super::vertex::VertexId;
 use formualizer_common::Coord as AbsCoord;
 use std::collections::HashSet;
+use std::ops::ControlFlow;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct SheetIndexQueryStats {
+    pub coordinate_nodes_visited: usize,
+    pub values_visited: usize,
+}
 
 /// Sheet-level sparse index for efficient range queries on vertex positions.
 ///
@@ -44,6 +54,11 @@ pub struct SheetIndex {
     /// Column interval tree: maps column ranges → vertices in those columns  
     /// For a cell at (r,c), we store the point interval [c,c] → VertexId
     col_tree: IntervalTree<VertexId>,
+
+    #[cfg(test)]
+    query_coordinate_nodes_visited: AtomicUsize,
+    #[cfg(test)]
+    query_values_visited: AtomicUsize,
 }
 
 impl SheetIndex {
@@ -53,6 +68,10 @@ impl SheetIndex {
             memberships: HashSet::new(),
             row_tree: IntervalTree::new(),
             col_tree: IntervalTree::new(),
+            #[cfg(test)]
+            query_coordinate_nodes_visited: AtomicUsize::new(0),
+            #[cfg(test)]
+            query_values_visited: AtomicUsize::new(0),
         }
     }
 
@@ -137,15 +156,8 @@ impl SheetIndex {
             return;
         }
 
-        // Remove from row tree
-        if let Some(vertices) = self.row_tree.get_mut(row, row) {
-            vertices.remove(&vertex_id);
-        }
-
-        // Remove from column tree
-        if let Some(vertices) = self.col_tree.get_mut(col, col) {
-            vertices.remove(&vertex_id);
-        }
+        self.row_tree.remove(row, row, &vertex_id);
+        self.col_tree.remove(col, col, &vertex_id);
     }
 
     /// Update a vertex's position in the index (move operation).
@@ -157,18 +169,65 @@ impl SheetIndex {
         self.add_vertex(new_coord, vertex_id);
     }
 
+    fn record_coordinate_visits(&self, count: usize) {
+        #[cfg(test)]
+        self.query_coordinate_nodes_visited
+            .fetch_add(count, Ordering::Relaxed);
+        #[cfg(not(test))]
+        let _ = count;
+    }
+
+    fn record_value_visit(&self) {
+        #[cfg(test)]
+        self.query_values_visited.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn visit_axis_range(
+        &self,
+        tree: &IntervalTree<VertexId>,
+        start: u32,
+        end: u32,
+        mut visitor: impl FnMut(VertexId),
+    ) {
+        let _ = tree.visit_point_intervals(start, end, |entry| {
+            match entry {
+                None => self.record_coordinate_visits(1),
+                Some(vertex) => {
+                    self.record_value_visit();
+                    visitor(*vertex);
+                }
+            }
+            ControlFlow::Continue(())
+        });
+    }
+
+    fn axis_range_value_count(&self, tree: &IntervalTree<VertexId>, start: u32, end: u32) -> usize {
+        let (nodes, values) = tree.point_interval_stats(start, end);
+        self.record_coordinate_visits(nodes);
+        values
+    }
+
+    fn collect_axis_range(
+        &self,
+        tree: &IntervalTree<VertexId>,
+        start: u32,
+        end: u32,
+    ) -> HashSet<VertexId> {
+        let mut result = HashSet::new();
+        self.visit_axis_range(tree, start, end, |vertex| {
+            result.insert(vertex);
+        });
+        result
+    }
+
     /// Query all vertices in the given row range.
     ///
     /// ## Complexity
     /// O(log n + k) where k is the number of vertices in the range
     pub fn vertices_in_row_range(&self, start: u32, end: u32) -> Vec<VertexId> {
-        let mut result = HashSet::new();
-
-        for (_low, _high, values) in self.row_tree.query(start, end) {
-            result.extend(values.iter());
-        }
-
-        result.into_iter().collect()
+        self.collect_axis_range(&self.row_tree, start, end)
+            .into_iter()
+            .collect()
     }
 
     /// Query all vertices in the given column range.
@@ -176,19 +235,16 @@ impl SheetIndex {
     /// ## Complexity
     /// O(log n + k) where k is the number of vertices in the range
     pub fn vertices_in_col_range(&self, start: u32, end: u32) -> Vec<VertexId> {
-        let mut result = HashSet::new();
-
-        for (_low, _high, values) in self.col_tree.query(start, end) {
-            result.extend(values.iter());
-        }
-
-        result.into_iter().collect()
+        self.collect_axis_range(&self.col_tree, start, end)
+            .into_iter()
+            .collect()
     }
 
     /// Query all vertices in a rectangular range.
     ///
-    /// ## Complexity
-    /// O(log n + k) where k is the number of vertices in the range
+    /// Sheet indexes contain point intervals only, so exact-cell queries use two
+    /// direct B-tree lookups. Wider rectangles materialize only the cheaper axis
+    /// set and stream the other axis while intersecting it.
     pub fn vertices_in_rect(
         &self,
         start_row: u32,
@@ -196,20 +252,71 @@ impl SheetIndex {
         start_col: u32,
         end_col: u32,
     ) -> Vec<VertexId> {
-        // Get vertices in row range
-        let row_vertices: HashSet<_> = self
-            .vertices_in_row_range(start_row, end_row)
-            .into_iter()
-            .collect();
+        if start_row > end_row || start_col > end_col {
+            return Vec::new();
+        }
 
-        // Get vertices in column range
-        let col_vertices: HashSet<_> = self
-            .vertices_in_col_range(start_col, end_col)
-            .into_iter()
-            .collect();
+        if start_row == end_row && start_col == end_col {
+            self.record_coordinate_visits(2);
+            let Some(row_vertices) = self.row_tree.point_values(start_row) else {
+                return Vec::new();
+            };
+            let Some(col_vertices) = self.col_tree.point_values(start_col) else {
+                return Vec::new();
+            };
+            let (candidates, membership) = if row_vertices.len() <= col_vertices.len() {
+                (row_vertices, col_vertices)
+            } else {
+                (col_vertices, row_vertices)
+            };
+            return candidates
+                .iter()
+                .filter_map(|vertex| {
+                    self.record_value_visit();
+                    membership.contains(vertex).then_some(*vertex)
+                })
+                .collect();
+        }
 
-        // Return intersection - vertices that are in both ranges
-        row_vertices.intersection(&col_vertices).copied().collect()
+        let row_count = self.axis_range_value_count(&self.row_tree, start_row, end_row);
+        let col_count = self.axis_range_value_count(&self.col_tree, start_col, end_col);
+        let (candidates, other_tree, other_start, other_end) = if row_count <= col_count {
+            (
+                self.collect_axis_range(&self.row_tree, start_row, end_row),
+                &self.col_tree,
+                start_col,
+                end_col,
+            )
+        } else {
+            (
+                self.collect_axis_range(&self.col_tree, start_col, end_col),
+                &self.row_tree,
+                start_row,
+                end_row,
+            )
+        };
+        let mut result = Vec::with_capacity(candidates.len().min(row_count).min(col_count));
+        self.visit_axis_range(other_tree, other_start, other_end, |vertex| {
+            if candidates.contains(&vertex) {
+                result.push(vertex);
+            }
+        });
+        result
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reset_query_stats(&self) {
+        self.query_coordinate_nodes_visited
+            .store(0, Ordering::Relaxed);
+        self.query_values_visited.store(0, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn query_stats(&self) -> SheetIndexQueryStats {
+        SheetIndexQueryStats {
+            coordinate_nodes_visited: self.query_coordinate_nodes_visited.load(Ordering::Relaxed),
+            values_visited: self.query_values_visited.load(Ordering::Relaxed),
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -393,5 +500,149 @@ mod tests {
 
         // Should find 11 rows (500, 600, ..., 1500) × 6 columns (2-7) = 66 vertices
         assert_eq!(viewport.len(), 66);
+    }
+
+    #[test]
+    fn exact_cell_query_visits_only_exact_coordinate_buckets() {
+        let mut index = SheetIndex::new();
+        for row in 0..10_000 {
+            index.add_vertex(AbsCoord::new(row, 7), VertexId(1024 + row));
+        }
+
+        index.reset_query_stats();
+        assert_eq!(
+            index.vertices_in_rect(9_999, 9_999, 7, 7),
+            vec![VertexId(11_023)]
+        );
+        assert_eq!(
+            index.query_stats(),
+            SheetIndexQueryStats {
+                coordinate_nodes_visited: 2,
+                values_visited: 1,
+            }
+        );
+    }
+
+    fn sorted(mut vertices: Vec<VertexId>) -> Vec<VertexId> {
+        vertices.sort_unstable();
+        vertices
+    }
+
+    fn assert_query_parity(
+        index: &SheetIndex,
+        model: &[(AbsCoord, VertexId)],
+        start_row: u32,
+        end_row: u32,
+        start_col: u32,
+        end_col: u32,
+    ) {
+        let naive_rect = model
+            .iter()
+            .filter_map(|(coord, vertex)| {
+                (coord.row() >= start_row
+                    && coord.row() <= end_row
+                    && coord.col() >= start_col
+                    && coord.col() <= end_col)
+                    .then_some(*vertex)
+            })
+            .collect::<Vec<_>>();
+        let naive_rows = model
+            .iter()
+            .filter_map(|(coord, vertex)| {
+                (coord.row() >= start_row && coord.row() <= end_row).then_some(*vertex)
+            })
+            .collect::<Vec<_>>();
+        let naive_cols = model
+            .iter()
+            .filter_map(|(coord, vertex)| {
+                (coord.col() >= start_col && coord.col() <= end_col).then_some(*vertex)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            sorted(index.vertices_in_rect(start_row, end_row, start_col, end_col)),
+            sorted(naive_rect)
+        );
+        assert_eq!(
+            sorted(index.vertices_in_row_range(start_row, end_row)),
+            sorted(naive_rows)
+        );
+        assert_eq!(
+            sorted(index.vertices_in_col_range(start_col, end_col)),
+            sorted(naive_cols)
+        );
+    }
+
+    #[test]
+    fn point_range_rectangle_sparse_move_remove_and_randomized_queries_match_naive_filtering() {
+        let mut state = 0x5eed_cafe_u64;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1);
+            (state >> 32) as u32
+        };
+        let mut model = (0..300)
+            .map(|offset| {
+                let row = if offset < 5 {
+                    offset * 200_000
+                } else {
+                    next() % 2_000
+                };
+                let col = if offset < 5 { offset * 20 } else { next() % 80 };
+                (AbsCoord::new(row, col), VertexId(1024 + offset))
+            })
+            .collect::<Vec<_>>();
+
+        let mut incremental = SheetIndex::new();
+        for &(coord, vertex) in &model {
+            incremental.add_vertex(coord, vertex);
+        }
+        let mut bulk_items = model.clone();
+        bulk_items.sort_unstable_by_key(|(coord, _)| (coord.row(), coord.col()));
+        let mut bulk = SheetIndex::new();
+        bulk.build_from_sorted(&bulk_items);
+
+        for index in [&incremental, &bulk] {
+            assert_query_parity(index, &model, 1_500, 1_500, 40, 40);
+            assert_query_parity(index, &model, 500, 1_500, 0, 79);
+            assert_query_parity(index, &model, 0, u32::MAX, 20, 40);
+            assert_query_parity(index, &model, 0, 800_000, 0, 80);
+        }
+
+        for (offset, entry) in model.iter_mut().take(40).enumerate() {
+            let (old_coord, vertex) = *entry;
+            let new_coord = AbsCoord::new(3_000 + offset as u32, 100 + offset as u32 % 7);
+            incremental.update_vertex(old_coord, new_coord, vertex);
+            bulk.update_vertex(old_coord, new_coord, vertex);
+            entry.0 = new_coord;
+        }
+        for _ in 0..30 {
+            let index = (next() as usize) % model.len();
+            let (coord, vertex) = model.swap_remove(index);
+            incremental.remove_vertex(coord, vertex);
+            bulk.remove_vertex(coord, vertex);
+        }
+        let point = model[0].0;
+        for index in [&incremental, &bulk] {
+            assert_query_parity(
+                index,
+                &model,
+                point.row(),
+                point.row(),
+                point.col(),
+                point.col(),
+            );
+        }
+
+        for _ in 0..200 {
+            let row_a = next() % 4_000;
+            let row_b = next() % 4_000;
+            let col_a = next() % 120;
+            let col_b = next() % 120;
+            let (start_row, end_row) = (row_a.min(row_b), row_a.max(row_b));
+            let (start_col, end_col) = (col_a.min(col_b), col_a.max(col_b));
+            assert_query_parity(&incremental, &model, start_row, end_row, start_col, end_col);
+            assert_query_parity(&bulk, &model, start_row, end_row, start_col, end_col);
+        }
     }
 }

--- a/crates/formualizer-eval/src/engine/tests/recalc_plan.rs
+++ b/crates/formualizer-eval/src/engine/tests/recalc_plan.rs
@@ -367,6 +367,100 @@ fn target_plan_layer_count_documents_run_local_recipe() -> Result<(), ExcelError
 }
 
 #[test]
+fn prepared_chain_cells_and_rebuilt_target_plans_have_bounded_exact_index_visits()
+-> Result<(), ExcelError> {
+    const FORMULAS: u32 = 256;
+    const REPEATS: usize = 3;
+
+    fn setup() -> Result<Engine<TestWorkbook>, ExcelError> {
+        let mut engine = make_engine();
+        engine.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))?;
+        engine.set_cell_formula("Sheet1", 1, 2, parse("=A1*2").unwrap())?;
+        for row in 2..=FORMULAS {
+            engine.set_cell_formula(
+                "Sheet1",
+                row,
+                2,
+                parse(format!("=B{}+1", row - 1)).unwrap(),
+            )?;
+        }
+        engine.set_cell_formula("Sheet1", 1, 3, parse("=1/0").unwrap())?;
+        engine.set_cell_value("Sheet1", 1, 5, LiteralValue::Int(10))?;
+        engine.set_cell_formula("Sheet1", 1, 4, parse("=E1*2").unwrap())?;
+        engine.evaluate_all()?;
+        Ok(engine)
+    }
+
+    let mut cells = setup()?;
+    let mut plans = setup()?;
+    let cell_targets = [("Sheet1", FORMULAS, 2), ("Sheet1", 1, 3)];
+    let typed_targets = [
+        EvaluationTarget::Cell {
+            sheet: "Sheet1".to_string(),
+            row: FORMULAS,
+            col: 2,
+        },
+        EvaluationTarget::Cell {
+            sheet: "Sheet1".to_string(),
+            row: 1,
+            col: 3,
+        },
+    ];
+
+    cells.graph.reset_sheet_index_query_stats();
+    plans.graph.reset_sheet_index_query_stats();
+    for value in 2..2 + REPEATS as i64 {
+        for engine in [&mut cells, &mut plans] {
+            engine.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(value))?;
+            engine.set_cell_value("Sheet1", 1, 5, LiteralValue::Int(value + 10))?;
+        }
+        assert_eq!(
+            cells.baseline_stats().dirty_vertex_count,
+            plans.baseline_stats().dirty_vertex_count
+        );
+
+        let cell_values = cells.evaluate_cells(&cell_targets)?;
+        let plan = plans.build_recalc_plan_for_targets(&typed_targets)?;
+        plans.evaluate_recalc_plan(&plan)?;
+        let plan_values = cell_targets
+            .iter()
+            .map(|(sheet, row, col)| plans.get_cell_value(sheet, *row, *col))
+            .collect::<Vec<_>>();
+
+        assert_eq!(cell_values, plan_values);
+        assert!(matches!(cell_values[1], Some(LiteralValue::Error(_))));
+        assert_eq!(
+            cells.baseline_stats().dirty_vertex_count,
+            plans.baseline_stats().dirty_vertex_count
+        );
+        assert_eq!(
+            cells.get_cell_value("Sheet1", 1, 4),
+            Some(LiteralValue::Number(20.0))
+        );
+        assert_eq!(
+            plans.get_cell_value("Sheet1", 1, 4),
+            Some(LiteralValue::Number(20.0))
+        );
+    }
+
+    let linear_visit_bound = (FORMULAS as usize + 4) * REPEATS * 4;
+    for stats in [
+        cells.graph.sheet_index_query_stats(),
+        plans.graph.sheet_index_query_stats(),
+    ] {
+        assert!(
+            stats.coordinate_nodes_visited <= linear_visit_bound,
+            "exact target discovery visited too many coordinate nodes: {stats:?}"
+        );
+        assert!(
+            stats.values_visited <= linear_visit_bound,
+            "exact target discovery visited too many values: {stats:?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn recalc_plan_reused_for_multiple_runs() -> Result<(), ExcelError> {
     let mut engine = make_engine();
     engine.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))?;


### PR DESCRIPTION
## Summary

- add point-specialized interval traversal for SheetIndex, whose row/column memberships are exclusively point intervals
- make exact-cell queries inspect only the matching row and column buckets instead of scanning coordinate prefixes
- make wider rectangular queries materialize only the cheaper axis and filter candidates by coordinates
- preserve generic overlapping `IntervalTree` queries used by spill-region locks
- remove empty point buckets correctly during vertex removal
- add deterministic query counters, randomized naive-filter parity, lifecycle tests, and repeated target-evaluation/plan equivalence coverage

## Motivation

The C6 target-locality harness in PR #200 found that warm target discovery over a fully populated 50k graph was quadratic. Every exact formula-cell region used `IntervalTree::query`, which scanned all interval starts up to the target coordinate. Across a chain this produced prefix work proportional to `1 + 2 + ... + n`.

## 50k result

All 84 seven-sample C6 matrix children passed analytical output parity, exact locality assertions, staged/dirty retention, and cross-path parity.

- `evaluate_cells` full-scope warm API: `74–75s` diagnostic baseline → `3.714s` median / `3.888s` p95
- SheetPort full-scope batch-plan build: `75.020s` → `3.693s` median / `3.745s` p95
- Cold first target evaluation: effectively unchanged around `4.6s`
- Cold direct target-plan build: effectively unchanged around `4.4s`
- Retained full target-plan warm execution: `1.91ms` median
- Warm discovery scales near-linearly: `250 = 18.2ms`, `5k = 375.9ms`, `50k = 3.714s`

The remaining ordinary `evaluate_cells` cost is linear recipe rediscovery; retained plans avoid it.

## Validation

- full `formualizer-eval` suite: 2382 passed, 12 ignored
- focused interval-tree, SheetIndex, and recalc-plan tests
- randomized exact/row/column/rectangle parity across incremental and bulk indexes, moves, and removals
- C6 smoke matrix
- full randomized seven-sample 50k C6 matrix: 84/84 passed
- strict eval and C6 Clippy
- formatting and diff checks
- fresh review: `MERGEABLE: YES`

No resource defaults, widening policy, dirty ownership, budget semantics, FormulaPlane mode, or generic spill-lock overlap behavior changes.
