### PR TITLE
fix(eval): represent deleted references as error literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Structural row and column deletes now rewrite invalidated reference leaves to ordinary `#REF!` error literals instead of magic `#REF` sheet sentinels. This preserves lazy `IF`/`IFERROR` semantics, dependency rewiring, formula display/reparse, undo/redo, whole-axis adjustment, cross-sheet locality, and legitimate worksheets named `#REF` across legacy and FormulaPlane structural paths.
 - Fixed deferred `evaluate_cells_with_delta` requests missing transitive formula precedents staged on non-target sheets.
 - Fixed experimental FormulaPlane capacity fallbacks evaluating legacy readers before required span results were available. Unsafe requests now transactionally demote exactly their scheduled spans, retain pending dirty regions across failed attempts, and fail closed behind a finite materialization limit.
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -13283,7 +13283,12 @@ where
                         let shift_op = shift_operation_for(op);
                         let adjuster =
                             crate::engine::graph::editor::reference_adjuster::ReferenceAdjuster::new();
-                        let Some(adjusted_ast) = adjuster.adjust_ast_if_changed(&ast, &shift_op)
+                        let context = crate::engine::graph::editor::reference_adjuster::ReferenceContext::new(
+                            span.sheet_id,
+                            self.graph.sheet_reg(),
+                        );
+                        let Some(adjusted_ast) =
+                            adjuster.adjust_ast_if_changed_in_context(&ast, &shift_op, &context)
                         else {
                             // The classifier saw a displaced absolute read,
                             // so an unchanged AST is a contract violation;

--- a/crates/formualizer-eval/src/engine/graph/editor/reference_adjuster.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/reference_adjuster.rs
@@ -1,5 +1,7 @@
 use crate::reference::{CellRef, Coord};
-use formualizer_parse::parser::{ASTNode, ASTNodeType};
+use crate::{SheetId, engine::sheet_registry::SheetRegistry};
+use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::{ASTNode, ASTNodeType, ReferenceType};
 
 /// How absolute (`$`-anchored) references respond to structural shifts.
 ///
@@ -32,6 +34,37 @@ impl AbsShiftPolicy {
 /// Centralized reference adjustment logic for structural changes
 pub struct ReferenceAdjuster;
 
+/// Sheet binding context for references in the AST being adjusted.
+///
+/// This lets structural adjustment distinguish unqualified references on the
+/// formula's sheet from qualified references to another sheet.
+pub struct ReferenceContext<'a> {
+    formula_sheet_id: SheetId,
+    sheet_registry: &'a SheetRegistry,
+}
+
+impl<'a> ReferenceContext<'a> {
+    pub fn new(formula_sheet_id: SheetId, sheet_registry: &'a SheetRegistry) -> Self {
+        Self {
+            formula_sheet_id,
+            sheet_registry,
+        }
+    }
+
+    fn reference_sheet_id(&self, sheet: Option<&str>) -> Option<SheetId> {
+        match sheet {
+            Some(name) => self.sheet_registry.get_id(name),
+            None => Some(self.formula_sheet_id),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ReferenceAdjustment {
+    Reference(ReferenceType),
+    Invalidated,
+}
+
 #[derive(Debug, Clone)]
 pub enum ShiftOperation {
     InsertRows {
@@ -61,74 +94,28 @@ impl ReferenceAdjuster {
         Self
     }
 
-    /// Adjust an AST for a shift operation, preserving source tokens.
+    /// Adjust an AST for a shift operation.
     /// Absolute references track the shift (see [`AbsShiftPolicy::Track`]).
+    ///
+    /// This compatibility API retains the historical context-free behavior and
+    /// assumes every cell/range reference binds to the operation's sheet. New
+    /// callers should use [`Self::adjust_ast_in_context`].
     pub fn adjust_ast(&self, ast: &ASTNode, op: &ShiftOperation) -> ASTNode {
         self.adjust_ast_with_policy(ast, op, AbsShiftPolicy::Track)
     }
 
-    /// Adjust an AST for a shift operation under an explicit absolute-ref
-    /// policy, preserving source tokens.
+    /// Adjust an AST under an explicit absolute-reference policy.
     pub fn adjust_ast_with_policy(
         &self,
         ast: &ASTNode,
         op: &ShiftOperation,
         policy: AbsShiftPolicy,
     ) -> ASTNode {
-        match &ast.node_type {
-            ASTNodeType::Reference {
-                original,
-                reference,
-            } => {
-                let adjusted = self.adjust_reference(reference, op, policy);
-                ASTNode {
-                    node_type: ASTNodeType::Reference {
-                        original: original.clone(),
-                        reference: adjusted,
-                    },
-                    source_token: ast.source_token.clone(),
-                    contains_volatile: ast.contains_volatile,
-                }
-            }
-            ASTNodeType::BinaryOp {
-                op: bin_op,
-                left,
-                right,
-            } => ASTNode {
-                node_type: ASTNodeType::BinaryOp {
-                    op: bin_op.clone(),
-                    left: Box::new(self.adjust_ast_with_policy(left, op, policy)),
-                    right: Box::new(self.adjust_ast_with_policy(right, op, policy)),
-                },
-                source_token: ast.source_token.clone(),
-                contains_volatile: ast.contains_volatile,
-            },
-            ASTNodeType::UnaryOp { op: un_op, expr } => ASTNode {
-                node_type: ASTNodeType::UnaryOp {
-                    op: un_op.clone(),
-                    expr: Box::new(self.adjust_ast_with_policy(expr, op, policy)),
-                },
-                source_token: ast.source_token.clone(),
-                contains_volatile: ast.contains_volatile,
-            },
-            ASTNodeType::Function { name, args } => ASTNode {
-                node_type: ASTNodeType::Function {
-                    name: name.clone(),
-                    args: args
-                        .iter()
-                        .map(|arg| self.adjust_ast_with_policy(arg, op, policy))
-                        .collect(),
-                },
-                source_token: ast.source_token.clone(),
-                contains_volatile: ast.contains_volatile,
-            },
-            _ => ast.clone(),
-        }
+        self.adjust_ast_if_changed_inner(ast, op, policy, None)
+            .unwrap_or_else(|| ast.clone())
     }
 
-    /// Adjust an AST against a structural shift, returning Some(adjusted) only
-    /// if at least one reference actually changed. Avoids cloning when no work
-    /// is needed.
+    /// Return an adjusted AST only when at least one reference changed.
     pub fn adjust_ast_if_changed(&self, ast: &ASTNode, op: &ShiftOperation) -> Option<ASTNode> {
         self.adjust_ast_if_changed_with_policy(ast, op, AbsShiftPolicy::Track)
     }
@@ -140,84 +127,157 @@ impl ReferenceAdjuster {
         op: &ShiftOperation,
         policy: AbsShiftPolicy,
     ) -> Option<ASTNode> {
-        match &ast.node_type {
-            ASTNodeType::Reference {
-                original,
-                reference,
-            } => {
-                let adjusted = self.adjust_reference(reference, op, policy);
-                if adjusted == *reference {
-                    return None;
-                }
-                Some(ASTNode {
-                    node_type: ASTNodeType::Reference {
-                        original: original.clone(),
+        self.adjust_ast_if_changed_inner(ast, op, policy, None)
+    }
+
+    pub fn adjust_ast_in_context(
+        &self,
+        ast: &ASTNode,
+        op: &ShiftOperation,
+        context: &ReferenceContext<'_>,
+    ) -> ASTNode {
+        self.adjust_ast_with_policy_in_context(ast, op, AbsShiftPolicy::Track, context)
+    }
+
+    pub fn adjust_ast_with_policy_in_context(
+        &self,
+        ast: &ASTNode,
+        op: &ShiftOperation,
+        policy: AbsShiftPolicy,
+        context: &ReferenceContext<'_>,
+    ) -> ASTNode {
+        self.adjust_ast_if_changed_inner(ast, op, policy, Some(context))
+            .unwrap_or_else(|| ast.clone())
+    }
+
+    pub fn adjust_ast_if_changed_in_context(
+        &self,
+        ast: &ASTNode,
+        op: &ShiftOperation,
+        context: &ReferenceContext<'_>,
+    ) -> Option<ASTNode> {
+        self.adjust_ast_if_changed_with_policy_in_context(ast, op, AbsShiftPolicy::Track, context)
+    }
+
+    pub fn adjust_ast_if_changed_with_policy_in_context(
+        &self,
+        ast: &ASTNode,
+        op: &ShiftOperation,
+        policy: AbsShiftPolicy,
+        context: &ReferenceContext<'_>,
+    ) -> Option<ASTNode> {
+        self.adjust_ast_if_changed_inner(ast, op, policy, Some(context))
+    }
+
+    fn adjust_ast_if_changed_inner(
+        &self,
+        ast: &ASTNode,
+        op: &ShiftOperation,
+        policy: AbsShiftPolicy,
+        context: Option<&ReferenceContext<'_>>,
+    ) -> Option<ASTNode> {
+        let changed_node_type = match &ast.node_type {
+            ASTNodeType::Reference { reference, .. } => {
+                match self.adjust_reference(reference, op, policy, context) {
+                    ReferenceAdjustment::Reference(adjusted) if adjusted == *reference => {
+                        return None;
+                    }
+                    ReferenceAdjustment::Reference(adjusted) => ASTNodeType::Reference {
+                        original: adjusted.normalise(),
                         reference: adjusted,
                     },
-                    source_token: ast.source_token.clone(),
-                    contains_volatile: ast.contains_volatile,
-                })
+                    ReferenceAdjustment::Invalidated => ASTNodeType::Literal(LiteralValue::Error(
+                        ExcelError::new(ExcelErrorKind::Ref),
+                    )),
+                }
             }
             ASTNodeType::BinaryOp {
                 op: bin_op,
                 left,
                 right,
             } => {
-                let adjusted_left = self.adjust_ast_if_changed_with_policy(left, op, policy);
-                let adjusted_right = self.adjust_ast_if_changed_with_policy(right, op, policy);
+                let adjusted_left = self.adjust_ast_if_changed_inner(left, op, policy, context);
+                let adjusted_right = self.adjust_ast_if_changed_inner(right, op, policy, context);
                 if adjusted_left.is_none() && adjusted_right.is_none() {
                     return None;
                 }
-                Some(ASTNode {
-                    node_type: ASTNodeType::BinaryOp {
-                        op: bin_op.clone(),
-                        left: Box::new(adjusted_left.unwrap_or_else(|| (**left).clone())),
-                        right: Box::new(adjusted_right.unwrap_or_else(|| (**right).clone())),
-                    },
-                    source_token: ast.source_token.clone(),
-                    contains_volatile: ast.contains_volatile,
-                })
+                ASTNodeType::BinaryOp {
+                    op: bin_op.clone(),
+                    left: Box::new(adjusted_left.unwrap_or_else(|| (**left).clone())),
+                    right: Box::new(adjusted_right.unwrap_or_else(|| (**right).clone())),
+                }
             }
-            ASTNodeType::UnaryOp { op: un_op, expr } => {
-                let adjusted_expr = self.adjust_ast_if_changed_with_policy(expr, op, policy)?;
-                Some(ASTNode {
-                    node_type: ASTNodeType::UnaryOp {
-                        op: un_op.clone(),
-                        expr: Box::new(adjusted_expr),
-                    },
-                    source_token: ast.source_token.clone(),
-                    contains_volatile: ast.contains_volatile,
-                })
-            }
+            ASTNodeType::UnaryOp { op: un_op, expr } => ASTNodeType::UnaryOp {
+                op: un_op.clone(),
+                expr: Box::new(self.adjust_ast_if_changed_inner(expr, op, policy, context)?),
+            },
             ASTNodeType::Function { name, args } => {
+                let (args, changed) = self.adjust_children(args, op, policy, context);
+                if !changed {
+                    return None;
+                }
+                ASTNodeType::Function {
+                    name: name.clone(),
+                    args,
+                }
+            }
+            ASTNodeType::Call { callee, args } => {
+                let adjusted_callee = self.adjust_ast_if_changed_inner(callee, op, policy, context);
+                let (args, args_changed) = self.adjust_children(args, op, policy, context);
+                if adjusted_callee.is_none() && !args_changed {
+                    return None;
+                }
+                ASTNodeType::Call {
+                    callee: Box::new(adjusted_callee.unwrap_or_else(|| (**callee).clone())),
+                    args,
+                }
+            }
+            ASTNodeType::Array(rows) => {
                 let mut changed = false;
-                let adjusted_args = args
+                let rows = rows
                     .iter()
-                    .map(|arg| {
-                        if let Some(adjusted) =
-                            self.adjust_ast_if_changed_with_policy(arg, op, policy)
-                        {
-                            changed = true;
-                            adjusted
-                        } else {
-                            arg.clone()
-                        }
+                    .map(|row| {
+                        let (row, row_changed) = self.adjust_children(row, op, policy, context);
+                        changed |= row_changed;
+                        row
                     })
                     .collect();
                 if !changed {
                     return None;
                 }
-                Some(ASTNode {
-                    node_type: ASTNodeType::Function {
-                        name: name.clone(),
-                        args: adjusted_args,
-                    },
-                    source_token: ast.source_token.clone(),
-                    contains_volatile: ast.contains_volatile,
-                })
+                ASTNodeType::Array(rows)
             }
-            _ => None,
-        }
+            _ => return None,
+        };
+
+        Some(ASTNode {
+            node_type: changed_node_type,
+            source_token: None,
+            contains_volatile: ast.contains_volatile,
+        })
+    }
+
+    fn adjust_children(
+        &self,
+        children: &[ASTNode],
+        op: &ShiftOperation,
+        policy: AbsShiftPolicy,
+        context: Option<&ReferenceContext<'_>>,
+    ) -> (Vec<ASTNode>, bool) {
+        let mut changed = false;
+        let children = children
+            .iter()
+            .map(|child| {
+                if let Some(adjusted) = self.adjust_ast_if_changed_inner(child, op, policy, context)
+                {
+                    changed = true;
+                    adjusted
+                } else {
+                    child.clone()
+                }
+            })
+            .collect();
+        (children, changed)
     }
 
     /// Adjust a cell reference for a shift operation.
@@ -331,11 +391,27 @@ impl ReferenceAdjuster {
     /// Adjust a reference type (cell or range) for a shift operation
     fn adjust_reference(
         &self,
-        reference: &formualizer_parse::parser::ReferenceType,
+        reference: &ReferenceType,
         op: &ShiftOperation,
         policy: AbsShiftPolicy,
-    ) -> formualizer_parse::parser::ReferenceType {
-        use formualizer_parse::parser::ReferenceType;
+        context: Option<&ReferenceContext<'_>>,
+    ) -> ReferenceAdjustment {
+        let op_sheet_id = match op {
+            ShiftOperation::InsertRows { sheet_id, .. }
+            | ShiftOperation::DeleteRows { sheet_id, .. }
+            | ShiftOperation::InsertColumns { sheet_id, .. }
+            | ShiftOperation::DeleteColumns { sheet_id, .. } => *sheet_id,
+        };
+        match reference {
+            ReferenceType::Cell { sheet, .. } | ReferenceType::Range { sheet, .. } => {
+                if context.is_some_and(|context| {
+                    context.reference_sheet_id(sheet.as_deref()) != Some(op_sheet_id)
+                }) {
+                    return ReferenceAdjustment::Reference(reference.clone());
+                }
+            }
+            _ => return ReferenceAdjustment::Reference(reference.clone()),
+        }
 
         let shared = reference.to_sheet_ref_lossy();
 
@@ -349,32 +425,20 @@ impl ReferenceAdjuster {
                 },
                 Some(crate::reference::SharedRef::Cell(cell)),
             ) => {
-                let sheet_id = match op {
-                    ShiftOperation::InsertRows { sheet_id, .. }
-                    | ShiftOperation::DeleteRows { sheet_id, .. }
-                    | ShiftOperation::InsertColumns { sheet_id, .. }
-                    | ShiftOperation::DeleteColumns { sheet_id, .. } => *sheet_id,
-                };
                 let temp_ref = CellRef::new(
-                    sheet_id,
+                    op_sheet_id,
                     Coord::new(cell.coord.row(), cell.coord.col(), *row_abs, *col_abs),
                 );
 
                 match self.adjust_cell_ref_with_policy(&temp_ref, op, policy) {
-                    None => ReferenceType::Cell {
-                        sheet: Some("#REF".to_string()),
-                        row: 0,
-                        col: 0,
-                        row_abs: *row_abs,
-                        col_abs: *col_abs,
-                    },
-                    Some(adjusted) => ReferenceType::Cell {
+                    None => ReferenceAdjustment::Invalidated,
+                    Some(adjusted) => ReferenceAdjustment::Reference(ReferenceType::Cell {
                         sheet: sheet.clone(),
                         row: adjusted.coord.row() + 1,
                         col: adjusted.coord.col() + 1,
                         row_abs: *row_abs,
                         col_abs: *col_abs,
-                    },
+                    }),
                 }
             }
             (
@@ -388,12 +452,6 @@ impl ReferenceAdjuster {
                 },
                 Some(crate::reference::SharedRef::Range(range)),
             ) => {
-                let is_unbounded_column = range.start_row.is_none() && range.end_row.is_none();
-                let is_unbounded_row = range.start_col.is_none() && range.end_col.is_none();
-                if is_unbounded_column || is_unbounded_row {
-                    return reference.clone();
-                }
-
                 let sr = range.start_row;
                 let sc = range.start_col;
                 let er = range.end_row;
@@ -445,17 +503,7 @@ impl ReferenceAdjuster {
                                 };
                                 (Some(adj_start), Some(adj_end))
                             } else if range_start >= *start && range_end < start + count {
-                                return ReferenceType::Range {
-                                    sheet: Some("#REF".to_string()),
-                                    start_row: Some(0),
-                                    start_col: Some(0),
-                                    end_row: Some(0),
-                                    end_col: Some(0),
-                                    start_row_abs: *start_row_abs,
-                                    start_col_abs: *start_col_abs,
-                                    end_row_abs: *end_row_abs,
-                                    end_col_abs: *end_col_abs,
-                                };
+                                return ReferenceAdjustment::Invalidated;
                             } else {
                                 let adj_start = if range_start < *start {
                                     range_start
@@ -509,17 +557,7 @@ impl ReferenceAdjuster {
                                 };
                                 (Some(adj_start), Some(adj_end))
                             } else if range_start >= *start && range_end < start + count {
-                                return ReferenceType::Range {
-                                    sheet: Some("#REF".to_string()),
-                                    start_row: Some(0),
-                                    start_col: Some(0),
-                                    end_row: Some(0),
-                                    end_col: Some(0),
-                                    start_row_abs: *start_row_abs,
-                                    start_col_abs: *start_col_abs,
-                                    end_row_abs: *end_row_abs,
-                                    end_col_abs: *end_col_abs,
-                                };
+                                return ReferenceAdjustment::Invalidated;
                             } else {
                                 let adj_start = if range_start < *start {
                                     range_start
@@ -549,7 +587,7 @@ impl ReferenceAdjuster {
                     _ => (sc.map(|b| b.index), ec.map(|b| b.index)),
                 };
 
-                ReferenceType::Range {
+                ReferenceAdjustment::Reference(ReferenceType::Range {
                     sheet: sheet.clone(),
                     start_row: adj_sr0.map(|i| i + 1),
                     start_col: adj_sc0.map(|i| i + 1),
@@ -559,9 +597,9 @@ impl ReferenceAdjuster {
                     start_col_abs: *start_col_abs,
                     end_row_abs: *end_row_abs,
                     end_col_abs: *end_col_abs,
-                }
+                })
             }
-            _ => reference.clone(),
+            _ => ReferenceAdjustment::Reference(reference.clone()),
         }
     }
 }
@@ -997,6 +1035,19 @@ impl MoveReferenceAdjuster {
 mod tests {
     use super::*;
     use formualizer_parse::parser::parse;
+    use std::sync::OnceLock;
+
+    fn context(sheet_id: SheetId) -> ReferenceContext<'static> {
+        static REGISTRY: OnceLock<SheetRegistry> = OnceLock::new();
+        let registry = REGISTRY.get_or_init(|| {
+            let mut registry = SheetRegistry::new();
+            registry.id_for("Sheet1");
+            registry.id_for("Other");
+            registry.id_for("#REF");
+            registry
+        });
+        ReferenceContext::new(sheet_id, registry)
+    }
 
     fn format_formula(ast: &ASTNode) -> String {
         // TODO: Use the actual formualizer_parse::parser::to_string when available
@@ -1005,17 +1056,34 @@ mod tests {
     }
 
     #[test]
+    fn context_free_adjuster_compatibility_api_remains_available() {
+        let adjuster = ReferenceAdjuster::new();
+        let ast = parse("=A1").unwrap();
+        let op = ShiftOperation::InsertRows {
+            sheet_id: 0,
+            before: 0,
+            count: 1,
+        };
+
+        let _ = adjuster.adjust_ast(&ast, &op);
+        let _ = adjuster.adjust_ast_with_policy(&ast, &op, AbsShiftPolicy::Track);
+        let _ = adjuster.adjust_ast_if_changed(&ast, &op);
+        let _ = adjuster.adjust_ast_if_changed_with_policy(&ast, &op, AbsShiftPolicy::Track);
+    }
+
+    #[test]
     fn adjust_ast_if_changed_returns_none_for_unaffected_column_insert() {
         let adjuster = ReferenceAdjuster::new();
         let ast = parse("=A1+1").unwrap();
 
-        let adjusted = adjuster.adjust_ast_if_changed(
+        let adjusted = adjuster.adjust_ast_if_changed_in_context(
             &ast,
             &ShiftOperation::InsertColumns {
                 sheet_id: 0,
                 before: 3,
                 count: 1,
             },
+            &context(0),
         );
 
         assert!(adjusted.is_none());
@@ -1027,13 +1095,14 @@ mod tests {
         let ast = parse("=A1+1").unwrap();
 
         let adjusted = adjuster
-            .adjust_ast_if_changed(
+            .adjust_ast_if_changed_in_context(
                 &ast,
                 &ShiftOperation::InsertColumns {
                     sheet_id: 0,
                     before: 0,
                     count: 1,
                 },
+                &context(0),
             )
             .expect("A1 reference should shift");
 
@@ -1059,13 +1128,14 @@ mod tests {
         let ast = parse("=A5+B10").unwrap();
 
         // Insert 2 rows before row 7
-        let adjusted = adjuster.adjust_ast(
+        let adjusted = adjuster.adjust_ast_in_context(
             &ast,
             &ShiftOperation::InsertRows {
                 sheet_id: 0,
                 before: 7,
                 count: 2,
             },
+            &context(0),
         );
 
         // A5 unchanged (before insert point), B10 -> B12
@@ -1098,38 +1168,40 @@ mod tests {
         let ast = parse("=C1+F1").unwrap();
 
         // Delete columns B and C (columns 2 and 3)
-        let adjusted = adjuster.adjust_ast(
+        let adjusted = adjuster.adjust_ast_in_context(
             &ast,
             &ShiftOperation::DeleteColumns {
                 sheet_id: 0,
                 start: 2, // Column B
                 count: 2,
             },
+            &context(0),
         );
 
-        // C1 -> #REF! (deleted), F1 -> D1 (shifted left by 2)
-        if let ASTNodeType::BinaryOp { left, right, .. } = &adjusted.node_type {
-            if let ASTNodeType::Reference {
-                reference:
-                    formualizer_parse::parser::ReferenceType::Cell {
-                        sheet, row, col, ..
-                    },
-                ..
-            } = &left.node_type
-            {
-                assert_eq!(sheet.as_deref(), Some("#REF"));
-                assert_eq!(*row, 0);
-                assert_eq!(*col, 0);
+        // C1 -> #REF! (deleted), F1 -> D1 (shifted left by 2).
+        let ASTNodeType::BinaryOp { left, right, .. } = &adjusted.node_type else {
+            panic!("expected adjusted binary expression, got {adjusted:?}");
+        };
+        match &left.node_type {
+            ASTNodeType::Literal(LiteralValue::Error(error)) => {
+                assert_eq!(error.kind, ExcelErrorKind::Ref);
+                assert!(left.source_token.is_none());
             }
-            if let ASTNodeType::Reference {
-                reference: formualizer_parse::parser::ReferenceType::Cell { row, col, .. },
-                ..
-            } = &right.node_type
-            {
+            other => panic!("expected deleted C1 to become a #REF! literal, got {other:?}"),
+        }
+        match &right.node_type {
+            ASTNodeType::Reference {
+                original,
+                reference: ReferenceType::Cell { row, col, .. },
+            } => {
+                assert_eq!(original, "D1");
                 assert_eq!(*row, 1); // Row unchanged
                 assert_eq!(*col, 4); // F1 (col 6) -> D1 (col 4)
+                assert!(right.source_token.is_none());
             }
+            other => panic!("expected surviving F1 reference to shift to D1, got {other:?}"),
         }
+        assert!(adjusted.source_token.is_none());
     }
 
     #[test]
@@ -1140,13 +1212,14 @@ mod tests {
         let ast = parse("=SUM(A1:A10)").unwrap();
 
         // Insert 3 rows before row 5
-        let adjusted = adjuster.adjust_ast(
+        let adjusted = adjuster.adjust_ast_in_context(
             &ast,
             &ShiftOperation::InsertRows {
                 sheet_id: 0,
                 before: 5,
                 count: 3,
             },
+            &context(0),
         );
 
         // Range should expand: A1:A10 -> A1:A13
@@ -1417,13 +1490,14 @@ mod tests {
         let ast = parse("=SUM(B2:D10)").unwrap();
 
         // Insert rows in the middle of the range
-        let adjusted = adjuster.adjust_ast(
+        let adjusted = adjuster.adjust_ast_in_context(
             &ast,
             &ShiftOperation::InsertRows {
                 sheet_id: 0,
                 before: 5,
                 count: 3,
             },
+            &context(0),
         );
 
         // Range should expand: B2:D10 -> B2:D13
@@ -1455,13 +1529,14 @@ mod tests {
         let ast = parse("=SUM(A5:A20)").unwrap();
 
         // Delete rows in the middle of the range
-        let adjusted = adjuster.adjust_ast(
+        let adjusted = adjuster.adjust_ast_in_context(
             &ast,
             &ShiftOperation::DeleteRows {
                 sheet_id: 0,
                 start: 10,
                 count: 5,
             },
+            &context(0),
         );
 
         // Range should contract: A5:A20 -> A5:A15
@@ -1476,6 +1551,205 @@ mod tests {
         {
             assert_eq!(*start_row, Some(5)); // Start unchanged
             assert_eq!(*end_row, Some(15)); // End contracted from 20 to 15
+        }
+    }
+
+    #[test]
+    fn fully_deleted_range_becomes_ref_error_literal() {
+        let ast = parse("=SUM(A2:A4)").unwrap();
+        let adjusted = ReferenceAdjuster::new().adjust_ast_in_context(
+            &ast,
+            &ShiftOperation::DeleteRows {
+                sheet_id: 0,
+                start: 1,
+                count: 3,
+            },
+            &context(0),
+        );
+
+        let ASTNodeType::Function { args, .. } = &adjusted.node_type else {
+            panic!("expected SUM function, got {adjusted:?}");
+        };
+        match &args[0].node_type {
+            ASTNodeType::Literal(LiteralValue::Error(error)) => {
+                assert_eq!(error.kind, ExcelErrorKind::Ref)
+            }
+            other => panic!("expected deleted range to become #REF!, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn structural_adjustment_respects_formula_and_qualified_sheets() {
+        let adjuster = ReferenceAdjuster::new();
+        let op = ShiftOperation::DeleteRows {
+            sheet_id: 0,
+            start: 0,
+            count: 1,
+        };
+
+        // An unqualified reference belongs to the formula's own sheet.
+        assert!(
+            adjuster
+                .adjust_ast_if_changed_in_context(&parse("=A1").unwrap(), &op, &context(1))
+                .is_none()
+        );
+
+        // Explicit references change only when their named sheet is edited.
+        assert!(
+            adjuster
+                .adjust_ast_if_changed_in_context(&parse("=Other!A1").unwrap(), &op, &context(0))
+                .is_none()
+        );
+        let matching = adjuster
+            .adjust_ast_if_changed_in_context(&parse("=Sheet1!A1").unwrap(), &op, &context(1))
+            .expect("qualified reference to edited sheet must change");
+        assert!(matches!(
+            matching.node_type,
+            ASTNodeType::Literal(LiteralValue::Error(ref error))
+                if error.kind == ExcelErrorKind::Ref
+        ));
+
+        // `#REF` remains a legitimate quoted worksheet name, never a magic marker.
+        let real_ref_sheet = parse("='#REF'!A1").unwrap();
+        assert!(
+            adjuster
+                .adjust_ast_if_changed_in_context(&real_ref_sheet, &op, &context(0))
+                .is_none()
+        );
+        let shifted = adjuster
+            .adjust_ast_if_changed_in_context(
+                &real_ref_sheet,
+                &ShiftOperation::InsertRows {
+                    sheet_id: 2,
+                    before: 0,
+                    count: 1,
+                },
+                &context(0),
+            )
+            .expect("a real #REF sheet reference should shift normally");
+        match shifted.node_type {
+            ASTNodeType::Reference {
+                original,
+                reference:
+                    ReferenceType::Cell {
+                        sheet, row, col, ..
+                    },
+            } => {
+                assert_eq!(original, "'#REF'!A2");
+                assert_eq!(sheet.as_deref(), Some("#REF"));
+                assert_eq!((row, col), (2, 1));
+            }
+            other => panic!("expected a shifted ordinary sheet reference, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn whole_axis_ranges_adjust_only_on_their_bounded_axis() {
+        let adjuster = ReferenceAdjuster::new();
+        let whole_col = parse("=SUM(A:A)").unwrap();
+        assert!(
+            adjuster
+                .adjust_ast_if_changed_in_context(
+                    &whole_col,
+                    &ShiftOperation::DeleteRows {
+                        sheet_id: 0,
+                        start: 0,
+                        count: 1,
+                    },
+                    &context(0),
+                )
+                .is_none()
+        );
+        let deleted_col = adjuster.adjust_ast_in_context(
+            &whole_col,
+            &ShiftOperation::DeleteColumns {
+                sheet_id: 0,
+                start: 0,
+                count: 1,
+            },
+            &context(0),
+        );
+        let ASTNodeType::Function { args, .. } = &deleted_col.node_type else {
+            panic!("expected SUM function");
+        };
+        assert!(matches!(
+            args[0].node_type,
+            ASTNodeType::Literal(LiteralValue::Error(ref error))
+                if error.kind == ExcelErrorKind::Ref
+        ));
+
+        let whole_row = parse("=SUM(1:1)").unwrap();
+        assert!(
+            adjuster
+                .adjust_ast_if_changed_in_context(
+                    &whole_row,
+                    &ShiftOperation::DeleteColumns {
+                        sheet_id: 0,
+                        start: 0,
+                        count: 1,
+                    },
+                    &context(0),
+                )
+                .is_none()
+        );
+        let deleted_row = adjuster.adjust_ast_in_context(
+            &whole_row,
+            &ShiftOperation::DeleteRows {
+                sheet_id: 0,
+                start: 0,
+                count: 1,
+            },
+            &context(0),
+        );
+        let ASTNodeType::Function { args, .. } = &deleted_row.node_type else {
+            panic!("expected SUM function");
+        };
+        assert!(matches!(
+            args[0].node_type,
+            ASTNodeType::Literal(LiteralValue::Error(ref error))
+                if error.kind == ExcelErrorKind::Ref
+        ));
+    }
+
+    #[test]
+    fn call_and_array_children_receive_literal_rewrites() {
+        let adjuster = ReferenceAdjuster::new();
+        let op = ShiftOperation::DeleteColumns {
+            sheet_id: 0,
+            start: 0,
+            count: 1,
+        };
+
+        let call =
+            adjuster.adjust_ast_in_context(&parse("=LAMBDA(x,x)(A1)").unwrap(), &op, &context(0));
+        let ASTNodeType::Call { args, .. } = &call.node_type else {
+            panic!("expected immediate call, got {call:?}");
+        };
+        assert!(matches!(
+            args[0].node_type,
+            ASTNodeType::Literal(LiteralValue::Error(ref error))
+                if error.kind == ExcelErrorKind::Ref
+        ));
+        assert!(call.source_token.is_none());
+
+        let array = adjuster.adjust_ast_in_context(&parse("={A1,B1}").unwrap(), &op, &context(0));
+        let ASTNodeType::Array(rows) = &array.node_type else {
+            panic!("expected array, got {array:?}");
+        };
+        assert!(matches!(
+            rows[0][0].node_type,
+            ASTNodeType::Literal(LiteralValue::Error(ref error))
+                if error.kind == ExcelErrorKind::Ref
+        ));
+        match &rows[0][1].node_type {
+            ASTNodeType::Reference {
+                original,
+                reference: ReferenceType::Cell { row, col, .. },
+            } => {
+                assert_eq!(original, "A1");
+                assert_eq!((*row, *col), (1, 1));
+            }
+            other => panic!("expected B1 to shift to A1, got {other:?}"),
         }
     }
 }

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -1,7 +1,8 @@
 use crate::SheetId;
 use crate::engine::graph::DependencyGraph;
 use crate::engine::graph::editor::reference_adjuster::{
-    MoveReferenceAdjuster, ReferenceAdjuster, RelativeReferenceAdjuster, ShiftOperation,
+    MoveReferenceAdjuster, ReferenceAdjuster, ReferenceContext, RelativeReferenceAdjuster,
+    ShiftOperation,
 };
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::{ChangeEvent, ChangeLogger, VertexId, VertexKind};
@@ -925,7 +926,11 @@ impl<'g> VertexEditor<'g> {
 
         for id in formula_vertices {
             if let Some(ast) = self.get_formula_ast(id)
-                && let Some(adjusted) = adjuster.adjust_ast_if_changed(&ast, &op)
+                && let Some(adjusted) = adjuster.adjust_ast_if_changed_in_context(
+                    &ast,
+                    &op,
+                    &ReferenceContext::new(self.graph.get_sheet_id(id), self.graph.sheet_reg()),
+                )
             {
                 if self.has_logger() {
                     self.log_change(ChangeEvent::FormulaAdjusted {
@@ -1049,7 +1054,11 @@ impl<'g> VertexEditor<'g> {
 
         for id in formula_vertices {
             if let Some(ast) = self.get_formula_ast(id)
-                && let Some(adjusted) = adjuster.adjust_ast_if_changed(&ast, &op)
+                && let Some(adjusted) = adjuster.adjust_ast_if_changed_in_context(
+                    &ast,
+                    &op,
+                    &ReferenceContext::new(self.graph.get_sheet_id(id), self.graph.sheet_reg()),
+                )
             {
                 if self.has_logger() {
                     self.log_change(ChangeEvent::FormulaAdjusted {
@@ -1161,7 +1170,11 @@ impl<'g> VertexEditor<'g> {
 
         for id in formula_vertices {
             if let Some(ast) = self.get_formula_ast(id)
-                && let Some(adjusted) = adjuster.adjust_ast_if_changed(&ast, &op)
+                && let Some(adjusted) = adjuster.adjust_ast_if_changed_in_context(
+                    &ast,
+                    &op,
+                    &ReferenceContext::new(self.graph.get_sheet_id(id), self.graph.sheet_reg()),
+                )
             {
                 if self.has_logger() {
                     self.log_change(ChangeEvent::FormulaAdjusted {
@@ -1285,7 +1298,11 @@ impl<'g> VertexEditor<'g> {
 
         for id in formula_vertices {
             if let Some(ast) = self.get_formula_ast(id)
-                && let Some(adjusted) = adjuster.adjust_ast_if_changed(&ast, &op)
+                && let Some(adjusted) = adjuster.adjust_ast_if_changed_in_context(
+                    &ast,
+                    &op,
+                    &ReferenceContext::new(self.graph.get_sheet_id(id), self.graph.sheet_reg()),
+                )
             {
                 if self.has_logger() {
                     self.log_change(ChangeEvent::FormulaAdjusted {

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -4285,32 +4285,16 @@ impl DependencyGraph {
         // Get the sheet_id for this vertex
         let sheet_id = self.store.sheet_id(id);
 
-        // If the adjusted AST contains special #REF markers (from structural edits),
-        // treat this as a REF error on the vertex instead of attempting to resolve.
-        // This prevents failures when reference_adjuster injected placeholder refs.
-        let has_ref_marker = ast.get_dependencies().into_iter().any(|r| {
-            matches!(
-                r,
-                ReferenceType::Cell { sheet: Some(s), .. }
-                    | ReferenceType::Range { sheet: Some(s), .. } if s == "#REF"
-            )
-        });
-        if has_ref_marker {
-            // Store the adjusted AST for round-tripping/display, but set value state to #REF!
-            let ast_id = self.data_store.store_ast(&ast, &self.sheet_reg);
-            self.vertex_formulas.insert(id, ast_id);
-            self.mark_as_ref_error(id);
-            self.store.set_kind(id, VertexKind::FormulaScalar);
-            return Ok(());
-        }
+        // Extract dependencies from AST, retaining unresolved names for later linking.
+        let (new_dependencies, new_range_dependencies, _, named_dependencies, unresolved_names) =
+            self.extract_dependencies_with_pending_names(&ast, sheet_id)?;
 
-        // Extract dependencies from AST
-        let (new_dependencies, new_range_dependencies, _, named_dependencies) =
-            self.extract_dependencies(&ast, sheet_id)?;
+        let old_kind = self.store.kind(id);
 
-        // Remove old dependencies first
+        // Remove all links owned by the previous formula.
         self.remove_dependent_edges(id);
         self.detach_vertex_from_names(id);
+        self.clear_pending_name_references(id);
 
         // Store the new formula
         let ast_id = self.data_store.store_ast(&ast, &self.sheet_reg);
@@ -4323,9 +4307,24 @@ impl DependencyGraph {
         if !named_dependencies.is_empty() {
             self.attach_vertex_to_names(id, &named_dependencies);
         }
+        for unresolved_name in &unresolved_names {
+            self.record_pending_name_reference(sheet_id, unresolved_name, id);
+        }
 
-        // Mark as formula vertex
-        self.store.set_kind(id, VertexKind::FormulaScalar);
+        // Formula replacement supersedes any structural error/cache state left when a
+        // deleted dependency marked this vertex before its AST was rewritten.
+        self.ref_error_vertices.remove(&id);
+        self.vertex_values.remove(&id);
+
+        // A structural rewrite must not collapse an existing array formula kind.
+        self.store.set_kind(
+            id,
+            if old_kind == VertexKind::FormulaArray {
+                VertexKind::FormulaArray
+            } else {
+                VertexKind::FormulaScalar
+            },
+        );
 
         Ok(())
     }

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -55,6 +55,7 @@ fn adjust_named_definition(
     definition: &mut NamedDefinition,
     adjuster: &crate::engine::graph::editor::reference_adjuster::ReferenceAdjuster,
     operation: &crate::engine::graph::editor::reference_adjuster::ShiftOperation,
+    context: &crate::engine::graph::editor::reference_adjuster::ReferenceContext<'_>,
 ) -> Result<(), ExcelError> {
     use crate::engine::graph::editor::reference_adjuster::AbsShiftPolicy;
     match definition {
@@ -94,7 +95,12 @@ fn adjust_named_definition(
             dependencies,
             range_deps,
         } => {
-            let adjusted_ast = adjuster.adjust_ast_with_policy(ast, operation, AbsShiftPolicy::Pin);
+            let adjusted_ast = adjuster.adjust_ast_with_policy_in_context(
+                ast,
+                operation,
+                AbsShiftPolicy::Pin,
+                context,
+            );
             *ast = adjusted_ast;
 
             dependencies.clear();
@@ -729,14 +735,28 @@ impl DependencyGraph {
         let adjuster = crate::engine::graph::editor::reference_adjuster::ReferenceAdjuster::new();
 
         let changed = !self.named_ranges.is_empty() || !self.sheet_named_ranges.is_empty();
-        // Adjust workbook-scoped names
+        // Workbook-scoped formulas bind unqualified references to the default sheet.
+        let workbook_context =
+            crate::engine::graph::editor::reference_adjuster::ReferenceContext::new(
+                self.default_sheet_id,
+                &self.sheet_reg,
+            );
         for named_range in self.named_ranges.values_mut() {
-            adjust_named_definition(&mut named_range.definition, &adjuster, operation)?;
+            adjust_named_definition(
+                &mut named_range.definition,
+                &adjuster,
+                operation,
+                &workbook_context,
+            )?;
         }
 
-        // Adjust sheet-scoped names
-        for named_range in self.sheet_named_ranges.values_mut() {
-            adjust_named_definition(&mut named_range.definition, &adjuster, operation)?;
+        // Sheet-scoped formulas bind unqualified references to their scope sheet.
+        for ((scope_sheet_id, _), named_range) in self.sheet_named_ranges.iter_mut() {
+            let context = crate::engine::graph::editor::reference_adjuster::ReferenceContext::new(
+                *scope_sheet_id,
+                &self.sheet_reg,
+            );
+            adjust_named_definition(&mut named_range.definition, &adjuster, operation, &context)?;
         }
         if changed {
             self.bump_symbol_revision();

--- a/crates/formualizer-eval/src/engine/tests/arrow_canonical_611.rs
+++ b/crates/formualizer-eval/src/engine/tests/arrow_canonical_611.rs
@@ -1,9 +1,9 @@
 //! Ticket 611: Structural invalidation in canonical (Arrow-truth) mode.
 //!
 //! These tests ensure structural operations that induce #REF! correctly:
-//! - record the invalidation in the dependency graph (via `is_ref_error`)
-//! - propagate dirtying so downstream dependents recompute
-//! - mirror results into Arrow truth so `Engine::get_cell_value` reflects #REF!
+//! - preserve invalid references as ordinary AST error literals where an expression survives;
+//! - propagate dirtying so downstream dependents recompute;
+//! - mirror results into Arrow truth so `Engine::get_cell_value` reflects #REF!.
 
 use crate::engine::eval::Engine;
 use crate::test_workbook::TestWorkbook;
@@ -439,4 +439,112 @@ fn canonical_delete_rows_creates_ref_and_propagates_downstream() {
         Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Ref),
         other => panic!("expected Sheet1!B2 to be #REF! (propagated), got {other:?}"),
     }
+}
+
+#[test]
+fn structural_ref_literal_preserves_lazy_error_semantics_and_round_trips() {
+    let cfg = arrow_eval_config();
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 3, 3, parse("=IF(FALSE,A1,5)").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 4, 3, parse("=IFERROR(A1,7)").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 3, 4, parse("=C3+1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    engine.delete_rows("Sheet1", 1, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 3),
+        Some(LiteralValue::Number(5.0)),
+        "an invalid reference in an unselected IF branch must not poison the formula"
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 3, 3),
+        Some(LiteralValue::Number(7.0)),
+        "IFERROR must catch the structurally synthesized #REF! literal"
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 4),
+        Some(LiteralValue::Number(6.0)),
+        "downstream formulas must recompute from the lazy result"
+    );
+
+    for (row, expected) in [(2, "=IF(false, #REF!, 5)"), (3, "=IFERROR(#REF!, 7)")] {
+        let (ast, _) = engine
+            .get_cell("Sheet1", row, 3)
+            .expect("formula cell exists");
+        let ast = ast.expect("formula AST exists");
+        let rendered = canonical_formula(&ast);
+        assert_eq!(rendered, expected);
+        assert_eq!(
+            canonical_formula(&parse(&rendered).expect("rendered #REF! formula must reparse")),
+            rendered
+        );
+    }
+}
+
+#[test]
+fn structural_adjustment_is_sheet_local_and_ref_is_a_valid_sheet_name() {
+    let cfg = arrow_eval_config();
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+
+    engine.add_sheet("Other").unwrap();
+    engine.add_sheet("#REF").unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+    engine
+        .set_cell_value("Other", 1, 1, LiteralValue::Number(20.0))
+        .unwrap();
+    engine
+        .set_cell_value("#REF", 1, 1, LiteralValue::Number(30.0))
+        .unwrap();
+    engine
+        .set_cell_formula("Other", 2, 2, parse("=A1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Other", 3, 2, parse("=Sheet1!A1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Other", 4, 2, parse("='#REF'!A1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    engine.delete_rows("Sheet1", 1, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Other", 2, 2),
+        Some(LiteralValue::Number(20.0)),
+        "unqualified references on another sheet must remain local"
+    );
+    match engine.get_cell_value("Other", 3, 2) {
+        Some(LiteralValue::Error(error)) => assert_eq!(error.kind, ExcelErrorKind::Ref),
+        other => panic!("expected the matching qualified reference to become #REF!, got {other:?}"),
+    }
+    assert_eq!(
+        engine.get_cell_value("Other", 4, 2),
+        Some(LiteralValue::Number(30.0)),
+        "a real sheet named #REF must remain addressable"
+    );
+
+    let formula = |row| {
+        let (ast, _) = engine
+            .get_cell("Other", row, 2)
+            .expect("formula cell exists");
+        canonical_formula(&ast.expect("formula AST exists"))
+    };
+    assert_eq!(formula(2), "=A1");
+    assert_eq!(formula(3), "=#REF!");
+    assert_eq!(formula(4), "='#REF'!A1");
 }

--- a/crates/formualizer-eval/src/engine/tests/column_operations.rs
+++ b/crates/formualizer-eval/src/engine/tests/column_operations.rs
@@ -3,6 +3,7 @@ use crate::engine::graph::DependencyGraph;
 use crate::reference::{CellRef, Coord};
 use formualizer_common::LiteralValue;
 use formualizer_parse::parser::parse;
+use formualizer_parse::pretty::canonical_formula;
 
 fn lit_num(value: f64) -> LiteralValue {
     LiteralValue::Number(value)
@@ -355,7 +356,52 @@ fn test_delete_columns_with_dependencies() {
 
     drop(editor);
 
-    // C1 -> B1, should have #REF! since it referenced deleted B1
-    // Check that the formula that was at C1 (now at B1) has been marked as #REF!
-    assert!(graph.is_ref_error(c1_id));
+    // C1 -> B1. Its deleted B1 operand is now an ordinary #REF! literal;
+    // the graph-global forced-error marker is reserved for errors without an AST expression.
+    let ast = graph
+        .get_formula(c1_id)
+        .expect("the moved formula should still exist");
+    assert_eq!(canonical_formula(&ast), "=#REF! + 5");
+    assert!(!graph.is_ref_error(c1_id));
+}
+
+#[test]
+fn structural_ref_literal_survives_undo_and_redo() {
+    use crate::engine::ChangeLog;
+    use crate::engine::graph::editor::undo_engine::UndoEngine;
+
+    let mut graph = super::common::graph_truth_graph();
+    graph.set_cell_value("Sheet1", 1, 2, lit_num(10.0)).unwrap();
+    let formula_id = graph
+        .set_cell_formula("Sheet1", 1, 3, parse("=B1+5").unwrap())
+        .unwrap()
+        .affected_vertices[0];
+
+    let mut log = ChangeLog::new();
+    {
+        let mut editor = VertexEditor::with_logger(&mut graph, &mut log);
+        editor.delete_columns(0, 1, 1).unwrap();
+    }
+    assert_eq!(
+        canonical_formula(&graph.get_formula(formula_id).expect("formula after delete")),
+        "=#REF! + 5"
+    );
+
+    let mut undo = UndoEngine::new();
+    undo.undo(&mut graph, &mut log).unwrap();
+    assert_eq!(
+        canonical_formula(&graph.get_formula(formula_id).expect("formula after undo")),
+        "=B1 + 5"
+    );
+    assert!(
+        graph
+            .get_vertex_id_for_address(&sheet1_cell(&graph, 1, 2))
+            .is_some()
+    );
+
+    undo.redo(&mut graph, &mut log).unwrap();
+    assert_eq!(
+        canonical_formula(&graph.get_formula(formula_id).expect("formula after redo")),
+        "=#REF! + 5"
+    );
 }

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_structural.rs
@@ -5,8 +5,9 @@ use crate::engine::{
     Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
 };
 use crate::test_workbook::TestWorkbook;
-use formualizer_common::LiteralValue;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
+use formualizer_parse::pretty::canonical_formula;
 
 fn record(
     engine: &mut Engine<TestWorkbook>,
@@ -726,6 +727,40 @@ fn formula_plane_delete_on_read_range_sheet_straddles_and_demotes() {
     assert_eq!(
         engine.get_cell_value("Sheet1", 1, 1),
         Some(LiteralValue::Number(50.0))
+    );
+}
+
+#[test]
+fn formula_plane_full_read_delete_demotes_to_ref_error_literals() {
+    let mut engine = authoritative_engine();
+    engine.add_sheet("Data").unwrap();
+    engine
+        .set_cell_value("Data", 1, 1, LiteralValue::Number(10.0))
+        .unwrap();
+    let mut formulas = Vec::new();
+    for row in 1..=100 {
+        formulas.push(record(&mut engine, row, 1, "=SUM(Data!$A$1:$A$1)"));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+
+    engine.delete_rows("Data", 1, 1).unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    engine.evaluate_all().unwrap();
+
+    match engine.get_cell_value("Sheet1", 50, 1) {
+        Some(LiteralValue::Error(error)) => assert_eq!(error.kind, ExcelErrorKind::Ref),
+        other => panic!("expected demoted formula to evaluate to #REF!, got {other:?}"),
+    }
+    let (ast, _) = engine
+        .get_cell("Sheet1", 50, 1)
+        .expect("demoted formula cell exists");
+    assert_eq!(
+        canonical_formula(&ast.expect("demoted formula AST exists")),
+        "=SUM(#REF!)"
     );
 }
 

--- a/crates/formualizer-eval/src/engine/tests/named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/named_ranges.rs
@@ -6,6 +6,7 @@ use crate::reference::{CellRef, Coord, RangeRef};
 use crate::test_workbook::TestWorkbook;
 use formualizer_common::{ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
+use formualizer_parse::pretty::canonical_formula;
 use rustc_hash::FxHashSet;
 
 /// Helper to create a literal number value
@@ -1728,6 +1729,58 @@ fn test_named_formula_adjustment() {
             ));
         }
         _ => panic!("Expected Formula definition"),
+    }
+}
+
+#[test]
+fn named_formula_adjustment_is_scope_and_sheet_aware() {
+    use crate::engine::graph::editor::reference_adjuster::ShiftOperation;
+
+    let mut graph = DependencyGraph::new();
+    let other_id = graph.add_sheet("Other").unwrap();
+
+    graph
+        .define_name(
+            "WorkbookFormula",
+            NamedDefinition::Formula {
+                ast: parse("=A1+Other!A1").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            NameScope::Workbook,
+        )
+        .unwrap();
+    graph
+        .define_name(
+            "SheetFormula",
+            NamedDefinition::Formula {
+                ast: parse("=A1+Sheet1!A1").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            NameScope::Sheet(other_id),
+        )
+        .unwrap();
+
+    graph
+        .adjust_named_ranges(&ShiftOperation::DeleteRows {
+            sheet_id: 0,
+            start: 0,
+            count: 1,
+        })
+        .unwrap();
+
+    match graph.resolve_name("WorkbookFormula", other_id).unwrap() {
+        NamedDefinition::Formula { ast, .. } => {
+            assert_eq!(canonical_formula(ast), "=#REF! + Other!A1");
+        }
+        other => panic!("expected workbook formula, got {other:?}"),
+    }
+    match graph.resolve_name("SheetFormula", other_id).unwrap() {
+        NamedDefinition::Formula { ast, .. } => {
+            assert_eq!(canonical_formula(ast), "=A1 + #REF!");
+        }
+        other => panic!("expected sheet formula, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

- replace structural-edit `sheet: Some("#REF")` reference sentinels with canonical `Literal(Error(Ref))` AST leaves
- preserve normal lazy/error semantics so dead `IF` branches do not poison formulas and `IFERROR` can recover
- rebuild surviving dependencies, pending names, cached/error state, and formula kinds through the ordinary formula replacement path
- make structural adjustment sheet-aware for formula vertices, named formulas, and FormulaPlane template rewrites
- correctly adjust whole-row and whole-column references on their bounded axes
- preserve the existing context-free `ReferenceAdjuster` API while adding explicit sheet-context APIs for correct engine use

## Why

PR #197 correctly reported that structural reference sentinels rendered as malformed references such as `'#REF'!0`. Rendering `sheet == "#REF"` specially is unsafe because `#REF` is also a valid worksheet name, and it would leave sentinel-specific evaluation, stale dependencies, arena ambiguity, and formula-global error behavior intact.

This change uses the same AST representation produced when parsing an ordinary `#REF!` formula. A structurally invalidated operand therefore displays, reparses, stores, evaluates, and participates in control flow as a normal error literal.

Supersedes #197 and credits its reporter as a co-author.

## Semantics covered

- deleted cell and fully deleted range leaves become `#REF!` literals
- partially deleted ranges contract normally
- whole-axis references adjust only on their bounded axis
- unqualified references bind to the formula or name scope sheet
- qualified references adjust only when their sheet is edited
- a real worksheet named `#REF` remains addressable as `'#REF'!A1`
- lazy `IF`, `IFERROR`, downstream recomputation, arena display/reparse, cached/canonical graph state, undo/redo, and authoritative FormulaPlane demotion retain parity
- absolute Track versus named-definition Pin behavior remains unchanged

## Validation

- `cargo test -p formualizer-eval`: 2,392 passed, 12 ignored, plus integration and doc tests
- `cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- final independent review: `MERGEABLE: YES`
