### PR TITLE
perf(eval): contract isolated legacy formula islands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Performance
 
+- Experimental authoritative FormulaPlane evaluation now contracts proven span-disconnected legacy islands into the compressed legacy scheduler while retaining span-connected legacy producers in the mixed cycle detector. Dynamic references, names, spills, structural-summary uncertainty, and boundary-discovery overflow fail closed to the global mixed planner. (#251)
 - Mixed FormulaPlane topology overflow now retains the bounded, accounted prefix and its indexes instead of discarding successful compile work. Paged schedule discovery reuses complete cached sources and derives only the uncovered tail exactly, so dense growing-range workbooks avoid rebuilding the same overflowed topology on every recalculation.
 - Experimental authoritative FormulaPlane evaluation now uses the existing consumer-read interval index when exact schedule construction falls back after topology-cache overflow, avoiding full-table scans per dirty formula during the first evaluation of bulk-loaded workbooks. (#240)
 - Experimental authoritative FormulaPlane evaluation now caches accounted consumer and precedent topology across warm and value-only evaluations. Exact graph, authority, semantic, provider, and dynamic-reference revisions invalidate or bypass stale cache generations; candidate, edge, and retained-byte cache overflow selects exact paged/run/native/repeated-pass request topology without span demotion, while span-free and warm no-dirty requests retain topology-free sparse paths.

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -28,9 +28,10 @@ use crate::engine::{
     EvaluationRequestOutcome, EvaluationResourceBaselineStats, EvaluationResourceReason,
     EvaluationResourceRequestStats, FormulaDirtyLeaseOutcome, FormulaIngestBatch,
     FormulaIngestRecord, FormulaIngestReport, FormulaParseDiagnostic, FormulaParsePolicy,
-    FormulaPlaneMode, FormulaPlaneTopologyCacheOutcome, FormulaPlaneTopologyStrategy,
-    ResourceLedger, RowVisibilitySource, ScheduleUnit, Scheduler, VertexId, VertexKind,
-    VisibilityMaskMode,
+    FormulaPlaneMode, FormulaPlaneRoute, FormulaPlaneRouteEvent, FormulaPlaneRoutePhase,
+    FormulaPlaneRouteTransitionReason, FormulaPlaneTopologyCacheOutcome,
+    FormulaPlaneTopologyStrategy, ResourceLedger, RowVisibilitySource, ScheduleUnit, Scheduler,
+    VertexId, VertexKind, VisibilityMaskMode,
 };
 use crate::formula_plane::placement::prepare_anchor_once_fragment;
 use crate::formula_plane::placement::{
@@ -473,12 +474,31 @@ pub(crate) fn classify_mixed_topology_incomplete(
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct LegacyIslandPlan {
+    membership: Vec<VertexId>,
+    dirty_vertices: Vec<VertexId>,
+    sheet_ids: Vec<SheetId>,
+    island_id: u64,
+    retained_bytes: usize,
+    boundary_relationships: usize,
+    omitted_relationships: usize,
+    omitted_direct_relationships: usize,
+}
+
+impl LegacyIslandPlan {
+    fn is_empty(&self) -> bool {
+        self.membership.is_empty()
+    }
+}
+
 type FormulaPlaneMixedScheduleBuild = (
     MixedSchedule,
     BTreeMap<crate::formula_plane::runtime::FormulaSpanId, FormulaSpanRef>,
     u64,
     Vec<VertexId>,
     Vec<usize>,
+    LegacyIslandPlan,
 );
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -901,6 +921,9 @@ pub struct Engine<R> {
     pub recalc_epoch: u64,
     snapshot_id: std::sync::atomic::AtomicU64,
     topology_epoch: u64,
+    /// False after a structural axis operation. While #171 remains open we
+    /// must not use relocated span read summaries to prove disconnection.
+    legacy_island_structural_summaries_trusted: bool,
     cached_static_schedule: Option<CachedScheduleEntry>,
     cached_mixed_topology: Option<CachedMixedTopology>,
     mixed_topology_cache_builds: u64,
@@ -1029,6 +1052,8 @@ pub struct Engine<R> {
 
     #[cfg(test)]
     last_formula_plane_span_eval_report: Option<SpanEvalReport>,
+    #[cfg(test)]
+    evaluation_request_begin_count_for_test: u64,
     before_prepared_span_commit_hook: Option<Box<dyn FnOnce() + Send + Sync>>,
     before_target_preparation_commit_hook: Option<Box<dyn FnOnce() + Send + Sync>>,
     #[cfg(test)]
@@ -1749,6 +1774,11 @@ struct MixedTopologyCacheKey {
     engine_topology_epoch: u64,
     graph_topology_revision: u64,
     authority_indexes_epoch: u64,
+    /// Explicit revisions for retained island membership and boundary views.
+    /// They currently share the authoritative graph/index clocks but remain
+    /// distinct key fields so future independent indexes cannot omit them.
+    legacy_island_revision: u64,
+    boundary_index_revision: u64,
     function_semantic_epoch: u64,
     function_provider_revision: Option<u64>,
     max_candidates: usize,
@@ -1764,6 +1794,7 @@ struct CachedMixedTopology {
     consumer_reads: FormulaConsumerReadIndex,
     span_refs_by_id: BTreeMap<FormulaSpanId, FormulaSpanRef>,
     plane_epoch: u64,
+    island: LegacyIslandPlan,
 }
 
 #[derive(Debug)]
@@ -1774,6 +1805,7 @@ struct SkippedMixedTopology {
     consumer_reads: FormulaConsumerReadIndex,
     span_refs_by_id: BTreeMap<FormulaSpanId, FormulaSpanRef>,
     plane_epoch: u64,
+    island: LegacyIslandPlan,
 }
 
 #[derive(Debug)]
@@ -2493,6 +2525,7 @@ where
             recalc_epoch: 0,
             snapshot_id: std::sync::atomic::AtomicU64::new(1),
             topology_epoch: 0,
+            legacy_island_structural_summaries_trusted: true,
             cached_static_schedule: None,
             cached_mixed_topology: None,
             mixed_topology_cache_builds: 0,
@@ -2543,6 +2576,8 @@ where
             function_provider_revision_seen,
             #[cfg(test)]
             last_formula_plane_span_eval_report: None,
+            #[cfg(test)]
+            evaluation_request_begin_count_for_test: 0,
             before_prepared_span_commit_hook: None,
             before_target_preparation_commit_hook: None,
             #[cfg(test)]
@@ -2628,6 +2663,7 @@ where
             recalc_epoch: 0,
             snapshot_id: std::sync::atomic::AtomicU64::new(1),
             topology_epoch: 0,
+            legacy_island_structural_summaries_trusted: true,
             cached_static_schedule: None,
             cached_mixed_topology: None,
             mixed_topology_cache_builds: 0,
@@ -2678,6 +2714,8 @@ where
             function_provider_revision_seen,
             #[cfg(test)]
             last_formula_plane_span_eval_report: None,
+            #[cfg(test)]
+            evaluation_request_begin_count_for_test: 0,
             before_prepared_span_commit_hook: None,
             before_target_preparation_commit_hook: None,
             #[cfg(test)]
@@ -3255,6 +3293,55 @@ where
         }
     }
 
+    fn observe_formula_plane_route(
+        &mut self,
+        plan: &LegacyIslandPlan,
+        phase: FormulaPlaneRoutePhase,
+        reason: FormulaPlaneRouteTransitionReason,
+        demotion_generation: usize,
+        replan_generation: usize,
+    ) {
+        if plan.is_empty() {
+            return;
+        }
+        let mut sheet_ids = [0_u16;
+            crate::engine::resource_observability::FORMULA_PLANE_ROUTE_EVENT_SHEET_CAPACITY];
+        let sheet_count = plan.sheet_ids.len().min(sheet_ids.len());
+        sheet_ids[..sheet_count].copy_from_slice(&plan.sheet_ids[..sheet_count]);
+        let authority = self.graph.formula_authority();
+        let event = FormulaPlaneRouteEvent {
+            island_id: plan.island_id,
+            phase,
+            route: FormulaPlaneRoute::ContractedLegacyIsland,
+            sheet_ids,
+            sheet_count: sheet_count as u8,
+            authority_epoch: authority.plane.epoch().0,
+            index_epoch: authority.indexes_epoch(),
+            transition_reason: reason,
+            demotion_generation: demotion_generation.min(u32::MAX as usize) as u32,
+            replan_generation: replan_generation.min(u32::MAX as usize) as u32,
+        };
+        if let Some(stats) = self.active_evaluation_resource_request.as_mut() {
+            let index = usize::from(stats.topology.route_event_count);
+            if index < stats.topology.route_events.len() {
+                stats.topology.route_events[index] = event;
+                stats.topology.route_event_count =
+                    stats.topology.route_event_count.saturating_add(1);
+            } else {
+                stats.topology.route_events_dropped =
+                    stats.topology.route_events_dropped.saturating_add(1);
+            }
+            stats.topology.route_event_bytes_observed = stats
+                .topology
+                .route_event_bytes_observed
+                .saturating_add(std::mem::size_of::<FormulaPlaneRouteEvent>() as u64);
+            stats.topology.island_membership_vertices = plan.membership.len() as u64;
+            stats.topology.island_membership_retained_bytes = plan.retained_bytes as u64;
+            stats.topology.legacy_relationships_omitted = plan.omitted_relationships as u64;
+            stats.topology.boundary_relationships_retained = plan.boundary_relationships as u64;
+        }
+    }
+
     fn observe_materialization(
         &mut self,
         placements: usize,
@@ -3340,6 +3427,12 @@ where
     /// take the per-recalc volatile clock sample. Called at the start of
     /// every evaluation request that walks schedule units.
     fn begin_evaluation_request(&mut self) {
+        #[cfg(test)]
+        {
+            self.evaluation_request_begin_count_for_test = self
+                .evaluation_request_begin_count_for_test
+                .saturating_add(1);
+        }
         self.last_cycle_telemetry = CycleTelemetry::default();
         // Defensive: consumed at the end of the previous request; a request
         // that errored out mid-walk must not leak its members into this one.
@@ -5354,6 +5447,11 @@ where
     #[cfg(test)]
     pub(crate) fn last_formula_plane_span_eval_report(&self) -> Option<&SpanEvalReport> {
         self.last_formula_plane_span_eval_report.as_ref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn evaluation_request_begin_count_for_test(&self) -> u64 {
+        self.evaluation_request_begin_count_for_test
     }
 
     #[cfg(test)]
@@ -12406,6 +12504,9 @@ where
         if op.count() == 0 {
             return Ok(());
         }
+        // #171: after an axis edit, retained read-summary relocation cannot be
+        // used as a proof of disconnection. Fail closed for this engine.
+        self.legacy_island_structural_summaries_trusted = false;
         self.demote_spans_for_structural_op_impl(Some(op), affected_region, true)
     }
 
@@ -18127,13 +18228,9 @@ where
         target_roots: Option<&[crate::engine::target_preparation::TargetProducer]>,
         mut delta: Option<&mut DeltaCollector>,
     ) -> Result<EvalResult, ExcelError> {
-        // Fresh per-request cycle counters. Some callers (`evaluate_vertex`,
-        // `evaluate_cells*`) reach this coordinator without an entry-point
-        // reset; callers that did reset have accumulated nothing in between,
-        // so the duplicate reset is harmless. The composed legacy primitive
-        // below intentionally does not reset, so `evaluate_legacy_cycle_prepass`
-        // counts survive into the final telemetry.
-        self.begin_evaluation_request();
+        // The public/request coordinators begin exactly once. Every primitive
+        // below is deliberately non-beginning and non-finalising so the dirty
+        // lease, iterative accumulator and §7.11 clock sample have one owner.
         let mut formula_dirty = self.graph.lease_formula_dirty();
         self.observe_dirty_lease_acquired(formula_dirty.is_empty());
 
@@ -18190,22 +18287,35 @@ where
             .then(|| self.start_virtual_dep_telemetry());
         'virtual_replan: loop {
             self.cancellation_checkpoint("Evaluation cancelled before mixed topology")?;
-            let (schedule, span_refs_by_id, plane_epoch, legacy_vertices, owned_dirty_events) = loop {
-                let (schedule, span_refs_by_id, plane_epoch, legacy_vertices, owned_dirty_events) =
-                    if let Some(target_roots) = runtime_target_roots.as_deref() {
-                        self.build_formula_plane_target_schedule(
-                            &formula_dirty,
-                            &retry_whole_spans,
-                            include_dirty_regions,
-                            target_roots,
-                        )?
-                    } else {
-                        self.build_formula_plane_mixed_schedule(
-                            &formula_dirty,
-                            &retry_whole_spans,
-                            include_dirty_regions,
-                        )?
-                    };
+            let (
+                schedule,
+                span_refs_by_id,
+                plane_epoch,
+                legacy_vertices,
+                owned_dirty_events,
+                island_plan,
+            ) = loop {
+                let (
+                    schedule,
+                    span_refs_by_id,
+                    plane_epoch,
+                    legacy_vertices,
+                    owned_dirty_events,
+                    island_plan,
+                ) = if let Some(target_roots) = runtime_target_roots.as_deref() {
+                    self.build_formula_plane_target_schedule(
+                        &formula_dirty,
+                        &retry_whole_spans,
+                        include_dirty_regions,
+                        target_roots,
+                    )?
+                } else {
+                    self.build_formula_plane_mixed_schedule(
+                        &formula_dirty,
+                        &retry_whole_spans,
+                        include_dirty_regions,
+                    )?
+                };
                 #[cfg(test)]
                 let mut schedule = schedule;
                 #[cfg(test)]
@@ -18232,6 +18342,7 @@ where
                         plane_epoch,
                         legacy_vertices,
                         owned_dirty_events,
+                        island_plan,
                     );
                 }
 
@@ -18362,6 +18473,30 @@ where
                     ));
                 }
             };
+            self.observe_formula_plane_route(
+                &island_plan,
+                FormulaPlaneRoutePhase::Planned,
+                FormulaPlaneRouteTransitionReason::ProvenIsolated,
+                cycle_demote_iters,
+                runtime_replan_iterations,
+            );
+            if !island_plan.dirty_vertices.is_empty() {
+                self.cancellation_checkpoint("Evaluation cancelled before legacy island")?;
+                let (island_computed, island_cycles) = self.evaluate_legacy_island_non_finalizing(
+                    &island_plan.dirty_vertices,
+                    delta.as_deref_mut(),
+                )?;
+                computed_vertices = computed_vertices.saturating_add(island_computed);
+                prepass_cycle_errors = prepass_cycle_errors.saturating_add(island_cycles);
+                self.observe_formula_plane_route(
+                    &island_plan,
+                    FormulaPlaneRoutePhase::Executed,
+                    FormulaPlaneRouteTransitionReason::ProvenIsolated,
+                    cycle_demote_iters,
+                    runtime_replan_iterations,
+                );
+                self.cancellation_checkpoint("Evaluation cancelled after legacy island")?;
+            }
             let old_virtual_dependencies = VirtualDepBuilder::new(self).build(&legacy_vertices).0;
             let old_dynamic_regions = self.dynamic_virtual_regions(&legacy_vertices);
 
@@ -18661,6 +18796,8 @@ where
             engine_topology_epoch: self.topology_epoch,
             graph_topology_revision: self.graph.topology_revision(),
             authority_indexes_epoch: self.graph.formula_authority().indexes_epoch(),
+            legacy_island_revision: self.graph.topology_revision(),
+            boundary_index_revision: self.graph.formula_authority().indexes_epoch(),
             function_semantic_epoch: self.function_semantic_epoch_seen,
             function_provider_revision: self.function_provider_revision_seen,
             max_candidates,
@@ -18736,6 +18873,328 @@ where
             .saturating_add((span_refs.len() as u64).saturating_mul(BINDING_BYTES))
     }
 
+    fn prove_sheet_disjoint_legacy_island(
+        &self,
+        span_results: &FormulaProducerResultIndex,
+        span_reads: &FormulaConsumerReadIndex,
+        legacy_vertices: &[VertexId],
+    ) -> Option<LegacyIslandPlan> {
+        if !self.legacy_island_structural_summaries_trusted
+            || self.graph.named_ranges_iter().next().is_some()
+            || self.graph.sheet_named_ranges_iter().next().is_some()
+            || self.graph.spill_registry_counts() != (0, 0)
+            || legacy_vertices.iter().copied().any(|vertex| {
+                self.graph.is_dynamic(vertex)
+                    || self.graph.get_vertex_kind(vertex) == VertexKind::FormulaArray
+            })
+        {
+            return None;
+        }
+        let span_result_sheets = span_results
+            .entries()
+            .filter(|entry| matches!(entry.producer, FormulaProducerId::Span(_)))
+            .map(|entry| entry.result_region.sheet_id())
+            .collect::<FxHashSet<_>>();
+        let span_read_sheets = span_reads
+            .entries()
+            .filter(|entry| matches!(entry.consumer, FormulaProducerId::Span(_)))
+            .map(|entry| entry.read_region.sheet_id())
+            .collect::<FxHashSet<_>>();
+
+        let span_boundary_sheets = span_result_sheets
+            .union(&span_read_sheets)
+            .copied()
+            .collect::<FxHashSet<_>>();
+        for vertex in legacy_vertices {
+            let cell = self.graph.get_cell_ref_for_vertex(*vertex)?;
+            if span_boundary_sheets.contains(&cell.sheet_id) {
+                return None;
+            }
+            for dependency in self.graph.get_dependencies(*vertex) {
+                let dependency_cell = self.graph.get_cell_ref_for_vertex(dependency)?;
+                if span_boundary_sheets.contains(&dependency_cell.sheet_id) {
+                    return None;
+                }
+            }
+            if let Some(ranges) = self.graph.get_range_dependencies(*vertex) {
+                for range in ranges {
+                    let region = self.shared_range_to_region_pattern(range).ok()??;
+                    if span_boundary_sheets.contains(&region.sheet_id()) {
+                        return None;
+                    }
+                }
+            }
+        }
+
+        let mut membership = legacy_vertices.to_vec();
+        membership.sort_unstable();
+        if membership.is_empty() {
+            return None;
+        }
+        let mut sheet_ids = membership
+            .iter()
+            .filter_map(|vertex| self.graph.get_cell_ref_for_vertex(*vertex))
+            .map(|cell| cell.sheet_id)
+            .collect::<Vec<_>>();
+        sheet_ids.sort_unstable();
+        sheet_ids.dedup();
+        let island_id = membership
+            .iter()
+            .fold(0xcbf29ce484222325_u64, |hash, vertex| {
+                (hash ^ u64::from(vertex.0)).wrapping_mul(0x100000001b3)
+            });
+        let retained_bytes = membership
+            .capacity()
+            .saturating_mul(std::mem::size_of::<VertexId>())
+            .saturating_add(
+                sheet_ids
+                    .capacity()
+                    .saturating_mul(std::mem::size_of::<SheetId>()),
+            );
+        Some(LegacyIslandPlan {
+            membership,
+            dirty_vertices: Vec::new(),
+            sheet_ids,
+            island_id,
+            retained_bytes,
+            boundary_relationships: 0,
+            omitted_relationships: legacy_vertices.len(),
+            omitted_direct_relationships: 0,
+        })
+    }
+
+    fn contract_legacy_islands(
+        &self,
+        full_results: &FormulaProducerResultIndex,
+        full_reads: &FormulaConsumerReadIndex,
+        legacy_reads_complete: bool,
+        candidate_cap: usize,
+    ) -> Option<(
+        FormulaProducerResultIndex,
+        FormulaConsumerReadIndex,
+        LegacyIslandPlan,
+    )> {
+        use crate::formula_plane::producer::ProjectionResult;
+        use crate::formula_plane::region_index::BoundedRegionQueryResult;
+
+        if !self.legacy_island_structural_summaries_trusted
+            || !legacy_reads_complete
+            || self.graph.named_ranges_iter().next().is_some()
+            || self.graph.sheet_named_ranges_iter().next().is_some()
+            || self.graph.spill_registry_counts() != (0, 0)
+        {
+            return None;
+        }
+        let legacy_vertices = self.graph.formula_vertices();
+        if legacy_vertices.iter().copied().any(|vertex| {
+            self.graph.is_dynamic(vertex)
+                || self.graph.get_vertex_kind(vertex) == VertexKind::FormulaArray
+        }) {
+            return None;
+        }
+
+        let mut reads_by_consumer: FxHashMap<VertexId, Vec<Region>> = FxHashMap::default();
+        for entry in full_reads.entries() {
+            if let FormulaProducerId::Legacy(vertex) = entry.consumer {
+                reads_by_consumer
+                    .entry(vertex)
+                    .or_default()
+                    .push(entry.read_region);
+            }
+        }
+
+        let mut connected = FxHashSet::default();
+        let mut queue = VecDeque::new();
+        let mut observed_candidates = 0usize;
+        let mut boundary_relationships = 0usize;
+        let add_connected = |vertex: VertexId,
+                             connected: &mut FxHashSet<VertexId>,
+                             queue: &mut VecDeque<VertexId>| {
+            if connected.insert(vertex) {
+                queue.push_back(vertex);
+            }
+        };
+
+        // Span results -> legacy consumers.
+        for result in full_results.entries() {
+            if !matches!(result.producer, FormulaProducerId::Span(_)) {
+                continue;
+            }
+            let remaining = candidate_cap.saturating_sub(observed_candidates);
+            let query = full_reads.query_changed_region_bounded(result.result_region, remaining);
+            let BoundedRegionQueryResult::Complete(query) = query else {
+                return None;
+            };
+            observed_candidates = observed_candidates.saturating_add(query.stats.candidate_count);
+            for matched in query.matches {
+                if let FormulaProducerId::Legacy(vertex) = matched.value.consumer {
+                    match matched.value.dirty {
+                        ProjectionResult::NoIntersection => {}
+                        ProjectionResult::Unsupported(_) => return None,
+                        ProjectionResult::Exact(_) | ProjectionResult::Conservative { .. } => {
+                            boundary_relationships = boundary_relationships.saturating_add(1);
+                            add_connected(vertex, &mut connected, &mut queue);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Span reads -> legacy producers.
+        for read in full_reads.entries() {
+            if !matches!(read.consumer, FormulaProducerId::Span(_)) {
+                continue;
+            }
+            let remaining = candidate_cap.saturating_sub(observed_candidates);
+            let query = full_results.query_bounded(read.read_region, remaining);
+            let BoundedRegionQueryResult::Complete(query) = query else {
+                return None;
+            };
+            observed_candidates = observed_candidates.saturating_add(query.stats.candidate_count);
+            for matched in query.matches {
+                if let FormulaProducerId::Legacy(vertex) = matched.value.producer {
+                    boundary_relationships = boundary_relationships.saturating_add(1);
+                    add_connected(vertex, &mut connected, &mut queue);
+                }
+            }
+        }
+
+        // Undirected closure through legacy relationships. Every vertex in this
+        // closure remains in the mixed scheduler, preserving the only detector
+        // for cycles whose path crosses a virtual span member.
+        while let Some(vertex) = queue.pop_front() {
+            let producer = FormulaProducerId::Legacy(vertex);
+            if let Some(result_region) = full_results.producer_result_region(producer) {
+                let remaining = candidate_cap.saturating_sub(observed_candidates);
+                let query = full_reads.query_changed_region_bounded(result_region, remaining);
+                let BoundedRegionQueryResult::Complete(query) = query else {
+                    return None;
+                };
+                observed_candidates =
+                    observed_candidates.saturating_add(query.stats.candidate_count);
+                for matched in query.matches {
+                    if let FormulaProducerId::Legacy(consumer) = matched.value.consumer {
+                        match matched.value.dirty {
+                            ProjectionResult::NoIntersection => {}
+                            ProjectionResult::Unsupported(_) => return None,
+                            ProjectionResult::Exact(_) | ProjectionResult::Conservative { .. } => {
+                                add_connected(consumer, &mut connected, &mut queue);
+                            }
+                        }
+                    }
+                }
+            }
+            for read_region in reads_by_consumer.get(&vertex).into_iter().flatten() {
+                let remaining = candidate_cap.saturating_sub(observed_candidates);
+                let query = full_results.query_bounded(*read_region, remaining);
+                let BoundedRegionQueryResult::Complete(query) = query else {
+                    return None;
+                };
+                observed_candidates =
+                    observed_candidates.saturating_add(query.stats.candidate_count);
+                for matched in query.matches {
+                    if let FormulaProducerId::Legacy(precedent) = matched.value.producer {
+                        add_connected(precedent, &mut connected, &mut queue);
+                    }
+                }
+            }
+        }
+
+        let mut membership = legacy_vertices
+            .iter()
+            .copied()
+            .filter(|vertex| !connected.contains(vertex))
+            .collect::<Vec<_>>();
+        membership.sort_unstable();
+        if membership.is_empty() {
+            return None;
+        }
+
+        let mut producer_results = FormulaProducerResultIndex::default();
+        let mut consumer_reads = FormulaConsumerReadIndex::default();
+        let retained_span_results = full_results
+            .entries()
+            .filter(|entry| matches!(entry.producer, FormulaProducerId::Span(_)))
+            .count();
+        producer_results
+            .try_reserve(retained_span_results.saturating_add(connected.len()))
+            .ok()?;
+        for entry in full_results.entries() {
+            let retain = match entry.producer {
+                FormulaProducerId::Span(_) => true,
+                FormulaProducerId::Legacy(vertex) => connected.contains(&vertex),
+            };
+            if retain {
+                producer_results.insert_producer(entry.producer, entry.result_region);
+            }
+        }
+        for entry in full_reads.entries() {
+            let retain = match entry.consumer {
+                FormulaProducerId::Span(_) => true,
+                FormulaProducerId::Legacy(vertex) => connected.contains(&vertex),
+            };
+            if retain {
+                consumer_reads.try_reserve(1).ok()?;
+                consumer_reads.insert_read(
+                    entry.consumer,
+                    entry.read_region,
+                    entry.consumer_result_region,
+                    entry.projection,
+                );
+            }
+        }
+
+        let mut sheet_ids = membership
+            .iter()
+            .filter_map(|vertex| self.graph.get_cell_ref_for_vertex(*vertex))
+            .map(|cell| cell.sheet_id)
+            .collect::<Vec<_>>();
+        sheet_ids.sort_unstable();
+        sheet_ids.dedup();
+        let island_id = membership
+            .iter()
+            .fold(0xcbf29ce484222325_u64, |hash, vertex| {
+                (hash ^ u64::from(vertex.0)).wrapping_mul(0x100000001b3)
+            });
+        let retained_bytes = membership
+            .capacity()
+            .saturating_mul(std::mem::size_of::<VertexId>())
+            .saturating_add(
+                sheet_ids
+                    .capacity()
+                    .saturating_mul(std::mem::size_of::<SheetId>()),
+            );
+        let omitted_relationships = full_reads
+            .entries()
+            .filter(|entry| matches!(entry.consumer, FormulaProducerId::Legacy(vertex) if !connected.contains(&vertex)))
+            .count();
+        let membership_set = membership.iter().copied().collect::<FxHashSet<_>>();
+        let omitted_direct_relationships = membership
+            .iter()
+            .map(|vertex| {
+                self.graph
+                    .get_dependencies(*vertex)
+                    .into_iter()
+                    .filter(|dependency| membership_set.contains(dependency))
+                    .count()
+            })
+            .sum();
+        Some((
+            producer_results,
+            consumer_reads,
+            LegacyIslandPlan {
+                membership,
+                dirty_vertices: Vec::new(),
+                sheet_ids,
+                island_id,
+                retained_bytes,
+                boundary_relationships,
+                omitted_relationships,
+                omitted_direct_relationships,
+            },
+        ))
+    }
+
     fn compile_formula_plane_mixed_topology(
         &mut self,
         key: MixedTopologyCacheKey,
@@ -18748,16 +19207,17 @@ where
         let authority = self.graph.formula_authority();
         let mut producer_results = FormulaProducerResultIndex::default();
         let mut consumer_reads = FormulaConsumerReadIndex::default();
+        let mut legacy_reads_complete = true;
         let span_refs = authority.active_span_refs();
         let legacy_vertices = self.graph.formula_vertices();
-        let producer_count = span_refs
+        let _producer_count = span_refs
             .len()
             .checked_add(legacy_vertices.len())
             .ok_or_else(|| {
                 ExcelError::new(ExcelErrorKind::NImpl)
                     .with_message("FormulaPlane cache producer count overflow")
             })?;
-        producer_results.try_reserve(producer_count).map_err(|_| {
+        producer_results.try_reserve(_producer_count).map_err(|_| {
             ExcelError::new(ExcelErrorKind::NImpl)
                 .with_message("FormulaPlane cache producer index reservation failed")
         })?;
@@ -18800,48 +19260,40 @@ where
             }
         }
 
-        for vertex in &legacy_vertices {
-            let Some(cell) = self.graph.get_cell_ref_for_vertex(*vertex) else {
-                continue;
-            };
-            producer_results.insert_producer(
-                FormulaProducerId::Legacy(*vertex),
-                Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col()),
-            );
-        }
-        for vertex in &legacy_vertices {
-            let Some(cell) = self.graph.get_cell_ref_for_vertex(*vertex) else {
-                continue;
-            };
-            let result_region = Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col());
-            let mut seen = rustc_hash::FxHashSet::default();
-            for dep in self.graph.get_dependencies(*vertex) {
-                let Some(dep_cell) = self.graph.get_cell_ref_for_vertex(dep) else {
+        let sheet_disjoint_island = self.prove_sheet_disjoint_legacy_island(
+            &producer_results,
+            &consumer_reads,
+            &legacy_vertices,
+        );
+        if sheet_disjoint_island.is_none() {
+            for vertex in &legacy_vertices {
+                let Some(cell) = self.graph.get_cell_ref_for_vertex(*vertex) else {
                     continue;
                 };
-                let read_region = Region::point(
-                    dep_cell.sheet_id,
-                    dep_cell.coord.row(),
-                    dep_cell.coord.col(),
+                producer_results.insert_producer(
+                    FormulaProducerId::Legacy(*vertex),
+                    Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col()),
                 );
-                if seen.insert(read_region) {
-                    consumer_reads.try_reserve(1).map_err(|_| {
-                        ExcelError::new(ExcelErrorKind::NImpl)
-                            .with_message("FormulaPlane cache read-index reservation failed")
-                    })?;
-                    consumer_reads.insert_read(
-                        FormulaProducerId::Legacy(*vertex),
-                        read_region,
-                        result_region,
-                        DirtyProjectionRule::WholeResult,
-                    );
-                }
             }
-            if let Some(ranges) = self.graph.get_range_dependencies(*vertex) {
-                for range in ranges {
-                    let Some(read_region) = self.shared_range_to_region_pattern(range)? else {
+            for vertex in &legacy_vertices {
+                let Some(cell) = self.graph.get_cell_ref_for_vertex(*vertex) else {
+                    continue;
+                };
+                let result_region =
+                    Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col());
+                let mut seen = rustc_hash::FxHashSet::default();
+                for dep in self.graph.get_dependencies(*vertex) {
+                    let Some(dep_cell) = self.graph.get_cell_ref_for_vertex(dep) else {
+                        // Named/table/source vertices do not have a trustworthy
+                        // regional boundary summary. Preserve the global planner.
+                        legacy_reads_complete = false;
                         continue;
                     };
+                    let read_region = Region::point(
+                        dep_cell.sheet_id,
+                        dep_cell.coord.row(),
+                        dep_cell.coord.col(),
+                    );
                     if seen.insert(read_region) {
                         consumer_reads.try_reserve(1).map_err(|_| {
                             ExcelError::new(ExcelErrorKind::NImpl)
@@ -18855,46 +19307,89 @@ where
                         );
                     }
                 }
-            }
-            let (virtual_dependencies, _) = VirtualDepBuilder::new(self).build(&[*vertex]);
-            for dependency in virtual_dependencies
-                .get(vertex)
-                .into_iter()
-                .flatten()
-                .copied()
-            {
-                let Some(cell) = self.graph.get_cell_ref_for_vertex(dependency) else {
-                    continue;
-                };
-                let read_region = Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col());
-                if seen.insert(read_region) {
-                    consumer_reads.try_reserve(1).map_err(|_| {
-                        ExcelError::new(ExcelErrorKind::NImpl)
-                            .with_message("FormulaPlane cache virtual read reservation failed")
-                    })?;
-                    consumer_reads.insert_read(
-                        FormulaProducerId::Legacy(*vertex),
-                        read_region,
-                        result_region,
-                        DirtyProjectionRule::WholeResult,
-                    );
+                if let Some(ranges) = self.graph.get_range_dependencies(*vertex) {
+                    for range in ranges {
+                        let Some(read_region) = self.shared_range_to_region_pattern(range)? else {
+                            legacy_reads_complete = false;
+                            continue;
+                        };
+                        if seen.insert(read_region) {
+                            consumer_reads.try_reserve(1).map_err(|_| {
+                                ExcelError::new(ExcelErrorKind::NImpl).with_message(
+                                    "FormulaPlane cache read-index reservation failed",
+                                )
+                            })?;
+                            consumer_reads.insert_read(
+                                FormulaProducerId::Legacy(*vertex),
+                                read_region,
+                                result_region,
+                                DirtyProjectionRule::WholeResult,
+                            );
+                        }
+                    }
                 }
-            }
-            for read_region in DynamicRefVirtualDepProvider::get_virtual_regions(self, *vertex) {
-                if seen.insert(read_region) {
-                    consumer_reads.try_reserve(1).map_err(|_| {
-                        ExcelError::new(ExcelErrorKind::NImpl)
-                            .with_message("FormulaPlane dynamic-region reservation failed")
-                    })?;
-                    consumer_reads.insert_read(
-                        FormulaProducerId::Legacy(*vertex),
-                        read_region,
-                        result_region,
-                        DirtyProjectionRule::WholeResult,
-                    );
+                let (virtual_dependencies, _) = VirtualDepBuilder::new(self).build(&[*vertex]);
+                for dependency in virtual_dependencies
+                    .get(vertex)
+                    .into_iter()
+                    .flatten()
+                    .copied()
+                {
+                    let Some(cell) = self.graph.get_cell_ref_for_vertex(dependency) else {
+                        continue;
+                    };
+                    let read_region =
+                        Region::point(cell.sheet_id, cell.coord.row(), cell.coord.col());
+                    if seen.insert(read_region) {
+                        consumer_reads.try_reserve(1).map_err(|_| {
+                            ExcelError::new(ExcelErrorKind::NImpl)
+                                .with_message("FormulaPlane cache virtual read reservation failed")
+                        })?;
+                        consumer_reads.insert_read(
+                            FormulaProducerId::Legacy(*vertex),
+                            read_region,
+                            result_region,
+                            DirtyProjectionRule::WholeResult,
+                        );
+                    }
+                }
+                for read_region in DynamicRefVirtualDepProvider::get_virtual_regions(self, *vertex)
+                {
+                    if seen.insert(read_region) {
+                        consumer_reads.try_reserve(1).map_err(|_| {
+                            ExcelError::new(ExcelErrorKind::NImpl)
+                                .with_message("FormulaPlane dynamic-region reservation failed")
+                        })?;
+                        consumer_reads.insert_read(
+                            FormulaProducerId::Legacy(*vertex),
+                            read_region,
+                            result_region,
+                            DirtyProjectionRule::WholeResult,
+                        );
+                    }
                 }
             }
         }
+
+        // Boundary discovery uses complete, request-local indexes. Only the
+        // span-connected closure is retained and compiled; disconnected legacy
+        // membership is contracted into the legacy scheduler primitive.
+        let (producer_results, consumer_reads, island) = if let Some(island) = sheet_disjoint_island
+        {
+            (producer_results, consumer_reads, island)
+        } else {
+            self.contract_legacy_islands(
+                &producer_results,
+                &consumer_reads,
+                legacy_reads_complete,
+                key.max_candidates,
+            )
+            .unwrap_or((
+                producer_results,
+                consumer_reads,
+                LegacyIslandPlan::default(),
+            ))
+        };
 
         let retained_memory_bytes = std::mem::size_of::<CachedMixedTopology>()
             .checked_add(
@@ -18910,6 +19405,7 @@ where
                 )
             })
             .and_then(|bytes| bytes.checked_add(estimated_span_bindings_bytes(&span_refs_by_id)?))
+            .and_then(|bytes| bytes.checked_add(island.retained_bytes))
             .unwrap_or(usize::MAX);
         let config = MixedTopologyConfig {
             max_candidates: key.max_candidates,
@@ -18917,7 +19413,35 @@ where
             max_memory_bytes: key.max_memory_bytes,
             retained_memory_bytes,
         };
-        let compiled = compile_mixed_topology(&producer_results, &consumer_reads, &config);
+        let mut compiled = compile_mixed_topology(&producer_results, &consumer_reads, &config);
+        // `producers_observed` remains a discovery counter, not merely the
+        // post-contraction mixed-node count. Preserve that established meaning
+        // while exposing omissions separately in route telemetry.
+        match &mut compiled {
+            MixedTopologyCompileResult::Cached(topology) => {
+                topology.stats.producers = topology
+                    .stats
+                    .producers
+                    .saturating_add(island.membership.len());
+                topology.stats.candidates = topology
+                    .stats
+                    .candidates
+                    .saturating_add(island.omitted_direct_relationships);
+                topology.stats.relationships = topology
+                    .stats
+                    .relationships
+                    .saturating_add(island.omitted_direct_relationships);
+            }
+            MixedTopologyCompileResult::CacheSkipped { observed, .. } => {
+                observed.producers = observed.producers.saturating_add(island.membership.len());
+                observed.candidates = observed
+                    .candidates
+                    .saturating_add(island.omitted_direct_relationships);
+                observed.relationships = observed
+                    .relationships
+                    .saturating_add(island.omitted_direct_relationships);
+            }
+        }
         let plane_epoch = authority.plane.epoch().0;
         Ok(match compiled {
             MixedTopologyCompileResult::Cached(topology) => {
@@ -18928,6 +19452,7 @@ where
                     consumer_reads,
                     span_refs_by_id,
                     plane_epoch,
+                    island,
                 })
             }
             MixedTopologyCompileResult::CacheSkipped { reason, observed } => {
@@ -18938,6 +19463,7 @@ where
                     consumer_reads,
                     span_refs_by_id,
                     plane_epoch,
+                    island,
                 })
             }
         })
@@ -19061,7 +19587,8 @@ where
                     })
                     .and_then(|bytes| {
                         bytes.checked_add(estimated_span_bindings_bytes(&compiled.span_refs_by_id)?)
-                    }),
+                    })
+                    .and_then(|bytes| bytes.checked_add(compiled.island.retained_bytes)),
                 FormulaPlaneTopologyCompileResult::CacheSkipped(skipped) => skipped
                     .producer_results
                     .estimated_memory_bytes()
@@ -19070,7 +19597,8 @@ where
                     })
                     .and_then(|bytes| {
                         bytes.checked_add(estimated_span_bindings_bytes(&skipped.span_refs_by_id)?)
-                    }),
+                    })
+                    .and_then(|bytes| bytes.checked_add(skipped.island.retained_bytes)),
             }
             .unwrap_or(usize::MAX) as u64;
             debug_assert!(
@@ -19114,6 +19642,7 @@ where
                         consumer_reads: compiled.consumer_reads,
                         span_refs_by_id: compiled.span_refs_by_id,
                         plane_epoch: compiled.plane_epoch,
+                        island: compiled.island,
                     });
                     (
                         FormulaPlaneTopologyCacheOutcome::SkippedDynamicLegacy,
@@ -19201,6 +19730,7 @@ where
                 plane_epoch,
                 cached_topology,
                 partial_topology,
+                island,
             ) = if let Some(skipped) = skipped_topology.as_ref() {
                 (
                     &skipped.producer_results,
@@ -19209,6 +19739,7 @@ where
                     skipped.plane_epoch,
                     None,
                     None,
+                    &skipped.island,
                 )
             } else {
                 let cached = self
@@ -19227,6 +19758,7 @@ where
                     cached.plane_epoch,
                     complete,
                     partial,
+                    &cached.island,
                 )
             };
             let demand = if let Some(target_roots) = target_roots {
@@ -19466,6 +19998,35 @@ where
             };
 
             let dirty_legacy = self.graph.get_evaluation_vertices();
