### PR TITLE
fix(parse): accept control whitespace without changing intersection semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Formula tokenization now accepts TAB, CR, LF, and CRLF as lexical whitespace in both tokenizer frontends while preserving raw source spans. Only an ASCII space can spell the range-intersection operator, whose semantic token/AST value is canonicalized to `" "` even when its source run also contains line breaks or tabs.
 - Structural row and column deletes now rewrite invalidated reference leaves to ordinary `#REF!` error literals instead of magic `#REF` sheet sentinels. This preserves lazy `IF`/`IFERROR` semantics, dependency rewiring, formula display/reparse, undo/redo, whole-axis adjustment, cross-sheet locality, and legitimate worksheets named `#REF` across legacy and FormulaPlane structural paths.
 - Fixed deferred `evaluate_cells_with_delta` requests missing transitive formula precedents staged on non-target sheets.
 - Fixed experimental FormulaPlane capacity fallbacks evaluating legacy readers before required span results were available. Unsafe requests now transactionally demote exactly their scheduled spans, retain pending dirty regions across failed attempts, and fail closed behind a finite materialization limit.

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -2424,9 +2424,24 @@ impl Parser {
         &self.source[span.start..span.end]
     }
 
+    fn semantic_span_value(&self, span: &TokenSpan) -> &str {
+        let value = self.span_value(span);
+        if span.token_type == TokenType::OpInfix
+            && value.as_bytes().contains(&b' ')
+            && value
+                .as_bytes()
+                .iter()
+                .all(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+        {
+            " "
+        } else {
+            value
+        }
+    }
+
     fn span_to_token(&self, span: &TokenSpan) -> Token {
         Token::new_with_span(
-            self.span_value(span).to_string(),
+            self.semantic_span_value(span).to_string(),
             span.token_type,
             span.subtype,
             span.start,
@@ -2445,7 +2460,7 @@ impl Parser {
         let op = if span.token_type == TokenType::OpPrefix {
             "u"
         } else {
-            self.span_value(span)
+            self.semantic_span_value(span)
         };
 
         match op {

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -1969,6 +1969,7 @@ mod tests {
     }
 
     mod reference_operators {
+        use crate::parser::{ASTNodeType, parse};
         use crate::tokenizer::{TokenStream, TokenSubType, TokenType, Tokenizer};
 
         fn classic_non_ws(formula: &str) -> Vec<(TokenType, TokenSubType, String)> {
@@ -2125,40 +2126,102 @@ mod tests {
         }
 
         #[test]
-        fn space_with_newline_between_refs_is_intersection_op() {
-            // Whitespace runs (including \n) collapse to OpInfix(" ") when both
-            // sides are reference-producing.
-            let classic = classic_non_ws("=A1:A3\n B1:B3");
-            assert!(
-                classic
-                    .iter()
-                    .any(|t| t.0 == TokenType::OpInfix && t.2.contains(' '))
-                    || classic
-                        .iter()
-                        .any(|t| t.0 == TokenType::OpInfix && t.2 == " ")
-            );
+        fn mixed_whitespace_with_space_is_canonical_intersection() {
+            let formula = "=A1:A3\r\n \tB1:B3";
+            let classic = Tokenizer::new(formula).expect("classic tokenize");
+            let classic_op = classic
+                .items
+                .iter()
+                .find(|token| token.token_type == TokenType::OpInfix)
+                .expect("classic intersection token");
+            assert_eq!(classic_op.value, " ");
+            assert_eq!(&formula[classic_op.start..classic_op.end], "\r\n \t");
+
+            let stream = TokenStream::new(formula).expect("span tokenize");
+            let span = stream
+                .spans
+                .iter()
+                .find(|span| span.token_type == TokenType::OpInfix)
+                .expect("span intersection token");
+            assert_eq!(&formula[span.start..span.end], "\r\n \t");
+            let owned = stream.to_tokens();
+            let owned_op = owned
+                .iter()
+                .find(|token| token.token_type == TokenType::OpInfix)
+                .expect("owned span intersection token");
+            assert_eq!(owned_op.value, " ");
+            assert_eq!(stream.render_formula(), formula);
+
+            let ast = parse(formula).expect("intersection parse");
+            assert!(matches!(
+                ast.node_type,
+                ASTNodeType::BinaryOp { ref op, .. } if op == " "
+            ));
         }
 
         #[test]
-        fn crlf_and_tabs_are_whitespace() {
+        fn crlf_and_tabs_are_ordinary_whitespace_without_space() {
             // Regression: the tokenizer treated only ' ' and '\n' as whitespace,
-            // so the Windows CRLF sequence "\r\n" (Alt+Enter line breaks) and tabs
-            // broke parsing — even though '\r' and '\n' individually did not.
-            for f in [
-                "=SUM(\r\n1,2\r\n)", // Apache POI test-data case
-                "=A1 +\r\n B1",
+            // so Windows CRLF and tabs could be absorbed into operands.
+            for formula in [
+                "=SUM(\r\n1,2\r\n)",
+                "=A1 +\r\nB1",
                 "=IF(A1,\r\nB1)",
                 "=SUM(A1,\tA2)",
                 "=\tSUM(A1,A2)\t",
             ] {
-                assert!(Tokenizer::new(f).is_ok(), "failed to tokenize {f:?}");
+                let classic = Tokenizer::new(formula).expect("classic tokenize");
+                let stream = TokenStream::new(formula).expect("span tokenize");
+                assert!(parse(formula).is_ok(), "failed to parse {formula:?}");
+                assert_eq!(stream.render_formula(), formula);
+                assert!(
+                    classic.items.iter().all(|token| {
+                        !matches!(token.token_type, TokenType::Operand)
+                            || !token
+                                .value
+                                .bytes()
+                                .any(|byte| matches!(byte, b'\t' | b'\r' | b'\n'))
+                    }),
+                    "control whitespace leaked into an operand: {:?}",
+                    classic.items
+                );
+                assert_eq!(classic.items.len(), stream.spans.len());
             }
-            // CRLF/tab whitespace is filtered out, leaving the real tokens intact.
-            let toks = classic_non_ws("=SUM(\r\n1,2\r\n)");
-            assert!(
-                toks.iter().any(|t| t.2.starts_with("SUM")),
-                "expected SUM token, got {toks:?}"
-            );
+
+            // Only ASCII space spells intersection. Other whitespace between
+            // adjacent references remains ordinary whitespace, so the formula
+            // is rejected rather than creating a raw CR/LF/TAB operator.
+            for formula in ["=A1\tB1", "=A1\rB1", "=A1\nB1", "=A1\r\nB1"] {
+                let classic = Tokenizer::new(formula).expect("classic tokenize");
+                let stream = TokenStream::new(formula).expect("span tokenize");
+                assert!(
+                    classic
+                        .items
+                        .iter()
+                        .all(|token| token.token_type != TokenType::OpInfix)
+                );
+                assert!(
+                    stream
+                        .spans
+                        .iter()
+                        .all(|span| span.token_type != TokenType::OpInfix)
+                );
+                assert!(parse(formula).is_err(), "unexpectedly parsed {formula:?}");
+            }
+        }
+
+        #[test]
+        fn control_whitespace_inside_quotes_is_preserved() {
+            for formula in ["=\"a\tb\r\nc\"", "='Sheet\tOne'!A1"] {
+                let classic = Tokenizer::new(formula).expect("classic tokenize");
+                let stream = TokenStream::new(formula).expect("span tokenize");
+                assert_eq!(stream.render_formula(), formula);
+                assert!(parse(formula).is_ok(), "failed to parse {formula:?}");
+                assert!(classic.items.iter().any(|token| {
+                    token.value.contains('\t')
+                        && !matches!(token.token_type, TokenType::Whitespace | TokenType::OpInfix)
+                }));
+            }
         }
     }
 }

--- a/crates/formualizer-parse/src/tests/tokenizer.rs
+++ b/crates/formualizer-parse/src/tests/tokenizer.rs
@@ -2138,5 +2138,27 @@ mod tests {
                         .any(|t| t.0 == TokenType::OpInfix && t.2 == " ")
             );
         }
+
+        #[test]
+        fn crlf_and_tabs_are_whitespace() {
+            // Regression: the tokenizer treated only ' ' and '\n' as whitespace,
+            // so the Windows CRLF sequence "\r\n" (Alt+Enter line breaks) and tabs
+            // broke parsing — even though '\r' and '\n' individually did not.
+            for f in [
+                "=SUM(\r\n1,2\r\n)", // Apache POI test-data case
+                "=A1 +\r\n B1",
+                "=IF(A1,\r\nB1)",
+                "=SUM(A1,\tA2)",
+                "=\tSUM(A1,A2)\t",
+            ] {
+                assert!(Tokenizer::new(f).is_ok(), "failed to tokenize {f:?}");
+            }
+            // CRLF/tab whitespace is filtered out, leaving the real tokens intact.
+            let toks = classic_non_ws("=SUM(\r\n1,2\r\n)");
+            assert!(
+                toks.iter().any(|t| t.2.starts_with("SUM")),
+                "expected SUM token, got {toks:?}"
+            );
+        }
     }
 }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -662,7 +662,7 @@ fn is_reference_operand_value(value: &str) -> bool {
 
 fn next_starts_reference_expression(formula: &str, mut offset: usize) -> bool {
     let bytes = formula.as_bytes();
-    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\n') {
+    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\t' | b'\r' | b'\n') {
         offset += 1;
     }
     if offset >= bytes.len() {
@@ -674,7 +674,7 @@ fn next_starts_reference_expression(formula: &str, mut offset: usize) -> bool {
 
 fn next_reference_has_sheet_qualifier(formula: &str, mut offset: usize) -> bool {
     let bytes = formula.as_bytes();
-    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\n') {
+    while offset < bytes.len() && matches!(bytes[offset], b' ' | b'\t' | b'\r' | b'\n') {
         offset += 1;
     }
 
@@ -690,7 +690,7 @@ fn next_reference_has_sheet_qualifier(formula: &str, mut offset: usize) -> bool 
             }
             b'!' => return true,
             b':' if !in_quote => return false,
-            b',' | b';' | b'}' | b')' | b' ' | b'\n' | b'+' | b'-' | b'*' | b'/' | b'^' | b'&'
+            b',' | b';' | b'}' | b')' | b' ' | b'\t' | b'\r' | b'\n' | b'+' | b'-' | b'*' | b'/' | b'^' | b'&'
             | b'=' | b'>' | b'<' | b'%' | b'@'
                 if !in_quote =>
             {
@@ -878,7 +878,7 @@ impl<'a> SpanTokenizer<'a> {
                         self.parse_error()
                     }
                 }
-                b' ' | b'\n' => self.parse_whitespace(),
+                b' ' | b'\t' | b'\r' | b'\n' => self.parse_whitespace(),
                 b':' => {
                     if self.should_emit_colon_infix() {
                         self.emit_infix_operator(self.offset, self.offset + 1);
@@ -1212,6 +1212,8 @@ impl<'a> SpanTokenizer<'a> {
             let ch = self.formula.as_bytes()[end];
             if is_token_ender(ch)
                 || ch == b' '
+                || ch == b'\t'
+                || ch == b'\r'
                 || ch == b'\n'
                 || ch == b'('
                 || ch == b'{'
@@ -1239,7 +1241,7 @@ impl<'a> SpanTokenizer<'a> {
         let ws_start = self.offset;
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
-                b' ' | b'\n' => self.offset += 1,
+                b' ' | b'\t' | b'\r' | b'\n' => self.offset += 1,
                 _ => break,
             }
         }
@@ -1650,7 +1652,7 @@ impl Tokenizer {
                         self.parse_error()?
                     }
                 }
-                b' ' | b'\n' => self.parse_whitespace()?,
+                b' ' | b'\t' | b'\r' | b'\n' => self.parse_whitespace()?,
                 b':' => {
                     if self.should_emit_colon_infix() {
                         self.emit_infix_operator(self.offset, self.offset + 1);
@@ -1987,7 +1989,7 @@ impl Tokenizer {
         let ws_start = self.offset;
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
-                b' ' | b'\n' => self.offset += 1,
+                b' ' | b'\t' | b'\r' | b'\n' => self.offset += 1,
                 _ => break,
             }
         }

--- a/crates/formualizer-parse/src/tokenizer.rs
+++ b/crates/formualizer-parse/src/tokenizer.rs
@@ -472,6 +472,20 @@ pub struct TokenStream {
     diagnostics: Vec<TokenDiagnostic>,
 }
 
+fn is_whitespace_intersection_span(source: &str, span: &TokenSpan) -> bool {
+    if span.token_type != TokenType::OpInfix {
+        return false;
+    }
+    let Some(value) = source.get(span.start..span.end) else {
+        return false;
+    };
+    value.as_bytes().contains(&b' ')
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+}
+
 impl TokenStream {
     pub fn new(formula: &str) -> Result<Self, TokenizerError> {
         Self::new_with_dialect(formula, FormulaDialect::Excel)
@@ -560,11 +574,14 @@ impl TokenStream {
         self.spans
             .iter()
             .map(|s| {
-                let value = self
-                    .source
-                    .get(s.start..s.end)
-                    .unwrap_or_default()
-                    .to_string();
+                let value = if is_whitespace_intersection_span(&self.source, s) {
+                    " ".to_string()
+                } else {
+                    self.source
+                        .get(s.start..s.end)
+                        .unwrap_or_default()
+                        .to_string()
+                };
                 Token::new_with_span(value, s.token_type, s.subtype, s.start, s.end)
             })
             .collect()
@@ -690,8 +707,8 @@ fn next_reference_has_sheet_qualifier(formula: &str, mut offset: usize) -> bool 
             }
             b'!' => return true,
             b':' if !in_quote => return false,
-            b',' | b';' | b'}' | b')' | b' ' | b'\t' | b'\r' | b'\n' | b'+' | b'-' | b'*' | b'/' | b'^' | b'&'
-            | b'=' | b'>' | b'<' | b'%' | b'@'
+            b',' | b';' | b'}' | b')' | b' ' | b'\t' | b'\r' | b'\n' | b'+' | b'-' | b'*'
+            | b'/' | b'^' | b'&' | b'=' | b'>' | b'<' | b'%' | b'@'
                 if !in_quote =>
             {
                 return false;
@@ -1239,14 +1256,22 @@ impl<'a> SpanTokenizer<'a> {
         self.save_token();
 
         let ws_start = self.offset;
+        let mut contains_intersection_space = false;
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
-                b' ' | b'\t' | b'\r' | b'\n' => self.offset += 1,
+                b' ' => {
+                    contains_intersection_space = true;
+                    self.offset += 1;
+                }
+                b'\t' | b'\r' | b'\n' => self.offset += 1,
                 _ => break,
             }
         }
 
-        let token_type = if self.prev_is_reference_producing()
+        // Excel accepts TAB/CR/LF as lexical whitespace, but only an ASCII
+        // space in the run can spell the range-intersection operator.
+        let token_type = if contains_intersection_space
+            && self.prev_is_reference_producing()
             && next_starts_reference_expression(self.formula, self.offset)
         {
             TokenType::OpInfix
@@ -1987,14 +2012,22 @@ impl Tokenizer {
         self.save_token();
 
         let ws_start = self.offset;
+        let mut contains_intersection_space = false;
         while self.offset < self.formula.len() {
             match self.formula.as_bytes()[self.offset] {
-                b' ' | b'\t' | b'\r' | b'\n' => self.offset += 1,
+                b' ' => {
+                    contains_intersection_space = true;
+                    self.offset += 1;
+                }
+                b'\t' | b'\r' | b'\n' => self.offset += 1,
                 _ => break,
             }
         }
 
-        let token_type = if self.prev_is_reference_producing()
+        // Excel accepts TAB/CR/LF as lexical whitespace, but only an ASCII
+        // space in the run can spell the range-intersection operator.
+        let token_type = if contains_intersection_space
+            && self.prev_is_reference_producing()
             && next_starts_reference_expression(&self.formula, self.offset)
         {
             TokenType::OpInfix
@@ -2002,13 +2035,24 @@ impl Tokenizer {
             TokenType::Whitespace
         };
 
-        self.items.push(Token::from_slice(
-            &self.formula,
-            token_type,
-            TokenSubType::None,
-            ws_start,
-            self.offset,
-        ));
+        let token = if token_type == TokenType::OpInfix {
+            Token::new_with_span(
+                " ".to_string(),
+                token_type,
+                TokenSubType::None,
+                ws_start,
+                self.offset,
+            )
+        } else {
+            Token::from_slice(
+                &self.formula,
+                token_type,
+                TokenSubType::None,
+                ws_start,
+                self.offset,
+            )
+        };
+        self.items.push(token);
         self.start_token();
         Ok(())
     }


### PR DESCRIPTION
## Summary

- accept TAB, CR, LF, and CRLF as lexical whitespace in both tokenizer frontends
- keep ASCII space as the only character that can spell Excel's range-intersection operator
- canonicalize semantic intersection tokens and AST operators to `" "` while retaining exact source byte spans and render output
- preserve control whitespace inside quoted strings and quoted sheet names
- add exact owned-token, span-tokenizer, parser-AST, quote, boundary, and source-round-trip coverage

## Why

PR #202 correctly found that CR and TAB fell through into operand accumulation, causing Windows CRLF formulas such as `SUM(\r\n1,2\r\n)` to fail.

The original patch needed one semantic refinement: a whitespace run between references was emitted as an infix operator with its raw value, such as `"\r\n"` or `"\t"`. The parser assigns intersection precedence only to `" "`, and Excel/Apache POI treat TAB/CR/LF as ordinary whitespace while only an actual ASCII space enables intersection.

This branch includes the contributor's original commit and adds the semantic/span/test refinements. Paul Harrington is credited as co-author.

## Validation

- `cargo test -p formualizer-parse`: 320 unit, 4 differential, and 3 best-effort integration tests passed
- `cargo clippy -p formualizer-parse --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent review: `MERGEABLE: YES`
