### PR TITLE
test(eval): pin topology retention after candidate overflow

### DIFF
--- a/crates/formualizer-eval/src/engine/tests/evaluation_resource_observability.rs
+++ b/crates/formualizer-eval/src/engine/tests/evaluation_resource_observability.rs
@@ -259,6 +259,83 @@ fn topology_build_hit_and_overflow_materialization_are_exactly_observed() {
 }
 
 #[test]
+fn candidate_overflow_retains_topology_for_next_request_hit() {
+    let mut config =
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    config.max_formula_plane_cache_candidates = 1;
+    let mut engine = Engine::new(TestWorkbook::default(), config);
+    let mut formulas = Vec::new();
+    for row in 1..=100 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        formulas.push(record(&mut engine, row, 2, &format!("=A{row}*2")));
+        formulas.push(record(&mut engine, row, 3, &format!("=B{row}+1")));
+        formulas.push(record(&mut engine, row, 4, &format!("=C{row}+1")));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 3);
+
+    engine.evaluate_all().unwrap();
+    let overflow = engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(
+        overflow.topology.cache_outcome,
+        FormulaPlaneTopologyCacheOutcome::Built
+    );
+    assert_eq!(
+        overflow.topology.strategy,
+        FormulaPlaneTopologyStrategy::ExactPagedIndexed
+    );
+    assert_eq!(overflow.topology.candidate_cap, Some(1));
+    assert_eq!(
+        overflow.topology.overflow_reason,
+        Some(EvaluationResourceReason::FormulaPlaneTopologyCandidates)
+    );
+    assert_eq!(overflow.topology.candidates_observed, 2);
+    assert_eq!(overflow.topology.edges_observed, 1);
+    assert_eq!(overflow.topology.candidate_cap_hits, 1);
+    assert_eq!(overflow.topology.cache_build_events, 1);
+    assert_eq!(overflow.topology.cache_skip_events, 0);
+    assert_eq!(overflow.topology.cache_skip_streak, 0);
+    assert!(overflow.topology.retained_bytes_observed > 0);
+    assert!(engine.mixed_topology_cache_present_for_test());
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 100, 4),
+        Some(LiteralValue::Number(202.0))
+    );
+
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(9.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    let hit = engine.last_evaluation_resource_request_stats().unwrap();
+    assert_eq!(
+        hit.topology.cache_outcome,
+        FormulaPlaneTopologyCacheOutcome::Hit
+    );
+    assert_eq!(
+        hit.topology.strategy,
+        FormulaPlaneTopologyStrategy::ExactPagedIndexed
+    );
+    assert_eq!(hit.topology.cache_hit_events, 1);
+    assert_eq!(hit.topology.cache_build_events, 0);
+    assert_eq!(hit.topology.cache_skip_events, 0);
+    assert_eq!(hit.topology.producers_observed, 0);
+    assert_eq!(hit.topology.candidates_observed, 0);
+    assert_eq!(hit.topology.edges_observed, 0);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 4),
+        Some(LiteralValue::Number(20.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 100, 4),
+        Some(LiteralValue::Number(202.0))
+    );
+}
+
+#[test]
 fn perpetual_cache_skip_preserves_values_streak_and_no_disk_policy() {
     for (policy, scratch_limit, expected) in [
         (


### PR DESCRIPTION
## What
- Add an engine-level authoritative-mode regression workbook with three promoted formula spans and a candidate cap of one.
- Assert the first evaluation observes two candidates against that cap, retains the one-edge useful prefix as `Built`, and routes through exact paged scheduling.
- Edit one input value and assert the second evaluation is a telemetry `Hit`, performs no topology compile work, and preserves hardcoded edited and untouched values.
- Keep production code unchanged and reuse existing zero/no-prefix, retained-byte-overflow, and perpetual-skip coverage for the negative direction.

## Validation
- `cargo test -p formualizer-eval --lib --all-features candidate_overflow_retains_topology_for_next_request_hit -- --nocapture` (1 passed)
- `cargo test -p formualizer-eval --lib --all-features engine::tests::evaluation_resource_observability -- --nocapture` (8 passed)
- `cargo test -p formualizer-eval --lib --all-features skipped_topology_is_typed_atomic_and_never_cached -- --nocapture` (1 passed)
- `cargo fmt --all --check`
- `cargo clippy -p formualizer-eval --all-targets --all-features -- -D warnings`
- `cargo test -p formualizer-eval --lib --all-features` (2,450 passed, 12 ignored)

## Mutation evidence
- Disabled overflow compile retention itself by changing the partial-cache branch from `else if !relationships.is_empty() && matches!(...)` to `else if false && !relationships.is_empty() && matches!(...)` in `compile_mixed_topology`.
- A freshly rebuilt baseline test binary hashed `189d98f833d3b696b1ef6649713846ac4e62ae62c8e27edc35904543d8423f00`; the rebuilt mutant binary timestamp advanced and hashed `35a4ba6237828dadeaa9da5729d04c0d4f5f3b494aff829a5fe2b6acfafdf2ff`.
- `candidate_overflow_retains_topology_for_next_request_hit` failed as required: telemetry was `SkippedOverflow` instead of expected `Built`.
- Restored the implementation and freshly rebuilt the passing binary before final validation.

Closes #250

drafted with love by (agent) Manfred, with approval from Frankie
