### PR TITLE
perf(bench): broaden C6 native calibration

### DIFF
--- a/crates/formualizer-bench-core/src/bin/probe-c6-target-locality-matrix.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-c6-target-locality-matrix.rs
@@ -16,13 +16,14 @@ use std::time::{Duration, Instant};
 #[cfg(feature = "c6_calibration")]
 use anyhow::{Context, Result, bail};
 #[cfg(feature = "c6_calibration")]
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 #[cfg(feature = "c6_calibration")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "c6_calibration")]
 use formualizer_bench_core::c6_calibration::{
-    CalibrationPath, ChildReport, Distribution, TargetScope, distribution, sha256_file,
+    CalibrationPath, ChildReport, Distribution, FixtureFamily, TargetScope, distribution,
+    path_supported, sha256_file,
 };
 
 #[cfg(not(feature = "c6_calibration"))]
@@ -32,9 +33,30 @@ fn main() {
 }
 
 #[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CalibrationTier {
+    AllFamilySmoke,
+    Breadth50k,
+    Scalar250k,
+    LargestSafe,
+}
+
+#[cfg(feature = "c6_calibration")]
 #[derive(Debug, Clone, Parser)]
 #[command(about = "Run randomized fresh-process C6 target-locality samples")]
 struct Cli {
+    /// Named acceptance tier. Tier values intentionally override matrix sizing.
+    #[arg(long, value_enum)]
+    tier: Option<CalibrationTier>,
+
+    /// Fixture families. The default remains the original scalar matrix.
+    #[arg(
+        long,
+        value_enum,
+        value_delimiter = ',',
+        default_values_t = [FixtureFamily::Scalar]
+    )]
+    families: Vec<FixtureFamily>,
     /// Total formula count across the deterministic independent branches.
     #[arg(long, default_value_t = 50_000)]
     formulas: u32,
@@ -92,9 +114,18 @@ struct RunIdentity {
 #[cfg(feature = "c6_calibration")]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct Job {
+    family: FixtureFamily,
     path: CalibrationPath,
     scope: TargetScope,
     sample: usize,
+}
+
+#[cfg(feature = "c6_calibration")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FixtureIdentity {
+    family: FixtureFamily,
+    path: String,
+    sha256: String,
 }
 
 #[cfg(feature = "c6_calibration")]