+            let dirty_legacy_set = dirty_legacy.iter().copied().collect::<FxHashSet<_>>();
+            let island_target_demand = target_roots.map(|roots| {
+                use crate::engine::target_preparation::TargetProducer;
+                let graph_roots = roots
+                    .iter()
+                    .filter_map(|root| match *root {
+                        TargetProducer::Legacy(vertex) | TargetProducer::Symbol(vertex) => {
+                            Some(vertex)
+                        }
+                        TargetProducer::Span { .. } | TargetProducer::ValueOnly(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+                self.build_demand_subgraph(&graph_roots)
+                    .0
+                    .into_iter()
+                    .collect::<FxHashSet<_>>()
+            });
+            let mut island_plan = island.clone();
+            island_plan.dirty_vertices = island_plan
+                .membership
+                .iter()
+                .copied()
+                .filter(|vertex| dirty_legacy_set.contains(vertex))
+                .filter(|vertex| {
+                    island_target_demand
+                        .as_ref()
+                        .is_none_or(|demand| demand.contains(vertex))
+                })
+                .collect();
             let mut work = Vec::new();
             let mut scheduled_legacy_vertices = Vec::new();
             let demanded_dirty = |producer: FormulaProducerId,
@@ -19924,6 +20485,7 @@ where
                 plane_epoch,
                 scheduled_legacy_vertices,
                 owned_dirty_events,
+                island_plan,
             ))
         })();
         let scratch_release_result = self
