### PR TITLE
ci(release): verify staged crate archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-public-api-0.52.0-nightly-2026-02-16-
 
+    - name: Test release preflight helpers
+      run: python3 -m unittest scripts/tests/test_release_preflight.py
+
     - name: Verify public API tools
       run: scripts/public-api.sh setup
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up pinned preflight Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.93.0
+
       - name: Verify product tag versions match manifests
         shell: bash
         run: |
@@ -71,6 +76,9 @@ jobs:
           print(f"OK: v{tag_version} matches product manifests")
           PY
 
+      - name: Verify staged product package chain
+        run: python3 scripts/release-preflight.py --track product
+
   verify-parse:
     if: startsWith(github.ref_name, 'parse-v')
     runs-on: ubuntu-latest
@@ -82,6 +90,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+
+      - name: Set up pinned preflight Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.93.0
 
       - name: Verify parse/common tag versions match manifests
         shell: bash
@@ -125,6 +138,9 @@ jobs:
           print(f"OK: parse-v{tag_version} matches parser/common manifests")
           PY
 
+      - name: Verify staged parser/SDK package chain
+        run: python3 scripts/release-preflight.py --track parse
+
   verify-spec:
     if: startsWith(github.ref_name, 'sheetport-spec-v')
     runs-on: ubuntu-latest
@@ -136,6 +152,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+
+      - name: Set up pinned preflight Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.93.0
 
       - name: Verify spec tag version matches manifest
         shell: bash
@@ -160,6 +181,9 @@ jobs:
 
           print(f"OK: sheetport-spec-v{tag_version} matches manifest")
           PY