@@ -112,11 +143,15 @@ struct SampleResult {
 #[cfg(feature = "c6_calibration")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CaseSummary {
+    family: FixtureFamily,
+    selector_set: String,
     path: CalibrationPath,
     scope: TargetScope,
     successful_samples: usize,
     cold_total_ms: Option<Distribution>,
     load_ms: Option<Distribution>,
+    selector_setup_ms: Option<Distribution>,
+    name_binding_probe_ms: Option<Distribution>,
     bind_resolution_ms: Option<Distribution>,
     preparation_plan_ms: Option<Distribution>,
     first_evaluation_ms: Option<Distribution>,
@@ -136,6 +171,7 @@ struct CaseSummary {
     exact_locality_counts_all_passed: bool,
     unrelated_staged_all_retained: bool,
     unrelated_dirty_all_retained: bool,
+    family_gates_all_passed: bool,
 }
 
 #[cfg(feature = "c6_calibration")]
@@ -143,6 +179,7 @@ struct CaseSummary {
 struct MatrixReport {
     schema_version: u32,
     identity: RunIdentity,
+    families: Vec<FixtureFamily>,
     formulas: u32,
     samples_per_case: usize,
     warm_repeats: usize,
@@ -150,6 +187,7 @@ struct MatrixReport {
     random_seed: u64,
     fixture_path: String,
     fixture_sha256: String,
+    fixtures: Vec<FixtureIdentity>,
     randomized_jobs: Vec<Job>,
     results: Vec<SampleResult>,
     summaries: Vec<CaseSummary>,
@@ -164,14 +202,34 @@ fn main() -> Result<()> {
 
 #[cfg(feature = "c6_calibration")]
 fn run(mut cli: Cli) -> Result<()> {
+    apply_tier(&mut cli)?;
     if cli.formulas >= 50_000 {
         cli.timeout_seconds = cli.timeout_seconds.max(600);
+    }
+    if cli.formulas >= 250_000 {
+        cli.timeout_seconds = cli.timeout_seconds.max(1_800);
     }
     if cli.samples == 0 {
         bail!("--samples must be greater than zero");
     }
-    if cli.paths.is_empty() || cli.scopes.is_empty() {
-        bail!("--paths and --scopes must not be empty");
+    if cli.families.is_empty() || cli.paths.is_empty() || cli.scopes.is_empty() {
+        bail!("--families, --paths, and --scopes must not be empty");
+    }
+    if cli.tier.is_none() {
+        for &family in &cli.families {
+            for &scope in &cli.scopes {
+                for &path in &cli.paths {
+                    if !job_supported(family, path, scope) {
+                        bail!(
+                            "unsupported family/path/scope combination: {}/{}/{}",
+                            family.label(),
+                            path.label(),
+                            scope.label()
+                        );
+                    }
+                }
+            }
+        }
     }
     let root = repo_root();
     fs::create_dir_all(&cli.output_dir)?;
@@ -186,29 +244,53 @@ fn run(mut cli: Cli) -> Result<()> {
         );
     }
 
-    let fixture = cli
-        .output_dir
-        .join(format!("fixture-{}.xlsx", cli.formulas));
-    let generation_log = cli.output_dir.join("fixture-generation.stderr.log");
-    let generation = run_process(
-        command_for_generate(&probe, &fixture, cli.formulas),
-        Duration::from_secs(cli.timeout_seconds),
-        &generation_log,
-    )?;
-    if !generation.success {
-        bail!("fixture generation failed: {}", generation.error);
+    let mut fixture_paths = BTreeMap::new();
+    let mut fixtures = Vec::new();
+    for &family in &cli.families {
+        let fixture =
+            cli.output_dir
+                .join(format!("fixture-{}-{}.xlsx", family.label(), cli.formulas));
+        let generation_log = cli
+            .output_dir
+            .join(format!("fixture-{}-generation.stderr.log", family.label()));
+        let generation = run_process(
+            command_for_generate(&probe, &fixture, cli.formulas, family),
+            Duration::from_secs(cli.timeout_seconds),
+            &generation_log,
+        )?;
+        if !generation.success {
+            bail!(
+                "{} fixture generation failed: {}",
+                family.label(),
+                generation.error
+            );
+        }
+        let sha256 = sha256_file(&fixture)?;
+        fixtures.push(FixtureIdentity {
+            family,
+            path: fixture.display().to_string(),
+            sha256,
+        });
+        fixture_paths.insert(family, fixture);
     }
-    let fixture_sha256 = sha256_file(&fixture)?;
+    let legacy_fixture = fixtures.first().context("at least one fixture")?;
+    let fixture_path = legacy_fixture.path.clone();
+    let fixture_sha256 = legacy_fixture.sha256.clone();
 
     let mut jobs = Vec::new();
     for sample in 1..=cli.samples {
-        for &scope in &cli.scopes {
-            for &path in &cli.paths {
-                jobs.push(Job {
-                    path,
-                    scope,
-                    sample,
-                });
+        for &family in &cli.families {
+            for &scope in &cli.scopes {
+                for &path in &cli.paths {
+                    if job_supported(family, path, scope) {
+                        jobs.push(Job {
+                            family,
+                            path,
+                            scope,
+                            sample,
+                        });
+                    }
+                }
             }
         }
     }
@@ -217,42 +299,50 @@ fn run(mut cli: Cli) -> Result<()> {
     let mut results = Vec::with_capacity(jobs.len());
     for (order, job) in jobs.iter().copied().enumerate() {
         eprintln!(
-            "[c6] {}/{} path={} scope={} sample={}",
+            "[c6] {}/{} family={} path={} scope={} sample={}",
             order + 1,
             jobs.len(),
+            job.family.label(),
             job.path.label(),
             job.scope.label(),
             job.sample
         );
         let stderr_log = cli.output_dir.join(format!(
-            "{:03}-{}-{}-sample{}.stderr.log",
+            "{:03}-{}-{}-{}-sample{}.stderr.log",
             order + 1,
+            job.family.label(),
             job.path.label(),
             job.scope.label(),
             job.sample
         ));
         let time_log = cli.output_dir.join(format!(
-            "{:03}-{}-{}-sample{}.time.log",
+            "{:03}-{}-{}-{}-sample{}.time.log",
             order + 1,
+            job.family.label(),
             job.path.label(),
             job.scope.label(),
             job.sample
         ));
-        results.push(run_job(&probe, &fixture, job, &cli, &stderr_log, &time_log));
+        let fixture = fixture_paths
+            .get(&job.family)
+            .expect("fixture generated for every family");
+        results.push(run_job(&probe, fixture, job, &cli, &stderr_log, &time_log));
     }
 
     let summaries = summarize(&results, &cli);
-    let parity_by_scope = parity(&results, &cli.scopes);
+    let parity_by_scope = parity(&results);
     let report = MatrixReport {
-        schema_version: 1,
+        schema_version: 3,
         identity: identity(&root),
+        families: cli.families.clone(),
         formulas: cli.formulas,
         samples_per_case: cli.samples,
         warm_repeats: cli.warm_repeats,
         timeout_seconds: cli.timeout_seconds,
         random_seed: cli.seed,
-        fixture_path: fixture.display().to_string(),
+        fixture_path,
         fixture_sha256,
+        fixtures,
         randomized_jobs: jobs,
         results,
         summaries,
@@ -276,6 +366,50 @@ fn run(mut cli: Cli) -> Result<()> {
         bail!("output/error parity failed");
     }
     Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+fn apply_tier(cli: &mut Cli) -> Result<()> {
+    match cli.tier {
+        None => {}
+        Some(CalibrationTier::AllFamilySmoke) => {
+            cli.formulas = 1_000;
+            cli.samples = 1;
+            cli.warm_repeats = 1;
+            cli.timeout_seconds = cli.timeout_seconds.max(120);
+            cli.families = FixtureFamily::ALL.to_vec();
+            cli.paths = CalibrationPath::ALL.to_vec();
+            cli.scopes = TargetScope::ALL.to_vec();
+        }
+        Some(CalibrationTier::Breadth50k) => {
+            cli.formulas = 50_000;
+            cli.samples = 7;
+            cli.warm_repeats = 3;
+            cli.timeout_seconds = cli.timeout_seconds.max(600);
+            cli.families = FixtureFamily::BREADTH.to_vec();
+            cli.paths = CalibrationPath::ALL.to_vec();
+            cli.scopes = vec![TargetScope::Full];
+        }
+        Some(CalibrationTier::Scalar250k) => {
+            cli.formulas = 250_000;
+            cli.samples = 7;
+            cli.warm_repeats = 3;
+            cli.timeout_seconds = cli.timeout_seconds.max(1_800);
+            cli.families = vec![FixtureFamily::Scalar];
+            cli.paths = CalibrationPath::SCALAR_V2.to_vec();
+            cli.scopes = TargetScope::ALL.to_vec();
+        }
+        Some(CalibrationTier::LargestSafe) => {
+            bail!("largest-safe is intentionally unsupported in Phase A")
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "c6_calibration")]
+const fn job_supported(family: FixtureFamily, path: CalibrationPath, scope: TargetScope) -> bool {
+    path_supported(family, path)
+        && (matches!(family, FixtureFamily::Scalar) || matches!(scope, TargetScope::Full))
 }
 
 #[cfg(feature = "c6_calibration")]
@@ -326,14 +460,21 @@ fn build_child(root: &Path) -> Result<()> {
 }
 
 #[cfg(feature = "c6_calibration")]
-fn command_for_generate(probe: &Path, fixture: &Path, formulas: u32) -> Command {
+fn command_for_generate(
+    probe: &Path,
+    fixture: &Path,
+    formulas: u32,
+    family: FixtureFamily,
+) -> Command {
     let mut command = Command::new(probe);
     command
         .arg("generate")
         .arg("--fixture")
         .arg(fixture)
         .arg("--formulas")
-        .arg(formulas.to_string());
+        .arg(formulas.to_string())
+        .arg("--family")
+        .arg(family.cli_label());
     command
 }
 
@@ -345,6 +486,8 @@ fn sample_args(fixture: &Path, job: Job, cli: &Cli) -> Vec<String> {
         fixture.display().to_string(),
         "--formulas".to_string(),
         cli.formulas.to_string(),
+        "--family".to_string(),
+        job.family.cli_label().to_string(),
         "--path".to_string(),
         job.path.label().to_string(),
         "--scope".to_string(),
@@ -544,197 +687,235 @@ fn shuffle<T>(values: &mut [T], seed: u64) {
 #[cfg(feature = "c6_calibration")]
 fn summarize(results: &[SampleResult], cli: &Cli) -> Vec<CaseSummary> {
     let mut summaries = Vec::new();
-    for &scope in &cli.scopes {
-        for &path in &cli.paths {
-            let children = results
-                .iter()
-                .filter(|result| result.job.path == path && result.job.scope == scope)
-                .filter_map(|result| result.child.as_ref())
-                .filter(|child| child.status == "ok")
-                .collect::<Vec<_>>();
-            let phase = |extract: fn(&ChildReport) -> Option<f64>| {
-                distribution(
-                    &children
-                        .iter()
-                        .filter_map(|child| extract(child))
-                        .collect::<Vec<_>>(),
-                )
-            };
-            let flattened = |extract: fn(&ChildReport) -> Vec<f64>| {
-                distribution(
-                    &children
-                        .iter()
-                        .flat_map(|child| extract(child))
-                        .collect::<Vec<_>>(),
-                )
-            };
-            let cold_total_ms = distribution(
-                &children
+    for &family in &cli.families {
+        for &scope in &cli.scopes {
+            for &path in &cli.paths {
+                if !job_supported(family, path, scope) {
+                    continue;
+                }
+                let children = results
                     .iter()
-                    .map(|child| {
-                        [
-                            child.phases.load.as_ref(),
-                            child.phases.unrelated_dirty_setup.as_ref(),
-                            child.phases.bind_target_resolution.as_ref(),
-                            if path == CalibrationPath::Sheetport {
-                                None
-                            } else {
-                                child.phases.preparation_plan_build.as_ref()
-                            },
-                            child.phases.first_evaluation.as_ref(),
-                            child.phases.output_read.as_ref(),
-                        ]
-                        .into_iter()
-                        .flatten()
-                        .map(|phase| phase.milliseconds)
-                        .sum()
+                    .filter(|result| {
+                        result.job.family == family
+                            && result.job.path == path
+                            && result.job.scope == scope
                     })
-                    .collect::<Vec<_>>(),
-            );
-            let rss = results
-                .iter()
-                .filter(|result| {
-                    result.job.path == path
-                        && result.job.scope == scope
-                        && result.status == "ok"
-                        && result
-                            .child
-                            .as_ref()
-                            .is_some_and(|child| child.status == "ok")
-                })
-                .filter_map(|result| {
-                    result
-                        .external_max_rss_bytes
-                        .or_else(|| result.child.as_ref()?.peak_rss_bytes)
-                })
-                .map(|bytes| bytes as f64)
-                .collect::<Vec<_>>();
-            let prepared = children
-                .iter()
-                .filter_map(|child| {
-                    Some(
-                        child
-                            .graph_after_run
-                            .as_ref()?
-                            .graph_formula_vertices
-                            .saturating_sub(
-                                child.graph_after_setup.as_ref()?.graph_formula_vertices,
-                            ) as u64,
+                    .filter_map(|result| result.child.as_ref())
+                    .filter(|child| child.status == "ok")
+                    .collect::<Vec<_>>();
+                let phase = |extract: fn(&ChildReport) -> Option<f64>| {
+                    distribution(
+                        &children
+                            .iter()
+                            .filter_map(|child| extract(child))
+                            .collect::<Vec<_>>(),
                     )
-                })
-                .max();
-            let max_telemetry =
-                |extract: fn(&formualizer_bench_core::c6_calibration::EngineTelemetry) -> u64| {
+                };
+                let flattened = |extract: fn(&ChildReport) -> Vec<f64>| {
+                    distribution(
+                        &children
+                            .iter()
+                            .flat_map(|child| extract(child))
+                            .collect::<Vec<_>>(),
+                    )
+                };
+                let cold_total_ms = distribution(
+                    &children
+                        .iter()
+                        .map(|child| {
+                            [
+                                child.phases.load.as_ref(),
+                                child.phases.unrelated_dirty_setup.as_ref(),
+                                child.phases.selector_setup.as_ref(),
+                                child.phases.bind_target_resolution.as_ref(),
+                                if path == CalibrationPath::Sheetport {
+                                    None
+                                } else {
+                                    child.phases.preparation_plan_build.as_ref()
+                                },
+                                child.phases.first_evaluation.as_ref(),
+                                child.phases.output_read.as_ref(),
+                            ]
+                            .into_iter()
+                            .flatten()
+                            .map(|phase| phase.milliseconds)
+                            .sum()
+                        })
+                        .collect::<Vec<_>>(),
+                );
+                let rss = results
+                    .iter()
+                    .filter(|result| {
+                        result.job.family == family
+                            && result.job.path == path
+                            && result.job.scope == scope
+                            && result.status == "ok"
+                            && result
+                                .child
+                                .as_ref()
+                                .is_some_and(|child| child.status == "ok")
+                    })
+                    .filter_map(|result| {
+                        result
+                            .external_max_rss_bytes
+                            .or_else(|| result.child.as_ref()?.peak_rss_bytes)
+                    })
+                    .map(|bytes| bytes as f64)
+                    .collect::<Vec<_>>();
+                let prepared = children
+                    .iter()
+                    .filter_map(|child| {
+                        Some(
+                            child
+                                .graph_after_run
+                                .as_ref()?
+                                .graph_formula_vertices
+                                .saturating_sub(
+                                    child.graph_after_setup.as_ref()?.graph_formula_vertices,
+                                ) as u64,
+                        )
+                    })
+                    .max();
+                let max_telemetry = |extract: fn(
+                    &formualizer_bench_core::c6_calibration::EngineTelemetry,
+                ) -> u64| {
                     children
                         .iter()
                         .flat_map(|child| child.telemetry.values())
                         .map(extract)
                         .max()
                 };
-            let telemetry_phase = |key: &str| {
-                distribution(
-                    &children
+                let telemetry_phase = |key: &str| {
+                    distribution(
+                        &children
+                            .iter()
+                            .filter_map(|child| child.telemetry.get(key))
+                            .map(|telemetry| telemetry.request_total_ms)
+                            .collect::<Vec<_>>(),
+                    )
+                };
+                summaries.push(CaseSummary {
+                    family,
+                    selector_set: children
+                        .first()
+                        .map_or_else(String::new, |child| child.selector_set.clone()),
+                    path,
+                    scope,
+                    successful_samples: children.len(),
+                    cold_total_ms,
+                    load_ms: phase(|child| child.phases.load.as_ref().map(|p| p.milliseconds)),
+                    selector_setup_ms: phase(|child| {
+                        child.phases.selector_setup.as_ref().map(|p| p.milliseconds)
+                    }),
+                    name_binding_probe_ms: phase(|child| {
+                        child
+                            .phases
+                            .name_binding_probe
+                            .as_ref()
+                            .map(|p| p.milliseconds)
+                    }),
+                    bind_resolution_ms: phase(|child| {
+                        child
+                            .phases
+                            .bind_target_resolution
+                            .as_ref()
+                            .map(|p| p.milliseconds)
+                    }),
+                    preparation_plan_ms: phase(|child| {
+                        child
+                            .phases
+                            .preparation_plan_build
+                            .as_ref()
+                            .map(|p| p.milliseconds)
+                    }),
+                    first_evaluation_ms: phase(|child| {
+                        child
+                            .phases
+                            .first_evaluation
+                            .as_ref()
+                            .map(|p| p.milliseconds)
+                    }),
+                    output_read_ms: phase(|child| {
+                        child.phases.output_read.as_ref().map(|p| p.milliseconds)
+                    }),
+                    edit_ms: flattened(|child| {
+                        child.phases.edit.iter().map(|p| p.milliseconds).collect()
+                    }),
+                    warm_evaluation_ms: flattened(|child| {
+                        child
+                            .phases
+                            .warm_evaluation
+                            .iter()
+                            .map(|p| p.milliseconds)
+                            .collect()
+                    }),
+                    batch_restore_ms: phase(|child| {
+                        child.phases.batch_restore.as_ref().map(|p| p.milliseconds)
+                    }),
+                    sheetport_batch_plan_telemetry_ms: telemetry_phase(
+                        "sheetport_batch_plan_build",
+                    ),
+                    sheetport_batch_execution_telemetry_ms: telemetry_phase(
+                        "sheetport_batch_execution",
+                    ),
+                    peak_rss_bytes: distribution(&rss),
+                    max_prepared_formula_delta: prepared,
+                    max_staged_selected: max_telemetry(|stats| stats.staged_selected),
+                    max_target_actual_work: max_telemetry(|stats| stats.target_commit_actual_work),
+                    locality_oracle_all_passed: children
                         .iter()
-                        .filter_map(|child| child.telemetry.get(key))
-                        .map(|telemetry| telemetry.request_total_ms)
-                        .collect::<Vec<_>>(),
-                )
-            };
-            summaries.push(CaseSummary {
-                path,
-                scope,
-                successful_samples: children.len(),
-                cold_total_ms,
-                load_ms: phase(|child| child.phases.load.as_ref().map(|p| p.milliseconds)),
-                bind_resolution_ms: phase(|child| {
-                    child
-                        .phases
-                        .bind_target_resolution
-                        .as_ref()
-                        .map(|p| p.milliseconds)
-                }),
-                preparation_plan_ms: phase(|child| {
-                    child
-                        .phases
-                        .preparation_plan_build
-                        .as_ref()
-                        .map(|p| p.milliseconds)
-                }),
-                first_evaluation_ms: phase(|child| {
-                    child
-                        .phases
-                        .first_evaluation
-                        .as_ref()
-                        .map(|p| p.milliseconds)
-                }),
-                output_read_ms: phase(|child| {
-                    child.phases.output_read.as_ref().map(|p| p.milliseconds)
-                }),
-                edit_ms: flattened(|child| {
-                    child.phases.edit.iter().map(|p| p.milliseconds).collect()
-                }),
-                warm_evaluation_ms: flattened(|child| {
-                    child
-                        .phases
-                        .warm_evaluation
+                        .all(|child| child.oracle_within_one_percent.unwrap_or(true)),
+                    analytical_output_oracle_all_passed: children
                         .iter()
-                        .map(|p| p.milliseconds)
-                        .collect()
-                }),
-                batch_restore_ms: phase(|child| {
-                    child.phases.batch_restore.as_ref().map(|p| p.milliseconds)
-                }),
-                sheetport_batch_plan_telemetry_ms: telemetry_phase("sheetport_batch_plan_build"),
-                sheetport_batch_execution_telemetry_ms: telemetry_phase(
-                    "sheetport_batch_execution",
-                ),
-                peak_rss_bytes: distribution(&rss),
-                max_prepared_formula_delta: prepared,
-                max_staged_selected: max_telemetry(|stats| stats.staged_selected),
-                max_target_actual_work: max_telemetry(|stats| stats.target_commit_actual_work),
-                locality_oracle_all_passed: children
-                    .iter()
-                    .all(|child| child.oracle_within_one_percent.unwrap_or(true)),
-                analytical_output_oracle_all_passed: children
-                    .iter()
-                    .all(|child| child.analytical_output_oracle_passed.unwrap_or(false)),
-                exact_fixture_counts_all_passed: children
-                    .iter()
-                    .all(|child| child.exact_fixture_counts_passed.unwrap_or(false)),
-                exact_locality_counts_all_passed: children
-                    .iter()
-                    .all(|child| child.exact_locality_counts_passed.unwrap_or(false)),
-                unrelated_staged_all_retained: children
-                    .iter()
-                    .all(|child| child.unrelated_staged_retained.unwrap_or(true)),
-                unrelated_dirty_all_retained: children
-                    .iter()
-                    .all(|child| child.unrelated_dirty_retained.unwrap_or(true)),
-            });
+                        .all(|child| child.analytical_output_oracle_passed.unwrap_or(false)),
+                    exact_fixture_counts_all_passed: children
+                        .iter()
+                        .all(|child| child.exact_fixture_counts_passed.unwrap_or(false)),
+                    exact_locality_counts_all_passed: children
+                        .iter()
+                        .all(|child| child.exact_locality_counts_passed.unwrap_or(false)),
+                    unrelated_staged_all_retained: children
+                        .iter()
+                        .all(|child| child.unrelated_staged_retained.unwrap_or(true)),
+                    unrelated_dirty_all_retained: children
+                        .iter()
+                        .all(|child| child.unrelated_dirty_retained.unwrap_or(true)),
+                    family_gates_all_passed: children
+                        .iter()
+                        .all(|child| child.family_gates.values().all(|passed| *passed)),
+                });
+            }
         }
     }
     summaries
 }
 
 #[cfg(feature = "c6_calibration")]
-fn parity(results: &[SampleResult], scopes: &[TargetScope]) -> BTreeMap<String, bool> {
-    let mut parity = BTreeMap::new();
-    for &scope in scopes {
-        let outcomes = results
-            .iter()
-            .filter(|result| result.job.scope == scope && result.status == "ok")
-            .filter_map(|result| result.child.as_ref())
-            .filter(|child| child.status == "ok")
-            .map(|child| {
-                child
-                    .typed_error
-                    .clone()
-                    .unwrap_or_else(|| child.output_checksum.clone().unwrap_or_default())
-            })
-            .collect::<BTreeSet<_>>();
-        parity.insert(scope.label().to_string(), outcomes.len() == 1);
+fn parity(results: &[SampleResult]) -> BTreeMap<String, bool> {
+    let mut grouped = BTreeMap::<String, BTreeSet<String>>::new();
+    for child in results
+        .iter()
+        .filter(|result| result.status == "ok")
+        .filter_map(|result| result.child.as_ref())
+        .filter(|child| child.status == "ok")
+    {
+        let key = format!(
+            "{}/{}/{}",
+            child.family.label(),
+            child.scope.label(),
+            child.selector_set
+        );
+        grouped.entry(key).or_default().insert(
+            child
+                .typed_error
+                .clone()
+                .unwrap_or_else(|| child.output_checksum.clone().unwrap_or_default()),
+        );
     }
-    parity
+    grouped
+        .into_iter()
+        .map(|(key, outcomes)| (key, outcomes.len() == 1))
+        .collect()
 }
 
 #[cfg(feature = "c6_calibration")]
@@ -792,9 +973,23 @@ fn render_markdown(report: &MatrixReport) -> String {
         report.identity.os,
         report.identity.architecture,
     );
-    out.push_str("All timing cells are `median / p95 / MAD / max` in milliseconds, using nearest-rank p95. With seven per-child samples, per-child p95 is the maximum; pooled warm calls contain 21 observations. `cold` is process-cold but normally OS-page-cache-warm and includes load, the explicitly reported unrelated-dirty setup, binding/resolution, first evaluation, and preparation/plan plus separate output read where those precede the first evaluation. SheetPort cold is its one-shot path; its subsequent batch-plan build is shown only in `prepare/plan`. Cells and SheetPort retain combined phases when their public APIs do not expose a split.\n\n");
-    out.push_str("| scope | path | n | cold | prepare/plan | first eval | warm API cost | batch restore | peak RSS MiB | prepared formulas | staged selected | actual target work | gates |\n");
-    out.push_str("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n");
+    out.push_str("Immutable family fixtures:\n");
+    for fixture in &report.fixtures {
+        out.push_str(&format!(
+            "- `{}`: SHA-256 `{}`\n",
+            fixture.family.label(),
+            fixture.sha256
+        ));
+    }
+    out.push_str(&format!(
+        "\nAll timing cells are `median / p95 / MAD / max` in milliseconds, using nearest-rank p95. Per-child distributions contain {} samples; pooled warm calls contain {} observations. `cold` is process-cold but normally OS-page-cache-warm and includes load, the explicitly reported unrelated-dirty setup, binding/resolution, first evaluation, and preparation/plan plus separate output read where those precede the first evaluation. SheetPort cold is its one-shot path; its subsequent batch-plan build is shown only in `prepare/plan`. Cells and SheetPort retain combined phases when their public APIs do not expose a split. The names `name binding probe` is post-warm and excluded from both cold and ordinary warm distributions.\n\n",
+        report.samples_per_case,
+        report.samples_per_case.saturating_mul(report.warm_repeats),
+    ));
+    out.push_str("| family | selector set | scope | path | n | cold | selector setup | name binding probe | prepare/plan | first eval | warm API cost | batch restore | peak RSS MiB | prepared formulas | staged selected | actual target work | gates |\n");
+    out.push_str(
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|\n",
+    );
     for summary in &report.summaries {
         let rss = summary.peak_rss_bytes.map(|mut stats| {
             stats.median /= 1_048_576.0;
@@ -809,17 +1004,22 @@ fn render_markdown(report: &MatrixReport) -> String {
             && summary.exact_locality_counts_all_passed
             && summary.unrelated_staged_all_retained
             && summary.unrelated_dirty_all_retained
+            && summary.family_gates_all_passed
         {
             "pass"
         } else {
             "FAIL"
         };
         out.push_str(&format!(
-            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+            summary.family.label(),
+            summary.selector_set,
             summary.scope.label(),
             summary.path.label(),
             summary.successful_samples,
             fmt_stat(summary.cold_total_ms),
+            fmt_stat(summary.selector_setup_ms),
+            fmt_stat(summary.name_binding_probe_ms),
             fmt_stat(summary.preparation_plan_ms),
             fmt_stat(summary.first_evaluation_ms),
             fmt_stat(summary.warm_evaluation_ms),
@@ -838,14 +1038,15 @@ fn render_markdown(report: &MatrixReport) -> String {
         ));
     }
     out.push_str("\n## SheetPort telemetry snapshots\n\nThe raw telemetry keys `first_evaluation`, `sheetport_batch_plan_build`, and `sheetport_batch_execution` are distinct and never overwrite one another. The last key is captured after `batch.run`, so its request ledger describes the final baseline-restoration evaluation. Values are engine request-total milliseconds.\n\n");
-    out.push_str("| scope | after batch-plan construction | after batch execution/restoration |\n|---|---:|---:|\n");
+    out.push_str("| family | scope | after batch-plan construction | after batch execution/restoration |\n|---|---|---:|---:|\n");
     for summary in report
         .summaries
         .iter()
         .filter(|summary| summary.path == CalibrationPath::Sheetport)
     {
         out.push_str(&format!(
-            "| {} | {} | {} |\n",
+            "| {} | {} | {} | {} |\n",
+            summary.family.label(),
             summary.scope.label(),
             fmt_stat(summary.sheetport_batch_plan_telemetry_ms),
             fmt_stat(summary.sheetport_batch_execution_telemetry_ms),
@@ -860,7 +1061,7 @@ fn render_markdown(report: &MatrixReport) -> String {
             if *passed { "pass" } else { "FAIL" }
         ));
     }
-    out.push_str("\n## Interpretation limits\n\n- `warm API cost` means the public API latency after one selected-branch input edit; it is not a claim that 100% of formulas are dirty or recomputed. In `full_100pct`, the fixed edit is `Tiny!A1`, a 0.5% branch, while all terminal outputs are requested.\n- `cells` first/warm timings combine target preparation, ephemeral plan construction, evaluation, and returned output because `evaluate_cells` exposes one public call.\n- SheetPort one-shot combines selector resolution, target preparation, evaluation, and runtime output read; batch iterations combine input edit, plan evaluation, and runtime output read. Checked baseline-restoration accounting is reported separately.\n- SheetPort batch creation follows its one-shot evaluation on the already prepared workbook. Its separately reported batch-plan build is not a second cold latency and is not setup-equivalent to the direct plan build on deferred staging.\n- Prepared formula deltas and public request telemetry prove locality; no allocator-specific counter is available, so RSS/HWM and ledger retained/scratch accounting are reported instead.\n");
+    out.push_str("\n## Interpretation limits\n\n- `warm API cost` means public API latency after one input edit; it is not a claim that every requested formula is dirty or recomputed. In the scalar `full_100pct` case, the fixed edit remains the 0.5% `Tiny` branch while all terminals are requested. Breadth families edit the local chain source.\n- `cells` first/warm timings combine target preparation, ephemeral plan construction, evaluation, and returned output because `evaluate_cells` exposes one public call.\n- SheetPort one-shot combines selector resolution, target preparation, evaluation, and runtime output read; batch iterations combine input edit, plan evaluation, and runtime output read. Checked baseline-restoration accounting is reported separately.\n- SheetPort batch creation follows its one-shot evaluation on the already prepared workbook. Its separately reported batch-plan build is not a second cold latency and is not setup-equivalent to the direct plan build on deferred staging.\n- Prepared formula deltas and public request telemetry prove locality; no allocator-specific counter is available, so RSS/HWM and ledger retained/scratch accounting are reported instead.\n");
     out
 }
 
@@ -891,6 +1092,35 @@ mod tests {
             vec![CalibrationPath::Full, CalibrationPath::Cells]
         );
         assert_eq!(cli.scopes, vec![TargetScope::Tiny, TargetScope::Full]);
+    }
+
+    #[test]
+    fn named_tiers_are_exact_and_largest_safe_is_rejected() {
+        let mut smoke = Cli::try_parse_from(["matrix", "--tier", "all-family-smoke"]).unwrap();
+        apply_tier(&mut smoke).unwrap();
+        assert_eq!(smoke.formulas, 1_000);
+        assert_eq!(smoke.samples, 1);
+        assert_eq!(smoke.families, FixtureFamily::ALL);
+        assert!(job_supported(
+            FixtureFamily::Layout,
+            CalibrationPath::Sheetport,
+            TargetScope::Full
+        ));
+        assert!(!job_supported(
+            FixtureFamily::Layout,
+            CalibrationPath::Targets,
+            TargetScope::Full
+        ));
+
+        let mut scalar = Cli::try_parse_from(["matrix", "--tier", "scalar250k"]).unwrap();
+        apply_tier(&mut scalar).unwrap();
+        assert_eq!(scalar.formulas, 250_000);
+        assert_eq!(scalar.samples, 7);
+        assert_eq!(scalar.timeout_seconds, 1_800);
+        assert_eq!(scalar.paths, CalibrationPath::SCALAR_V2);
+
+        let mut largest = Cli::try_parse_from(["matrix", "--tier", "largest-safe"]).unwrap();
+        assert!(apply_tier(&mut largest).is_err());
     }
 
     #[test]

--- a/crates/formualizer-bench-core/src/bin/probe-c6-target-locality.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-c6-target-locality.rs
@@ -13,9 +13,9 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 #[cfg(feature = "c6_calibration")]
 use formualizer_bench_core::c6_calibration::{
-    CalibrationPath, ChildReport, EngineTelemetry, FixtureShape, GraphSnapshot, PhaseTimings,
-    TargetScope, TimedPhase, allowed_oracle, analytical_expected_outputs, checksum_values,
-    generate_fixture, manifest_yaml, sha256_file,
+    CalibrationPath, ChildReport, EngineTelemetry, FixtureFamily, FixtureShape, GraphSnapshot,
+    PhaseTimings, TargetScope, TimedPhase, allowed_oracle, analytical_expected_outputs,
+    checksum_values, manifest_yaml, path_supported, sha256_file,
 };
 #[cfg(feature = "c6_calibration")]
 use formualizer_common::LiteralValue;
@@ -29,6 +29,10 @@ use formualizer_workbook::{
 };
 #[cfg(feature = "c6_calibration")]
 use sheetport_spec::Manifest;
+
+#[cfg(feature = "c6_calibration")]
+#[path = "probe-c6-target-locality/family_runner.rs"]
+mod family_runner;
 
 #[cfg(not(feature = "c6_calibration"))]
 fn main() {
@@ -52,12 +56,16 @@ enum Command {
         fixture: PathBuf,
         #[arg(long)]
         formulas: u32,
+        #[arg(long, value_enum, default_value_t = FixtureFamily::Scalar)]
+        family: FixtureFamily,
     },
     Sample {
         #[arg(long)]
         fixture: PathBuf,
         #[arg(long)]
         formulas: u32,
+        #[arg(long, value_enum, default_value_t = FixtureFamily::Scalar)]
+        family: FixtureFamily,
         #[arg(long, value_enum)]
         path: CalibrationPath,
         #[arg(long, value_enum)]
@@ -70,8 +78,14 @@ enum Command {
 #[cfg(feature = "c6_calibration")]
 fn main() -> Result<()> {
     match Cli::parse().command {
-        Command::Generate { fixture, formulas } => {
-            let shape = generate_fixture(&fixture, formulas)?;
+        Command::Generate {
+            fixture,
+            formulas,
+            family,
+        } => {
+            let shape = formualizer_bench_core::c6_calibration::families::generate_family_fixture(
+                &fixture, family, formulas,
+            )?;
             println!(
                 "{}",
                 serde_json::to_string(&serde_json::json!({
@@ -84,12 +98,20 @@ fn main() -> Result<()> {
         Command::Sample {
             fixture,
             formulas,
+            family,
             path,
             scope,
             warm_repeats,
         } => println!(
             "{}",
-            serde_json::to_string(&run_sample(&fixture, formulas, path, scope, warm_repeats)?)?
+            serde_json::to_string(&run_sample(
+                &fixture,
+                formulas,
+                family,
+                path,
+                scope,
+                warm_repeats,
+            )?)?
         ),
     }
     Ok(())
@@ -104,10 +126,27 @@ fn elapsed_ms(started: Instant) -> f64 {
 fn run_sample(
     fixture: &std::path::Path,
     formulas: u32,
+    family: FixtureFamily,
     path: CalibrationPath,
     scope: TargetScope,
     warm_repeats: usize,
 ) -> Result<ChildReport> {
+    anyhow::ensure!(
+        path_supported(family, path),
+        "unsupported family/path combination: {}/{}",
+        family.label(),
+        path.label()
+    );
+    if family != FixtureFamily::Scalar {
+        return family_runner::run_family_sample(
+            fixture,
+            formulas,
+            family,
+            path,
+            scope,
+            warm_repeats,
+        );
+    }
     let shape = FixtureShape::new(formulas)?;
     let fixture_sha256 = sha256_file(fixture)?;
     let mut phases = PhaseTimings::default();
@@ -170,6 +209,7 @@ fn run_sample(
             &mut telemetry,
             &mut outputs,
         ),
+        CalibrationPath::Targets => unreachable!("targets is not a scalar-v2 path"),
         CalibrationPath::Plan => run_plan(
             &mut workbook,
             shape,
@@ -266,7 +306,10 @@ fn run_sample(
     let (current_rss_bytes, peak_rss_bytes) = process_memory_bytes();
 
     Ok(ChildReport {
-        schema_version: 2,
+        schema_version: 3,
+        family: FixtureFamily::Scalar,
+        path_schema_version: 3,
+        selector_set: "scalar_terminals".to_string(),
         path,
         scope,
         formulas,
@@ -285,6 +328,11 @@ fn run_sample(
         outputs,
         analytical_expected_outputs,
         analytical_output_oracle_passed,
+        typed_outputs: Vec::new(),
+        typed_expected_outputs: Vec::new(),
+        family_gates: BTreeMap::new(),
+        structural_oracles: BTreeMap::new(),
+        plan_stale_reason: None,
         typed_error,
         telemetry,
         graph_after_load: Some(graph_after_load),
@@ -797,20 +845,225 @@ mod tests {
     fn fixture_bytes_are_deterministic() {
         let first = temp_fixture("determinism-a");
         let second = temp_fixture("determinism-b");
-        generate_fixture(&first, 200).unwrap();
-        generate_fixture(&second, 200).unwrap();
+        formualizer_bench_core::c6_calibration::generate_fixture(&first, 200).unwrap();
+        formualizer_bench_core::c6_calibration::generate_fixture(&second, 200).unwrap();
         assert_eq!(sha256_file(&first).unwrap(), sha256_file(&second).unwrap());
         let _ = std::fs::remove_file(first);
         let _ = std::fs::remove_file(second);
     }
 
     #[test]
+    fn native_family_supported_paths_pass_exact_gates() {
+        for family in FixtureFamily::BREADTH {
+            let fixture = temp_fixture(family.label());
+            formualizer_bench_core::c6_calibration::families::generate_family_fixture(
+                &fixture, family, 64,
+            )
+            .unwrap();
+            for path in CalibrationPath::ALL
+                .into_iter()
+                .filter(|path| path_supported(family, *path))
+            {
+                let report = run_sample(&fixture, 64, family, path, TargetScope::Full, 2).unwrap();
+                assert_eq!(
+                    report.status,
+                    "ok",
+                    "{}/{}: {:?}",
+                    family.label(),
+                    path.label(),
+                    report.typed_error
+                );
+                assert!(report.family_gates.values().all(|passed| *passed));
+            }
+            let _ = std::fs::remove_file(fixture);
+        }
+    }
+
+    #[test]
+    fn all_family_full_controls_match_exact_oracles_at_zero_and_three_warms() {
+        for family in FixtureFamily::ALL {
+            let fixture = temp_fixture(&format!("full-dirty-oracle-{}", family.label()));
+            formualizer_bench_core::c6_calibration::families::generate_family_fixture(
+                &fixture, family, 200,
+            )
+            .unwrap();
+            let warm_counts: &[usize] = if family == FixtureFamily::Scalar {
+                &[3]
+            } else {
+                &[0, 3]
+            };
+            for &warm_repeats in warm_counts {
+                let report = run_sample(
+                    &fixture,
+                    200,
+                    family,
+                    CalibrationPath::Full,
+                    TargetScope::Full,
+                    warm_repeats,
+                )
+                .unwrap();
+                assert_eq!(
+                    report.status,
+                    "ok",
+                    "{}/warm={warm_repeats}: {:?}",
+                    family.label(),
+                    report.typed_error
+                );
+                assert_eq!(report.exact_locality_counts_passed, Some(true));
+                if family != FixtureFamily::Scalar {
+                    assert_eq!(
+                        report.family_gates.get("full_control_dirty_residual_exact"),
+                        Some(&true)
+                    );
+                    assert!(
+                        report
+                            .structural_oracles
+                            .contains_key("full_control_dirty_residual")
+                    );
+                }
+            }
+            let _ = std::fs::remove_file(fixture);
+        }
+    }
+
+    #[test]
+    fn zero_warm_plan_samples_omit_reuse_gate_and_keep_name_staleness_probe() {
+        for family in FixtureFamily::BREADTH
+            .into_iter()
+            .filter(|family| path_supported(*family, CalibrationPath::Plan))
+        {
+            let fixture = temp_fixture(&format!("zero-warm-plan-{}", family.label()));
+            formualizer_bench_core::c6_calibration::families::generate_family_fixture(
+                &fixture, family, 64,
+            )
+            .unwrap();
+            let report = run_sample(
+                &fixture,
+                64,
+                family,
+                CalibrationPath::Plan,
+                TargetScope::Full,
+                0,
+            )
+            .unwrap();
+            assert_eq!(
+                report.status,
+                "ok",
+                "{}: {:?}",
+                family.label(),
+                report.typed_error
+            );
+            assert!(
+                !report
+                    .family_gates
+                    .contains_key("retained_plan_reused_across_value_edits")
+            );
+            if family == FixtureFamily::Names {
+                assert_eq!(report.plan_stale_reason.as_deref(), Some("symbols"));
+                assert_eq!(
+                    report.family_gates.get("deterministic_plan_stale_symbols"),
+                    Some(&true)
+                );
+            }
+            let _ = std::fs::remove_file(fixture);
+        }
+    }
+
+    #[test]
+    fn layout_separates_returned_bounds_package_commit_and_scheduled_evaluation() {
+        let fixture = temp_fixture("layout-honest-package-envelope");
+        formualizer_bench_core::c6_calibration::families::generate_family_fixture(
+            &fixture,
+            FixtureFamily::Layout,
+            64,
+        )
+        .unwrap();
+        let report = run_sample(
+            &fixture,
+            64,
+            FixtureFamily::Layout,
+            CalibrationPath::Sheetport,
+            TargetScope::Full,
+            1,
+        )
+        .unwrap();
+        assert_eq!(report.status, "ok", "{:?}", report.typed_error);
+        for gate in [
+            "layout_exact_resolved_bounds_A2_D2",
+            "layout_preparation_envelope_A2_D9",
+            "layout_below_guard_inside_envelope_evaluated",
+            "layout_below_envelope_committed_but_unevaluated",
+            "layout_package_commit_selected_chain_c4_c10",
+            "layout_six_retained_sheet_formulas_staged",
+        ] {
+            assert_eq!(report.family_gates.get(gate), Some(&true), "{gate}");
+        }
+        assert_eq!(report.typed_outputs[0].len(), 5);
+        assert_eq!(report.graph_after_run.unwrap().staged_formulas, 6);
+        assert!(
+            report.structural_oracles["resolved_layout_bounds"]
+                .contains("conservative preparation envelope A2:D9")
+        );
+        let _ = std::fs::remove_file(fixture);
+    }
+
+    #[test]
+    fn dynamic_initial_preparation_requires_exact_widening_mask() {
+        let fixture = temp_fixture("dynamic-exact-mask");
+        formualizer_bench_core::c6_calibration::families::generate_family_fixture(
+            &fixture,
+            FixtureFamily::Dynamic,
+            64,
+        )
+        .unwrap();
+        let report = run_sample(
+            &fixture,
+            64,
+            FixtureFamily::Dynamic,
+            CalibrationPath::Targets,
+            TargetScope::Full,
+            1,
+        )
+        .unwrap();
+        assert_eq!(report.status, "ok", "{:?}", report.typed_error);
+        assert_eq!(
+            report.family_gates.get("workbook_widening_observed"),
+            Some(&true)
+        );
+        assert_eq!(
+            report
+                .structural_oracles
+                .get("dynamic_widening_reason_mask_expected")
+                .map(String::as_str),
+            Some("3 (0b11): DynamicReference | RuntimeTextReference")
+        );
+        assert_eq!(
+            report
+                .structural_oracles
+                .get("dynamic_widening_reason_mask_observed")
+                .map(String::as_str),
+            Some("3 (0b11) at first_evaluation")
+        );
+        let _ = std::fs::remove_file(fixture);
+    }
+
+    #[test]
     fn smoke_paths_have_output_parity_and_target_locality() {
         let fixture = temp_fixture("path-parity");
-        generate_fixture(&fixture, 200).unwrap();
-        let reports = CalibrationPath::ALL
+        formualizer_bench_core::c6_calibration::generate_fixture(&fixture, 200).unwrap();
+        let reports = CalibrationPath::SCALAR_V2
             .into_iter()
-            .map(|path| run_sample(&fixture, 200, path, TargetScope::Tiny, 1).unwrap())
+            .map(|path| {
+                run_sample(
+                    &fixture,
+                    200,
+                    FixtureFamily::Scalar,
+                    path,
+                    TargetScope::Tiny,
+                    1,
+                )
+                .unwrap()
+            })
             .collect::<Vec<_>>();
         let expected = &reports[0].outputs;
         assert!(reports.iter().all(|report| report.outputs == *expected));

--- a/crates/formualizer-bench-core/src/bin/probe-c6-target-locality/family_runner.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-c6-target-locality/family_runner.rs
@@ -1,0 +1,1214 @@
+use super::*;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use formualizer_bench_core::c6_calibration::TypedOracleValue;
+use formualizer_bench_core::c6_calibration::families::{
+    DIRTY_FORMULAS, FamilyFixtureShape, LAYOUT_BELOW_ENVELOPE_ROW, LAYOUT_BLANK_GUARD_ROW,
+    LAYOUT_MAX_SCAN_ROWS, LAYOUT_PREPARATION_ENVELOPE_END_ROW, expected_typed_outputs,
+    layout_manifest, scalar_manifest, table_manifest,
+};
+use formualizer_common::{ExcelErrorExtra, LiteralValue, PlanStaleReason, RangeAddress};
+use formualizer_eval::engine::{EvaluationTarget, TableSelection};
+use formualizer_eval::reference::{CellRef, Coord, RangeRef};
+use formualizer_sheetport::{BatchInput, BatchOptions, InputUpdate, PortValue, SheetPort};
+use formualizer_workbook::{IoError, NamedRangeScope};
+
+pub(super) fn run_family_sample(
+    fixture: &Path,
+    formulas: u32,
+    family: FixtureFamily,
+    path: CalibrationPath,
+    scope: TargetScope,
+    warm_repeats: usize,
+) -> Result<ChildReport> {
+    anyhow::ensure!(
+        scope == TargetScope::Full,
+        "native breadth families support only --scope full"
+    );
+    let shape = formualizer_bench_core::c6_calibration::families::generate_family_fixture_shape(
+        family, formulas,
+    )?;
+    let reachable_oracle = if family == FixtureFamily::Names && path == CalibrationPath::Sheetport {
+        shape.reachable_formulas - 1
+    } else {
+        shape.reachable_formulas
+    };
+    let fixture_sha256 = sha256_file(fixture)?;
+    let mut phases = PhaseTimings::default();
+    let mut telemetry = BTreeMap::new();
+    let mut gates = BTreeMap::new();
+    let mut structural = BTreeMap::new();
+
+    let load_started = Instant::now();
+    let reader =
+        CalamineAdapter::open_path(fixture).context("open family fixture with Calamine")?;
+    let mut workbook = Workbook::from_reader(
+        reader,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .context("interactive deferred family workbook load")?;
+    phases.load = Some(TimedPhase::new(
+        elapsed_ms(load_started),
+        &["xlsx_open", "load"],
+    ));
+    let graph_after_load = graph_snapshot(&workbook);
+
+    let dirty_started = Instant::now();
+    workbook
+        .prepare_graph_for_cells(&[("Dirty", DIRTY_FORMULAS, 2)])
+        .context("prepare family dirty branch")?;
+    workbook
+        .evaluate_cell("Dirty", DIRTY_FORMULAS, 2)
+        .context("evaluate family dirty branch")?;
+    workbook
+        .set_value("Dirty", 1, 1, LiteralValue::Number(40.0))
+        .context("dirty family branch")?;
+    phases.unrelated_dirty_setup = Some(TimedPhase::new(
+        elapsed_ms(dirty_started),
+        &[
+            "target_resolution",
+            "preparation",
+            "evaluation",
+            "unrelated_edit",
+        ],
+    ));
+    let graph_after_setup = graph_snapshot(&workbook);
+
+    let selector_setup = Instant::now();
+    setup_selectors(&mut workbook, family)?;
+    if matches!(family, FixtureFamily::Names | FixtureFamily::NativeTable) {
+        phases.selector_setup = Some(TimedPhase::new(
+            elapsed_ms(selector_setup),
+            match family {
+                FixtureFamily::Names => &["public_name_registration"],
+                FixtureFamily::NativeTable => &["public_native_table_registration"],
+                _ => unreachable!(),
+            },
+        ));
+    }
+
+    let expected = expected_typed_outputs(&shape, path, warm_repeats);
+    let mut typed_outputs = Vec::new();
+    let mut debug_outputs = Vec::new();
+    let mut plan_stale_reason = None;
+    let run_result = if path == CalibrationPath::Full {
+        run_full_family(
+            &mut workbook,
+            &shape,
+            warm_repeats,
+            &mut phases,
+            &mut telemetry,
+            &mut typed_outputs,
+            &mut gates,
+            &mut structural,
+        )
+    } else if path == CalibrationPath::Sheetport {
+        run_sheetport_family(
+            &mut workbook,
+            &shape,
+            warm_repeats,
+            &mut phases,
+            &mut telemetry,
+            &mut typed_outputs,
+            &mut gates,
+            &mut structural,
+        )
+    } else {
+        run_direct_family(
+            &mut workbook,
+            &shape,
+            path,
+            warm_repeats,
+            &mut phases,
+            &mut telemetry,
+            &mut typed_outputs,
+            &mut plan_stale_reason,
+        )
+    };
+    let mut typed_error = run_result.err().map(|error| format!("{error:#}"));
+    if path == CalibrationPath::Plan && warm_repeats > 0 {
+        gates.insert(
+            "retained_plan_reused_across_value_edits".to_string(),
+            typed_error.is_none(),
+        );
+    }
+    debug_outputs.extend(
+        typed_outputs
+            .iter()
+            .map(|values| values.iter().map(|value| format!("{value:?}")).collect()),
+    );
+
+    let typed_oracle_passed =
+        typed_error.is_none() && typed_values_match(&typed_outputs, &expected);
+    gates.insert("typed_output_oracle".to_string(), typed_oracle_passed);
+    if family == FixtureFamily::Names && path == CalibrationPath::Plan {
+        gates.insert(
+            "deterministic_plan_stale_symbols".to_string(),
+            plan_stale_reason.as_deref() == Some("symbols"),
+        );
+    }
+
+    let graph_after_run = graph_snapshot(&workbook);
+    let load_exact = graph_after_load.graph_formula_vertices == 0
+        && graph_after_load.staged_formulas == formulas as usize
+        && graph_after_load.dirty_vertices == 0;
+    let setup_exact = graph_after_setup.graph_formula_vertices == DIRTY_FORMULAS as usize
+        && graph_after_setup.staged_formulas == (formulas - DIRTY_FORMULAS) as usize
+        && graph_after_setup.dirty_vertices == 9;
+    gates.insert("fixture_load_counts_exact".to_string(), load_exact);
+    gates.insert("dirty_setup_counts_exact".to_string(), setup_exact);
+
+    if path == CalibrationPath::Full {
+        gates.insert(
+            "full_control_consumed_all_staging".to_string(),
+            graph_after_run.staged_formulas == 0,
+        );
+        let dirty_oracle = full_dirty_oracle(family, warm_repeats);
+        gates.insert(
+            "full_control_consumed_unrelated_dirty".to_string(),
+            graph_after_run.dirty_vertices == dirty_oracle.expected,
+        );
+        gates.insert(
+            "full_control_dirty_residual_exact".to_string(),
+            graph_after_run.dirty_vertices == dirty_oracle.expected,
+        );
+        structural.insert(
+            "full_control_dirty_residual".to_string(),
+            dirty_oracle.derivation,
+        );
+    } else {
+        if shape.retained_formulas > 0 {
+            let retained = graph_after_run.staged_formulas == shape.retained_formulas as usize;
+            gates.insert("unrelated_staged_retained".to_string(), retained);
+        }
+        if family != FixtureFamily::Dynamic {
+            gates.insert(
+                "unrelated_dirty_retained".to_string(),
+                graph_after_run.dirty_vertices >= 9,
+            );
+        }
+    }
+    let max_selected = telemetry
+        .values()
+        .map(|stats| stats.staged_selected)
+        .max()
+        .unwrap_or(0);
+    let locality_ok = if path == CalibrationPath::Full {
+        let dirty_oracle = full_dirty_oracle(family, warm_repeats);
+        graph_after_run.staged_formulas == 0
+            && graph_after_run.dirty_vertices == dirty_oracle.expected
+    } else if family == FixtureFamily::Dynamic {
+        let initial_preparation_stage = if path == CalibrationPath::Plan {
+            "plan_build"
+        } else {
+            "first_evaluation"
+        };
+        let observed_mask = telemetry
+            .get(initial_preparation_stage)
+            .filter(|stats| stats.preparation_scope_level == 2)
+            .map(|stats| stats.widening_reason_bits);
+        let widened = observed_mask == Some(DYNAMIC_WIDENING_REASON_MASK);
+        let exact_widened_selection = max_selected == u64::from(formulas - DIRTY_FORMULAS)
+            && graph_after_run.staged_formulas == 0;
+        gates.insert("workbook_widening_observed".to_string(), widened);
+        gates.insert(
+            "workbook_widening_selection_exact".to_string(),
+            exact_widened_selection,
+        );
+        structural.insert(
+            "dynamic_widening_scope".to_string(),
+            "PrepareScope::Workbook".to_string(),
+        );
+        structural.insert(
+            "dynamic_widening_reason_mask_expected".to_string(),
+            "3 (0b11): DynamicReference | RuntimeTextReference".to_string(),
+        );
+        structural.insert(
+            "dynamic_widening_reason_mask_observed".to_string(),
+            observed_mask
+                .map(|mask| format!("{mask} ({mask:#04b}) at {initial_preparation_stage}"))
+                .unwrap_or_else(|| format!("not observed at {initial_preparation_stage}")),
+        );
+        widened && exact_widened_selection
+    } else {
+        let preparation_oracle = if family == FixtureFamily::Names {
+            formulas - DIRTY_FORMULAS - shape.retained_formulas
+        } else {
+            reachable_oracle
+        };
+        let exact = max_selected == u64::from(preparation_oracle);
+        gates.insert(
+            "preparation_selected_formula_count_exact".to_string(),
+            exact,
+        );
+        if family == FixtureFamily::Names {
+            structural.insert(
+                "name_preparation_package_oracle".to_string(),
+                format!(
+                    "{preparation_oracle} formulas: target closure plus the four-formula Names source package"
+                ),
+            );
+        }
+        exact
+    };
+    match family {
+        FixtureFamily::CrossSheet => {
+            gates.insert(
+                "composed_cross_sheet_oracle".to_string(),
+                typed_oracle_passed,
+            );
+        }
+        FixtureFamily::Names => {
+            gates.insert(
+                "rebuilt_name_binding_outputs".to_string(),
+                typed_oracle_passed,
+            );
+        }
+        FixtureFamily::Layout if path == CalibrationPath::Sheetport => {
+            gates.insert(
+                "layout_package_commit_selected_chain_c4_c10".to_string(),
+                max_selected == u64::from(shape.reachable_formulas),
+            );
+            gates.insert(
+                "layout_six_retained_sheet_formulas_staged".to_string(),
+                graph_after_run.staged_formulas == shape.retained_formulas as usize
+                    && shape.retained_formulas == 6,
+            );
+        }
+        FixtureFamily::NativeTable => {
+            gates.insert(
+                "headers_body_totals_typed".to_string(),
+                typed_outputs.iter().all(|values| values.len() == 12),
+            );
+        }
+        FixtureFamily::Dynamic if path != CalibrationPath::Sheetport => {
+            gates.insert(
+                "explicit_ref_error_preserved".to_string(),
+                typed_outputs.iter().all(|values| {
+                    values.get(1) == Some(&TypedOracleValue::Error("#REF!".to_string()))
+                }),
+            );
+        }
+        _ => {}
+    }
+
+    if typed_error.is_none() {
+        let failed = gates
+            .iter()
+            .filter_map(|(gate, passed)| (!passed).then_some(gate.as_str()))
+            .collect::<Vec<_>>();
+        if !failed.is_empty() {
+            typed_error = Some(format!("family gates failed: {}", failed.join(", ")));
+        }
+    }
+
+    let flat = debug_outputs.iter().flatten().cloned().collect::<Vec<_>>();
+    let (current_rss_bytes, peak_rss_bytes) = process_memory_bytes();
+
+    Ok(ChildReport {
+        schema_version: 3,
+        family,
+        path_schema_version: 3,
+        selector_set: selector_set(family, path).to_string(),
+        path,
+        scope,
+        formulas,
+        reachable_oracle,
+        fixture_sha256,
+        status: if typed_error.is_none() {
+            "ok".to_string()
+        } else {
+            "path_error".to_string()
+        },
+        phases,
+        outputs: debug_outputs,
+        analytical_expected_outputs: Vec::new(),
+        analytical_output_oracle_passed: Some(typed_oracle_passed),
+        typed_outputs,
+        typed_expected_outputs: expected,
+        family_gates: gates,
+        structural_oracles: structural,
+        plan_stale_reason,
+        output_checksum: typed_error.is_none().then(|| checksum_values(&flat)),
+        typed_error,
+        telemetry,
+        graph_after_load: Some(graph_after_load),
+        graph_after_setup: Some(graph_after_setup),
+        graph_after_run: Some(graph_after_run.clone()),
+        unrelated_staged_retained: (path != CalibrationPath::Full && shape.retained_formulas > 0)
+            .then_some(graph_after_run.staged_formulas == shape.retained_formulas as usize),
+        unrelated_dirty_retained: (path != CalibrationPath::Full
+            && family != FixtureFamily::Dynamic)
+            .then_some(graph_after_run.dirty_vertices >= 9),
+        oracle_within_one_percent: Some(locality_ok),
+        exact_fixture_counts_passed: Some(load_exact && setup_exact),
+        exact_locality_counts_passed: Some(locality_ok),
+        current_rss_bytes,
+        peak_rss_bytes,
+    })
+}
+
+const DYNAMIC_WIDENING_REASON_MASK: u64 = 0b11;
+
+struct FullDirtyOracle {
+    expected: usize,
+    derivation: String,
+}
+
+fn full_dirty_oracle(family: FixtureFamily, warm_repeats: usize) -> FullDirtyOracle {
+    // Derive residuals from graph-producing operations, not observed baselines
+    // or family-specific fixture totals.
+    let dirty_setup_input = 1;
+    let warm_input = usize::from(warm_repeats > 0);
+    let volatile_dynamic_formulas = usize::from(family == FixtureFamily::Dynamic) * 2;
+    let table_metadata_vertex =
+        usize::from(family == FixtureFamily::NativeTable && warm_repeats > 0);
+    let expected =
+        dirty_setup_input + warm_input + volatile_dynamic_formulas + table_metadata_vertex;
+    let table_proof = if family == FixtureFamily::NativeTable {
+        if warm_repeats > 0 {
+            "; +1 C6Table metadata vertex dirtied through its registered table-range dependency when warm evaluation changes table formula values, then retained because it is not a formula evaluation vertex (the public baseline exposes only its aggregate residual, not vertex identity)"
+        } else {
+            "; +0 C6Table metadata residual because no warm edit changes a table-range value"
+        }
+    } else {
+        ""
+    };
+    FullDirtyOracle {
+        expected,
+        derivation: format!(
+            "expected {expected}: 1 edited non-formula Dirty!A1 source; +{warm_input} edited non-formula {}!A1 source; +{volatile_dynamic_formulas} volatile INDIRECT formulas re-dirtied after evaluation{table_proof}",
+            input_sheet(family)
+        ),
+    }
+}
+
+fn input_sheet(family: FixtureFamily) -> &'static str {
+    if family == FixtureFamily::CrossSheet {
+        "ChainA"
+    } else {
+        "Chain"
+    }
+}
+
+fn selector_set(family: FixtureFamily, path: CalibrationPath) -> &'static str {
+    match (family, path) {
+        (FixtureFamily::Names, CalibrationPath::Sheetport) => "workbook_name",
+        (FixtureFamily::Names, _) => "workbook_and_sheet_names",
+        (FixtureFamily::NativeTable, _) => "headers_body_totals",
+        (FixtureFamily::Layout, _) => "bounded_layout_table",
+        (FixtureFamily::Dynamic, CalibrationPath::Sheetport) => "dynamic_value",
+        (FixtureFamily::Dynamic, _) => "dynamic_value_and_explicit_error",
+        (FixtureFamily::CrossSheet, _) => "cross_sheet_terminal",
+        _ => "scalar_terminals",
+    }
+}
+
+fn setup_selectors(workbook: &mut Workbook, family: FixtureFamily) -> Result<()> {
+    match family {
+        FixtureFamily::Names => {
+            workbook.define_named_range(
+                "WorkbookOutput",
+                &RangeAddress::new("Names", 1, 2, 1, 2).unwrap(),
+                NamedRangeScope::Workbook,
+            )?;
+            workbook.define_named_range(
+                "SheetOutput",
+                &RangeAddress::new("Names", 2, 2, 2, 2).unwrap(),
+                NamedRangeScope::Sheet,
+            )?;
+        }
+        FixtureFamily::NativeTable => {
+            let sheet = workbook.engine().sheet_id("Table").context("Table sheet")?;
+            workbook.engine_mut().define_table(
+                "C6Table",
+                RangeRef::new(
+                    CellRef::new(sheet, Coord::from_excel(1, 1, true, true)),
+                    CellRef::new(sheet, Coord::from_excel(3, 4, true, true)),
+                ),
+                true,
+                vec![
+                    "Label".to_string(),
+                    "Count".to_string(),
+                    "Value".to_string(),
+                    "AsOf".to_string(),
+                ],
+                true,
+            )?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn family_targets(shape: &FamilyFixtureShape) -> Vec<EvaluationTarget> {
+    match shape.family {
+        FixtureFamily::CrossSheet => vec![EvaluationTarget::Cell {
+            sheet: shape.terminal_sheet.clone(),
+            row: shape.terminal_row,
+            col: shape.terminal_col,
+        }],
+        FixtureFamily::Names => vec![
+            EvaluationTarget::Name {
+                name: "WorkbookOutput".to_string(),
+                scope_sheet: None,
+            },
+            EvaluationTarget::Name {
+                name: "SheetOutput".to_string(),
+                scope_sheet: Some("Names".to_string()),
+            },
+        ],
+        FixtureFamily::NativeTable => vec![
+            EvaluationTarget::Table {
+                name: "C6Table".to_string(),
+                selection: TableSelection::Headers,
+            },
+            EvaluationTarget::Table {
+                name: "C6Table".to_string(),
+                selection: TableSelection::Data,
+            },
+            EvaluationTarget::Table {
+                name: "C6Table".to_string(),
+                selection: TableSelection::Totals,
+            },
+        ],
+        FixtureFamily::Dynamic => vec![EvaluationTarget::Range(
+            RangeAddress::new("Dynamic", 1, 2, 2, 2).unwrap(),
+        )],
+        _ => unreachable!("direct target family"),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_full_family(
+    workbook: &mut Workbook,
+    shape: &FamilyFixtureShape,
+    warm_repeats: usize,
+    phases: &mut PhaseTimings,
+    telemetry: &mut BTreeMap<String, EngineTelemetry>,
+    outputs: &mut Vec<Vec<TypedOracleValue>>,
+    gates: &mut BTreeMap<String, bool>,
+    structural: &mut BTreeMap<String, String>,
+) -> Result<()> {
+    if matches!(
+        shape.family,
+        FixtureFamily::Layout | FixtureFamily::NativeTable
+    ) {
+        let bind = Instant::now();
+        let yaml = if shape.family == FixtureFamily::Layout {
+            layout_manifest(shape.terminal_row)
+        } else {
+            table_manifest()
+        };
+        let manifest = Manifest::from_yaml_str(&yaml)?;
+        let mut sheetport = SheetPort::new(workbook, manifest)?;
+        phases.bind_target_resolution = Some(TimedPhase::new(
+            elapsed_ms(bind),
+            &[
+                "manifest_parse",
+                "manifest_bind",
+                "workbook_selector_validation",
+            ],
+        ));
+        let prepare = Instant::now();
+        sheetport.workbook_mut().prepare_graph_all()?;
+        phases.preparation_plan_build =
+            Some(TimedPhase::new(elapsed_ms(prepare), &["prepare_graph_all"]));
+        let evaluate = Instant::now();
+        sheetport.workbook_mut().evaluate_all()?;
+        phases.first_evaluation = Some(TimedPhase::new(elapsed_ms(evaluate), &["evaluate_all"]));
+        telemetry.insert(
+            "first_evaluation".to_string(),
+            collect_telemetry(sheetport.workbook()),
+        );
+        let read = Instant::now();
+        let snapshot = sheetport.read_outputs()?;
+        outputs.push(sheetport_output(&snapshot, shape.family)?);
+        phases.output_read = Some(TimedPhase::new(
+            elapsed_ms(read),
+            &["actual_selector_resolution", "typed_output_read"],
+        ));
+        for repeat in 0..warm_repeats {
+            let edit = Instant::now();
+            sheetport.workbook_mut().set_value(
+                input_sheet(shape.family),
+                1,
+                1,
+                LiteralValue::Number(2.0 + repeat as f64),
+            )?;
+            phases.edit.push(TimedPhase::new(
+                elapsed_ms(edit),
+                &["value_edit_inside_selected_closure"],
+            ));
+            let evaluate = Instant::now();
+            sheetport.workbook_mut().evaluate_all()?;
+            phases
+                .warm_evaluation
+                .push(TimedPhase::new(elapsed_ms(evaluate), &["evaluate_all"]));
+            telemetry.insert(
+                format!("warm_{repeat}"),
+                collect_telemetry(sheetport.workbook()),
+            );
+            let read = Instant::now();
+            let snapshot = sheetport.read_outputs()?;
+            outputs.push(sheetport_output(&snapshot, shape.family)?);
+            phases.warm_output_read.push(TimedPhase::new(
+                elapsed_ms(read),
+                &["actual_selector_resolution", "typed_output_read"],
+            ));
+        }
+        if shape.family == FixtureFamily::Layout {
+            let exact_bounds = outputs.iter().all(|values| values.len() == 5);
+            record_layout_bounds_gates(exact_bounds, gates, structural);
+        }
+        return Ok(());
+    }
+
+    let resolve = Instant::now();
+    phases.bind_target_resolution = Some(TimedPhase::new(
+        elapsed_ms(resolve),
+        &["typed_output_address_resolution"],
+    ));
+    let prepare = Instant::now();
+    workbook.prepare_graph_all()?;
+    phases.preparation_plan_build =
+        Some(TimedPhase::new(elapsed_ms(prepare), &["prepare_graph_all"]));
+    let evaluate = Instant::now();
+    workbook.evaluate_all()?;
+    phases.first_evaluation = Some(TimedPhase::new(elapsed_ms(evaluate), &["evaluate_all"]));
+    telemetry.insert("first_evaluation".to_string(), collect_telemetry(workbook));
+    let read = Instant::now();
+    outputs.push(read_family_outputs(workbook, shape));
+    phases.output_read = Some(TimedPhase::new(
+        elapsed_ms(read),
+        &["typed_direct_output_read"],
+    ));
+    for repeat in 0..warm_repeats {
+        let edit = Instant::now();
+        workbook.set_value(
+            input_sheet(shape.family),
+            1,
+            1,
+            LiteralValue::Number(2.0 + repeat as f64),
+        )?;
+        phases.edit.push(TimedPhase::new(
+            elapsed_ms(edit),
+            &["value_edit_inside_selected_closure"],
+        ));
+        let evaluate = Instant::now();
+        workbook.evaluate_all()?;
+        phases
+            .warm_evaluation
+            .push(TimedPhase::new(elapsed_ms(evaluate), &["evaluate_all"]));
+        telemetry.insert(format!("warm_{repeat}"), collect_telemetry(workbook));
+        let read = Instant::now();
+        outputs.push(read_family_outputs(workbook, shape));
+        phases.warm_output_read.push(TimedPhase::new(
+            elapsed_ms(read),
+            &["typed_direct_output_read"],
+        ));
+    }
+    if shape.family == FixtureFamily::Names {
+        let probe = Instant::now();
+        rebind_names(workbook)?;
+        workbook.evaluate_all()?;
+        outputs.push(read_family_outputs(workbook, shape));
+        phases.name_binding_probe = Some(TimedPhase::new(
+            elapsed_ms(probe),
+            &[
+                "public_name_binding_update",
+                "evaluate_all",
+                "typed_direct_output_read",
+            ],
+        ));
+        telemetry.insert(
+            "name_binding_probe".to_string(),
+            collect_telemetry(workbook),
+        );
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_direct_family(
+    workbook: &mut Workbook,
+    shape: &FamilyFixtureShape,
+    path: CalibrationPath,
+    warm_repeats: usize,
+    phases: &mut PhaseTimings,
+    telemetry: &mut BTreeMap<String, EngineTelemetry>,
+    outputs: &mut Vec<Vec<TypedOracleValue>>,
+    plan_stale_reason: &mut Option<String>,
+) -> Result<()> {
+    let resolve = Instant::now();
+    let targets = family_targets(shape);
+    phases.bind_target_resolution = Some(TimedPhase::new(
+        elapsed_ms(resolve),
+        &["typed_target_construction"],
+    ));
+
+    let mut plan = None;
+    if path == CalibrationPath::Plan {
+        let started = Instant::now();
+        plan = Some(workbook.build_recalc_plan_for_targets(&targets)?);
+        phases.preparation_plan_build = Some(TimedPhase::new(
+            elapsed_ms(started),
+            &["target_preparation", "revision_bound_plan_build"],
+        ));
+        telemetry.insert("plan_build".to_string(), collect_telemetry(workbook));
+    }
+
+    let first = Instant::now();
+    evaluate_direct(workbook, shape, path, &targets, plan.as_ref())?;
+    phases.first_evaluation = Some(TimedPhase::new(
+        elapsed_ms(first),
+        match path {
+            CalibrationPath::Cells => &[
+                "target_preparation",
+                "ephemeral_plan_build",
+                "evaluation",
+                "output_return",
+            ],
+            CalibrationPath::Targets => &["target_preparation", "evaluation"],
+            CalibrationPath::Plan => &["evaluate_with_plan"],
+            _ => unreachable!(),
+        },
+    ));
+    telemetry.insert("first_evaluation".to_string(), collect_telemetry(workbook));
+    let read = Instant::now();
+    outputs.push(read_family_outputs(workbook, shape));
+    phases.output_read = Some(TimedPhase::new(
+        elapsed_ms(read),
+        &["typed_direct_output_read"],
+    ));
+
+    for repeat in 0..warm_repeats {
+        let edit = Instant::now();
+        workbook.set_value(
+            input_sheet(shape.family),
+            1,
+            1,
+            LiteralValue::Number(2.0 + repeat as f64),
+        )?;
+        phases.edit.push(TimedPhase::new(
+            elapsed_ms(edit),
+            &["value_edit_inside_selected_closure"],
+        ));
+        let evaluate = Instant::now();
+        evaluate_direct(workbook, shape, path, &targets, plan.as_ref())?;
+        phases
+            .warm_evaluation
+            .push(TimedPhase::new(elapsed_ms(evaluate), &["evaluation"]));
+        telemetry.insert(format!("warm_{repeat}"), collect_telemetry(workbook));
+        let read = Instant::now();
+        outputs.push(read_family_outputs(workbook, shape));
+        phases.warm_output_read.push(TimedPhase::new(
+            elapsed_ms(read),
+            &["typed_direct_output_read"],
+        ));
+    }
+    if shape.family == FixtureFamily::Names {
+        let probe = Instant::now();
+        rebind_names(workbook)?;
+        if let Some(old_plan) = plan.as_ref() {
+            let error = workbook
+                .evaluate_with_plan(old_plan)
+                .expect_err("name binding update must stale retained plan");
+            *plan_stale_reason = stale_reason(&error).map(str::to_string);
+            plan = Some(workbook.build_recalc_plan_for_targets(&targets)?);
+        }
+        evaluate_direct(workbook, shape, path, &targets, plan.as_ref())?;
+        outputs.push(read_family_outputs(workbook, shape));
+        phases.name_binding_probe = Some(TimedPhase::new(
+            elapsed_ms(probe),
+            if path == CalibrationPath::Plan {
+                &[
+                    "public_name_binding_update",
+                    "exact_symbols_stale_probe",
+                    "single_revision_bound_plan_rebuild",
+                    "evaluation",
+                    "typed_direct_output_read",
+                ]
+            } else {
+                &[
+                    "public_name_binding_update",
+                    "evaluation",
+                    "typed_direct_output_read",
+                ]
+            },
+        ));
+        telemetry.insert(
+            "name_binding_probe".to_string(),
+            collect_telemetry(workbook),
+        );
+    }
+    Ok(())
+}
+
+fn evaluate_direct(
+    workbook: &mut Workbook,
+    shape: &FamilyFixtureShape,
+    path: CalibrationPath,
+    targets: &[EvaluationTarget],
+    plan: Option<&formualizer_eval::engine::RecalcPlan>,
+) -> Result<()> {
+    match path {
+        CalibrationPath::Cells => {
+            let cells = match shape.family {
+                FixtureFamily::CrossSheet => vec![(
+                    shape.terminal_sheet.as_str(),
+                    shape.terminal_row,
+                    shape.terminal_col,
+                )],
+                FixtureFamily::Dynamic => vec![("Dynamic", 1, 2), ("Dynamic", 2, 2)],
+                _ => unreachable!("cells family"),
+            };
+            workbook.evaluate_cells(&cells)?;
+        }
+        CalibrationPath::Targets => {
+            workbook.evaluate_targets(targets)?;
+        }
+        CalibrationPath::Plan => {
+            workbook.evaluate_with_plan(plan.context("retained target plan")?)?;
+        }
+        _ => unreachable!("direct family path"),
+    }
+    Ok(())
+}
+
+fn rebind_names(workbook: &mut Workbook) -> Result<()> {
+    workbook.update_named_range(
+        "WorkbookOutput",
+        &RangeAddress::new("Names", 3, 2, 3, 2).unwrap(),
+        NamedRangeScope::Workbook,
+    )?;
+    workbook.update_named_range(
+        "SheetOutput",
+        &RangeAddress::new("Names", 4, 2, 4, 2).unwrap(),
+        NamedRangeScope::Sheet,
+    )?;
+    Ok(())
+}
+
+fn stale_reason(error: &IoError) -> Option<&'static str> {
+    let IoError::Engine(excel) = error else {
+        return None;
+    };
+    let ExcelErrorExtra::PlanStale { reason } = excel.extra else {
+        return None;
+    };
+    Some(match reason {
+        PlanStaleReason::Engine => "engine",
+        PlanStaleReason::Provider => "provider",
+        PlanStaleReason::Semantic => "semantic",
+        PlanStaleReason::Budget => "budget",
+        PlanStaleReason::Staged => "staged",
+        PlanStaleReason::Symbols => "symbols",
+        PlanStaleReason::Authority => "authority",
+        PlanStaleReason::SpanGeneration => "span_generation",
+        PlanStaleReason::Graph => "graph",
+    })
+}
+
+fn read_family_outputs(workbook: &Workbook, shape: &FamilyFixtureShape) -> Vec<TypedOracleValue> {
+    match shape.family {
+        FixtureFamily::CrossSheet => vec![literal_to_typed(
+            workbook
+                .get_value(
+                    &shape.terminal_sheet,
+                    shape.terminal_row,
+                    shape.terminal_col,
+                )
+                .unwrap_or(LiteralValue::Empty),
+        )],
+        FixtureFamily::Names => vec![
+            literal_to_typed(
+                workbook
+                    .resolved_name_value("WorkbookOutput", None)
+                    .unwrap_or(LiteralValue::Empty),
+            ),
+            literal_to_typed(
+                workbook
+                    .resolved_name_value("SheetOutput", Some("Names"))
+                    .unwrap_or(LiteralValue::Empty),
+            ),
+        ],
+        FixtureFamily::NativeTable => {
+            let mut out = Vec::with_capacity(12);
+            for row in 1..=3 {
+                for col in 1..=4 {
+                    let value = workbook
+                        .get_value("Table", row, col)
+                        .unwrap_or(LiteralValue::Empty);
+                    out.push(if col == 2 && row > 1 {
+                        integer_to_typed(value)
+                    } else {
+                        literal_to_typed(value)
+                    });
+                }
+            }
+            out
+        }
+        FixtureFamily::Dynamic => (1..=2)
+            .map(|row| {
+                literal_to_typed(
+                    workbook
+                        .get_value("Dynamic", row, 2)
+                        .unwrap_or(LiteralValue::Empty),
+                )
+            })
+            .collect(),
+        _ => unreachable!("direct output family"),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_sheetport_family(
+    workbook: &mut Workbook,
+    shape: &FamilyFixtureShape,
+    warm_repeats: usize,
+    phases: &mut PhaseTimings,
+    telemetry: &mut BTreeMap<String, EngineTelemetry>,
+    outputs: &mut Vec<Vec<TypedOracleValue>>,
+    gates: &mut BTreeMap<String, bool>,
+    structural: &mut BTreeMap<String, String>,
+) -> Result<()> {
+    let bind = Instant::now();
+    let yaml = match shape.family {
+        FixtureFamily::Layout => layout_manifest(shape.terminal_row),
+        FixtureFamily::NativeTable => table_manifest(),
+        FixtureFamily::CrossSheet | FixtureFamily::Names | FixtureFamily::Dynamic => {
+            scalar_manifest(shape.family, &shape.terminal_sheet, shape.terminal_row)
+        }
+        FixtureFamily::Scalar => unreachable!(),
+    };
+    let manifest = Manifest::from_yaml_str(&yaml)?;
+    let mut sheetport = SheetPort::new(workbook, manifest)?;
+    phases.bind_target_resolution = Some(TimedPhase::new(
+        elapsed_ms(bind),
+        &[
+            "manifest_parse",
+            "manifest_bind",
+            "workbook_selector_validation",
+        ],
+    ));
+
+    let first = Instant::now();
+    let snapshot = sheetport.evaluate_once(EvalOptions::default())?;
+    phases.first_evaluation = Some(TimedPhase::new(
+        elapsed_ms(first),
+        &[
+            "actual_selector_resolution",
+            "target_preparation",
+            "evaluation",
+            "typed_output_read",
+        ],
+    ));
+    telemetry.insert(
+        "first_evaluation".to_string(),
+        collect_telemetry(sheetport.workbook()),
+    );
+    outputs.push(sheetport_output(&snapshot, shape.family)?);
+
+    if shape.family == FixtureFamily::Names {
+        for repeat in 0..warm_repeats {
+            let edit = Instant::now();
+            sheetport.workbook_mut().set_value(
+                input_sheet(shape.family),
+                1,
+                1,
+                LiteralValue::Number(2.0 + repeat as f64),
+            )?;
+            phases.edit.push(TimedPhase::new(
+                elapsed_ms(edit),
+                &["value_edit_inside_selected_closure"],
+            ));
+            let evaluate = Instant::now();
+            let snapshot = sheetport.evaluate_once(EvalOptions::default())?;
+            phases.warm_evaluation.push(TimedPhase::new(
+                elapsed_ms(evaluate),
+                &[
+                    "actual_name_selector_resolution",
+                    "target_evaluation",
+                    "typed_output_read",
+                ],
+            ));
+            telemetry.insert(
+                format!("warm_{repeat}"),
+                collect_telemetry(sheetport.workbook()),
+            );
+            outputs.push(sheetport_output(&snapshot, shape.family)?);
+        }
+        let probe = Instant::now();
+        rebind_names(sheetport.workbook_mut())?;
+        let snapshot = sheetport.evaluate_once(EvalOptions::default())?;
+        outputs.push(sheetport_output(&snapshot, shape.family)?);
+        phases.name_binding_probe = Some(TimedPhase::new(
+            elapsed_ms(probe),
+            &[
+                "public_workbook_name_binding_update",
+                "actual_name_selector_resolution",
+                "target_evaluation",
+                "typed_output_read",
+            ],
+        ));
+        telemetry.insert(
+            "name_binding_probe".to_string(),
+            collect_telemetry(sheetport.workbook()),
+        );
+        return Ok(());
+    }
+
+    let completion_ms = Arc::new(Mutex::new(Vec::new()));
+    let last = Arc::new(Mutex::new(Instant::now()));
+    let completion_capture = Arc::clone(&completion_ms);
+    let last_capture = Arc::clone(&last);
+    let batch_options = BatchOptions {
+        progress: Some(Box::new(move |_| {
+            let now = Instant::now();
+            let mut previous = last_capture.lock().expect("progress clock lock");
+            completion_capture
+                .lock()
+                .expect("progress samples lock")
+                .push(now.duration_since(*previous).as_secs_f64() * 1000.0);
+            *previous = now;
+        })),
+        ..BatchOptions::default()
+    };
+    let plan_started = Instant::now();
+    let mut batch = sheetport.batch(batch_options)?;
+    phases.preparation_plan_build = Some(TimedPhase::new(
+        elapsed_ms(plan_started),
+        &[
+            "input_baseline_read",
+            "actual_selector_resolution",
+            "target_preparation",
+            "revision_bound_plan_build",
+        ],
+    ));
+    telemetry.insert(
+        "sheetport_batch_plan_build".to_string(),
+        collect_telemetry(batch.workbook_for_benchmark()),
+    );
+    let cases = (0..warm_repeats)
+        .map(|repeat| {
+            let mut update = InputUpdate::new();
+            update.insert(
+                "input",
+                PortValue::Scalar(LiteralValue::Number(2.0 + repeat as f64)),
+            );
+            BatchInput::new(format!("warm_{repeat}"), update)
+        })
+        .collect::<Vec<_>>();
+    let batch_started = Instant::now();
+    *last.lock().expect("progress clock lock") = batch_started;
+    let results = batch.run(cases)?;
+    let batch_ms = elapsed_ms(batch_started);
+    telemetry.insert(
+        "sheetport_batch_execution".to_string(),
+        collect_telemetry(batch.workbook_for_benchmark()),
+    );
+    let restored_input = batch
+        .workbook_for_benchmark()
+        .get_value(input_sheet(shape.family), 1, 1);
+    let below_guard_inside_envelope_evaluated =
+        (shape.family == FixtureFamily::Layout).then(|| {
+            matches!(
+                batch.workbook_for_benchmark().get_value("Layout", 4, 3),
+                Some(LiteralValue::Number(value)) if (value - 999.0).abs() < f64::EPSILON
+            ) || matches!(
+                batch.workbook_for_benchmark().get_value("Layout", 4, 3),
+                Some(LiteralValue::Int(999))
+            )
+        });
+    let below_envelope_committed_but_unevaluated =
+        (shape.family == FixtureFamily::Layout).then(|| {
+            batch
+                .workbook_for_benchmark()
+                .get_value("Layout", LAYOUT_BELOW_ENVELOPE_ROW, 3)
+                .is_none_or(|value| value == LiteralValue::Empty)
+        });
+    let samples = completion_ms.lock().expect("progress samples lock").clone();
+    anyhow::ensure!(
+        samples.len() == warm_repeats,
+        "SheetPort progress count: actual {}, expected {warm_repeats}",
+        samples.len()
+    );
+    for sample in &samples {
+        phases.warm_evaluation.push(TimedPhase::new(
+            *sample,
+            &["input_edit", "plan_evaluation", "typed_output_read"],
+        ));
+    }
+    let sample_ms = samples.iter().sum::<f64>();
+    anyhow::ensure!(
+        batch_ms >= sample_ms,
+        "SheetPort batch restoration accounting is negative"
+    );
+    for result in results {
+        outputs.push(sheetport_output(&result.outputs, shape.family)?);
+    }
+    let restoration_passed = matches!(
+        restored_input,
+        Some(LiteralValue::Number(value)) if (value - 1.0).abs() < f64::EPSILON
+    ) || matches!(restored_input, Some(LiteralValue::Int(1)));
+    gates.insert("batch_baseline_restored".to_string(), restoration_passed);
+    phases.batch_restore = Some(TimedPhase::new(
+        batch_ms - sample_ms,
+        &[
+            "baseline_restore_edit",
+            "plan_evaluation",
+            "typed_output_read",
+        ],
+    ));
+
+    if shape.family == FixtureFamily::Layout {
+        let first = outputs.first().cloned().unwrap_or_default();
+        let exact_bounds = first.len() == 5;
+        record_layout_bounds_gates(exact_bounds, gates, structural);
+        gates.insert(
+            "layout_below_guard_inside_envelope_evaluated".to_string(),
+            below_guard_inside_envelope_evaluated.unwrap_or(false),
+        );
+        gates.insert(
+            "layout_below_envelope_committed_but_unevaluated".to_string(),
+            below_envelope_committed_but_unevaluated.unwrap_or(false),
+        );
+    }
+    Ok(())
+}
+
+fn record_layout_bounds_gates(
+    exact_bounds: bool,
+    gates: &mut BTreeMap<String, bool>,
+    structural: &mut BTreeMap<String, String>,
+) {
+    let envelope_extends_past_guard = LAYOUT_MAX_SCAN_ROWS > LAYOUT_BLANK_GUARD_ROW;
+    gates.insert(
+        "layout_exact_resolved_bounds_A2_D2".to_string(),
+        exact_bounds,
+    );
+    gates.insert(
+        "layout_scan_envelope_extends_past_blank_guard".to_string(),
+        envelope_extends_past_guard,
+    );
+    gates.insert(
+        "layout_preparation_envelope_A2_D9".to_string(),
+        LAYOUT_PREPARATION_ENVELOPE_END_ROW == 1 + LAYOUT_MAX_SCAN_ROWS,
+    );
+    gates.insert(
+        "layout_blank_guard_terminated_before_envelope".to_string(),
+        exact_bounds && envelope_extends_past_guard,
+    );
+    structural.insert(
+        "resolved_layout_bounds".to_string(),
+        format!(
+            "Layout!A2:D2: blank guard row {LAYOUT_BLANK_GUARD_ROW} terminated output resolution before max_scan_rows={LAYOUT_MAX_SCAN_ROWS}; conservative preparation envelope A2:D{LAYOUT_PREPARATION_ENVELOPE_END_ROW} evaluates below-guard C4; Layout-sheet package fallback also commits C{LAYOUT_BELOW_ENVELOPE_ROW}, which remains Empty, while six separate Retained-sheet formulas remain staged"
+        ),
+    );
+}
+
+fn sheetport_output(
+    snapshot: &formualizer_sheetport::OutputSnapshot,
+    family: FixtureFamily,
+) -> Result<Vec<TypedOracleValue>> {
+    match family {
+        FixtureFamily::CrossSheet | FixtureFamily::Names => match snapshot.get("output") {
+            Some(PortValue::Scalar(value)) => Ok(vec![literal_to_typed(value.clone())]),
+            other => anyhow::bail!("expected scalar SheetPort output, got {other:?}"),
+        },
+        FixtureFamily::Dynamic => match snapshot.get("value") {
+            Some(PortValue::Scalar(value)) => Ok(vec![literal_to_typed(value.clone())]),
+            other => anyhow::bail!("expected dynamic SheetPort scalar, got {other:?}"),
+        },
+        FixtureFamily::Layout => {
+            let mut values = table_port_values(snapshot, "rows", false)?;
+            match snapshot.get("breadth") {
+                Some(PortValue::Scalar(value)) => values.push(literal_to_typed(value.clone())),
+                other => anyhow::bail!("expected layout breadth scalar, got {other:?}"),
+            }
+            Ok(values)
+        }
+        FixtureFamily::NativeTable => {
+            let mut values = Vec::new();
+            values.extend(table_port_values(snapshot, "headers", true)?);
+            values.extend(table_port_values(snapshot, "body", false)?);
+            values.extend(table_port_values(snapshot, "totals", false)?);
+            Ok(values)
+        }
+        FixtureFamily::Scalar => unreachable!(),
+    }
+}
+
+fn table_port_values(
+    snapshot: &formualizer_sheetport::OutputSnapshot,
+    id: &str,
+    header: bool,
+) -> Result<Vec<TypedOracleValue>> {
+    let Some(PortValue::Table(table)) = snapshot.get(id) else {
+        anyhow::bail!("expected table SheetPort output `{id}`");
+    };
+    let mut values = Vec::new();
+    for row in &table.rows {
+        for column in ["Label", "Count", "Value", "AsOf"] {
+            let value = row
+                .values
+                .get(column)
+                .cloned()
+                .unwrap_or(LiteralValue::Empty);
+            values.push(if !header && column == "Count" {
+                integer_to_typed(value)
+            } else {
+                literal_to_typed(value)
+            });
+        }
+    }
+    Ok(values)
+}
+
+fn integer_to_typed(value: LiteralValue) -> TypedOracleValue {
+    match value {
+        LiteralValue::Int(value) => TypedOracleValue::Integer(value),
+        LiteralValue::Number(value) if value.fract() == 0.0 => {
+            TypedOracleValue::Integer(value as i64)
+        }
+        other => literal_to_typed(other),
+    }
+}
+
+fn literal_to_typed(value: LiteralValue) -> TypedOracleValue {
+    match value {
+        LiteralValue::Text(value) => TypedOracleValue::String(value),
+        LiteralValue::Int(value) => TypedOracleValue::Integer(value),
+        LiteralValue::Number(value) => TypedOracleValue::Number(value),
+        LiteralValue::Date(value) => TypedOracleValue::Date(value.to_string()),
+        LiteralValue::DateTime(value) => TypedOracleValue::Date(value.date().to_string()),
+        LiteralValue::Boolean(value) => TypedOracleValue::Boolean(value),
+        LiteralValue::Empty => TypedOracleValue::Empty,
+        LiteralValue::Error(error) => TypedOracleValue::Error(error.kind.to_string()),
+        other => TypedOracleValue::String(format!("{other:?}")),
+    }
+}
+
+fn typed_values_match(
+    actual: &[Vec<TypedOracleValue>],
+    expected: &[Vec<TypedOracleValue>],
+) -> bool {
+    actual.len() == expected.len()
+        && actual.iter().zip(expected).all(|(actual, expected)| {
+            actual.len() == expected.len()
+                && actual
+                    .iter()
+                    .zip(expected)
+                    .all(|(actual, expected)| match (actual, expected) {
+                        (TypedOracleValue::Number(actual), TypedOracleValue::Number(expected)) => {
+                            (actual - expected).abs() <= 1e-9 * expected.abs().max(1.0)
+                        }
+                        _ => actual == expected,
+                    })
+        })
+}

--- a/crates/formualizer-bench-core/src/c6_calibration.rs
+++ b/crates/formualizer-bench-core/src/c6_calibration.rs
@@ -10,26 +10,138 @@ use sha2::{Digest, Sha256};
 use formualizer_eval::engine::EvaluationTarget;
 use formualizer_testkit::write_workbook;
 
+pub mod families;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum FixtureFamily {
+    Scalar,
+    CrossSheet,
+    Names,
+    Layout,
+    NativeTable,
+    Dynamic,
+}
+
+impl FixtureFamily {
+    pub const ALL: [Self; 6] = [
+        Self::Scalar,
+        Self::CrossSheet,
+        Self::Names,
+        Self::Layout,
+        Self::NativeTable,
+        Self::Dynamic,
+    ];
+
+    pub const BREADTH: [Self; 5] = [
+        Self::CrossSheet,
+        Self::Names,
+        Self::Layout,
+        Self::NativeTable,
+        Self::Dynamic,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Scalar => "scalar",
+            Self::CrossSheet => "cross_sheet",
+            Self::Names => "names",
+            Self::Layout => "layout",
+            Self::NativeTable => "native_table",
+            Self::Dynamic => "dynamic",
+        }
+    }
+
+    pub const fn cli_label(self) -> &'static str {
+        match self {
+            Self::CrossSheet => "cross-sheet",
+            Self::NativeTable => "native-table",
+            _ => self.label(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum CalibrationPath {
     Full,
     Cells,
+    Targets,
     Plan,
     Sheetport,
 }
 
 impl CalibrationPath {
-    pub const ALL: [Self; 4] = [Self::Full, Self::Cells, Self::Plan, Self::Sheetport];
+    /// The original scalar matrix. Keep this stable for CLI/default compatibility.
+    pub const SCALAR_V2: [Self; 4] = [Self::Full, Self::Cells, Self::Plan, Self::Sheetport];
+    pub const ALL: [Self; 5] = [
+        Self::Full,
+        Self::Cells,
+        Self::Targets,
+        Self::Plan,
+        Self::Sheetport,
+    ];
 
     pub const fn label(self) -> &'static str {
         match self {
             Self::Full => "full",
             Self::Cells => "cells",
+            Self::Targets => "targets",
             Self::Plan => "plan",
             Self::Sheetport => "sheetport",
         }
     }
+}
+
+/// The hard-coded Phase-A native family/path contract. Unsupported selectors are
+/// deliberately absent instead of being emulated through a less specific API.
+pub const fn path_supported(family: FixtureFamily, path: CalibrationPath) -> bool {
+    match family {
+        FixtureFamily::Scalar => matches!(
+            path,
+            CalibrationPath::Full
+                | CalibrationPath::Cells
+                | CalibrationPath::Plan
+                | CalibrationPath::Sheetport
+        ),
+        FixtureFamily::CrossSheet | FixtureFamily::Dynamic => matches!(
+            path,
+            CalibrationPath::Full
+                | CalibrationPath::Cells
+                | CalibrationPath::Targets
+                | CalibrationPath::Plan
+                | CalibrationPath::Sheetport
+        ),
+        FixtureFamily::Names => matches!(
+            path,
+            CalibrationPath::Full
+                | CalibrationPath::Targets
+                | CalibrationPath::Plan
+                | CalibrationPath::Sheetport
+        ),
+        FixtureFamily::Layout => {
+            matches!(path, CalibrationPath::Full | CalibrationPath::Sheetport)
+        }
+        FixtureFamily::NativeTable => matches!(
+            path,
+            CalibrationPath::Full
+                | CalibrationPath::Targets
+                | CalibrationPath::Plan
+                | CalibrationPath::Sheetport
+        ),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum TypedOracleValue {
+    String(String),
+    Integer(i64),
+    Number(f64),
+    Date(String),
+    Boolean(bool),
+    Empty,
+    Error(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ValueEnum)]
@@ -256,6 +368,10 @@ impl TimedPhase {
 pub struct PhaseTimings {
     pub load: Option<TimedPhase>,
     pub unrelated_dirty_setup: Option<TimedPhase>,
+    #[serde(default)]
+    pub selector_setup: Option<TimedPhase>,
+    #[serde(default)]
+    pub name_binding_probe: Option<TimedPhase>,
     pub bind_target_resolution: Option<TimedPhase>,
     pub preparation_plan_build: Option<TimedPhase>,
     pub first_evaluation: Option<TimedPhase>,
@@ -324,6 +440,12 @@ pub struct GraphSnapshot {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChildReport {
     pub schema_version: u32,
+    #[serde(default = "default_scalar_family")]
+    pub family: FixtureFamily,
+    #[serde(default = "default_path_schema_version")]
+    pub path_schema_version: u32,
+    #[serde(default)]
+    pub selector_set: String,
     pub path: CalibrationPath,
     pub scope: TargetScope,
     pub formulas: u32,
@@ -334,6 +456,16 @@ pub struct ChildReport {
     pub outputs: Vec<Vec<String>>,
     pub analytical_expected_outputs: Vec<Vec<f64>>,
     pub analytical_output_oracle_passed: Option<bool>,
+    #[serde(default)]
+    pub typed_outputs: Vec<Vec<TypedOracleValue>>,
+    #[serde(default)]
+    pub typed_expected_outputs: Vec<Vec<TypedOracleValue>>,
+    #[serde(default)]
+    pub family_gates: BTreeMap<String, bool>,
+    #[serde(default)]
+    pub structural_oracles: BTreeMap<String, String>,
+    #[serde(default)]
+    pub plan_stale_reason: Option<String>,
     pub output_checksum: Option<String>,
     pub typed_error: Option<String>,
     pub telemetry: BTreeMap<String, EngineTelemetry>,
@@ -355,6 +487,14 @@ pub struct Distribution {
     pub p95: f64,
     pub mad: f64,
     pub max: f64,
+}
+
+const fn default_scalar_family() -> FixtureFamily {
+    FixtureFamily::Scalar
+}
+
+const fn default_path_schema_version() -> u32 {
+    2
 }
 
 pub fn distribution(values: &[f64]) -> Option<Distribution> {
@@ -413,6 +553,72 @@ mod tests {
                 + shape.dirty_formulas,
             shape.formulas
         );
+    }
+
+    #[test]
+    fn supported_family_path_matrix_is_explicit() {
+        let expected = [
+            (
+                FixtureFamily::Scalar,
+                vec![
+                    CalibrationPath::Full,
+                    CalibrationPath::Cells,
+                    CalibrationPath::Plan,
+                    CalibrationPath::Sheetport,
+                ],
+            ),
+            (
+                FixtureFamily::CrossSheet,
+                vec![
+                    CalibrationPath::Full,
+                    CalibrationPath::Cells,
+                    CalibrationPath::Targets,
+                    CalibrationPath::Plan,
+                    CalibrationPath::Sheetport,
+                ],
+            ),
+            (
+                FixtureFamily::Names,
+                vec![
+                    CalibrationPath::Full,
+                    CalibrationPath::Targets,
+                    CalibrationPath::Plan,
+                    CalibrationPath::Sheetport,
+                ],
+            ),
+            (
+                FixtureFamily::Layout,
+                vec![CalibrationPath::Full, CalibrationPath::Sheetport],
+            ),
+            (
+                FixtureFamily::NativeTable,
+                vec![
+                    CalibrationPath::Full,
+                    CalibrationPath::Targets,
+                    CalibrationPath::Plan,
+                    CalibrationPath::Sheetport,
+                ],
+            ),
+            (
+                FixtureFamily::Dynamic,
+                vec![
+                    CalibrationPath::Full,
+                    CalibrationPath::Cells,
+                    CalibrationPath::Targets,
+                    CalibrationPath::Plan,
+                    CalibrationPath::Sheetport,
+                ],
+            ),
+        ];
+        for (family, supported) in expected {
+            assert_eq!(
+                CalibrationPath::ALL
+                    .into_iter()
+                    .filter(|path| path_supported(family, *path))
+                    .collect::<Vec<_>>(),
+                supported
+            );
+        }
     }
 
     #[test]

--- a/crates/formualizer-bench-core/src/c6_calibration/families.rs
+++ b/crates/formualizer-bench-core/src/c6_calibration/families.rs
@@ -1,0 +1,558 @@
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+
+use formualizer_testkit::write_workbook;
+
+use super::{CalibrationPath, FixtureFamily, TypedOracleValue, generate_fixture};
+
+pub const DIRTY_FORMULAS: u32 = 8;
+pub const RETAINED_FORMULAS: u32 = 8;
+pub const LAYOUT_BLANK_GUARD_ROW: u32 = 3;
+pub const LAYOUT_MAX_SCAN_ROWS: u32 = 8;
+pub const LAYOUT_PREPARATION_ENVELOPE_END_ROW: u32 = 9;
+pub const LAYOUT_BELOW_ENVELOPE_ROW: u32 = 10;
+pub const LAYOUT_RETAINED_FORMULAS: u32 = 6;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FamilyFixtureShape {
+    pub family: FixtureFamily,
+    pub formulas: u32,
+    pub reachable_formulas: u32,
+    pub dirty_formulas: u32,
+    pub retained_formulas: u32,
+    pub terminal_sheet: String,
+    pub terminal_row: u32,
+    pub terminal_col: u32,
+}
+
+pub fn generate_family_fixture_shape(
+    family: FixtureFamily,
+    formulas: u32,
+) -> Result<FamilyFixtureShape> {
+    if formulas < 32 {
+        bail!("--formulas must be at least 32 for native breadth families");
+    }
+    let (reachable_formulas, retained_formulas, terminal_sheet, terminal_row) = match family {
+        FixtureFamily::CrossSheet => {
+            let chain = formulas - DIRTY_FORMULAS - RETAINED_FORMULAS;
+            let (sheet, row) = cross_terminal(chain);
+            (chain, RETAINED_FORMULAS, sheet, row)
+        }
+        FixtureFamily::Names => (
+            formulas - DIRTY_FORMULAS - RETAINED_FORMULAS - 2,
+            RETAINED_FORMULAS,
+            "Chain",
+            formulas - DIRTY_FORMULAS - RETAINED_FORMULAS - 4,
+        ),
+        FixtureFamily::Layout => (
+            formulas - DIRTY_FORMULAS - LAYOUT_RETAINED_FORMULAS,
+            LAYOUT_RETAINED_FORMULAS,
+            "Chain",
+            formulas - DIRTY_FORMULAS - RETAINED_FORMULAS,
+        ),
+        FixtureFamily::NativeTable => (
+            formulas - DIRTY_FORMULAS - RETAINED_FORMULAS,
+            RETAINED_FORMULAS,
+            "Chain",
+            formulas - DIRTY_FORMULAS - RETAINED_FORMULAS - 3,
+        ),
+        FixtureFamily::Dynamic => (formulas, 0, "Chain", formulas - DIRTY_FORMULAS - 2),
+        FixtureFamily::Scalar => bail!("scalar shape uses FixtureShape"),
+    };
+    Ok(FamilyFixtureShape {
+        family,
+        formulas,
+        reachable_formulas,
+        dirty_formulas: DIRTY_FORMULAS,
+        retained_formulas,
+        terminal_sheet: terminal_sheet.to_string(),
+        terminal_row,
+        terminal_col: 2,
+    })
+}
+
+pub fn generate_family_fixture(
+    path: &Path,
+    family: FixtureFamily,
+    formulas: u32,
+) -> Result<FamilyFixtureShape> {
+    if family == FixtureFamily::Scalar {
+        let shape = generate_fixture(path, formulas)?;
+        return Ok(FamilyFixtureShape {
+            family,
+            formulas,
+            reachable_formulas: shape.formulas,
+            dirty_formulas: shape.dirty_formulas,
+            retained_formulas: shape.large_formulas,
+            terminal_sheet: "Tiny".to_string(),
+            terminal_row: shape.tiny_formulas,
+            terminal_col: 2,
+        });
+    }
+    if formulas < 32 {
+        bail!("--formulas must be at least 32 for native breadth families");
+    }
+    match family {
+        FixtureFamily::CrossSheet => generate_cross_sheet(path, formulas),
+        FixtureFamily::Names => generate_names(path, formulas),
+        FixtureFamily::Layout => generate_layout(path, formulas),
+        FixtureFamily::NativeTable => generate_native_table(path, formulas),
+        FixtureFamily::Dynamic => generate_dynamic(path, formulas),
+        FixtureFamily::Scalar => unreachable!(),
+    }
+}
+
+fn base_book(book: &mut umya_spreadsheet::Spreadsheet, sheets: &[&str]) {
+    book.get_sheet_by_name_mut("Sheet1")
+        .expect("default sheet")
+        .set_name("Inputs");
+    for sheet in sheets {
+        book.new_sheet(*sheet).expect("unique fixture sheet");
+    }
+    book.get_sheet_by_name_mut("Inputs")
+        .expect("Inputs")
+        .get_cell_mut((1, 1))
+        .set_value_number(1.0);
+}
+
+fn populate_single_chain(
+    book: &mut umya_spreadsheet::Spreadsheet,
+    sheet_name: &str,
+    formulas: u32,
+) {
+    let sheet = book.get_sheet_by_name_mut(sheet_name).expect("chain sheet");
+    sheet.get_cell_mut((1, 1)).set_value_number(1.0);
+    sheet.get_cell_mut((2, 1)).set_formula("=$A$1*1.015-0.25");
+    for row in 2..=formulas {
+        sheet
+            .get_cell_mut((2, row))
+            .set_formula(format!("=B{}*1.0001+0.00001", row - 1));
+    }
+}
+
+fn populate_dirty_and_retained(book: &mut umya_spreadsheet::Spreadsheet, retained: u32) {
+    let dirty = book.get_sheet_by_name_mut("Dirty").expect("Dirty");
+    dirty.get_cell_mut((1, 1)).set_value_number(4.0);
+    dirty.get_cell_mut((2, 1)).set_formula("=A1*2");
+    for row in 2..=DIRTY_FORMULAS {
+        dirty
+            .get_cell_mut((2, row))
+            .set_formula(format!("=B{}+1", row - 1));
+    }
+    if retained > 0 {
+        let staged = book.get_sheet_by_name_mut("Retained").expect("Retained");
+        for row in 1..=retained {
+            staged
+                .get_cell_mut((2, row))
+                .set_formula(format!("={row}+100"));
+        }
+    }
+}
+
+fn cross_terminal(formulas: u32) -> (&'static str, u32) {
+    if formulas % 2 == 1 {
+        ("ChainA", formulas.div_ceil(2))
+    } else {
+        ("ChainB", formulas / 2)
+    }
+}
+
+fn generate_cross_sheet(path: &Path, formulas: u32) -> Result<FamilyFixtureShape> {
+    let chain = formulas - DIRTY_FORMULAS - RETAINED_FORMULAS;
+    write_workbook(path, |book| {
+        base_book(book, &["ChainA", "ChainB", "Dirty", "Retained"]);
+        book.get_sheet_by_name_mut("ChainA")
+            .expect("ChainA")
+            .get_cell_mut((1, 1))
+            .set_value_number(1.0);
+        for index in 1..=chain {
+            let (sheet_name, row) = cross_terminal(index);
+            let formula = if index == 1 {
+                "=$A$1*1.015-0.25".to_string()
+            } else {
+                let (previous_sheet, previous_row) = cross_terminal(index - 1);
+                format!("='{previous_sheet}'!B{previous_row}*1.0001+0.00001")
+            };
+            book.get_sheet_by_name_mut(sheet_name)
+                .expect("alternating chain sheet")
+                .get_cell_mut((2, row))
+                .set_formula(formula);
+        }
+        populate_dirty_and_retained(book, RETAINED_FORMULAS);
+    });
+    let (sheet, row) = cross_terminal(chain);
+    Ok(FamilyFixtureShape {
+        family: FixtureFamily::CrossSheet,
+        formulas,
+        reachable_formulas: chain,
+        dirty_formulas: DIRTY_FORMULAS,
+        retained_formulas: RETAINED_FORMULAS,
+        terminal_sheet: sheet.to_string(),
+        terminal_row: row,
+        terminal_col: 2,
+    })
+}
+
+fn generate_names(path: &Path, formulas: u32) -> Result<FamilyFixtureShape> {
+    let chain = formulas - DIRTY_FORMULAS - RETAINED_FORMULAS - 4;
+    write_workbook(path, |book| {
+        base_book(book, &["Chain", "Names", "Dirty", "Retained"]);
+        populate_single_chain(book, "Chain", chain);
+        let names = book.get_sheet_by_name_mut("Names").expect("Names");
+        for (row, offset) in [(1, 10), (2, 20), (3, 30), (4, 40)] {
+            names
+                .get_cell_mut((2, row))
+                .set_formula(format!("=Chain!B{chain}+{offset}"));
+        }
+        populate_dirty_and_retained(book, RETAINED_FORMULAS);
+    });
+    Ok(FamilyFixtureShape {
+        family: FixtureFamily::Names,
+        formulas,
+        reachable_formulas: chain + 2,
+        dirty_formulas: DIRTY_FORMULAS,
+        retained_formulas: RETAINED_FORMULAS,
+        terminal_sheet: "Chain".to_string(),
+        terminal_row: chain,
+        terminal_col: 2,
+    })
+}
+
+fn generate_layout(path: &Path, formulas: u32) -> Result<FamilyFixtureShape> {
+    let selector_formulas = 2;
+    let chain = formulas - DIRTY_FORMULAS - LAYOUT_RETAINED_FORMULAS - selector_formulas;
+    write_workbook(path, |book| {
+        base_book(book, &["Chain", "Layout", "Dirty", "Retained"]);
+        populate_single_chain(book, "Chain", chain);
+        let layout = book.get_sheet_by_name_mut("Layout").expect("Layout");
+        for (col, header) in [(1, "Label"), (2, "Count"), (3, "Value"), (4, "AsOf")] {
+            layout.get_cell_mut((col, 1)).set_value(header);
+        }
+        layout.get_cell_mut((1, 2)).set_value("row-1");
+        layout.get_cell_mut((2, 2)).set_value_number(7);
+        layout.get_cell_mut((3, 2)).set_value_number(5.0);
+        layout.get_cell_mut((4, 2)).set_value_number(45_659.0);
+        let _ = layout
+            .get_style_mut("D2")
+            .get_number_format_mut()
+            .set_format_code(umya_spreadsheet::NumberingFormat::FORMAT_DATE_XLSX14);
+        // Row 3 is the blank guard. C4 is inside the conservative preparation
+        // envelope and C10 is below it; neither belongs to the resolved output.
+        // Deferred Calamine preparation commits their whole worksheet package,
+        // but only C4 is scheduled by the A2:D9 target envelope.
+        layout.get_cell_mut((3, 4)).set_formula("=999");
+        layout.get_cell_mut((3, 10)).set_formula("=1000");
+        populate_dirty_and_retained(book, LAYOUT_RETAINED_FORMULAS);
+    });
+    Ok(FamilyFixtureShape {
+        family: FixtureFamily::Layout,
+        formulas,
+        reachable_formulas: chain + selector_formulas,
+        dirty_formulas: DIRTY_FORMULAS,
+        retained_formulas: LAYOUT_RETAINED_FORMULAS,
+        terminal_sheet: "Chain".to_string(),
+        terminal_row: chain,
+        terminal_col: 2,
+    })
+}
+
+fn generate_native_table(path: &Path, formulas: u32) -> Result<FamilyFixtureShape> {
+    let selector_formulas = 3;
+    let chain = formulas - DIRTY_FORMULAS - RETAINED_FORMULAS - selector_formulas;
+    write_workbook(path, |book| {
+        base_book(book, &["Chain", "Table", "Dirty", "Retained"]);
+        populate_single_chain(book, "Chain", chain);
+        let table = book.get_sheet_by_name_mut("Table").expect("Table");
+        for (col, header) in [(1, "Label"), (2, "Count"), (3, "Value"), (4, "AsOf")] {
+            table.get_cell_mut((col, 1)).set_value(header);
+        }
+        table.get_cell_mut((1, 2)).set_value("body");
+        table.get_cell_mut((2, 2)).set_value_number(7);
+        table
+            .get_cell_mut((3, 2))
+            .set_formula(format!("=Chain!B{chain}+5"));
+        table.get_cell_mut((4, 2)).set_value_number(45_659.0);
+        let _ = table
+            .get_style_mut("D2")
+            .get_number_format_mut()
+            .set_format_code(umya_spreadsheet::NumberingFormat::FORMAT_DATE_XLSX14);
+        table.get_cell_mut((1, 3)).set_value("totals");
+        table.get_cell_mut((2, 3)).set_formula("=7");
+        table
+            .get_cell_mut((3, 3))
+            .set_formula(format!("=Chain!B{chain}+12"));
+        table.get_cell_mut((4, 3)).set_value_number(45_660.0);
+        let _ = table
+            .get_style_mut("D3")
+            .get_number_format_mut()
+            .set_format_code(umya_spreadsheet::NumberingFormat::FORMAT_DATE_XLSX14);
+        populate_dirty_and_retained(book, RETAINED_FORMULAS);
+    });
+    Ok(FamilyFixtureShape {
+        family: FixtureFamily::NativeTable,
+        formulas,
+        reachable_formulas: chain + selector_formulas,
+        dirty_formulas: DIRTY_FORMULAS,
+        retained_formulas: RETAINED_FORMULAS,
+        terminal_sheet: "Chain".to_string(),
+        terminal_row: chain,
+        terminal_col: 2,
+    })
+}
+
+fn generate_dynamic(path: &Path, formulas: u32) -> Result<FamilyFixtureShape> {
+    let chain = formulas - DIRTY_FORMULAS - 2;
+    write_workbook(path, |book| {
+        base_book(book, &["Chain", "Dynamic", "Dirty"]);
+        populate_single_chain(book, "Chain", chain);
+        let dynamic = book.get_sheet_by_name_mut("Dynamic").expect("Dynamic");
+        dynamic
+            .get_cell_mut((2, 1))
+            .set_formula(format!("=INDIRECT(\"Chain!A1\")+Chain!B{chain}"));
+        dynamic
+            .get_cell_mut((2, 2))
+            .set_formula("=INDIRECT(\"Missing!A1\")");
+        populate_dirty_and_retained(book, 0);
+    });
+    Ok(FamilyFixtureShape {
+        family: FixtureFamily::Dynamic,
+        formulas,
+        reachable_formulas: formulas,
+        dirty_formulas: DIRTY_FORMULAS,
+        retained_formulas: 0,
+        terminal_sheet: "Chain".to_string(),
+        terminal_row: chain,
+        terminal_col: 2,
+    })
+}
+
+pub fn chain_value(shape: &FamilyFixtureShape, seed: f64) -> f64 {
+    let chain_formulas = match shape.family {
+        FixtureFamily::CrossSheet => shape.formulas - DIRTY_FORMULAS - RETAINED_FORMULAS,
+        FixtureFamily::Names => shape.formulas - DIRTY_FORMULAS - RETAINED_FORMULAS - 4,
+        FixtureFamily::Layout => shape.formulas - DIRTY_FORMULAS - RETAINED_FORMULAS,
+        FixtureFamily::NativeTable => shape.formulas - DIRTY_FORMULAS - RETAINED_FORMULAS - 3,
+        FixtureFamily::Dynamic => shape.formulas - DIRTY_FORMULAS - 2,
+        FixtureFamily::Scalar => shape.formulas,
+    };
+    let first = seed * 1.015 - 0.25;
+    if chain_formulas == 1 {
+        return first;
+    }
+    let ratio = 1.0001_f64;
+    let power = ratio.powi((chain_formulas - 1) as i32);
+    first * power + 0.00001 * (power - 1.0) / (ratio - 1.0)
+}
+
+pub fn expected_typed_outputs(
+    shape: &FamilyFixtureShape,
+    path: CalibrationPath,
+    warm_repeats: usize,
+) -> Vec<Vec<TypedOracleValue>> {
+    let mut outputs = (0..=warm_repeats)
+        .map(|evaluation| {
+            let seed = if evaluation == 0 {
+                1.0
+            } else {
+                1.0 + evaluation as f64
+            };
+            let terminal = chain_value(shape, seed);
+            match shape.family {
+                FixtureFamily::CrossSheet => vec![TypedOracleValue::Number(terminal)],
+                FixtureFamily::Names if path == CalibrationPath::Sheetport => {
+                    vec![TypedOracleValue::Number(terminal + 10.0)]
+                }
+                FixtureFamily::Names => vec![
+                    TypedOracleValue::Number(terminal + 10.0),
+                    TypedOracleValue::Number(terminal + 20.0),
+                ],
+                FixtureFamily::Layout => vec![
+                    TypedOracleValue::String("row-1".to_string()),
+                    TypedOracleValue::Integer(7),
+                    TypedOracleValue::Number(5.0),
+                    TypedOracleValue::Date("2025-01-02".to_string()),
+                    TypedOracleValue::Number(terminal),
+                ],
+                FixtureFamily::NativeTable => native_table_expected(terminal),
+                FixtureFamily::Dynamic if path == CalibrationPath::Sheetport => {
+                    vec![TypedOracleValue::Number(seed + terminal)]
+                }
+                FixtureFamily::Dynamic => vec![
+                    TypedOracleValue::Number(seed + terminal),
+                    TypedOracleValue::Error("#REF!".to_string()),
+                ],
+                FixtureFamily::Scalar => Vec::new(),
+            }
+        })
+        .collect::<Vec<_>>();
+    if shape.family == FixtureFamily::Names {
+        let seed = if warm_repeats == 0 {
+            1.0
+        } else {
+            1.0 + warm_repeats as f64
+        };
+        let terminal = chain_value(shape, seed);
+        outputs.push(if path == CalibrationPath::Sheetport {
+            vec![TypedOracleValue::Number(terminal + 30.0)]
+        } else {
+            vec![
+                TypedOracleValue::Number(terminal + 30.0),
+                TypedOracleValue::Number(terminal + 40.0),
+            ]
+        });
+    }
+    outputs
+}
+
+fn native_table_expected(terminal: f64) -> Vec<TypedOracleValue> {
+    vec![
+        TypedOracleValue::String("Label".to_string()),
+        TypedOracleValue::String("Count".to_string()),
+        TypedOracleValue::String("Value".to_string()),
+        TypedOracleValue::String("AsOf".to_string()),
+        TypedOracleValue::String("body".to_string()),
+        TypedOracleValue::Integer(7),
+        TypedOracleValue::Number(terminal + 5.0),
+        TypedOracleValue::Date("2025-01-02".to_string()),
+        TypedOracleValue::String("totals".to_string()),
+        TypedOracleValue::Integer(7),
+        TypedOracleValue::Number(terminal + 12.0),
+        TypedOracleValue::Date("2025-01-03".to_string()),
+    ]
+}
+
+pub fn layout_manifest(terminal_row: u32) -> String {
+    r#"spec: fio
+spec_version: "0.3.0"
+manifest: { id: c6-layout, name: C6 Layout }
+ports:
+  - id: input
+    dir: in
+    shape: scalar
+    location: { a1: Chain!A1 }
+    schema: { type: number }
+  - id: rows
+    dir: out
+    shape: table
+    location:
+      layout:
+        sheet: Layout
+        header_row: 1
+        anchor_col: A
+        terminate: first_blank_row
+        max_scan_rows: {max_scan_rows}
+    schema:
+      kind: table
+      columns:
+        - { name: Label, type: string, col: A }
+        - { name: Count, type: integer, col: B }
+        - { name: Value, type: number, col: C }
+        - { name: AsOf, type: date, col: D }
+  - id: breadth
+    dir: out
+    shape: scalar
+    location: { a1: Chain!B{terminal_row} }
+    schema: { type: number }
+"#
+    .replace("{terminal_row}", &terminal_row.to_string())
+    .replace("{max_scan_rows}", &LAYOUT_MAX_SCAN_ROWS.to_string())
+}
+
+pub fn table_manifest() -> String {
+    let columns = "      columns:\n        - { name: Label, type: string }\n        - { name: Count, type: integer }\n        - { name: Value, type: number }\n        - { name: AsOf, type: date }\n";
+    format!(
+        "spec: fio\nspec_version: \"0.3.0\"\ncapabilities: {{ profile: full-v0 }}\nmanifest: {{ id: c6-table, name: C6 Native Table }}\nports:\n  - id: input\n    dir: in\n    shape: scalar\n    location: {{ a1: Chain!A1 }}\n    schema: {{ type: number }}\n  - id: headers\n    dir: out\n    shape: table\n    location:\n      table: {{ name: C6Table, area: header }}\n    schema:\n      kind: table\n{header_columns}  - id: body\n    dir: out\n    shape: table\n    location:\n      table: {{ name: C6Table, area: body }}\n    schema:\n      kind: table\n{columns}  - id: totals\n    dir: out\n    shape: table\n    location:\n      table: {{ name: C6Table, area: totals }}\n    schema:\n      kind: table\n{columns}",
+        header_columns = "      columns:\n        - { name: Label, type: string }\n        - { name: Count, type: string }\n        - { name: Value, type: string }\n        - { name: AsOf, type: string }\n",
+    )
+}
+
+pub fn scalar_manifest(family: FixtureFamily, terminal_sheet: &str, terminal_row: u32) -> String {
+    let input_sheet = if family == FixtureFamily::CrossSheet {
+        "ChainA"
+    } else {
+        "Chain"
+    };
+    let (id, outputs) = match family {
+        FixtureFamily::CrossSheet => (
+            "c6-cross-sheet",
+            format!(
+                "  - id: output\n    dir: out\n    shape: scalar\n    location: {{ a1: {terminal_sheet}!B{terminal_row} }}\n    schema: {{ type: number }}\n"
+            ),
+        ),
+        FixtureFamily::Names => (
+            "c6-name",
+            "  - id: output\n    dir: out\n    shape: scalar\n    location: { name: WorkbookOutput }\n    schema: { type: number }\n"
+                .to_string(),
+        ),
+        FixtureFamily::Dynamic => (
+            "c6-dynamic",
+            "  - id: value\n    dir: out\n    shape: scalar\n    location: { a1: Dynamic!B1 }\n    schema: { type: number }\n"
+                .to_string(),
+        ),
+        _ => unreachable!("scalar manifest family"),
+    };
+    format!(
+        "spec: fio\nspec_version: \"0.3.0\"\nmanifest: {{ id: {id}, name: C6 Native }}\nports:\n  - id: input\n    dir: in\n    shape: scalar\n    location: {{ a1: {input_sheet}!A1 }}\n    schema: {{ type: number }}\n{outputs}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::c6_calibration::sha256_file;
+
+    #[test]
+    fn all_family_formula_accounting_is_exact() {
+        for family in FixtureFamily::BREADTH {
+            let path = std::env::temp_dir().join(format!(
+                "c6-family-accounting-{}-{}.xlsx",
+                family.label(),
+                std::process::id()
+            ));
+            let shape = generate_family_fixture(&path, family, 200).unwrap();
+            assert_eq!(shape.formulas, 200);
+            assert!(shape.reachable_formulas <= 200);
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn family_fixture_bytes_are_deterministic() {
+        for family in FixtureFamily::BREADTH {
+            let a = std::env::temp_dir().join(format!("c6-det-a-{}.xlsx", family.label()));
+            let b = std::env::temp_dir().join(format!("c6-det-b-{}.xlsx", family.label()));
+            generate_family_fixture(&a, family, 64).unwrap();
+            generate_family_fixture(&b, family, 64).unwrap();
+            assert_eq!(sha256_file(&a).unwrap(), sha256_file(&b).unwrap());
+            let _ = std::fs::remove_file(a);
+            let _ = std::fs::remove_file(b);
+        }
+    }
+
+    #[test]
+    fn independent_oracles_cover_initial_and_warm_edits() {
+        let shape = FamilyFixtureShape {
+            family: FixtureFamily::Dynamic,
+            formulas: 100,
+            reachable_formulas: 100,
+            dirty_formulas: 8,
+            retained_formulas: 0,
+            terminal_sheet: "Chain".to_string(),
+            terminal_row: 90,
+            terminal_col: 2,
+        };
+        let outputs = expected_typed_outputs(&shape, CalibrationPath::Targets, 2);
+        assert_eq!(outputs.len(), 3);
+        assert_ne!(outputs[0][0], outputs[1][0]);
+        assert_eq!(outputs[0][1], TypedOracleValue::Error("#REF!".to_string()));
+    }
+
+    #[test]
+    fn layout_scan_envelope_extends_beyond_blank_guard() {
+        let manifest = layout_manifest(64);
+        assert!(manifest.contains("terminate: first_blank_row"));
+        assert!(manifest.contains(&format!("max_scan_rows: {LAYOUT_MAX_SCAN_ROWS}")));
+    }
+}

--- a/docs/architecture/evaluation-c6-calibration.md
+++ b/docs/architecture/evaluation-c6-calibration.md
@@ -1,32 +1,54 @@
-# C6 Target-Locality Calibration
+# C6 Native Target Calibration
 
-Status: focused Phase A harness; measurement only
+Status: Phase-A measurement harness; benchmark and documentation changes only
 
-This harness compares four native public evaluation paths in fresh processes:
+The harness compares public native evaluation paths in fresh processes without changing engine semantics, authority, budgets, defaults, or algorithms. The original scalar CLI remains the default: 50,000 formulas, seven samples, the `full,cells,plan,sheetport` paths, and the tiny/medium/full 12-case matrix.
 
-- `full`: interactive/deferred XLSX load, explicit `prepare_graph_all`, `evaluate_all`, and direct output reads.
-- `cells`: ordinary `evaluate_cells`; its public call necessarily combines target preparation, ephemeral target-plan construction, evaluation, and returned outputs.
-- `plan`: a revision-bound target plan built once with `build_recalc_plan_for_targets`, followed by `evaluate_with_plan` and direct output reads.
-- `sheetport`: a parsed and validated FIO manifest bound with `SheetPort::new`; one-shot output is read by `evaluate_once`, then warm edits use a SheetPort batch and its reusable target plan.
+Schema v3 adds a `targets` path and these fixture families:
 
-The child probe and matrix runner require the `c6_calibration` feature. Fixtures are generated before timed child samples. Every sample loads the same immutable XLSX in a new process using `WorkbookConfig::interactive()`, so graph preparation remains deferred and request-time locality is visible.
+| family | supported paths | selector set |
+|---|---|---|
+| `scalar` | `full`, `cells`, `plan`, `sheetport` | original independent scalar terminals |
+| `cross-sheet` | `full`, `cells`, `targets`, `plan`, `sheetport` | one alternating two-sheet chain terminal |
+| `names` | `full`, `targets`, `plan` | workbook- and sheet-scoped names |
+| `names` | `sheetport` | workbook-scoped name only |
+| `layout` | `full`, `sheetport` | bounded table layout plus a scalar breadth dependency |
+| `native-table` | `full`, `targets`, `plan`, `sheetport` | headers, body, and totals |
+| `dynamic` | `full`, `cells`, `targets`, `plan` | numeric runtime-text result and explicit `#REF!` result |
+| `dynamic` | `sheetport` | numeric runtime-text result only |
 
-## Fixture
+The matrix is hard-coded and tested. Unsupported combinations fail instead of being represented through a less specific API. Native breadth families support only `--scope full`; this is the single target scope used at 50k.
 
-The deterministic fixture contains exactly the requested formula count split across independent finance-shaped chains:
+## Fixtures and Oracles
 
-- `Tiny`: 0.5% of formulas, providing the less-than-1% target.
-- `Medium`: 10% of formulas.
-- `Large`: the remaining primary formulas.
-- `Dirty`: eight formulas used to establish an unrelated prepared and dirty branch.
+Each family gets one deterministic, immutable XLSX generated before samples. The matrix records one SHA-256 per family and every randomized sample reads the same family file in a fresh process. Every fixture contains exactly the requested formula count and an eight-formula branch that is prepared, evaluated, and dirtied before the measured path. The editable value is local to the selected formula package (`ChainA!A1` for cross-sheet and `Chain!A1` otherwise), matching the scalar control and allowing retained plans to remain valid across ordinary value edits.
 
-A target is the terminal balance in a branch. The 100% scope requests every terminal balance. Before the measured path, every child prepares and evaluates `Dirty`, edits its input, and reports that common setup separately. Tiny and medium runs therefore begin with both unrelated staged formulas and unrelated dirty prepared work. Target-local runs must retain both. The prepared-formula locality gate subtracts the eight-formula common setup and allows at most the reachable oracle plus 1%.
+Every breadth family also has a `full` control. It uses `prepare_graph_all` and `evaluate_all`, then the same typed output reader as its targeted paths. Full controls require zero staged formulas and the exact family-specific post-evaluation dirty count, proving the unrelated staged and dirty branches were broadly consumed rather than retained. Focused tests cover every family full control with three warm edits and every breadth full control with zero edits, including the long-tier repeat count.
 
-Repeated value edits change `A1` inside the selected closure. These rows report public API cost after that edit, not a claim that the full requested scope is dirty or recomputed. In particular, `full_100pct` always edits the fixed 0.5% `Tiny` branch while requesting all four terminals. Direct plan runs reuse the same revision-bound plan. SheetPort repeated runs go through `BatchExecutor`; its progress clock is reset immediately before `batch.run`, each edit/evaluate/output iteration is separated, and checked nonnegative baseline-restoration accounting is reported independently.
+The full-control dirty residual is independently derived from graph behavior rather than fitted per family. `Dirty!A1`, an edited non-formula source, contributes one vertex. If at least one ordinary warm edit runs, `Chain!A1` (or `ChainA!A1`) contributes one more, regardless of repeat count. The two dynamic `INDIRECT` formulas are volatile and are therefore re-dirtied after every evaluation. `Engine::define_table` registers the `C6Table` metadata vertex as a dependent of its table range; after a warm edit changes the table's formula values, propagation dirties that metadata vertex, which is not a formula evaluation vertex and therefore remains dirty. It contributes zero without a warm edit and one with any positive repeat count. The public baseline reports only the aggregate dirty count and cannot expose that vertex identity; the table gate is therefore the narrow aggregate count implied by this engine behavior, and its structural oracle discloses that limitation. No other family has a persistent component.
+
+- `cross-sheet` alternates every recurrence edge between `ChainA` and `ChainB`. Its initial and edited terminal values use the closed form `B_n = B_1*r^(n-1) + 0.00001*(r^(n-1)-1)/(r-1)`. Eight unrelated formulas must remain staged and the dirty branch must remain dirty.
+- `names` registers `WorkbookOutput` and sheet-scoped `Names!SheetOutput` through the public workbook name API after load. Initial targets point at two formula outputs. All ordinary warm value edits run first against those bindings with retained-plan reuse. A separate post-warm probe then moves both bindings to independent rebound outputs. A retained plan must reject that symbol revision with exactly `PlanStale(Symbols)`; one rebuilt plan must return the rebound oracle. The probe intentionally performs no subsequent value edit: harness development exposed a propagation concern for value edits after a name-binding mutation, so that combination is a follow-up and is not measured here. SheetPort is intentionally limited to `WorkbookOutput`, because its current name selector has no sheet-scope field.
+- `layout` uses the actual SheetPort `first_blank_row` layout resolver with `max_scan_rows: 8`. The returned structural oracle is exactly `Layout!A2:D2`, with row 3 as the blank guard. SheetPort conservatively targets the complete A2:D9 scan envelope before resolving output bounds, so below-guard `Layout!C4` is prepared and must evaluate to 999 even though it is excluded from the returned table. A second formula at `Layout!C10` is below the envelope, but staged discovery commits the whole Layout-sheet source package once C4 is selected; after that commit C10 is not staged, remains Empty, and is not scheduled. Exact selected work is the long chain plus C4 and C10, while exactly six formulas on the separate Retained sheet stay staged. The one-row result and envelope extending past row 3 prove that blank termination, not envelope exhaustion, controls returned output. These gates distinguish output termination, conservative preparation demand, package commit, and scheduled evaluation. Batch output and restored input are checked, and restoration latency is separated with the public progress callback.
+- `native-table` has header, body, and totals rows with string, integer, number, and date values. Direct paths use three `EvaluationTarget::Table` selections; SheetPort uses three full-v0 native table selectors. Typed values are represented as tagged v3 values rather than compared through debug or JSON spellings. The number/date outputs have independent analytical oracles for every edit.
+- `dynamic` targets `INDIRECT("Chain!A1")` from the `Dynamic` sheet and a long chain. Initial preparation must report workbook scope and the exact widening mask `DynamicReference | RuntimeTextReference == 0b11`; both the expected and observed masks are recorded structurally, and extra bits fail the gate. Direct paths also target `INDIRECT("Missing!A1")` and require a typed `#REF!` literal on every evaluation.
+
+The family gates require exact load/setup formula counts, exact selected-staging or widened-workbook counts, independent initial/warm typed or numeric outputs, applicable staged/dirty retention, name staleness/rebuild, layout bounds/guard retention, native-table areas/types, and SheetPort batch restoration. Matrix summaries include only `status: ok` children and include all family gates in the displayed gate result.
+
+## Verified API Boundaries
+
+The Phase-A design was checked against current public APIs before implementation. Four boundaries constrain the benchmark:
+
+1. Calamine currently reports no native table metadata. The fixture carries table cells, while each child registers the same `C6Table` metadata through the public engine table API. This `public_native_table_registration` phase is timed and summarized as selector setup for all table paths; it is never labeled evaluation.
+2. SheetPort name selectors currently resolve with `scope_sheet: None`. Its names case therefore selects only the workbook-scoped name. Direct `targets` and `plan` cases cover both workbook and sheet scopes; parity keys include the selector set so unlike outputs are never compared.
+3. SheetPort validates outputs against the manifest schema and does not provide an unconstrained error-valued scalar schema. The dynamic SheetPort case selects the numeric result only. `cells`, `targets`, and `plan` preserve and compare the explicit `#REF!` value. This unsupported SheetPort selector/output combination is not forced into the API.
+4. SheetPort does not expose resolved layout bounds as a public return value. The harness proves returned bounds `A2:D2` structurally through the one-row/four-column typed table and `max_scan_rows: 8` extending beyond blank row 3. Public planning first targets conservative A2:D9, then staged source-package fallback commits both Layout formulas. Exact C4=999, C10=Empty-but-committed, selected work, and six separately staged Retained formulas distinguish preparation and scheduling from blank-terminated output resolution.
+
+Family `plan` cases build once and reuse the same revision-bound plan across ordinary local value edits. Any value-only `PlanStale` is a failed sample and gate. When `--warm-repeats 0`, no value edit was requested, so the reuse gate is omitted as not applicable; the names staleness probe still runs and must pass. The names case completes all requested ordinary `Chain!A1` warm edits with retained-plan reuse, then changes both name bindings in a separate post-warm probe. It proves the old retained plan returns exactly `PlanStale(Symbols)`, rebuilds once for that structural mutation, and evaluates the rebound outputs. The binding/stale-probe/rebuild work is recorded in `name_binding_probe`, not in cold setup or ordinary warm distributions. It deliberately stops after the rebound evaluation and does not measure a post-binding value edit because of the propagation concern described above.
 
 ## Commands
 
-Build and run the focused tests:
+Focused validation:
 
 ```bash
 cargo test -p formualizer-bench-core --features c6_calibration \
@@ -35,56 +57,60 @@ cargo test -p formualizer-bench-core --features c6_calibration \
   --bin probe-c6-target-locality-matrix
 cargo check -p formualizer-bench-core --features c6_calibration --bins
 cargo clippy -p formualizer-bench-core --features c6_calibration --bins --tests -- -D warnings
+cargo fmt --all -- --check
 ```
 
-Run a one-sample native smoke matrix:
+Required all-family 1k CI smoke:
 
 ```bash
 cargo run --release -p formualizer-bench-core --features c6_calibration \
   --bin probe-c6-target-locality-matrix -- \
-  --formulas 1000 --samples 1 --warm-repeats 1 --timeout-seconds 60 \
-  --output-dir target/c6-calibration/smoke
+  --tier all-family-smoke \
+  --output-dir target/c6-calibration/all-family-1k
 ```
 
-Run the required randomized seven-sample 50k matrix. The runner builds the release child once; use `--skip-build` only when that exact child is already built:
+Required seven-sample 50k breadth matrix (run after smoke):
 
 ```bash
 cargo run --release -p formualizer-bench-core --features c6_calibration \
   --bin probe-c6-target-locality-matrix -- \
-  --formulas 50000 --samples 7 --warm-repeats 3 --timeout-seconds 600 \
-  --output-dir target/c6-calibration/native-50k
+  --tier breadth50k \
+  --output-dir target/c6-calibration/native-breadth-50k
 ```
 
-The child can also generate and inspect one case directly:
+Required original 12-case, seven-sample scalar 250k matrix. The tier enforces at least 1,800 seconds per child:
 
 ```bash
 cargo run --release -p formualizer-bench-core --features c6_calibration \
-  --bin probe-c6-target-locality -- generate \
-  --fixture target/c6-calibration/manual-50000.xlsx --formulas 50000
-cargo run --release -p formualizer-bench-core --features c6_calibration \
-  --bin probe-c6-target-locality -- sample \
-  --fixture target/c6-calibration/manual-50000.xlsx --formulas 50000 \
-  --path plan --scope tiny --warm-repeats 3
+  --bin probe-c6-target-locality-matrix -- \
+  --tier scalar250k \
+  --output-dir target/c6-calibration/scalar-250k
 ```
 
-## Outputs and interpretation
+`--tier largest-safe` is deliberately rejected in Phase A. Without `--tier`, the existing scalar defaults and explicit `--formulas`, `--samples`, `--paths`, and `--scopes` behavior remain available. Manual native runs must choose a supported family/path and `--scope full`.
 
-The output directory contains:
+## Schema v3 and Output
 
-- `matrix-raw.json`: identity, randomized job order, per-child raw phase data, typed output/error fields, graph snapshots, request telemetry, RSS/HWM, and `/usr/bin/time -v` maximum RSS where available.
-- `matrix-summary.md`: median, nearest-rank p95, median absolute deviation, and maximum over successful samples.
-- the immutable fixture and its SHA-256 plus stderr and external-time logs.
+`matrix-raw.json` retains the v1 scalar identity, formula, fixture, job, result, summary, and parity fields. Additive v3 fields include:
 
-Machine-specific output stays under `target/c6-calibration/` and is not committed. Sample summaries include only `status: ok` children. The runner drains child stdout and stderr concurrently; on timeout it kills the complete child process group, including the `/usr/bin/time` wrapper and probe. Runs at 50,000 formulas or above enforce at least a 600-second per-child timeout.
+- matrix `families` and `fixtures`, where every fixture entry has `family`, `path`, and `sha256`;
+- job and summary `family`, plus summary `selector_set`;
+- child `family`, `path_schema_version: 3`, and `selector_set`;
+- child tagged `typed_outputs` and `typed_expected_outputs` (`string`, `integer`, `number`, `date`, `boolean`, `empty`, or `error`);
+- child `family_gates`, `structural_oracles`, and `plan_stale_reason`;
+- phases `selector_setup` for initial public name/table registration and `name_binding_probe` for the post-warm name mutation/staleness contract.
 
-A summary timing cell is `median / p95 / MAD / max`. Percentiles use nearest rank; with seven values a per-child p95 equals the maximum, while the pooled repeated-API cells contain 21 observations. Every child is process-cold, but fixture reads are normally OS-page-cache-warm. Cold total includes XLSX open/load, the common dirty-branch setup, binding/target resolution, first evaluation, and preparation/plan build plus output read when those precede the first evaluation. SheetPort cold total is its one-shot path; the subsequent reusable batch-plan build is reported separately in the `prepare/plan` column and raw phases rather than double-counted into one-shot cold latency. The raw `includes` list is authoritative when a public API combines phases. In particular, `cells` cannot split preparation from evaluation/output, and SheetPort one-shot and batch calls cannot split all selector, edit, evaluation, restoration, and output-read subphases.
+The legacy `fixture_path`, `fixture_sha256`, debug `outputs`, numeric analytical fields, and scalar fields remain populated for backward compatibility. For a multi-family run, the legacy fixture fields identify the first recorded family; `fixtures` is authoritative. For schema-v3 breadth children, legacy `oracle_within_one_percent` carries the exact family-locality/full-control boolean rather than a one-percent approximation; `exact_locality_counts_passed` is the authoritative field.
 
-Correctness does not rely only on agreement between APIs. For the finance recurrence, the harness computes every requested terminal after the initial seeds and every repeated edit from the closed form `B_n = B_1*r^(n-1) + A1*0.00001*(r^(n-1)-1)/(r-1)`, independently of the engine, and fails a sample on mismatch. It also asserts exact deferred, staged, prepared, and dirty counts for this deterministic fixture. Path shape is supported by the preparation scope/widening bits, requested/normalized targets, selected/retained staging, graph formula/edge deltas, target commit work, charged work, topology strategy/candidates/edges, materialization counts, dirty-lease outcome, and retained/scratch accounting. Formula count and target commit work are different units and are reported separately; the locality tolerance gate uses prepared formula deltas and selected staged formula counts only.
+`matrix-summary.md` reports median / nearest-rank p95 / MAD / maximum, successful count, selector setup, plan preparation, evaluations, batch restoration, RSS, selected/prepared work, gate status, and parity by family/scope/selector set. With seven child samples, per-child p95 is the maximum. Warm distributions pool all warm calls.
 
-SheetPort records three non-overwriting telemetry stages: `first_evaluation` immediately after one-shot evaluation, `sheetport_batch_plan_build` immediately after batch construction, and `sheetport_batch_execution` immediately after `batch.run` completes restoration. The summary identifies the latter two snapshots explicitly.
+The runner builds fixtures outside timed samples, randomizes jobs deterministically, invokes every sample in a fresh process, uses `/usr/bin/time -v` where available, drains stdout/stderr concurrently, and kills the whole process group on timeout. Timeout and child failures remain typed results; raw JSON, stderr, external-time logs, and all completed samples are written before the matrix returns failure.
 
-## Current limitations
+## Interpretation Limits
 
-This focused first deliverable covers deterministic independent scalar finance branches with Calamine native loading and the current default FormulaPlane mode. The SheetPort sample deliberately records both public modes in sequence: one-shot first, then batch creation/reuse on the already prepared workbook. Its separately reported batch-plan build is therefore not a second cold-path latency and is not directly setup-equivalent to the direct plan build on deferred staging. It does not yet add the remaining Phase A cross-sheet, name, bounded-layout, native-table, or dynamic/opaque widening fixture families. It also does not run 250k/largest-safe tiers, historical pre-C5 binaries, the broader native mode/budget matrix, WASM/no-disk, or recommend defaults. No algorithm, semantic behavior, cap, or default changes are part of this harness.
-
-The engine does not expose a stable allocator-specific counter. The harness therefore records process RSS/HWM, external maximum RSS, and existing request-ledger retained/scratch values. Failed child processes are preserved as typed matrix statuses with stderr; successful engine/SheetPort errors have a raw `typed_error` slot for parity, but the initial scalar fixture is expected to succeed and is not an error-injection suite.
+- Timing `includes` arrays are authoritative. `cells` and SheetPort APIs combine stages that public calls do not expose separately.
+- Initial table/name registration is selector setup, not evaluation. Ordinary warm value mutations are in the authoritative edit phase, while the post-warm name mutation is in `name_binding_probe`; layout resolution occurs inside the public SheetPort call.
+- Family plans are retained across value-only edits. Names perform exactly one post-warm rebuild after the deliberate binding change yields `PlanStale(Symbols)`; `name_binding_probe` includes the stale probe, rebuild, evaluation, and rebound read.
+- Name and dynamic SheetPort cases intentionally have narrower selector sets than direct paths; parity never compares different selector sets.
+- RSS/HWM and existing request-ledger counters are reported because there is no stable allocator-specific counter.
+- This tranche makes no recommendation about budgets, defaults, authority, or algorithms and does not cover historical binaries, largest-safe, WASM/no-disk, or non-default native modes.


### PR DESCRIPTION
## Summary

- extend the C6 calibration harness with cross-sheet, workbook/sheet-name, bounded-layout, native-table, and dynamic/widening fixture families
- add the public `evaluate_targets` path while retaining the original scalar CLI and four-path matrix
- add typed numeric/string/integer/date/error oracles, exact full controls, staging/dirty/widening gates, selector-set parity, and schema-v3 reporting
- add reproducible all-family smoke, 50k native-breadth, and 250k scalar tiers
- keep all engine defaults, budgets, authority modes, algorithms, SheetPort semantics, and specs unchanged

## Correctness coverage

The breadth matrix explicitly supports only selectors each public API can represent. Every breadth family includes a full-workbook control.

The layout case distinguishes returned output `A2:D2`, conservative preparation envelope `A2:D9`, whole-source-package commit of formulas at C4/C10, scheduled evaluation of C4, C10 remaining unevaluated, and six unrelated formulas remaining staged.

Dynamic targets must report Workbook scope with the exact widening mask `0b11` (`DynamicReference | RuntimeTextReference`) and exact selected work.

Name plans reuse one revision-bound plan across ordinary value edits, then perform a separate post-warm mutation that must return exactly `PlanStale(Symbols)` before one rebuild. No subsequent value edit is claimed after rebinding because harness development exposed a propagation concern for that combination; it remains a follow-up.

## Native results

All generated results remain ignored under `target/c6-calibration/`.

### 50k breadth

- 140/140 fresh child samples passed
- all analytical/typed oracles, exact gates, and seven selector-set parity groups passed
- full-control cold medians: 679–760 ms
- targeted full-scope cold medians: 4.42–4.50 s
- retained-plan/SheetPort warm medians: 49–61 ms
- ordinary cells/targets warm medians: 3.72–3.81 s because those public paths repeat target preparation
- name post-binding targeted probe: approximately 3.66–3.68 s

The breadth tier intentionally requests full family closure. It quantifies correctness and 100%-scope overhead; it does not claim small-scope wins for these families.

### 250k scalar scope sweep

| scope | full cold median | targeted cold median | full RSS | targeted RSS |
|---|---:|---:|---:|---:|
| 0.5% | 5.26 s | 0.71–0.72 s | 737 MiB | 23 MiB |
| 10% | 5.31 s | 2.79–2.82 s | 737 MiB | 86–87 MiB |
| 100% | 5.23 s | 24.40–24.70 s | 736 MiB | 700–701 MiB |

At 250k, retained-plan/SheetPort warm medians range from approximately 1.1 ms at 0.5% to 28–30 ms at 10% and 11–12 ms when requesting all outputs but editing the fixed 0.5% branch. Ordinary `evaluate_cells` re-pays target discovery and reaches an 18.7 s median at full requested scope.

## Validation

- focused benchmark suite: 19 passed
- strict Clippy for C6 bins/tests
- cargo check for benchmark bins
- formatting and diff checks
- canonical all-family smoke: 32/32 passed, all gates and 10 parity groups passed
- seven-sample 50k breadth: 140/140 passed
- seven-sample 250k scalar: 84/84 passed
- independent code review: `BENCHMARK_VALID: YES`, `READY_FOR_LONG_RUNS: YES`
- independent result audit: `BENCHMARK_VALID: YES`, `MERGEABLE_HARNESS: YES`

Machine-local results are intentionally not committed. The first archival run after merge should be repeated on the clean merge commit.
