### PR TITLE
perf(eval): deduplicate covered consumer reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Performance
 
+- Large workbooks with growing-range formulas now retain their experimental FormulaPlane topology cache at practical sizes instead of overflowing it with redundant per-cell reads and rebuilding exact topology per request. (#243)
 - Experimental authoritative FormulaPlane evaluation now uses the existing consumer-read interval index when exact schedule construction falls back after topology-cache overflow, avoiding full-table scans per dirty formula during the first evaluation of bulk-loaded workbooks. (#240)
 - Experimental authoritative FormulaPlane evaluation now caches accounted consumer and precedent topology across warm and value-only evaluations. Exact graph, authority, semantic, provider, and dynamic-reference revisions invalidate or bypass stale cache generations; candidate, edge, and retained-byte cache overflow selects exact paged/run/native/repeated-pass request topology without span demotion, while span-free and warm no-dirty requests retain topology-free sparse paths.
 - Proven complete source-formula families now parse and analyze one anchor and avoid per-descendant strings, ASTs, staging entries, and graph vertices. In same-machine release probes, a clean 100k-family load improved from 997 ms and 313 MiB RSS under forced replay to 129 ms and 26 MiB RSS; a 1M-family load completed in 2.2 s at 167 MiB RSS instead of 13.1 s at 3.0 GiB.

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -5415,6 +5415,30 @@ where
         self.cached_mixed_topology.is_some()
     }
 
+    #[cfg(test)]
+    pub(crate) fn mixed_topology_redundant_point_read_count_for_test(&self) -> Option<usize> {
+        let reads = &self.cached_mixed_topology.as_ref()?.consumer_reads;
+        Some(
+            reads
+                .entries()
+                .filter(|read| {
+                    let (rows, cols) = read.read_region.axis_ranges();
+                    matches!(
+                        (rows, cols),
+                        (
+                            crate::formula_plane::region_index::AxisRange::Point(_),
+                            crate::formula_plane::region_index::AxisRange::Point(_)
+                        )
+                    ) && reads.entries().any(|covering| {
+                        covering.consumer == read.consumer
+                            && covering.read_region != read.read_region
+                            && covering.read_region.contains_region(read.read_region)
+                    })
+                })
+                .count(),
+        )
+    }
+
     fn record_formula_ingest_report(&mut self, report: FormulaIngestReport) {
         self.formula_ingest_report_total.mode = report.mode;
         self.formula_ingest_report_total.accumulate(&report);
@@ -18815,33 +18839,13 @@ where
             };
             let result_region = Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col());
             let mut seen = rustc_hash::FxHashSet::default();