@@ -20045,6 +20607,56 @@ where
             }
         }
         Ok((computed_vertices, cycle_count))
+    }
+
+    /// Execute a proven span-disconnected legacy island without beginning or
+    /// finalising an evaluation request. The FormulaPlane coordinator retains
+    /// sole ownership of the dirty lease, volatile redirty, acknowledgement,
+    /// clock sample, and recalc-epoch advance.
+    fn evaluate_legacy_island_non_finalizing(
+        &mut self,
+        vertices: &[VertexId],
+        mut delta: Option<&mut DeltaCollector>,
+    ) -> Result<(usize, usize), ExcelError> {
+        if vertices.is_empty() {
+            return Ok((0, 0));
+        }
+        let (schedule, _, _) = self.create_evaluation_schedule(vertices)?;
+        let mut computed = 0usize;
+        let mut cycles = 0usize;
+        for &unit in &schedule.units {
+            self.cancellation_checkpoint("Evaluation cancelled during legacy island")?;
+            match unit {
+                ScheduleUnit::Cycle(index) => {
+                    if self.handle_cycle_unit(
+                        schedule.unit_cycle(index),
+                        delta.as_deref_mut(),
+                        None,
+                        None,
+                    )? > 0
+                    {
+                        cycles = cycles.saturating_add(1);
+                    }
+                }
+                ScheduleUnit::Layer(index) => {
+                    let layer = schedule.unit_layer(index);
+                    let evaluated = if let Some(delta) = delta.as_deref_mut() {
+                        if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                            self.evaluate_layer_parallel_with_delta(layer, delta)?
+                        } else {
+                            self.evaluate_layer_sequential_with_delta(layer, delta)?
+                        }
+                    } else if self.thread_pool.is_some() && layer.vertices.len() > 1 {
+                        self.evaluate_layer_parallel(layer)?
+                    } else {
+                        self.evaluate_layer_sequential(layer)?
+                    };
+                    computed = computed.saturating_add(evaluated);
+                }
+            }
+        }
+        self.graph.clear_dirty_flags(vertices);
+        Ok((computed, cycles))
     }
 
     /// Legacy `evaluate_all` body, reachable from the FormulaPlane coordinator

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -96,8 +96,9 @@ pub use resource_observability::{
     EvaluationRequestKind, EvaluationRequestOutcome, EvaluationRequestPhaseTimings,
     EvaluationResourceBaselineStats, EvaluationResourceClass, EvaluationResourceLedgerRequestStats,
     EvaluationResourceReason, EvaluationResourceRequestStats, FormulaDirtyLeaseOutcome,
-    FormulaPlaneTopologyCacheOutcome, FormulaPlaneTopologyRequestStats,
-    FormulaPlaneTopologyStrategy,
+    FormulaPlaneRoute, FormulaPlaneRouteEvent, FormulaPlaneRoutePhase,
+    FormulaPlaneRouteTransitionReason, FormulaPlaneTopologyCacheOutcome,
+    FormulaPlaneTopologyRequestStats, FormulaPlaneTopologyStrategy,
 };
 pub use row_visibility::{RowVisibilitySource, VisibilityMaskMode};
 pub use scheduler::{Layer, Schedule, ScheduleUnit, Scheduler};

