### PR TITLE
tokenizer: treat CR and TAB as whitespace (fix CRLF parse failures)

### DIFF
--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -2138,5 +2138,27 @@ mod tests {
                         .any(|t| t.0 == TokenType::OpInfix && t.2 == " ")
             );
         }
+
+        #[test]
+        fn crlf_and_tabs_are_whitespace() {
+            // Regression: the tokenizer treated only ' ' and '\n' as whitespace,
+            // so the Windows CRLF sequence "\r\n" (Alt+Enter line breaks) and tabs
+            // broke parsing — even though '\r' and '\n' individually did not.
+            for f in [
+                "=SUM(\r\n1,2\r\n)", // Apache POI test-data case
+                "=A1 +\r\n B1",
+                "=IF(A1,\r\nB1)",
+                "=SUM(A1,\tA2)",
+                "=\tSUM(A1,A2)\t",
+            ] {
+                assert!(Tokenizer::new(f).is_ok(), "failed to tokenize {f:?}");
+            }
+            // CRLF/tab whitespace is filtered out, leaving the real tokens intact.
+            let toks = classic_non_ws("=SUM(\r\n1,2\r\n)");
+            assert!(
+                toks.iter().any(|t| t.2.starts_with("SUM")),
+                "expected SUM token, got {toks:?}"
+            );
+        }
     }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -662,7 +662,7 @@ fn is_reference_operand_value(value: &str) -> bool {
 
 fn next_starts_reference_expression(formula: &str, mut offset: usize) -> bool {
     let bytes = formula.as_bytes();
-    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\n') {
+    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\t' | b'\r' | b'\n') {
         offset += 1;
     }
     if offset >= bytes.len() {
@@ -674,7 +674,7 @@ fn next_starts_reference_expression(formula: &str, mut offset: usize) -> bool {
 
 fn next_reference_has_sheet_qualifier(formula: &str, mut offset: usize) -> bool {
     let bytes = formula.as_bytes();
-    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\n') {
+    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\t' | b'\r' | b'\n') {
         offset += 1;
     }
 
@@ -690,7 +690,7 @@ fn next_reference_has_sheet_qualifier(formula: &str, mut offset: usize) -> bool 
             }
             b'!' => return true,
             b':' if !in_quote => return false,
-            b',' | b';' | b'}' | b')' | b' ' | b'\n' | b'+' | b'-' | b'*' | b'/' | b'^' | b'&'
+            b',' | b';' | b'}' | b')' | b' ' | b'\t' | b'\r' | b'\n' | b'+' | b'-' | b'*' | b'/' | b'^' | b'&'
             | b'=' | b'>' | b'<' | b'%' | b'@'
                 if !in_quote =>
             {
@@ -878,7 +878,7 @@ impl<'a> SpanTokenizer<'a> {
                         self.parse_error()
                     }
                 }
-                b' ' | b'\n' => self.parse_whitespace(),
+                b' ' | b'\t' | b'\r' | b'\n' => self.parse_whitespace(),
                 b':' => {
                     if self.should_emit_colon_infix() {
                         self.emit_infix_operator(self.offset, self.offset + 1);
@@ -1212,6 +1212,8 @@ impl<'a> SpanTokenizer<'a> {
             let ch = self.formula.as_bytes()[end];
             if is_token_ender(ch)
                 || ch == b' '
+                || ch == b'\t'
+                || ch == b'\r'
                 || ch == b'\n'
                 || ch == b'('
                 || ch == b'{'
@@ -1239,7 +1241,7 @@ impl<'a> SpanTokenizer<'a> {
         let ws_start = self.offset;
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
-                b' ' | b'\n' => self.offset += 1,
+                b' ' | b'\t' | b'\r' | b'\n' => self.offset += 1,
                 _ => break,
             }
         }
@@ -1650,7 +1652,7 @@ impl Tokenizer {
                         self.parse_error()?
                     }
                 }
-                b' ' | b'\n' => self.parse_whitespace()?,
+                b' ' | b'\t' | b'\r' | b'\n' => self.parse_whitespace()?,
                 b':' => {
                     if self.should_emit_colon_infix() {
                         self.emit_infix_operator(self.offset, self.offset + 1);
@@ -1987,7 +1989,7 @@ impl Tokenizer {
         let ws_start = self.offset;
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
-                b' ' | b'\n' => self.offset += 1,
+                b' ' | b'\t' | b'\r' | b'\n' => self.offset += 1,
                 _ => break,
             }
         }


### PR DESCRIPTION
Hi, 
this is another minor bug report and fix, this time for embedded newline  and carriage return characters in formulas. I found it while doing some back-testing on parsing formulas from large corpuses of spreadsheets. Claude Code generated the fix, the test fixtures, and the remainder of this text in the PR. All existing tests continued to pass with the fix incorporated so I hope you will the PR fit for use. I guess for completeness you could put in the two remaining ASCII whitespace characters, \v and \f (vertical tab and form-feed, respectively) but I have never encountered them in the wild as whitespace.


The tokenizer's whitespace set was `b' ' | b'\n'` — only space and LF. Carriage return (`\r`) and tab (`\t`) were not whitespace, so they fell through to the operand accumulator. A lone `\r` (e.g. in `SUM(A1,\rA2)`) usually got absorbed into an adjacent operand and survived, but the Windows CRLF sequence `\r\n` produced a stray operand token consisting of just `\r`, which the parser then rejected — so multi-line formulas entered with Alt+Enter (`SUM(\r\n1,2\r\n)`) failed to parse even though `\r` and `\n` individually did not.

Add `\r` and `\t` to every whitespace site (both the Tokenizer and SpanTokenizer dispatch + parse_whitespace consume loops, the boundary check, and the token-run scanner), mirroring the existing `\n` handling. parse_whitespace already saves the pending token, so no TOKEN_ENDERS change is needed.

Found by stress-testing the parser over a large real corpus (Enron) and independently reproduced by Apache POI's own `SUM(\r\n1,2\r\n)` test-data case.