-            for dep in self.graph.get_dependencies(*vertex) {
-                let Some(dep_cell) = self.graph.get_cell_ref_for_vertex(dep) else {
-                    continue;
-                };
-                let read_region = Region::point(
-                    dep_cell.sheet_id,
-                    dep_cell.coord.row(),
-                    dep_cell.coord.col(),
-                );
-                if seen.insert(read_region) {
-                    consumer_reads.try_reserve(1).map_err(|_| {
-                        ExcelError::new(ExcelErrorKind::NImpl)
-                            .with_message("FormulaPlane cache read-index reservation failed")
-                    })?;
-                    consumer_reads.insert_read(
-                        FormulaProducerId::Legacy(*vertex),
-                        read_region,
-                        result_region,
-                        DirtyProjectionRule::WholeResult,
-                    );
-                }
-            }
+            let mut covering_read_regions = Vec::new();
             if let Some(ranges) = self.graph.get_range_dependencies(*vertex) {
                 for range in ranges {
                     let Some(read_region) = self.shared_range_to_region_pattern(range)? else {
                         continue;
                     };
+                    covering_read_regions.push(read_region);
                     if seen.insert(read_region) {
                         consumer_reads.try_reserve(1).map_err(|_| {
                             ExcelError::new(ExcelErrorKind::NImpl)
@@ -18856,6 +18860,49 @@ where
                     }
                 }
             }
+            for read_region in DynamicRefVirtualDepProvider::get_virtual_regions(self, *vertex) {
+                covering_read_regions.push(read_region);
+                if seen.insert(read_region) {
+                    consumer_reads.try_reserve(1).map_err(|_| {
+                        ExcelError::new(ExcelErrorKind::NImpl)
+                            .with_message("FormulaPlane dynamic-region reservation failed")
+                    })?;
+                    consumer_reads.insert_read(
+                        FormulaProducerId::Legacy(*vertex),
+                        read_region,
+                        result_region,
+                        DirtyProjectionRule::WholeResult,
+                    );
+                }
+            }
+            for dep in self.graph.get_dependencies(*vertex) {
+                let Some(dep_cell) = self.graph.get_cell_ref_for_vertex(dep) else {
+                    continue;
+                };
+                let read_region = Region::point(
+                    dep_cell.sheet_id,
+                    dep_cell.coord.row(),
+                    dep_cell.coord.col(),
+                );
+                if covering_read_regions
+                    .iter()
+                    .any(|covering| covering.contains_region(read_region))
+                {
+                    continue;
+                }
+                if seen.insert(read_region) {
+                    consumer_reads.try_reserve(1).map_err(|_| {
+                        ExcelError::new(ExcelErrorKind::NImpl)
+                            .with_message("FormulaPlane cache read-index reservation failed")
+                    })?;
+                    consumer_reads.insert_read(
+                        FormulaProducerId::Legacy(*vertex),
+                        read_region,
+                        result_region,
+                        DirtyProjectionRule::WholeResult,
+                    );
+                }
+            }
             let (virtual_dependencies, _) = VirtualDepBuilder::new(self).build(&[*vertex]);
             for dependency in virtual_dependencies
                 .get(vertex)
@@ -18867,24 +18914,16 @@ where
                     continue;
                 };
                 let read_region = Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col());
