### PR TITLE
test(eval): make read-projection tests independent of global registry state

### DIFF
--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -1723,7 +1723,21 @@ mod tests {
         NameRegistryView::new(|_, _| None)
     }
 
+    /// `compute_read_projections` resolves functions through the process-global
+    /// registry. Without this, `SUM` is unknown and every projection collapses to
+    /// `UnsupportedDependencySummary` — which silently turns the accept-tests red
+    /// and, worse, makes the reject-tests pass for the wrong reason. Registering
+    /// here keeps each test in this module independent of what else has run.
+    fn ensure_builtins_registered() {
+        use std::sync::Once;
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| {
+            crate::builtins::math::register_builtins();
+        });
+    }
+
     fn read_projections_for(formula: &str, row: u32, col: u32) -> Vec<ReadProjection> {
+        ensure_builtins_registered();
         let mut sheet_registry = SheetRegistry::new();
         let sheet = sheet_registry.id_for("Sheet1");
         let ast = parse(formula).unwrap();
@@ -1773,6 +1787,7 @@ mod tests {
 
     #[test]
     fn formula_plane_ingest_read_projections_reject_top_level_and_open_ranges() {
+        ensure_builtins_registered();
         let mut sheet_registry = SheetRegistry::new();
         let sheet = sheet_registry.id_for("Sheet1");
         let placement = CellRef::new(sheet, Coord::from_excel(1, 2, true, true));
@@ -1838,6 +1853,7 @@ mod tests {
 
     #[test]
     fn formula_plane_ingest_read_projections_accept_mixed_anchor_ranges() {
+        ensure_builtins_registered();
         let mut sheet_registry = SheetRegistry::new();
         let sheet = sheet_registry.id_for("Sheet1");
         let placement = CellRef::new(sheet, Coord::from_excel(1, 2, true, true));


### PR DESCRIPTION
Closes the deterministic half of #241.

## What was wrong

The read-projection tests in `engine::ingest_pipeline` resolve functions through `GlobalRegistryFunctionProvider`, a process-global registry, but never registered any builtins. They passed only because unrelated tests populated that global first:

```
cargo test -p formualizer-eval --lib --all-features ingest_read_projections
  → FAILED. 1 passed; 3 failed        (deterministic, also under --test-threads=1)

cargo test -p formualizer-eval --lib --all-features
  → ok. 2443 passed; 0 failed
```

The three accept-tests failed loudly under a filter. The reject-test failed in the more dangerous direction: it asserts that top-level and open ranges are refused with `UnsupportedDependencySummary`, which is precisely the error an *unregistered* `SUM` produces. In isolation it passed **without exercising the rejection logic at all**.

## The fix

Registers the math builtins behind a `Once`, following the existing idiom at `planner.rs:376`, and calls it from the shared `read_projections_for` helper plus the three tests that call `compute_read_projections` directly.

## Verification

- **Full isolation sweep**: built the lib test binary and ran all **2,455 tests each in its own process**. Before: 3 failures. After: **0**. No other test in the crate depends on cross-test global state.
- **Mutation check** on the reject-test, since a test that passed vacuously deserves proof it no longer does. Pointing one assertion at a supported range (`=SUM($A$1:$A10)`) now fails with `Ok([ReadProjection { rule: AffineRange { .. } }])` against the expected `Err`. Before the fix that mutation would have passed, because `SUM` resolved to nothing either way.
- `cargo fmt --all --check`, `cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings`, and the full lib suite (2443 passed, 0 failed) all clean.

## Not included

The flaky half of #241 is left open deliberately. It is now reproducible — see the updated issue for the recipe and what is known — but the mechanism is not yet pinned down and I would rather not paper over it.

drafted with love by (agent) Manfred, with approval from Frankie