+
+      - name: Verify SheetPort spec package boundary
+        run: python3 scripts/release-preflight.py --track spec
 
   publish-parse-crates:
     if: startsWith(github.ref_name, 'parse-v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -85,6 +87,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -147,6 +151,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Security and hardening
 
+- Added a credential-free release preflight that packages each Rust release track through a temporary local registry in publish order, verifies downstream archives against the exact prospective upstream bytes, and rejects source drift when a package version already exists on crates.io. Clean-checkout, symlink, archive-member, checksum, exclusive-lock, and exact isolated-tool guards keep the pre-tag check transactional; tag workflows repeat it before any publish job receives a registry token. (#257, #258)
 - Upgraded PyO3 and NumPy bindings to 0.29.0, resolving the PyO3 out-of-bounds iterator and missing closure `Sync` advisories. Upgraded `pyo3-stub-gen` to 0.23.0, made existing clone-based Python extraction explicit, and aligned generated stubs with the private maturin extension-module path while preserving the public `formualizer` package API.
 
 ### Performance

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -105,7 +105,7 @@ python3 scripts/release-preflight.py --track product
 
 Use only the track being released. `--allow-dirty` exists for development checks and is forbidden for a release tag.
 
-For multi-crate tracks, the script packages crates in dependency order, adds each prospective archive to a temporary local Cargo registry, and verifies downstream archives against those exact bytes. Workspace path dependencies therefore cannot hide an unpublished or incompatible registry package. The staging registry and Cargo home are temporary and credential-free; the exact `cargo-local-registry` helper and its isolated download cache live under `target/release-preflight-*` without replacing a global tool.
+For multi-crate tracks, the script packages crates in dependency order, adds each prospective archive to a temporary local Cargo registry, and verifies downstream archives against those exact bytes. Workspace path dependencies therefore cannot hide an unpublished or incompatible registry package. The staging registry and Cargo home are temporary; inherited Cargo/GitHub token variables are removed and Git prompting is disabled. The exact `cargo-local-registry` helper and its isolated download cache live under `target/release-preflight-*` without replacing a global tool.
 
 For every package, the preflight queries crates.io. A version that does not yet exist is accepted. If the version exists, the shipped source/data/doc payload must match exactly; generated `Cargo.toml`, `Cargo.lock`, and `.cargo_vcs_info.json` are excluded because they vary with Cargo or the source commit, while `Cargo.toml.orig` remains compared so dependency requirements are covered. Any other difference means the source must be restored or the package version bumped.
 

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -93,6 +93,24 @@ Multiple tags can point at the same commit if we want “synced” releases with
 
 Bindings should enable features on `formualizer` (not on individual subcrates).
 
+## Release package preflight
+
+Run the credential-free package preflight from a clean release commit **before creating a tag**:
+
+```bash
+python3 scripts/release-preflight.py --track parse
+python3 scripts/release-preflight.py --track spec
+python3 scripts/release-preflight.py --track product
+```
+
+Use only the track being released. `--allow-dirty` exists for development checks and is forbidden for a release tag.
+
+For multi-crate tracks, the script packages crates in dependency order, adds each prospective archive to a temporary local Cargo registry, and verifies downstream archives against those exact bytes. Workspace path dependencies therefore cannot hide an unpublished or incompatible registry package. The staging registry and Cargo home are temporary and credential-free; the exact `cargo-local-registry` helper and its isolated download cache live under `target/release-preflight-*` without replacing a global tool.
+
+For every package, the preflight queries crates.io. A version that does not yet exist is accepted. If the version exists, the shipped source/data/doc payload must match exactly; generated `Cargo.toml`, `Cargo.lock`, and `.cargo_vcs_info.json` are excluded because they vary with Cargo or the source commit, while `Cargo.toml.orig` remains compared so dependency requirements are covered. Any other difference means the source must be restored or the package version bumped.
+
+The tag-triggered release workflow repeats the same preflight before any publish job receives a registry token. The pre-tag run avoids creating a bad tag; the workflow run prevents publication if a tag bypasses the human checklist.
+
 ## Publishing Order (Rust)
 
 ### Parser/SDK release (`parse-v*`)
@@ -173,7 +191,8 @@ After bumping, the script runs `cargo check` to verify the workspace compiles (u
 1. Decide which track(s) you are releasing.
 2. Run `./scripts/bump-version.py --track <track> --version <version>` (use `--dry-run` first to preview).
 3. Ensure `CHANGELOG` entries exist where applicable.
-4. Commit the version bump: `git commit -am "chore: bump <track> to <version>"`
-5. Create the tag: `git tag v<version>` (or `parse-v<version>` / `sheetport-spec-v<version>`).
-6. Push: `git push && git push --tags`
-7. Verify GitHub Actions publishes successfully.
+4. Commit the version bump: `git commit -am "chore: bump <track> to <version>"`.
+5. From the clean commit, run `python3 scripts/release-preflight.py --track <track>` and retain the package hashes in the release evidence.
+6. Create the tag: `git tag v<version>` (or `parse-v<version>` / `sheetport-spec-v<version>`).
+7. Push the branch and tag.
+8. Verify the tag workflow repeats the preflight and publishes successfully.

--- a/scripts/release-preflight.py
+++ b/scripts/release-preflight.py
@@ -444,7 +444,10 @@ def package_one(
 
 
 def seed_patched_registry_dependencies(
-    tool: Path, registry: Path, env: dict[str, str]
+    tool: Path,
+    registry: Path,
+    env: dict[str, str],
+    packages: tuple[Package, ...],
 ) -> None:
     """Add crates whose registry lock entry was replaced by a git/path patch."""
 
@@ -457,8 +460,11 @@ def seed_patched_registry_dependencies(
         locked.setdefault(str(package["name"]), set()).add(str(package["version"]))
 
     requirements: dict[str, set[str]] = {}
-    for package in metadata["packages"]:
-        for dependency in package["dependencies"]:
+    package_names = {package.name for package in packages}
+    for metadata_package in metadata["packages"]:
+        if metadata_package["name"] not in package_names:
+            continue
+        for dependency in metadata_package["dependencies"]:
             source = dependency.get("source") or ""
             if not source.startswith("registry+"):
                 continue
@@ -483,7 +489,9 @@ def seed_patched_registry_dependencies(
             )
 
 
-def prepare_local_registry(temp_root: Path) -> tuple[Path, dict[str, str]]:
+def prepare_local_registry(
+    temp_root: Path, packages: tuple[Package, ...]
+) -> tuple[Path, dict[str, str]]:
     tool = ensure_local_registry_tool()
     registry = temp_root / "registry"
     cargo_home = temp_root / "cargo-home"
@@ -491,7 +499,7 @@ def prepare_local_registry(temp_root: Path) -> tuple[Path, dict[str, str]]:
     env = os.environ.copy()
     env["CARGO_HOME"] = str(TOOL_CARGO_HOME)
     run([str(tool), "sync", str(ROOT / "Cargo.lock"), str(registry)], env=env)
-    seed_patched_registry_dependencies(tool, registry, env)
+    seed_patched_registry_dependencies(tool, registry, env, packages)
     return registry, staging_environment(cargo_home, registry)
 
 
@@ -510,7 +518,7 @@ def preflight(track: str, allow_dirty: bool) -> None:
         registry: Path | None = None
         package_env: dict[str, str] | None = None
         if len(packages) > 1:
-            registry, package_env = prepare_local_registry(temp_root)
+            registry, package_env = prepare_local_registry(temp_root, packages)
 
         results: list[dict[str, str]] = []
         for package in packages:

--- a/scripts/release-preflight.py
+++ b/scripts/release-preflight.py
@@ -38,6 +38,7 @@ TOOL_ROOT = TARGET / "release-preflight-tools" / f"cargo-local-registry-{TOOL_VE
 TOOL_BIN = TOOL_ROOT / "bin" / "cargo-local-registry"
 TOOL_CARGO_HOME = TARGET / "release-preflight-cargo-home"
 USER_AGENT = "formualizer-release-preflight/1 (https://github.com/psu3d0/formualizer)"
+DIRECT_SECRET_ENV = frozenset({"CARGO_REGISTRY_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"})
 
 
 @dataclass(frozen=True)
@@ -79,8 +80,19 @@ def run(command: list[str], *, env: dict[str, str] | None = None) -> None:
     subprocess.run(command, cwd=ROOT, env=env, check=True)
 
 
-def command_output(command: list[str]) -> str:
-    return subprocess.check_output(command, cwd=ROOT, text=True).strip()
+def command_output(command: list[str], *, env: dict[str, str] | None = None) -> str:
+    return subprocess.check_output(command, cwd=ROOT, env=env, text=True).strip()
+
+
+def credential_free_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in list(env):
+        if key in DIRECT_SECRET_ENV or (
+            key.startswith("CARGO_REGISTRIES_") and key.endswith("_TOKEN")
+        ):
+            env.pop(key)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    return env
 
 
 def assert_safe_project_path(path: Path) -> None:
@@ -152,7 +164,7 @@ def ensure_local_registry_tool() -> Path:
         tempfile.mkdtemp(prefix="cargo-local-registry-install-", dir=TOOL_ROOT.parent)
     )
     try:
-        env = os.environ.copy()
+        env = credential_free_environment()
         env["CARGO_HOME"] = str(TOOL_CARGO_HOME)
         run(
             [
@@ -418,7 +430,7 @@ def staging_environment(cargo_home: Path, registry: Path) -> dict[str, str]:
     cargo_home.mkdir(parents=True)
     config = f"""[source.crates-io]\nreplace-with = "formualizer-preflight"\n\n[source.formualizer-preflight]\nlocal-registry = {json.dumps(str(registry))}\n\n[net]\ngit-fetch-with-cli = true\n"""
     (cargo_home / "config.toml").write_text(config, encoding="utf-8")
-    env = os.environ.copy()
+    env = credential_free_environment()
     env["CARGO_HOME"] = str(cargo_home)
     return env
 
@@ -452,7 +464,10 @@ def seed_patched_registry_dependencies(
     """Add crates whose registry lock entry was replaced by a git/path patch."""
 
     metadata = json.loads(
-        command_output(["cargo", "metadata", "--no-deps", "--format-version", "1"])
+        command_output(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            env=credential_free_environment(),
+        )
     )
     lock = tomllib.loads((ROOT / "Cargo.lock").read_text(encoding="utf-8"))
     locked: dict[str, set[str]] = {}
@@ -496,7 +511,7 @@ def prepare_local_registry(
     registry = temp_root / "registry"
     cargo_home = temp_root / "cargo-home"
     registry.mkdir()
-    env = os.environ.copy()
+    env = credential_free_environment()
     env["CARGO_HOME"] = str(TOOL_CARGO_HOME)
     run([str(tool), "sync", str(ROOT / "Cargo.lock"), str(registry)], env=env)
     seed_patched_registry_dependencies(tool, registry, env, packages)
@@ -516,7 +531,7 @@ def preflight(track: str, allow_dirty: bool) -> None:
         downloads = temp_root / "downloads"
         downloads.mkdir()
         registry: Path | None = None
-        package_env: dict[str, str] | None = None
+        package_env = credential_free_environment()
         if len(packages) > 1:
             registry, package_env = prepare_local_registry(temp_root, packages)
 

--- a/scripts/release-preflight.py
+++ b/scripts/release-preflight.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Verify Formualizer release archives before a tag can publish them.
+
+The preflight builds crates in publish order against a temporary local Cargo
+registry, so downstream archives resolve the exact prospective upstream
+archives rather than workspace path dependencies or older crates.io releases.
+It also rejects source drift when a package version already exists on crates.io.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import tomllib
+
+ROOT = Path(__file__).resolve().parent.parent
+TARGET = ROOT / "target"
+LOCK_PATH = TARGET / "release-preflight.lock"
+TOOL_VERSION = "0.2.12"
+TOOLCHAIN = "1.93.0"
+TOOL_ROOT = TARGET / "release-preflight-tools" / f"cargo-local-registry-{TOOL_VERSION}"
+TOOL_BIN = TOOL_ROOT / "bin" / "cargo-local-registry"
+TOOL_CARGO_HOME = TARGET / "release-preflight-cargo-home"
+USER_AGENT = "formualizer-release-preflight/1 (https://github.com/psu3d0/formualizer)"
+
+
+@dataclass(frozen=True)
+class Package:
+    name: str
+    manifest: str
+
+    def version(self) -> str:
+        data = tomllib.loads((ROOT / self.manifest).read_text(encoding="utf-8"))
+        return str(data["package"]["version"])
+
+    def archive(self) -> Path:
+        return TARGET / "package" / f"{self.name}-{self.version()}.crate"
+
+
+COMMON = Package("formualizer-common", "crates/formualizer-common/Cargo.toml")
+PARSE = Package("formualizer-parse", "crates/formualizer-parse/Cargo.toml")
+SPEC = Package("sheetport-spec", "crates/sheetport-spec/Cargo.toml")
+MACROS = Package("formualizer-macros", "crates/formualizer-macros/Cargo.toml")
+EVAL = Package("formualizer-eval", "crates/formualizer-eval/Cargo.toml")
+WORKBOOK = Package("formualizer-workbook", "crates/formualizer-workbook/Cargo.toml")
+SHEETPORT = Package("formualizer-sheetport", "crates/formualizer-sheetport/Cargo.toml")
+FORMUALIZER = Package("formualizer", "crates/formualizer/Cargo.toml")
+
+TRACKS: dict[str, tuple[Package, ...]] = {
+    "parse": (COMMON, PARSE),
+    "spec": (SPEC,),
+    "product": (COMMON, PARSE, SPEC, MACROS, EVAL, WORKBOOK, SHEETPORT, FORMUALIZER),
+}
+
+# Cargo-generated metadata varies with the packaging Cargo version or source
+# commit. Cargo.toml.orig and every shipped source/data/doc file remain in the
+# comparison, so dependency requirements and payload behavior are still covered.
+DRIFT_EXCLUDES = frozenset({".cargo_vcs_info.json", "Cargo.toml", "Cargo.lock"})
+
+
+def run(command: list[str], *, env: dict[str, str] | None = None) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, cwd=ROOT, env=env, check=True)
+
+
+def command_output(command: list[str]) -> str:
+    return subprocess.check_output(command, cwd=ROOT, text=True).strip()
+
+
+def assert_safe_project_path(path: Path) -> None:
+    """Refuse symlinks for persistent preflight state below the repo target."""
+
+    target = TARGET
+    if target.exists() and target.is_symlink():
+        raise RuntimeError(f"refusing symlinked target directory: {target}")
+    try:
+        relative = path.relative_to(target)
+    except ValueError as exc:
+        raise RuntimeError(f"persistent path is outside target: {path}") from exc
+    cursor = target
+    for part in relative.parts:
+        cursor /= part
+        if cursor.exists() and cursor.is_symlink():
+            raise RuntimeError(f"refusing symlinked preflight path: {cursor}")
+
+
+def reject_tree_symlinks(root: Path) -> None:
+    if not root.exists():
+        return
+    for directory, names, files in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        for name in [*names, *files]:
+            candidate = directory_path / name
+            if candidate.is_symlink():
+                raise RuntimeError(
+                    f"refusing symlink in persistent preflight state: {candidate}"
+                )
+
+
+def ensure_clean(allow_dirty: bool) -> None:
+    status = command_output(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"]
+    )
+    if status and not allow_dirty:
+        raise RuntimeError(
+            "release preflight requires a clean checkout; commit/revert changes or pass "
+            "--allow-dirty for development-only validation\n" + status
+        )
+
+
+@contextlib.contextmanager
+def exclusive_lock() -> Iterator[None]:
+    assert_safe_project_path(LOCK_PATH)
+    TARGET.mkdir(parents=True, exist_ok=True)
+    with LOCK_PATH.open("a+", encoding="utf-8") as lock_file:
+        print("Waiting for exclusive release-preflight lock...", flush=True)
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        print("Acquired release-preflight lock.", flush=True)
+        yield
+
+
+def ensure_local_registry_tool() -> Path:
+    assert_safe_project_path(TOOL_BIN)
+    assert_safe_project_path(TOOL_CARGO_HOME)
+    reject_tree_symlinks(TOOL_ROOT)
+    reject_tree_symlinks(TOOL_CARGO_HOME)
+    if TOOL_BIN.exists():
+        actual = command_output([str(TOOL_BIN), "--version"])
+        if actual == f"cargo-local-registry {TOOL_VERSION}":
+            return TOOL_BIN
+        raise RuntimeError(f"unexpected tool at {TOOL_BIN}: {actual}")
+
+    TOOL_ROOT.parent.mkdir(parents=True, exist_ok=True)
+    TOOL_CARGO_HOME.mkdir(parents=True, exist_ok=True)
+    install_root = Path(
+        tempfile.mkdtemp(prefix="cargo-local-registry-install-", dir=TOOL_ROOT.parent)
+    )
+    try:
+        env = os.environ.copy()
+        env["CARGO_HOME"] = str(TOOL_CARGO_HOME)
+        run(
+            [
+                "cargo",
+                f"+{TOOLCHAIN}",
+                "install",
+                "cargo-local-registry",
+                "--version",
+                TOOL_VERSION,
+                "--locked",
+                "--root",
+                str(install_root),
+            ],
+            env=env,
+        )
+        candidate = install_root / "bin" / "cargo-local-registry"
+        actual = command_output([str(candidate), "--version"])
+        if actual != f"cargo-local-registry {TOOL_VERSION}":
+            raise RuntimeError(f"installed unexpected cargo-local-registry: {actual}")
+        if TOOL_ROOT.exists():
+            raise RuntimeError(f"tool destination appeared concurrently: {TOOL_ROOT}")
+        install_root.rename(TOOL_ROOT)
+    finally:
+        if install_root.exists():
+            shutil.rmtree(install_root)
+    return TOOL_BIN
+
+
+def registry_index_path(registry: Path, name: str) -> Path:
+    name = name.lower()
+    if len(name) == 1:
+        relative = Path("1") / name
+    elif len(name) == 2:
+        relative = Path("2") / name
+    elif len(name) == 3:
+        relative = Path("3") / name[0] / name
+    else:
+        relative = Path(name[:2]) / name[2:4] / name
+    return registry / "index" / relative
+
+
+def read_archive_file(archive: Path, relative: str) -> bytes:
+    root = f"{archive.name.removesuffix('.crate')}"
+    member_name = f"{root}/{relative}"
+    with tarfile.open(archive, "r:gz") as tf:
+        try:
+            member = tf.getmember(member_name)
+        except KeyError as exc:
+            raise RuntimeError(f"archive is missing {member_name}") from exc
+        fileobj = tf.extractfile(member)
+        if fileobj is None:
+            raise RuntimeError(f"archive member is not a file: {member_name}")
+        return fileobj.read()
+
+
+def dependency_records(
+    table: dict[str, Any], kind: str, target: str | None
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for alias, raw in sorted(table.items()):
+        data = raw if isinstance(raw, dict) else {"version": raw}
+        item: dict[str, Any] = {
+            "name": alias,
+            "req": str(data.get("version", "*")),
+            "features": list(data.get("features", [])),
+            "optional": bool(data.get("optional", False)),
+            "default_features": bool(data.get("default-features", True)),
+            "target": target,
+            "kind": kind,
+        }
+        if "package" in data:
+            item["package"] = str(data["package"])
+        if "registry" in data:
+            item["registry"] = str(data["registry"])
+        records.append(item)
+    return records
+
+
+def index_record_from_archive(archive: Path) -> dict[str, Any]:
+    manifest = tomllib.loads(read_archive_file(archive, "Cargo.toml").decode("utf-8"))
+    package = manifest["package"]
+    dependencies: list[dict[str, Any]] = []
+    dependencies.extend(
+        dependency_records(manifest.get("dependencies", {}), "normal", None)
+    )
+    dependencies.extend(
+        dependency_records(manifest.get("dev-dependencies", {}), "dev", None)
+    )
+    dependencies.extend(
+        dependency_records(manifest.get("build-dependencies", {}), "build", None)
+    )
+    for target, tables in sorted(manifest.get("target", {}).items()):
+        dependencies.extend(
+            dependency_records(tables.get("dependencies", {}), "normal", target)
+        )
+        dependencies.extend(
+            dependency_records(tables.get("dev-dependencies", {}), "dev", target)
+        )
+        dependencies.extend(
+            dependency_records(tables.get("build-dependencies", {}), "build", target)
+        )
+
+    ordinary_features: dict[str, list[str]] = {}
+    namespaced_features: dict[str, list[str]] = {}
+    for feature, values in sorted(manifest.get("features", {}).items()):
+        values = list(values)
+        if any(value.startswith("dep:") or "?/" in value for value in values):
+            namespaced_features[feature] = values
+        else:
+            ordinary_features[feature] = values
+
+    record: dict[str, Any] = {
+        "name": str(package["name"]),
+        "vers": str(package["version"]),
+        "deps": dependencies,
+        "cksum": hashlib.sha256(archive.read_bytes()).hexdigest(),
+        "features": ordinary_features,
+        "yanked": False,
+    }
+    if namespaced_features:
+        record["features2"] = namespaced_features
+        record["v"] = 2
+    if package.get("links"):
+        record["links"] = str(package["links"])
+    if package.get("rust-version"):
+        record["rust_version"] = str(package["rust-version"])
+    return record
+
+
+def registry_has_version(registry: Path, name: str, version: str) -> bool:
+    index_path = registry_index_path(registry, name)
+    if not index_path.exists():
+        return False
+    return any(
+        json.loads(line).get("vers") == version
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if line
+    )
+
+
+def add_archive_to_registry(registry: Path, archive: Path) -> dict[str, Any]:
+    record = index_record_from_archive(archive)
+    destination = registry / archive.name
+    shutil.copyfile(archive, destination)
+    index_path = registry_index_path(registry, record["name"])
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[dict[str, Any]] = []
+    if index_path.exists():
+        existing = [
+            json.loads(line) for line in index_path.read_text().splitlines() if line
+        ]
+    existing = [item for item in existing if item.get("vers") != record["vers"]]
+    existing.append(record)
+    existing.sort(key=lambda item: item["vers"])
+    index_path.write_text(
+        "".join(
+            json.dumps(item, separators=(",", ":"), sort_keys=True) + "\n"
+            for item in existing
+        ),
+        encoding="utf-8",
+    )
+    print(f"Staged {record['name']} {record['vers']} ({record['cksum']})", flush=True)
+    return record
+
+
+def archive_payload(archive: Path) -> dict[str, str]:
+    """Return stable shipped-file hashes and reject unsafe/ambiguous members."""
+
+    expected_root = archive.name.removesuffix(".crate")
+    payload: dict[str, str] = {}
+    with tarfile.open(archive, "r:gz") as tf:
+        for member in tf.getmembers():
+            path = PurePosixPath(member.name)
+            if path.is_absolute() or ".." in path.parts:
+                raise RuntimeError(f"unsafe archive path: {member.name}")
+            if not path.parts or path.parts[0] != expected_root:
+                raise RuntimeError(f"unexpected archive root: {member.name}")
+            if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+                raise RuntimeError(f"unsafe archive member type: {member.name}")
+            if member.isdir():
+                continue
+            if not member.isfile():
+                raise RuntimeError(f"unsupported archive member type: {member.name}")
+            relative = PurePosixPath(*path.parts[1:]).as_posix()
+            if relative in DRIFT_EXCLUDES:
+                continue
+            if relative in payload:
+                raise RuntimeError(f"duplicate archive member: {relative}")
+            fileobj = tf.extractfile(member)
+            if fileobj is None:
+                raise RuntimeError(f"could not read archive member: {member.name}")
+            payload[relative] = hashlib.sha256(fileobj.read()).hexdigest()
+    return payload
+
+
+def crates_io_version(name: str, version: str) -> dict[str, Any] | None:
+    url = f"https://crates.io/api/v1/crates/{name}/{version}"
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)["version"]
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def download_registry_archive(
+    name: str, version: str, destination: Path, expected: str
+) -> None:
+    url = f"https://crates.io/api/v1/crates/{name}/{version}/download"
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with (
+        urllib.request.urlopen(request, timeout=60) as response,
+        destination.open("wb") as output,
+    ):
+        shutil.copyfileobj(response, output)
+    actual = hashlib.sha256(destination.read_bytes()).hexdigest()
+    if actual != expected:
+        raise RuntimeError(
+            f"registry checksum mismatch for {name} {version}: expected {expected}, got {actual}"
+        )
+
+
+def check_same_version_drift(
+    package: Package, local_archive: Path, downloads: Path
+) -> str:
+    version = package.version()
+    metadata = crates_io_version(package.name, version)
+    if metadata is None:
+        print(f"No crates.io collision for {package.name} {version}.", flush=True)
+        return "new"
+
+    registry_archive = downloads / f"{package.name}-{version}.crate"
+    download_registry_archive(
+        package.name, version, registry_archive, str(metadata["checksum"])
+    )
+    local_payload = archive_payload(local_archive)
+    registry_payload = archive_payload(registry_archive)
+    if local_payload != registry_payload:
+        local_names = set(local_payload)
+        registry_names = set(registry_payload)
+        added = sorted(local_names - registry_names)
+        removed = sorted(registry_names - local_names)
+        changed = sorted(
+            name
+            for name in local_names & registry_names
+            if local_payload[name] != registry_payload[name]
+        )
+        details = [
+            f"same-version source drift for {package.name} {version}",
+            f"  added: {added[:20]}",
+            f"  removed: {removed[:20]}",
+            f"  changed: {changed[:20]}",
+            "bump the package version or restore the published payload before release",
+        ]
+        raise RuntimeError("\n".join(details))
+    print(f"Published payload matches {package.name} {version}.", flush=True)
+    return "matching"
+
+
+def staging_environment(cargo_home: Path, registry: Path) -> dict[str, str]:
+    cargo_home.mkdir(parents=True)
+    config = f"""[source.crates-io]\nreplace-with = "formualizer-preflight"\n\n[source.formualizer-preflight]\nlocal-registry = {json.dumps(str(registry))}\n\n[net]\ngit-fetch-with-cli = true\n"""
+    (cargo_home / "config.toml").write_text(config, encoding="utf-8")
+    env = os.environ.copy()
+    env["CARGO_HOME"] = str(cargo_home)
+    return env
+
+
+def package_one(
+    package: Package, env: dict[str, str] | None, *, allow_dirty: bool
+) -> Path:
+    archive = package.archive()
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    if archive.exists():
+        archive.unlink()
+    command = ["cargo", "package", "-p", package.name, "--locked"]
+    if allow_dirty:
+        command.append("--allow-dirty")
+    run(command, env=env)
+    if not archive.is_file():
+        raise RuntimeError(f"cargo package did not produce {archive}")
+    archive_payload(archive)
+    record = index_record_from_archive(archive)
+    if record["name"] != package.name or record["vers"] != package.version():
+        raise RuntimeError(f"archive identity mismatch for {package.name}: {record}")
+    return archive
+
+
+def seed_patched_registry_dependencies(
+    tool: Path, registry: Path, env: dict[str, str]
+) -> None:
+    """Add crates whose registry lock entry was replaced by a git/path patch."""
+
+    metadata = json.loads(
+        command_output(["cargo", "metadata", "--no-deps", "--format-version", "1"])
+    )
+    lock = tomllib.loads((ROOT / "Cargo.lock").read_text(encoding="utf-8"))
+    locked: dict[str, set[str]] = {}
+    for package in lock.get("package", []):
+        locked.setdefault(str(package["name"]), set()).add(str(package["version"]))
+
+    requirements: dict[str, set[str]] = {}
+    for package in metadata["packages"]:
+        for dependency in package["dependencies"]:
+            source = dependency.get("source") or ""
+            if not source.startswith("registry+"):
+                continue
+            requirements.setdefault(str(dependency["name"]), set()).add(
+                str(dependency["req"])
+            )
+
+    for name, reqs in sorted(requirements.items()):
+        candidates = locked.get(name, set())
+        exact = {req[1:] for req in reqs if req.startswith("=")}
+        versions = sorted(candidates & exact if exact else candidates)
+        for version in versions:
+            if registry_has_version(registry, name, version):
+                continue
+            print(
+                f"Seeding registry fallback for patched dependency {name} {version}.",
+                flush=True,
+            )
+            run(
+                [str(tool), "add", name, "--version", version, str(registry)],
+                env=env,
+            )
+
+
+def prepare_local_registry(temp_root: Path) -> tuple[Path, dict[str, str]]:
+    tool = ensure_local_registry_tool()
+    registry = temp_root / "registry"
+    cargo_home = temp_root / "cargo-home"
+    registry.mkdir()
+    env = os.environ.copy()
+    env["CARGO_HOME"] = str(TOOL_CARGO_HOME)
+    run([str(tool), "sync", str(ROOT / "Cargo.lock"), str(registry)], env=env)
+    seed_patched_registry_dependencies(tool, registry, env)
+    return registry, staging_environment(cargo_home, registry)
+
+
+def preflight(track: str, allow_dirty: bool) -> None:
+    ensure_clean(allow_dirty)
+    packages = TRACKS[track]
+    with (
+        exclusive_lock(),
+        tempfile.TemporaryDirectory(
+            prefix=f"formualizer-{track}-preflight-"
+        ) as temp_name,
+    ):
+        temp_root = Path(temp_name)
+        downloads = temp_root / "downloads"
+        downloads.mkdir()
+        registry: Path | None = None
+        package_env: dict[str, str] | None = None
+        if len(packages) > 1:
+            registry, package_env = prepare_local_registry(temp_root)
+
+        results: list[dict[str, str]] = []
+        for package in packages:
+            archive = package_one(package, package_env, allow_dirty=allow_dirty)
+            collision = check_same_version_drift(package, archive, downloads)
+            if registry is not None:
+                add_archive_to_registry(registry, archive)
+            results.append(
+                {
+                    "name": package.name,
+                    "version": package.version(),
+                    "archive_sha256": hashlib.sha256(archive.read_bytes()).hexdigest(),
+                    "registry_collision": collision,
+                }
+            )
+
+        print(json.dumps({"track": track, "packages": results}, indent=2), flush=True)
+        print(f"Release preflight passed for {track}.", flush=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--track", required=True, choices=sorted(TRACKS))
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="permit uncommitted source for development validation; never use for a release tag",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        preflight(args.track, args.allow_dirty)
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        subprocess.CalledProcessError,
+        tarfile.TarError,
+    ) as exc:
+        print(f"release preflight failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "release-preflight.py"
+SPEC = importlib.util.spec_from_file_location("release_preflight", SCRIPT)
+assert SPEC and SPEC.loader
+release_preflight = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release_preflight
+SPEC.loader.exec_module(release_preflight)
+
+
+def crate_archive(
+    path: Path, files: dict[str, bytes], *, symlink: str | None = None
+) -> Path:
+    root = path.name.removesuffix(".crate")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(path, "w:gz") as archive:
+        for relative, contents in files.items():
+            info = tarfile.TarInfo(f"{root}/{relative}")
+            info.size = len(contents)
+            archive.addfile(info, io.BytesIO(contents))
+        if symlink is not None:
+            info = tarfile.TarInfo(f"{root}/unsafe-link")
+            info.type = tarfile.SYMTYPE
+            info.linkname = symlink
+            archive.addfile(info)
+    return path
+
+
+class ReleasePreflightTests(unittest.TestCase):
+    def test_registry_index_paths_follow_cargo_layout(self) -> None:
+        registry = Path("/registry")
+        self.assertEqual(
+            release_preflight.registry_index_path(registry, "formualizer-common"),
+            registry / "index/fo/rm/formualizer-common",
+        )
+        self.assertEqual(
+            release_preflight.registry_index_path(registry, "abc"),
+            registry / "index/3/a/abc",
+        )
+        self.assertEqual(
+            release_preflight.registry_index_path(registry, "ab"),
+            registry / "index/2/ab",
+        )
+
+    def test_index_record_uses_packaged_manifest_and_checksum(self) -> None:
+        manifest = b"""[package]\nname = "demo-crate"\nversion = "1.2.3"\nrust-version = "1.80"\n\n[features]\ndefault = []\nserde = ["dep:serde", "common/serde"]\n\n[dependencies.common]\nversion = "3.0.0"\n\n[dependencies.serde]\nversion = "1"\noptional = true\nfeatures = ["derive"]\n\n[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom02]\nversion = "0.2"\npackage = "getrandom"\nfeatures = ["js"]\n"""
+        with tempfile.TemporaryDirectory() as temp:
+            archive = crate_archive(
+                Path(temp) / "demo-crate-1.2.3.crate",
+                {
+                    "Cargo.toml": manifest,
+                    "Cargo.toml.orig": manifest,
+                    "src/lib.rs": b"",
+                },
+            )
+            record = release_preflight.index_record_from_archive(archive)
+
+        self.assertEqual(record["name"], "demo-crate")
+        self.assertEqual(record["vers"], "1.2.3")
+        self.assertEqual(record["rust_version"], "1.80")
+        self.assertEqual(record["features"], {"default": []})
+        self.assertEqual(record["features2"], {"serde": ["dep:serde", "common/serde"]})
+        self.assertEqual(record["v"], 2)
+        renamed = next(dep for dep in record["deps"] if dep["name"] == "getrandom02")
+        self.assertEqual(renamed["package"], "getrandom")
+        self.assertEqual(renamed["target"], 'cfg(target_arch = "wasm32")')
+        self.assertEqual(renamed["kind"], "normal")
+
+    def test_index_record_requires_packaged_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            archive = crate_archive(
+                Path(temp) / "demo-1.0.0.crate", {"src/lib.rs": b""}
+            )
+            with self.assertRaisesRegex(RuntimeError, "archive is missing"):
+                release_preflight.index_record_from_archive(archive)
+
+    def test_payload_ignores_generated_metadata_but_not_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            first = crate_archive(
+                Path(temp) / "demo-1.0.0.crate",
+                {
+                    ".cargo_vcs_info.json": b"commit-a",
+                    "Cargo.toml": b"generated-a",
+                    "Cargo.lock": b"lock-a",
+                    "Cargo.toml.orig": b"version = '1.0.0'",
+                    "src/lib.rs": b"pub fn value() -> u8 { 1 }",
+                },
+            )
+            payload = release_preflight.archive_payload(first)
+            self.assertEqual(set(payload), {"Cargo.toml.orig", "src/lib.rs"})
+
+            second = crate_archive(
+                Path(temp) / "other" / "demo-1.0.0.crate",
+                {
+                    ".cargo_vcs_info.json": b"commit-b",
+                    "Cargo.toml": b"generated-b",
+                    "Cargo.lock": b"lock-b",
+                    "Cargo.toml.orig": b"version = '1.0.0'",
+                    "src/lib.rs": b"pub fn value() -> u8 { 2 }",
+                },
+            )
+            self.assertNotEqual(payload, release_preflight.archive_payload(second))
+
+    def test_payload_rejects_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            archive = crate_archive(
+                Path(temp) / "demo-1.0.0.crate",
+                {"Cargo.toml.orig": b"[package]"},
+                symlink="../../outside",
+            )
+            with self.assertRaisesRegex(RuntimeError, "unsafe archive member type"):
+                release_preflight.archive_payload(archive)
+
+    def test_persistent_state_rejects_nested_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "real").mkdir()
+            (root / "real" / "link").symlink_to(root / "outside")
+            with self.assertRaisesRegex(
+                RuntimeError, "symlink in persistent preflight state"
+            ):
+                release_preflight.reject_tree_symlinks(root)
+
+    def test_track_order_matches_publish_dependencies(self) -> None:
+        self.assertEqual(
+            [package.name for package in release_preflight.TRACKS["parse"]],
+            ["formualizer-common", "formualizer-parse"],
+        )
+        self.assertEqual(
+            [package.name for package in release_preflight.TRACKS["product"]],
+            [
+                "formualizer-common",
+                "formualizer-parse",
+                "sheetport-spec",
+                "formualizer-macros",
+                "formualizer-eval",
+                "formualizer-workbook",
+                "formualizer-sheetport",
+                "formualizer",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import os
 import sys
 import tarfile
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPT = Path(__file__).resolve().parents[1] / "release-preflight.py"
 SPEC = importlib.util.spec_from_file_location("release_preflight", SCRIPT)
@@ -35,6 +37,20 @@ def crate_archive(
 
 
 class ReleasePreflightTests(unittest.TestCase):
+    def test_subprocess_environment_drops_release_credentials(self) -> None:
+        source = {
+            "PATH": "/bin",
+            "CARGO_REGISTRY_TOKEN": "secret",
+            "CARGO_REGISTRIES_PRIVATE_TOKEN": "private",
+            "GH_TOKEN": "gh-secret",
+            "GITHUB_TOKEN": "actions-secret",
+        }
+        with mock.patch.dict(os.environ, source, clear=True):
+            env = release_preflight.credential_free_environment()
+        self.assertEqual(env["PATH"], "/bin")
+        self.assertEqual(env["GIT_TERMINAL_PROMPT"], "0")
+        self.assertFalse(any(key.endswith("TOKEN") for key in env))
+
     def test_registry_index_paths_follow_cargo_layout(self) -> None:
         registry = Path("/registry")
         self.assertEqual(


### PR DESCRIPTION
## Summary

- add a clean-checkout release preflight for the parse, spec, and product crate tracks
- package multi-crate tracks through a temporary local Cargo registry in publish order so downstream verification consumes the exact prospective upstream archives
- reject unchanged-version source drift against crates.io while excluding only Cargo-generated metadata
- repeat the preflight in tag workflows before publish jobs receive a registry token
- document the required pre-tag command and retain unit coverage in ordinary CI

## Package authority

`release-preflight.py` installs exact `cargo-local-registry 0.2.12` with Rust 1.93.0 into an isolated target directory. It syncs third-party locked crates, seeds registry fallbacks hidden by workspace git patches, packages each local crate, validates archive members, stages the archive and generated index record, and then packages the next dependent crate against those exact bytes.

The track order is:

- parse: common → parse
- spec: sheetport-spec
- product: common → parse → sheetport-spec → macros → eval → workbook → SheetPort → roll-up

For versions already on crates.io, the downloaded archive checksum is verified and its payload is compared to the local archive. Generated `Cargo.toml`, `Cargo.lock`, and `.cargo_vcs_info.json` are excluded; `Cargo.toml.orig`, source, tests, docs, schemas, and data remain authoritative.

## Validation

- clean parse preflight passed for common/parse 3.0.0
- clean spec preflight passed for sheetport-spec 0.3.1
- a temporary product 0.8.0 bump completed all eight staged package builds and verifications through the roll-up crate, including the patched umya registry fallback; all package versions were restored afterwards
- the current unbumped product track correctly fails on same-version eval 0.7.1 drift, listing added, removed, and changed payload files
- an existing unchanged macros 0.7.1 archive matches crates.io, proving the collision check accepts equality rather than rejecting every existing version
- two concurrent spec runs serialize on the exclusive lock and both pass
- dirty-checkout, persistent-state symlink, and unsafe archive-member mutations fail closed
- inherited Cargo/GitHub token variables are scrubbed, Git prompting is disabled, and verification checkouts do not persist GitHub credentials
- eight standard-library unit tests pass
- Ruff lint/format and Python AST checks pass
- CI and release workflow YAML parse successfully

Final clean prospective hashes at this commit:

- sheetport-spec 0.3.1: `1b10e422d5321f3ebe11aef264ef8d1bd6a6d552e9d53d0c04d4f4ad6a603178`
- formualizer-common 3.0.0: `d0690e7b6061a55a79b06d380f597beddfe7354aa4c705744770fb46c627d5bb`
- formualizer-parse 3.0.0: `16b0a758be871afe78cf41c588e3b547b55e0a2942527ed126fa2c028e3da93d`

## Release stop

No tags or publications are performed by this PR. After merge, the pre-tag commands still require explicit approval before `parse-v3.0.0` or `sheetport-spec-v0.3.1` is created.

Refs #257
Refs #258

drafted with love by (agent) Manfred, with approval from Frankie