+                if covering_read_regions
+                    .iter()
+                    .any(|covering| covering.contains_region(read_region))
+                {
+                    continue;
+                }
                 if seen.insert(read_region) {
                     consumer_reads.try_reserve(1).map_err(|_| {
                         ExcelError::new(ExcelErrorKind::NImpl)
                             .with_message("FormulaPlane cache virtual read reservation failed")
-                    })?;
-                    consumer_reads.insert_read(
-                        FormulaProducerId::Legacy(*vertex),
-                        read_region,
-                        result_region,
-                        DirtyProjectionRule::WholeResult,
-                    );
-                }
-            }
-            for read_region in DynamicRefVirtualDepProvider::get_virtual_regions(self, *vertex) {
-                if seen.insert(read_region) {
-                    consumer_reads.try_reserve(1).map_err(|_| {
-                        ExcelError::new(ExcelErrorKind::NImpl)
-                            .with_message("FormulaPlane dynamic-region reservation failed")
                     })?;
                     consumer_reads.insert_read(
                         FormulaProducerId::Legacy(*vertex),

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -225,6 +225,53 @@ fn cached_mixed_topology_matches_off_first_warm_and_post_edit() {
     assert_full_capacity_corpus_parity(&off, &authoritative);
 }
 
+#[test]
+fn cached_read_table_keeps_ranges_and_uncovered_points_without_expanding_ranges() {
+    const DEDUP_ROWS: u32 = 150;
+
+    let config =
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    engine
+        .set_cell_value(SHEET, 1, 3, LiteralValue::Number(1.0))
+        .unwrap();
+    let mut formulas = Vec::with_capacity((2 * DEDUP_ROWS - 1) as usize);
+    for row in 1..=DEDUP_ROWS {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(1.0))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}+1")));
+        if row > 1 {
+            formulas.push(record(
+                &mut engine,
+                row,
+                3,
+                &format!("=SUM($C$1:$C{})+$A{row}", row - 1),
+            ));
+        }
+    }
+    let report = engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .unwrap();
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(DEDUP_ROWS));
+
+    engine.evaluate_all().unwrap();
+
+    assert!(engine.mixed_topology_cache_present_for_test());
+    assert_eq!(
+        engine.mixed_topology_redundant_point_read_count_for_test(),
+        Some(0),
+        "a covering read region makes same-consumer point reads redundant"
+    );
+
+    let before = numeric_value(&engine, DEDUP_ROWS, 3);
+    engine
+        .set_cell_value(SHEET, DEDUP_ROWS, 1, LiteralValue::Number(5.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(numeric_value(&engine, DEDUP_ROWS, 3), before + 4.0);
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct CapacityOverlaySnapshot {
     overlay_ref: crate::formula_plane::runtime::FormulaOverlayRef,


### PR DESCRIPTION
Closes #243

## Mechanism

Mixed-topology compilation now inserts covering static and dynamic read regions before point reads for each legacy consumer, then skips real or virtual point reads contained by one of those same-consumer regions. Point reads outside the covering regions remain indexed.

I audited every `FormulaConsumerReadIndex` consumer. Dirty closure and topology compilation query region intersections and preserve the same `WholeResult` projection for legacy reads; all four exact schedule strategies call `inspect_exact_read` on intersecting regions and deduplicate source/target edges; exact demand builders query producer results over each read region. None depends on per-cell entries inside a covering region.

## Read table and cache

Temporary instrumentation (removed before commit) on `probe-fp-coverage --rows-per-section 500` measured 127,266 mixed consumer-read entries on current `main` and 4,532 after this change, a 28.1x reduction (96.4%).

At N=330 the changed branch compiles and caches the topology: 3,682 reads, 54,614 candidates, 54,614 relationships, no overflow. This is a size reported near the prior overflow threshold.

The issue's stronger prediction does not hold at N=500. Despite the reduced read table, compilation still reaches 100,001 candidates and returns `MaxCandidatesExceeded`; at the cutoff it has 99,598 relationships. The growing cumulative range creates a genuinely dense source-to-consumer DAG, so after redundant point reads are removed the default 100k candidate/edge cap remains too small for N=500 and above. I did not bypass the cap or change topology representation because that is outside this insertion-dedup fix.

## Release measurements

All timings are release builds from the stripped final source; the probe binary MD5 changed from `d5ac7f2ea96d40976dd1cff5dfea7b60` to `13aedc7a3f7ce4a18a5a23887fcc0f0a` before the final run.

| rows/section | Off first | Auth first | Auth warm | main Auth baseline | cache outcome | coverage | spans | mismatches |
|---:|---:|---:|---:|---:|---|---:|---:|---:|
| 500 | 53 ms | 481 ms | 3 ms | 527 ms | `SkippedOverflow` | 69.2% | 9 | 0 |
| 1000 | 162 ms | 1,051 ms | 1 ms | ~666 ms | `SkippedOverflow` | 69.2% | 9 | 0 |
| 2000 | 544 ms | 3,362 ms | 3 ms | ~2,967 ms | `SkippedOverflow` | 69.2% | 9 | 0 |

N=500 improves against the same-machine main run, but N=1000 and N=2000 do not reproduce the expected timing improvement versus the supplied main baselines. The structural table reduction is clear; the remaining compile/schedule work is dominated by the real quadratic relationship set once the cache cap is crossed.

## Tests

Added `cached_read_table_keeps_ranges_and_uncovered_points_without_expanding_ranges`, which builds cumulative range consumers, asserts there are zero same-consumer point reads covered by another read entry, and edits a point dependency outside the range to prove partial coverage is retained. No existing test was changed or relaxed.

- `cargo fmt --all --check`
- `cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings`
- `cargo clippy -p formualizer-wasm --target wasm32-unknown-unknown`
- `cargo test -p formualizer-eval --lib --all-features` — 2,447 passed, 0 failed, 12 ignored (one added test over the 2,446 baseline)
- `formula_plane_ingest_shadow` soak — 0/30 failures
