### PR TITLE
perf(eval): retain bounded topology prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Performance
 
+- Mixed FormulaPlane topology overflow now retains the bounded, accounted prefix and its indexes instead of discarding successful compile work. Paged schedule discovery reuses complete cached sources and derives only the uncovered tail exactly, so dense growing-range workbooks avoid rebuilding the same overflowed topology on every recalculation.
 - Experimental authoritative FormulaPlane evaluation now uses the existing consumer-read interval index when exact schedule construction falls back after topology-cache overflow, avoiding full-table scans per dirty formula during the first evaluation of bulk-loaded workbooks. (#240)
 - Experimental authoritative FormulaPlane evaluation now caches accounted consumer and precedent topology across warm and value-only evaluations. Exact graph, authority, semantic, provider, and dynamic-reference revisions invalidate or bypass stale cache generations; candidate, edge, and retained-byte cache overflow selects exact paged/run/native/repeated-pass request topology without span demotion, while span-free and warm no-dirty requests retain topology-free sparse paths.
 - Proven complete source-formula families now parse and analyze one anchor and avoid per-descendant strings, ASTs, staging entries, and graph vertices. In same-machine release probes, a clean 100k-family load improved from 997 ms and 313 MiB RSS under forced replay to 129 ms and 26 MiB RSS; a 1M-family load completed in 2.2 s at 167 MiB RSS instead of 13.1 s at 3.0 GiB.

--- a/crates/formualizer-bench-core/src/bin/probe-fp-coverage.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-fp-coverage.rs
@@ -71,6 +71,16 @@ mod probe {
         load_ms: u128,
         eval_first_ms: u128,
         eval_warm_ms: u128,
+        eval_warm_hit_ms: u128,
+        topology_cache_outcome_first: String,
+        topology_strategy_first: String,
+        topology_candidate_cap_hits_first: u64,
+        topology_cache_outcome_warm: String,
+        topology_strategy_warm: String,
+        topology_cache_hit_events_warm: u64,
+        topology_cache_outcome_warm_hit: String,
+        topology_strategy_warm_hit: String,
+        topology_cache_hit_events_warm_hit: u64,
     }
 
     #[derive(Debug, Serialize)]
@@ -193,10 +203,71 @@ mod probe {
         let t = Instant::now();
         wb.evaluate_all()?;
         let eval_first_ms = t.elapsed().as_millis();
+        let (
+            topology_cache_outcome_first,
+            topology_strategy_first,
+            topology_candidate_cap_hits_first,
+        ) = wb
+            .engine()
+            .last_evaluation_resource_request_stats()
+            .map(|stats| {
+                (
+                    stats.topology.cache_outcome.as_str().to_string(),
+                    stats.topology.strategy.as_str().to_string(),
+                    stats.topology.candidate_cap_hits,
+                )
+            })
+            .unwrap_or_else(|| ("not_used".to_string(), "not_used".to_string(), 0));
 
+        if let Some(input) = corpus.data_values.first() {
+            wb.set_value(
+                input.sheet,
+                input.row,
+                input.col,
+                LiteralValue::Number(input.value + 1.0),
+            )?;
+        }
         let t = Instant::now();
         wb.evaluate_all()?;
         let eval_warm_ms = t.elapsed().as_millis();
+        let (topology_cache_outcome_warm, topology_strategy_warm, topology_cache_hit_events_warm) =
+            wb.engine()
+                .last_evaluation_resource_request_stats()
+                .map(|stats| {
+                    (
+                        stats.topology.cache_outcome.as_str().to_string(),
+                        stats.topology.strategy.as_str().to_string(),
+                        stats.topology.cache_hit_events,
+                    )
+                })
+                .unwrap_or_else(|| ("not_used".to_string(), "not_used".to_string(), 0));
+
+        if let Some(input) = corpus.data_values.first() {
+            wb.set_value(
+                input.sheet,
+                input.row,
+                input.col,
+                LiteralValue::Number(input.value + 2.0),
+            )?;
+        }
+        let t = Instant::now();
+        wb.evaluate_all()?;
+        let eval_warm_hit_ms = t.elapsed().as_millis();
+        let (
+            topology_cache_outcome_warm_hit,
+            topology_strategy_warm_hit,
+            topology_cache_hit_events_warm_hit,
+        ) = wb
+            .engine()
+            .last_evaluation_resource_request_stats()
+            .map(|stats| {
+                (
+                    stats.topology.cache_outcome.as_str().to_string(),
+                    stats.topology.strategy.as_str().to_string(),
+                    stats.topology.cache_hit_events,
+                )
+            })
+            .unwrap_or_else(|| ("not_used".to_string(), "not_used".to_string(), 0));
 
         let mut values = Vec::new();
         for cell in corpus.sections.iter().flat_map(|s| s.formulas.iter()) {
@@ -233,6 +304,16 @@ mod probe {
                 load_ms,
                 eval_first_ms,
                 eval_warm_ms,
+                eval_warm_hit_ms,
+                topology_cache_outcome_first,
+                topology_strategy_first,
+                topology_candidate_cap_hits_first,
+                topology_cache_outcome_warm,
+                topology_strategy_warm,
+                topology_cache_hit_events_warm,
+                topology_cache_outcome_warm_hit,
+                topology_strategy_warm_hit,
+                topology_cache_hit_events_warm_hit,
             },
             values,
             coverage,

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -52,7 +52,7 @@ use crate::formula_plane::scheduler::{
     MixedTopologyCompileStats, MixedTopologyConfig, build_demand_closure_cached,
     build_demand_closure_in_memory_runs, build_demand_closure_paged,
     build_demand_closure_repeated_passes, compile_mixed_topology, schedule_dirty_work,
-    schedule_dirty_work_in_memory_runs, schedule_dirty_work_paged,
+    schedule_dirty_work_in_memory_runs, schedule_dirty_work_paged_hybrid,
     schedule_dirty_work_repeated_passes,
 };
 #[cfg(not(target_arch = "wasm32"))]
@@ -19010,23 +19010,22 @@ where
         let (cache_outcome, strategy, compile_stats) = if cache_hit {
             self.mixed_topology_cache_hits = self.mixed_topology_cache_hits.saturating_add(1);
             self.mixed_topology_cache_skip_streak = 0;
-            let stats = self
+            let cached = self
                 .cached_mixed_topology
                 .as_ref()
-                .expect("cache hit has topology")
-                .topology
-                .stats
-                .clone();
+                .expect("cache hit has topology");
+            let stats = cached.topology.stats.clone();
+            let strategy = if cached.topology.is_complete() {
+                FormulaPlaneTopologyStrategy::Cached
+            } else {
+                FormulaPlaneTopologyStrategy::ExactPagedIndexed
+            };
             if let Some(ledger) = self.active_resource_ledger.as_mut() {
                 ledger
                     .account_mixed_cache(stats.estimated_memory_bytes as u64)
                     .map_err(crate::engine::ResourceLedgerError::into_excel_error)?;
             }
-            (
-                FormulaPlaneTopologyCacheOutcome::Hit,
-                FormulaPlaneTopologyStrategy::Cached,
-                stats,
-            )
+            (FormulaPlaneTopologyCacheOutcome::Hit, strategy, stats)
         } else {
             // A key/cap miss makes the old retained topology stale. Drop it before building its
             // replacement so the request never accounts or owns both generations concurrently.
@@ -19124,6 +19123,11 @@ where
                 }
                 FormulaPlaneTopologyCompileResult::Cached(compiled) => {
                     let stats = compiled.topology.stats.clone();
+                    let strategy = if compiled.topology.is_complete() {
+                        FormulaPlaneTopologyStrategy::CompiledAndCached
+                    } else {
+                        FormulaPlaneTopologyStrategy::ExactPagedIndexed
+                    };
                     let retained_result = self
                         .active_resource_ledger
                         .as_mut()
@@ -19144,11 +19148,7 @@ where
                             .map_err(crate::engine::ResourceLedgerError::into_excel_error)?;
                     }
                     index_scratch_reserved = 0;
-                    (
-                        FormulaPlaneTopologyCacheOutcome::Built,
-                        FormulaPlaneTopologyStrategy::CompiledAndCached,
-                        stats,
-                    )
+                    (FormulaPlaneTopologyCacheOutcome::Built, strategy, stats)
                 }
                 FormulaPlaneTopologyCompileResult::CacheSkipped(skipped) => {
                     debug_assert!(self.cached_mixed_topology.is_none());
@@ -19192,29 +19192,43 @@ where
             }
         }
 
+        let reuse_partial_topology = cache_outcome == FormulaPlaneTopologyCacheOutcome::Hit;
         let schedule_result = (|| -> Result<FormulaPlaneMixedScheduleBuild, ExcelError> {
-            let (producer_results, consumer_reads, span_refs_by_id, plane_epoch, cached_topology) =
-                if let Some(skipped) = skipped_topology.as_ref() {
-                    (
-                        &skipped.producer_results,
-                        &skipped.consumer_reads,
-                        &skipped.span_refs_by_id,
-                        skipped.plane_epoch,
-                        None,
-                    )
+            let (
+                producer_results,
+                consumer_reads,
+                span_refs_by_id,
+                plane_epoch,
+                cached_topology,
+                partial_topology,
+            ) = if let Some(skipped) = skipped_topology.as_ref() {
+                (
+                    &skipped.producer_results,
+                    &skipped.consumer_reads,
+                    &skipped.span_refs_by_id,
+                    skipped.plane_epoch,
+                    None,
+                    None,
+                )
+            } else {
+                let cached = self
+                    .cached_mixed_topology
+                    .as_ref()
+                    .expect("mixed topology available for request");
+                let (complete, partial) = if cached.topology.is_complete() {
+                    (Some(&cached.topology), None)
                 } else {
-                    let cached = self
-                        .cached_mixed_topology
-                        .as_ref()
-                        .expect("complete mixed topology available for request");
-                    (
-                        &cached.producer_results,
-                        &cached.consumer_reads,
-                        &cached.span_refs_by_id,
-                        cached.plane_epoch,
-                        Some(&cached.topology),
-                    )
+                    (None, Some(&cached.topology))
                 };
+                (
+                    &cached.producer_results,
+                    &cached.consumer_reads,
+                    &cached.span_refs_by_id,
+                    cached.plane_epoch,
+                    complete,
+                    partial,
+                )
+            };
             let demand = if let Some(target_roots) = target_roots {
                 use crate::engine::target_preparation::TargetProducer;
                 let mut roots = Vec::new();
@@ -19750,10 +19764,11 @@ where
                             0,
                         ),
                         (_, Some(FormulaPlaneTopologyStrategy::ExactPagedIndexed)) => {
-                            let (schedule, passes) = schedule_dirty_work_paged(
+                            let (schedule, passes) = schedule_dirty_work_paged_hybrid(
                                 work,
                                 producer_results,
                                 consumer_reads,
+                                partial_topology.filter(|_| reuse_partial_topology),
                                 256,
                                 |units| {
                                     Self::resource_loop_checkpoint(

--- a/crates/formualizer-eval/src/formula_plane/scheduler.rs
+++ b/crates/formualizer-eval/src/formula_plane/scheduler.rs
@@ -141,6 +141,7 @@ struct CompiledPrecedent {
 pub(crate) struct MixedTopology {
     relationships: BTreeMap<FormulaProducerId, Vec<CompiledRelationship>>,
     precedents: BTreeMap<FormulaProducerId, Vec<CompiledPrecedent>>,
+    complete_sources: FxHashSet<FormulaProducerId>,
     pub(crate) stats: MixedTopologyCompileStats,
     pub(crate) fallbacks: Vec<MixedScheduleFallback>,
     complete: bool,
@@ -172,6 +173,7 @@ impl MixedTopology {
     fn estimated_memory_bytes(
         relationships: &BTreeMap<FormulaProducerId, Vec<CompiledRelationship>>,
         precedents: &BTreeMap<FormulaProducerId, Vec<CompiledPrecedent>>,
+        complete_source_capacity: usize,
         fallback_capacity: usize,
         retained_memory_bytes: usize,
     ) -> Option<usize> {
@@ -201,6 +203,9 @@ impl MixedTopology {
                     .checked_mul(std::mem::size_of::<CompiledPrecedent>())?,
             )?;
         }
+        bytes = bytes.checked_add(complete_source_capacity.checked_mul(
+            std::mem::size_of::<FormulaProducerId>() + 2 * std::mem::size_of::<usize>(),
+        )?)?;
         bytes = bytes.checked_add(
             fallback_capacity.checked_mul(std::mem::size_of::<MixedScheduleFallback>())?,
         )?;
@@ -250,11 +255,14 @@ pub(crate) fn compile_mixed_topology(
     };
     let mut relationships = BTreeMap::new();
     let mut precedents = BTreeMap::new();
+    let mut complete_sources = FxHashSet::default();
+    let mut complete_source_count = 0usize;
     let mut fallbacks = Vec::new();
     let mut complete = true;
     let initial_memory = MixedTopology::estimated_memory_bytes(
         &relationships,
         &precedents,
+        complete_sources.capacity(),
         fallbacks.capacity(),
         config.retained_memory_bytes,
     );
@@ -270,7 +278,7 @@ pub(crate) fn compile_mixed_topology(
         );
     }
 
-    for producer in producers {
+    for &producer in &producers {
         let Some(result_region) = producer_results.producer_result_region(producer) else {
             complete = false;
             fallbacks.push(MixedScheduleFallback {
@@ -365,6 +373,7 @@ pub(crate) fn compile_mixed_topology(
             let estimated = MixedTopology::estimated_memory_bytes(
                 &relationships,
                 &precedents,
+                complete_sources.capacity(),
                 fallbacks.capacity(),
                 config.retained_memory_bytes,
             );
@@ -382,15 +391,74 @@ pub(crate) fn compile_mixed_topology(
         if !complete {
             break;
         }
+        complete_source_count = complete_source_count.saturating_add(1);
+    }
+
+    if !complete
+        && matches!(
+            fallbacks.last().map(|fallback| fallback.reason),
+            Some(
+                MixedScheduleFallbackReason::MaxCandidatesExceeded
+                    | MixedScheduleFallbackReason::MaxEdgesExceeded
+            )
+        )
+    {
+        if complete_sources.try_reserve(complete_source_count).is_err() {
+            return memory_overflow_result(
+                stats,
+                producers
+                    .get(complete_source_count)
+                    .copied()
+                    .unwrap_or(FormulaProducerId::Legacy(crate::engine::VertexId(0))),
+                usize::MAX,
+            );
+        }
+        complete_sources.extend(producers[..complete_source_count].iter().copied());
+        let estimated = MixedTopology::estimated_memory_bytes(
+            &relationships,
+            &precedents,
+            complete_sources.capacity(),
+            fallbacks.capacity(),
+            config.retained_memory_bytes,
+        );
+        stats.estimated_memory_bytes = estimated.unwrap_or(usize::MAX);
+        if estimated.is_none() || stats.estimated_memory_bytes > config.max_memory_bytes {
+            stats.memory_overflow_count = stats.memory_overflow_count.saturating_add(1);
+            fallbacks.push(MixedScheduleFallback {
+                producer: fallbacks
+                    .last()
+                    .map(|fallback| fallback.producer)
+                    .unwrap_or(FormulaProducerId::Legacy(crate::engine::VertexId(0))),
+                reason: MixedScheduleFallbackReason::CacheMemoryExceeded,
+            });
+        }
     }
 
     if complete {
         MixedTopologyCompileResult::Cached(MixedTopology {
             relationships,
             precedents,
+            complete_sources,
             stats,
             fallbacks,
             complete: true,
+        })
+    } else if !relationships.is_empty()
+        && matches!(
+            fallbacks.last().map(|fallback| fallback.reason),
+            Some(
+                MixedScheduleFallbackReason::MaxCandidatesExceeded
+                    | MixedScheduleFallbackReason::MaxEdgesExceeded
+            )
+        )
+    {
+        MixedTopologyCompileResult::Cached(MixedTopology {
+            relationships,
+            precedents,
+            complete_sources,
+            stats,
+            fallbacks,
+            complete: false,
         })
     } else {
         let reason = fallbacks
@@ -1437,8 +1505,27 @@ pub(crate) fn schedule_dirty_work_paged<E>(
     producer_results: &FormulaProducerResultIndex,
     consumer_reads: &FormulaConsumerReadIndex,
     max_precise_edge_regions: usize,
+    checkpoint: impl FnMut(u64) -> Result<(), E>,
+) -> Result<(MixedSchedule, u64), E> {
+    schedule_dirty_work_paged_hybrid(
+        work,
+        producer_results,
+        consumer_reads,
+        None,
+        max_precise_edge_regions,
+        checkpoint,
+    )
+}
+
+pub(crate) fn schedule_dirty_work_paged_hybrid<E>(
+    work: impl IntoIterator<Item = FormulaProducerWork>,
+    producer_results: &FormulaProducerResultIndex,
+    consumer_reads: &FormulaConsumerReadIndex,
+    partial_topology: Option<&MixedTopology>,
+    max_precise_edge_regions: usize,
     mut checkpoint: impl FnMut(u64) -> Result<(), E>,
 ) -> Result<(MixedSchedule, u64), E> {
+    debug_assert!(partial_topology.is_none_or(|topology| !topology.is_complete()));
     let (merged_work, mut stats) = merge_work_items(work);
     let scheduled = merged_work
         .iter()
@@ -1463,6 +1550,68 @@ pub(crate) fn schedule_dirty_work_paged<E>(
         };
         stats.producer_result_region_lookups =
             stats.producer_result_region_lookups.saturating_add(1);
+        if let Some(topology) = partial_topology
+            && topology.complete_sources.contains(&item.producer)
+        {
+            let changed_regions = edge_derivation_regions(
+                &item.dirty,
+                source_region,
+                max_precise_edge_regions,
+                &mut stats,
+            );
+            let relationships = topology
+                .relationships
+                .get(&item.producer)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            checkpoint(u64::try_from(relationships.len()).unwrap_or(u64::MAX))?;
+            for relationship in relationships {
+                if !scheduled.contains(&relationship.target) {
+                    continue;
+                }
+                let mut applies = false;
+                for changed in &changed_regions {
+                    match relationship.projection.project_changed_region(
+                        *changed,
+                        relationship.read_region,
+                        relationship.consumer_result_region,
+                    ) {
+                        ProjectionResult::Exact(_) | ProjectionResult::Conservative { .. } => {
+                            applies = true;
+                            break;
+                        }
+                        ProjectionResult::NoIntersection => {
+                            stats.no_intersection_candidate_count =
+                                stats.no_intersection_candidate_count.saturating_add(1);
+                        }
+                        ProjectionResult::Unsupported(_) => {
+                            stats.unsupported_projection_count =
+                                stats.unsupported_projection_count.saturating_add(1);
+                            push_fallback_once(
+                                &mut fallbacks,
+                                relationship.target,
+                                MixedScheduleFallbackReason::UnsupportedProjection,
+                            );
+                            break;
+                        }
+                    }
+                }
+                if applies {
+                    if add_edge(
+                        item.producer,
+                        relationship.target,
+                        &mut edges,
+                        &mut reverse_edges,
+                    ) {
+                        stats.edges_added = stats.edges_added.saturating_add(1);
+                    } else {
+                        stats.duplicate_edges_skipped =
+                            stats.duplicate_edges_skipped.saturating_add(1);
+                    }
+                }
+            }
+            continue;
+        }
         checkpoint(0)?;
         let query = consumer_reads.entries_intersecting(source_region);
         checkpoint(exact_read_query_work(
@@ -2408,6 +2557,71 @@ mod tests {
         };
         assert_eq!(reason, MixedScheduleFallbackReason::MaxCandidatesExceeded);
         assert_eq!(observed.candidate_overflow_count, 1);
+    }
+
+    #[test]
+    fn candidate_cap_retains_a_safe_prefix_and_exactly_schedules_the_tail() {
+        let mut results = FormulaProducerResultIndex::default();
+        let mut reads = FormulaConsumerReadIndex::default();
+        results.insert_producer(span(1), cell(0, 0, 0));
+        results.insert_producer(span(2), cell(0, 1, 0));
+        results.insert_producer(span(3), cell(0, 10, 0));
+        for row in 0..=1 {
+            reads.insert_read(
+                span(3),
+                cell(0, row, 0),
+                cell(0, 10, 0),
+                DirtyProjectionRule::WholeResult,
+            );
+        }
+        let limited = compile_mixed_topology(
+            &results,
+            &reads,
+            &MixedTopologyConfig {
+                max_candidates: 1,
+                ..MixedTopologyConfig::default()
+            },
+        );
+        let MixedTopologyCompileResult::Cached(partial) = limited else {
+            panic!("a useful bounded prefix must be retained");
+        };
+        assert!(!partial.is_complete());
+        assert_eq!(partial.stats.candidate_overflow_count, 1);
+        assert!(partial.complete_sources.contains(&span(1)));
+        assert!(!partial.complete_sources.contains(&span(2)));
+
+        let work = [
+            work(span(1), ProducerDirtyDomain::Whole),
+            work(span(2), ProducerDirtyDomain::Whole),
+            work(span(3), ProducerDirtyDomain::Whole),
+        ];
+        let (hybrid, queries) = schedule_dirty_work_paged_hybrid(
+            work.clone(),
+            &results,
+            &reads,
+            Some(&partial),
+            256,
+            |_| Ok::<(), ()>(()),
+        )
+        .unwrap();
+        let (exact, _) =
+            schedule_dirty_work_paged(work, &results, &reads, 256, |_| Ok::<(), ()>(())).unwrap();
+        assert_eq!(hybrid.layers, exact.layers);
+        assert!(hybrid.is_authoritative_safe());
+        assert_eq!(queries, 2, "only the uncovered sources use exact queries");
+
+        let at_cap = compile_mixed_topology(
+            &results,
+            &reads,
+            &MixedTopologyConfig {
+                max_candidates: 2,
+                ..MixedTopologyConfig::default()
+            },
+        );
+        assert!(matches!(
+            at_cap,
+            MixedTopologyCompileResult::Cached(ref topology) if topology.is_complete()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retain a bounded mixed-topology prefix when the candidate or edge limit is reached instead of discarding all successful compile work
- record exactly which source producers are complete and combine those cached relationships with exact paged discovery for the uncovered tail on later requests
- keep retained-byte accounting authoritative, including the complete-source hash capacity, mirrored precedent adjacency, producer/read indexes, bindings, fallback capacity, and all vector capacities
- make the coverage probe perform two real value-edit recalculations and report cache outcomes, strategies, cap hits, and cache-hit telemetry; its previous “warm” call was a no-dirty no-op and could not demonstrate this issue

## Design decision

I chose bounded partial retention plus an exact tail.

The compiler still stops at the existing candidate, edge, or retained-byte bound. A source is added to `complete_sources` only after every relationship for that source was compiled. Candidate overflow publishes no partial query result, and an edge-overflow source is not marked complete. On a retained cache hit, paged scheduling uses cached relationships only for complete sources and runs the indexed exact query for every other source. The schedule therefore has the same authority as the exact path; the partial prefix is never treated as complete demand authority.

The first request continues to use the exact request path after compilation. Reuse starts on a later cache hit, avoiding additional work on the cold path and keeping partial-cache correctness isolated from initial publication. If an initial request cannot retain a prefix, a later stable generation may build it; this is visible at N=1000 and N=2000 below as `skipped_overflow -> built -> hit`.

A partial result is retained only when it contains useful relationships and its full retained estimate fits. Zero limits, allocation failure, unsupported projection, missing result regions, and retained-byte overflow still produce a typed atomic cache skip. Dynamic legacy dependencies still bypass retention. No admission, authority, or FormulaPlane placement semantics changed.

## Alternatives rejected

- **Raise or remove 100,000:** rejected. The growing-range relationships are genuine, and removing the bound violates resource accounting. Raising an uncalibrated constant merely moves the cliff.
- **Replace the three bounds with one cost score:** deferred. Candidate count remains a direct compile-work guard, edge count bounds relationship work, and retained bytes bound ownership. A combined weighting needs C6 calibration across workbook shapes; inventing weights here would be less defensible than retaining all three independent limits.
- **Cache an overflow marker only:** rejected because it would avoid repeated compilation but still rebuild every source relationship per request. The complete-source prefix lets paged discovery rebuild only the tail.
- **Use a partial topology as demand authority:** rejected. Backward demand closure needs complete precedent coverage. Target demand continues through the exact strategies unless the topology is complete.
- **Read-table deduplication:** already disproven by #243/#248. It reduces bookkeeping but not the genuine quadratic source-to-consumer relationships and regressed first evaluation.

## Provenance of `100_000`

`git log -S'max_formula_plane_cache_candidates'` traces the value to `3cca32e8` / merged commit `b33227bd` (`perf(eval): cache mixed FormulaPlane topology`, PR #186). The implementation and PR described it as a hard bound, but neither contains calibration data or a rationale for 100,000 specifically. I therefore treat it as an uncalibrated default and leave it unchanged.

## Measurements

Release binary SHA-256 after the final rebuild: `898b20edc21f1f906a564137ee9bd237953b4fd93ece4361c0844346d59315dc`.

The probe now performs: cold evaluation, edit `+1` and warm evaluation, edit `+2` and warm-hit evaluation. Edits are outside the timed evaluation windows. Every row below is one process/sample in milliseconds.

### Branch (`cc783ec2`)

| N | sample | Off first | Auth first | Off warm 1 | Auth warm 1 | Off warm hit | Auth warm hit | first / warm 1 / warm-hit cache outcome |
|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 500 | 1 | 56 | 513 | 0 | 1 | 1 | 1 | built / hit / hit |
| 500 | 2 | 57 | 520 | 1 | 1 | 0 | 2 | built / hit / hit |
| 500 | 3 | 56 | 523 | 0 | 1 | 0 | 0 | built / hit / hit |
| 1000 | 1 | 162 | 690 | 1 | 756 | 1 | 1 | skipped_overflow / built / hit |
| 1000 | 2 | 164 | 689 | 1 | 706 | 1 | 1 | skipped_overflow / built / hit |
| 1000 | 3 | 158 | 678 | 1 | 733 | 1 | 1 | skipped_overflow / built / hit |
| 2000 | 1 | 541 | 3030 | 2 | 1796 | 2 | 2 | skipped_overflow / built / hit |
| 2000 | 2 | 544 | 3040 | 2 | 1767 | 2 | 2 | skipped_overflow / built / hit |
| 2000 | 3 | 540 | 3030 | 2 | 1760 | 2 | 2 | skipped_overflow / built / hit |

All branch warm-hit requests reported `exact_paged_indexed`, `cache_hit_events=1`, and exact values. N=500 reported a candidate cap hit and retained the prefix on the cold request. At N=1000 and N=2000 the cold request could not retain that generation; the first edited request built the retained partial generation and the next request hit it.

### Contemporary main (`68cd42c4`), same real first edit

| N | sample | Off first | Auth first | Off warm 1 | Auth warm 1 | first / warm cache outcome |
|---:|---:|---:|---:|---:|---:|---|
| 500 | 1 | 54 | 501 | 0 | 368 | skipped_overflow / skipped_overflow |
| 500 | 2 | 54 | 528 | 0 | 368 | skipped_overflow / skipped_overflow |
| 500 | 3 | 55 | 494 | 0 | 379 | skipped_overflow / skipped_overflow |
| 1000 | 1 | 165 | 682 | 1 | 713 | skipped_overflow / skipped_overflow |
| 1000 | 2 | 157 | 681 | 1 | 706 | skipped_overflow / skipped_overflow |
| 1000 | 3 | 161 | 677 | 1 | 705 | skipped_overflow / skipped_overflow |
| 2000 | 1 | 544 | 3009 | 2 | 1756 | skipped_overflow / skipped_overflow |
| 2000 | 2 | 574 | 3052 | 2 | 1782 | skipped_overflow / skipped_overflow |
| 2000 | 3 | 557 | 3006 | 2 | 1753 | skipped_overflow / skipped_overflow |

Cold medians are branch/main 520/501, 689/681, and 3030/3009 ms. These small 19 ms (3.8%), 8 ms (1.2%), and 21 ms (0.7%) deltas sit inside the observed cold run spread and machine drift; N=500 remains below the previously verified 527 ms baseline. The material result is the removal of the perpetual warm cliff: main continues to report `skipped_overflow`, while the branch reaches a cache hit and evaluates the second edit in 0–2 ms at N=500, 1 ms at N=1000, and 2 ms at N=2000. I did not trade a substantial cold regression for this result; the exact cold path is retained, and contemporary first-eval distributions overlap.

Coverage was 69.2% with 9 spans in all 9 required branch probe runs, and `value_equality.mismatches` was 0 in every run after both edits.

The corpus changes from complete cached topology at N=315 to bounded partial topology at N=320. N=300, 310, and 315 reported `compiled_and_cached`; N=320, 325, 330, 350, and 500 reported `exact_paged_indexed` with a candidate cap hit while retaining the prefix.

## Fault matrix

The existing boundary coverage was extended rather than replaced:

- candidate limit 0: still `CacheSkipped(MaxCandidatesExceeded)`, no cache installed
- two-candidate fixture with limit 1 (cap+1 observed): retains one complete source, marks the topology incomplete, and the hybrid schedule is layer-identical to the full exact schedule while issuing exact queries only for uncovered sources
- same fixture with limit 2 (at cap): complete topology is cached
- edge limit 0: still a typed cache skip
- retained-byte limit 0: still a typed cache skip with zero retained relationships
- perpetual zero-limit skip: existing three-request strategy matrix still preserves the terminal value, increments the request streak 1/2/3 and aggregate current/max streak to 3, and leaves scratch at zero after every request

The zero-limit atomic assertion was not relaxed. The new test changes the expected behavior only when there is a useful, fully covered prefix that fits every retained bound.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings`
- `cargo clippy -p formualizer-wasm --target wasm32-unknown-unknown`
- `cargo test -p formualizer-eval --lib --all-features` — 2447 passed, 0 failed, 12 ignored (one new boundary test over the 2446 baseline)
- 30-run `formula_plane_ingest_shadow --test-threads=32` soak — 0 failures

Closes #244
