### PR TITLE
fix(python): invalidate cache before undo replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Python `Workbook.undo()` and `redo()` now invalidate the compatibility cell cache before replay, so `Workbook.get_value()` and existing `Sheet` handles immediately reflect authoritative values after successful, failed, or no-op replay without introducing a cache-lock panic.
 - Authoritative FormulaPlane fallback no longer reports a false `#CIRC!` when a statically indexed compressed range contains the formula cell but `INDEX` selects a different cell. Whole-row, whole-column, bounded, omitted-column, zero, negative, and genuine self-selection cases now follow the same reference semantics in Off and authoritative modes.
 - Deferred malformed-formula retries now publish one parse diagnostic per successful ingest event instead of duplicating a source record during authoritative replay; a later distinct ingest of the same malformed source still emits its own diagnostic.
 - Compatibility-widened target preparation now performs the same final graph, authority, staged, symbol, provider, and relevant function-semantic revision validation as exact preparation before publishing. Provider changes and injected final-validation failures remain atomic in Off, Shadow, and authoritative modes.

--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -1042,8 +1042,15 @@ impl PyWorkbook {
             .inner
             .write()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        {
+            let mut sheets = self.sheets.write().map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
+            })?;
+            sheets.clear();
+        }
         wb.undo()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(())
     }
 
     /// Redo the most recently undone edit.
@@ -1052,8 +1059,15 @@ impl PyWorkbook {
             .inner
             .write()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        {
+            let mut sheets = self.sheets.write().map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
+            })?;
+            sheets.clear();
+        }
         wb.redo()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        Ok(())
     }
 
     // Batch ops

--- a/bindings/python/tests/test_undo_redo_cache.py
+++ b/bindings/python/tests/test_undo_redo_cache.py
@@ -1,0 +1,46 @@
+import formualizer as fz
+
+
+def workbook_with_overwritten_value():
+    workbook = fz.Workbook(config=fz.WorkbookConfig(enable_changelog=True))
+    sheet = workbook.sheet("Sheet1")
+    sheet.set_value(1, 1, "before")
+    sheet.set_value(1, 1, "after")
+    return workbook, sheet
+
+
+def test_undo_updates_all_public_value_readers():
+    workbook, sheet = workbook_with_overwritten_value()
+
+    assert workbook.get_value("Sheet1", 1, 1) == "after"
+    assert sheet.get_cell(1, 1).value == "after"
+
+    workbook.undo()
+
+    assert workbook.get_value("Sheet1", 1, 1) == "before"
+    assert sheet.get_cell(1, 1).value == "before"
+
+
+def test_redo_updates_all_public_value_readers():
+    workbook, sheet = workbook_with_overwritten_value()
+    workbook.undo()
+
+    assert workbook.get_value("Sheet1", 1, 1) == "before"
+    assert sheet.get_cell(1, 1).value == "before"
+
+    workbook.redo()
+
+    assert workbook.get_value("Sheet1", 1, 1) == "after"
+    assert sheet.get_cell(1, 1).value == "after"
+
+
+def test_undo_redo_are_noops_when_changelog_disabled():
+    workbook = fz.Workbook(config=fz.WorkbookConfig(enable_changelog=False))
+    sheet = workbook.sheet("Sheet1")
+    sheet.set_value(1, 1, "value")
+
+    workbook.undo()
+    assert workbook.get_value("Sheet1", 1, 1) == "value"
+
+    workbook.redo()
+    assert workbook.get_value("Sheet1", 1, 1) == "value"


### PR DESCRIPTION
## Summary

- invalidate the Python compatibility cell cache before undo and redo replay
- return `PyRuntimeError` rather than panic if the cache lock is poisoned
- pin authoritative reads through both `Workbook.get_value()` and an existing `Sheet` handle

This extracts one independently reproduced correctness defect reported by @Ocean82 in #263. It does not merge or copy the broader PR bundle.

## Root cause

The Rust workbook is authoritative, while the Python binding maintains a write-through compatibility cache shared by `PyWorkbook` clones and `PySheet` handles. Python setters update both stores, but undo and redo previously changed only the authoritative workbook. A warmed cache therefore continued returning the pre-replay value.

Undo and redo now acquire the authoritative write lock, clear the cache through typed lock-error handling, release the cache guard, and then invoke replay. Clearing before replay means successful, failed, and no-op operations all fall back to whatever authoritative state actually remains. Readers release the cache lock before acquiring the workbook lock, so this preserves the established lock order.

## Validation

- red-before-green reproduction on `661b7d7a`
- focused Python regression: 3 passed
- full Python binding suite: 70 passed
- `cargo test -p formualizer-python --all-features`: 12 passed
- affected workbook and eval undo suites passed
- Ruff check and format check passed
- Cargo formatting and clippy with warnings denied passed
- two Luna review passes; final verdict: accept with no blocker or major finding

## Scope

All other #263 claims remain unaddressed and will be evaluated as separate serial tranches. This PR contains no generated binaries, dependency updates, npm/docs changes, broad unwrap cleanup, or unrelated math changes.

drafted with love by (agent) Manfred, with approval from Frankie