--- a/crates/formualizer-eval/src/engine/resource_observability.rs
+++ b/crates/formualizer-eval/src/engine/resource_observability.rs
@@ -148,6 +148,59 @@ pub enum FormulaDirtyLeaseOutcome {
     RetainedOnError,
 }
 
+/// Bounded routing telemetry for legacy-island contraction. The fixed-size
+/// representation prevents observability from introducing an unaccounted,
+/// input-sized allocation under retained-memory pressure.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FormulaPlaneRoute {
+    #[default]
+    GlobalMixed,
+    ContractedLegacyIsland,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FormulaPlaneRoutePhase {
+    #[default]
+    Planned,
+    Executed,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FormulaPlaneRouteTransitionReason {
+    #[default]
+    ProvenIsolated,
+    DynamicReference,
+    NamedDependency,
+    SpillOrArray,
+    StructuralSummaryUncertain,
+    UnsupportedReadSummary,
+    BoundaryDiscoveryOverflow,
+    SpanCycleDemotion,
+    RuntimeReplan,
+}
+
+pub const FORMULA_PLANE_ROUTE_EVENT_CAPACITY: usize = 16;
+pub const FORMULA_PLANE_ROUTE_EVENT_SHEET_CAPACITY: usize = 8;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct FormulaPlaneRouteEvent {
+    /// Deterministic request-local identity derived from island membership.
+    pub island_id: u64,
+    pub phase: FormulaPlaneRoutePhase,
+    pub route: FormulaPlaneRoute,
+    /// Sorted sheet IDs touched by the island, truncated at the fixed capacity.
+    pub sheet_ids: [u16; FORMULA_PLANE_ROUTE_EVENT_SHEET_CAPACITY],
+    pub sheet_count: u8,
+    pub authority_epoch: u64,
+    pub index_epoch: u64,
+    pub transition_reason: FormulaPlaneRouteTransitionReason,
+    pub demotion_generation: u32,
+    pub replan_generation: u32,
+}
+
 impl EvaluationRequestKind {
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -277,6 +330,18 @@ pub struct FormulaPlaneTopologyRequestStats {
     pub byte_cap_hits: u64,
     pub overflow_reason: Option<EvaluationResourceReason>,
     pub incomplete_reason: Option<EvaluationIncompleteReason>,
+    /// Bounded per-route records. Entries beyond the fixed capacity are
+    /// counted rather than allocated.
+    pub route_events: [FormulaPlaneRouteEvent; FORMULA_PLANE_ROUTE_EVENT_CAPACITY],
+    pub route_event_count: u8,
+    pub route_events_dropped: u64,
+    /// Inline telemetry bytes plus membership bytes charged to the retained
+    /// mixed-cache ledger.
+    pub route_event_bytes_observed: u64,
+    pub island_membership_vertices: u64,
+    pub island_membership_retained_bytes: u64,
+    pub legacy_relationships_omitted: u64,
+    pub boundary_relationships_retained: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_cycle_member_exclusion.rs
@@ -94,6 +94,46 @@ fn build_workbook(detection: CycleDetection) -> Engine<TestWorkbook> {
     engine
 }
 
+#[test]
+fn post_warm_cross_sheet_back_edge_demotes_before_legacy_tarjan() {
+    let mut engine = authoritative_engine(CycleDetection::Static);
+    engine.add_sheet("Aux").unwrap();
+    let mut col_b = Vec::new();
+    let mut col_e = Vec::new();
+    for row in 1..=120 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value("Aux", row, 1, LiteralValue::Number(0.0))
+            .unwrap();
+        col_b.push(record(&mut engine, row, 2, &format!("=A{row}+Aux!A{row}")));
+        col_e.push(record(&mut engine, row, 5, &format!("=A{row}*2")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(
+            "Sheet1",
+            col_b.into_iter().chain(col_e).collect(),
+        )])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 2);
+    engine.evaluate_all().unwrap();
+    assert_eq!(num(&engine, "Sheet1", 5, 2), 5.0);
+
+    // The back-edge is introduced only after the span is warm. Legacy Tarjan
+    // cannot see the virtual B5 member; the mixed schedule must detect the
+    // cycle and demote B before the residual legacy SCC is resolved.
+    engine
+        .set_cell_formula("Aux", 5, 1, parse("=Sheet1!B5").unwrap())
+        .unwrap();
+    let result = engine.evaluate_all().unwrap();
+    assert_eq!(result.cycle_errors, 1);
+    assert!(is_circ(&engine, "Sheet1", 5, 2));
+    assert!(is_circ(&engine, "Aux", 5, 1));
+    assert_eq!(num(&engine, "Sheet1", 5, 5), 10.0);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+}
+
 /// (a) cycle members are not span-evaluated — the cyclic span is demoted and the
 /// `CycleMember` placement-fallback reason is recorded; (b) results are correct
 /// under `CycleDetection::Static`: `#CIRC` for the cycle members, real span

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_mixed_legacy_tail_reads.rs
@@ -33,7 +33,8 @@ use formualizer_common::LiteralValue;
 use formualizer_parse::parser::parse;
 
 use crate::engine::{
-    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+    CycleConfig, Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+    FormulaPlaneRoute, FormulaPlaneRoutePhase,
 };
 use crate::test_workbook::TestWorkbook;
 
@@ -125,6 +126,21 @@ fn mixed_tail_reads_complete_in_one_authoritative_pass() {
 
     engine.evaluate_all().unwrap();
 
+    let request = engine.last_evaluation_resource_request_stats().unwrap();
+    let route_events =
+        &request.topology.route_events[..usize::from(request.topology.route_event_count)];
+    assert!(
+        route_events.iter().any(|event| {
+            event.route == FormulaPlaneRoute::ContractedLegacyIsland
+                && event.phase == FormulaPlaneRoutePhase::Executed
+        }),
+        "disabling island contraction must fail this routing assertion"
+    );
+    assert_eq!(request.topology.island_membership_vertices, u64::from(ROWS));
+    assert!(request.topology.island_membership_retained_bytes > 0);
+    assert!(request.topology.legacy_relationships_omitted >= u64::from(ROWS));
+    assert_eq!(request.topology.boundary_relationships_retained, 0);
+
     assert_eq!(
         engine.formula_plane_capacity_bailouts(),
         0,
@@ -150,6 +166,51 @@ fn mixed_tail_reads_complete_in_one_authoritative_pass() {
         "quiescent recalc must not re-evaluate spans"
     );
     assert_eq!(engine.formula_plane_capacity_bailouts(), 0);
+}
+
+#[test]
+fn independent_iterative_island_preserves_accumulator_and_single_request_lifecycle() {
+    let config = EvalConfig::default()
+        .with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental)
+        .with_cycle(CycleConfig::iterate(1, 0.001));
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    let mut formulas = Vec::new();
+    for row in 1..=120 {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}+1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .unwrap();
+    engine
+        .set_cell_value(SHEET, 1, 3, LiteralValue::Number(5.0))
+        .unwrap();
+    engine
+        .set_cell_formula(SHEET, 1, 4, parse("=D1+C1").unwrap())
+        .unwrap();
+
+    for (recalc, expected) in [5.0, 10.0, 15.0].into_iter().enumerate() {
+        let epoch = engine.recalc_epoch;
+        let begins = engine.evaluation_request_begin_count_for_test();
+        engine.evaluate_all().unwrap();
+        assert_eq!(numeric_value(&engine, 1, 4), expected);
+        assert_eq!(engine.recalc_epoch, epoch.wrapping_add(1));
+        assert_eq!(
+            engine.evaluation_request_begin_count_for_test(),
+            begins + 1,
+            "the clock and iterative-redirty state must be sampled once per request"
+        );
+        if recalc == 0 {
+            let request = engine.last_evaluation_resource_request_stats().unwrap();
+            assert!(
+                request.topology.route_events[..usize::from(request.topology.route_event_count)]
+                    .iter()
+                    .any(|event| event.phase == FormulaPlaneRoutePhase::Executed)
+            );
+        }
+    }
 }
 
 fn assert_full_capacity_corpus_parity(
@@ -188,6 +249,13 @@ fn cached_mixed_topology_matches_off_first_warm_and_post_edit() {
     off.evaluate_all().unwrap();
     authoritative.evaluate_all().unwrap();
     assert_eq!(authoritative.formula_plane_capacity_bailouts(), 0);
+    let connected_request = authoritative
+        .last_evaluation_resource_request_stats()
+        .unwrap();
+    assert_eq!(
+        connected_request.topology.route_event_count, 0,
+        "misclassifying a span-connected legacy component as isolated must fail this assertion"
+    );
     let first_stats = authoritative.baseline_stats();
     assert_eq!(first_stats.formula_plane_active_span_count, 1);
     assert_eq!(first_stats.formula_plane_mixed_topology_cache_builds, 1);

--- a/crates/formualizer-eval/src/formula_plane/producer.rs
+++ b/crates/formualizer-eval/src/formula_plane/producer.rs
@@ -253,6 +253,10 @@ impl FormulaProducerResultIndex {
         self.entries.iter().map(|entry| entry.producer)
     }
 
+    pub(crate) fn entries(&self) -> impl Iterator<Item = &FormulaProducerResultEntry> {
+        self.entries.iter()
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.entries.len()
     }


### PR DESCRIPTION
## Summary

- contract proven span-disconnected legacy work into a non-finalising legacy scheduler primitive under the existing FormulaPlane coordinator
- retain span-connected legacy producers in the mixed topology and preserve mixed-schedule cycle detection/demotion
- add bounded route events and accounted island/topology shape telemetry
- fail closed for dynamic references, names, spills/array formulas, unsupported read summaries, boundary-discovery overflow, and structural axis edits while #171 remains open

## Isolation proof

The retained mixed topology starts with every active span result and read summary. Boundary discovery finds both directions: span result to legacy consumer and legacy result to span consumer. It then computes an undirected fixed point through legacy result/read relationships. Every legacy producer in that closure remains in the existing mixed scheduler. Therefore any path from a legacy producer to a virtual span member, including a path that closes a cycle through the span, remains visible to the producer-bounded mixed cycle detector and follows the unchanged G8 demotion path before legacy Tarjan runs.

Only the complement is contracted. It is evaluated through `create_evaluation_schedule` and the existing layer/SCC walkers, but the primitive does not begin a request, lease or acknowledge dirty authority, redirty volatiles/iterative SCCs, refresh the clock, or advance `recalc_epoch`. Those operations remain owned once by the outer FormulaPlane coordinator.

A stricter fast proof handles the measured multi-sheet corpus without constructing irrelevant legacy indexes: every legacy result and every legacy read sheet must be disjoint from the union of all span result and span read sheets. Same-sheet work never uses that shortcut and goes through exact regional boundary discovery.

## Fail-closed conditions

- any dynamic legacy formula
- any workbook- or sheet-scoped name
- any active spill or legacy array formula
- a non-cell dependency or a range that cannot be represented by a structural read region
- a boundary query, closure query, allocation, candidate cap, edge cap, or retained-byte cap that cannot complete exactly
- any row/column structural edit after engine creation, because #171 leaves relocated summaries unsuitable as a disconnection proof
- no non-empty isolated membership

On all of these paths the existing global mixed coordinator and its exact overflow ladder remain in use.

## Request lifecycle and observability

`evaluate_authoritative_formula_plane` no longer begins a request a second time. Tests pin one begin/clock refresh and one epoch increment per public request while a legacy iterative accumulator runs repeatedly beside an unrelated active span.

Route telemetry is fixed at 16 inline events and records planned/executed phase, deterministic island ID, a bounded sorted sheet set, route, authority/index epochs, transition reason, and demotion/replan generations. It also reports dropped events, inline event bytes, retained membership bytes, omitted legacy relationships, and retained boundary relationships. Membership bytes are included in topology retained-memory accounting and the cache key explicitly carries island and boundary revisions.

## Correctness and regression tests

- hardcoded cross-sheet post-warm back-edge values/errors prove mixed detection demotes the span before legacy Tarjan
- repeated hardcoded iterative accumulator values prove persistence and exactly one begin/clock sample plus one epoch increment per request
- same-sheet disconnected work asserts an executed contraction route; the connected variant asserts no contraction
- the existing mixed-tail fault, cancellation, cache cap, retained plan, dirty lease, demotion, target, delta, and structural suites remain green
- no existing assertion was relaxed; the established `producers_observed`/candidate/edge telemetry meaning is preserved while omissions are exposed separately

## Mutations

- disabling both contraction proofs fails `mixed_tail_reads_complete_in_one_authoritative_pass` at the named executed-route assertion
- clearing the span-connected closure before classification fails `cached_mixed_topology_matches_off_first_warm_and_post_edit` at the named connected-island assertion

Both mutations exited 101 with exactly the intended named test failure.

## Measurements

Release binary hash changed from `02abd536d9fc4784b31dca87021611ed5ec99516fe75befb5e1077cd221039ec` to `a10f5f2283d8e98f133f8c00d6a8c82d8ff3e0dad1e7d42f46c0838d45fe2e28` before final measurements.

Three-section mixture at N=1000, five cold-process samples:

| run | Off first | authoritative first | warm hit | mismatches |
|---|---:|---:|---:|---:|
| 1 | 78 ms | 73 ms | 0 ms | 0 |
| 2 | 78 ms | 73 ms | 0 ms | 0 |
| 3 | 79 ms | 73 ms | 0 ms | 0 |
| 4 | 79 ms | 77 ms | 0 ms | 0 |
| 5 | 84 ms | 79 ms | 0 ms | 0 |

This moves the reported 619 ms authoritative result to a 73 ms median.

Full corpus:

| N | coverage | spans | mismatches | authoritative first | authoritative warm hit |
|---:|---:|---:|---:|---:|---:|
| 500 | 69.2% | 9 | 0 | 520 ms median (3 paired samples; main 531 ms) | 0 ms |
| 1000 | 69.2% | 9 | 0 | 689 ms (paired main 699 ms) | 1 ms |
| 2000 | 69.2% | 9 | 0 | 3104 ms median (10 paired samples; main 3096 ms) | 3 ms |

At N=2000 the paired medians differ by 0.2% with alternating wins and are within run noise; warm work did not regress. The supplied historical first-eval baseline was 3059 ms.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings`
- `cargo clippy -p formualizer-wasm --target wasm32-unknown-unknown`
- `cargo test -p formualizer-eval --lib --all-features`: 2449 passed, 0 failed, 12 ignored
- `formula_plane_ingest_shadow --test-threads=32`: 30/30 module runs passed
- `formula_plane_mixed_legacy_tail_reads`: 16 passed, including the demote-loop regression net

Closes #251
