### PR TITLE
ci: pin maturin action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
     - name: Build wheels
       uses: PyO3/maturin-action@v1
       with:
+        # Avoid maturin-action's broken automatic range resolution on Node 24.
+        maturin-version: v1.11.5
         working-directory: bindings/python
         # Build a single abi3 wheel (not one per Python interpreter)
         # In `act` (local CI), avoid nested manylinux Docker to keep things working.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,6 +398,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: v1.11.5
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -427,6 +428,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: v1.11.5
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -449,6 +451,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: v1.11.5
           target: x64
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -477,6 +480,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: v1.11.5
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -495,6 +499,7 @@ jobs:
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: v1.11.5
           command: sdist
           args: --out dist --manifest-path bindings/python/Cargo.toml
       - name: Upload sdist


### PR DESCRIPTION
## Summary

- pin `PyO3/maturin-action@v1` to maturin `v1.11.5` in CI and release wheel/sdist jobs
- avoid the action's failing automatic resolution of `maturin>=1.11,<2.0` under its Node 24 runtime
- keep the version within the existing `pyproject.toml` requirement

## Failure

The native wheel job currently exits before compilation with:

```text
TypeError: candidates is not iterable
  at manifest_awaiter
  at _findMatch
```

The failure reproduced twice in PR #203 while Rust, Python, WASM, Pyodide-wheel, and local native-wheel validation remained green. Supplying `maturin-version` bypasses the broken manifest-range lookup and makes the action input deterministic.

## Validation

- all six `PyO3/maturin-action@v1` invocations have the same explicit pin
- CI and release workflow YAML parse successfully
- `v1.11.5` is the action's documented current maturin version and satisfies `maturin>=1.11,<2.0`
- workflow diff check passes
