### PR TITLE
fix(cffi): validate cell coordinates at boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- CFFI cell and rectangular block entry points now reject zero, out-of-grid, and overflowing Excel coordinates with a typed status before touching workbook state, preventing packed-coordinate aborts.
 - Python `Workbook.undo()` and `redo()` now invalidate the compatibility cell cache before replay, so `Workbook.get_value()` and existing `Sheet` handles immediately reflect authoritative values after successful, failed, or no-op replay without introducing a cache-lock panic.
 - Authoritative FormulaPlane fallback no longer reports a false `#CIRC!` when a statically indexed compressed range contains the formula cell but `INDEX` selects a different cell. Whole-row, whole-column, bounded, omitted-column, zero, negative, and genuine self-selection cases now follow the same reference semantics in Off and authoritative modes.
 - Deferred malformed-formula retries now publish one parse diagnostic per successful ingest event instead of duplicating a source record during authoritative replay; a later distinct ingest of the same malformed source still emits its own diagnostic.

--- a/crates/formualizer-cffi/src/workbook.rs
+++ b/crates/formualizer-cffi/src/workbook.rs
@@ -39,6 +39,75 @@ struct CffiCellTarget {
     col: u32,
 }
 
+const EXCEL_MAX_ROWS: u32 = 1_048_576;
+const EXCEL_MAX_COLS: u32 = 16_384;
+
+/// Validate a 1-based cell or block before it reaches the workbook engine.
+fn checked_excel_coordinates(
+    start_row: u32,
+    start_col: u32,
+    block_dimensions: Option<(usize, usize)>,
+) -> Result<(), String> {
+    if !(1..=EXCEL_MAX_ROWS).contains(&start_row) {
+        return Err(format!(
+            "row {start_row} is outside Excel's valid range 1..={EXCEL_MAX_ROWS}"
+        ));
+    }
+    if !(1..=EXCEL_MAX_COLS).contains(&start_col) {
+        return Err(format!(
+            "column {start_col} is outside Excel's valid range 1..={EXCEL_MAX_COLS}"
+        ));
+    }
+
+    let Some((height, width)) = block_dimensions else {
+        return Ok(());
+    };
+    if height == 0 || width == 0 {
+        return Ok(());
+    }
+
+    let row_offset =
+        u32::try_from(height - 1).map_err(|_| "cell block row extent exceeds u32".to_string())?;
+    let col_offset =
+        u32::try_from(width - 1).map_err(|_| "cell block column extent exceeds u32".to_string())?;
+    let end_row = start_row
+        .checked_add(row_offset)
+        .ok_or_else(|| "cell block row extent overflows".to_string())?;
+    let end_col = start_col
+        .checked_add(col_offset)
+        .ok_or_else(|| "cell block column extent overflows".to_string())?;
+
+    if end_row > EXCEL_MAX_ROWS {
+        return Err(format!(
+            "cell block ends at row {end_row}, outside Excel's valid range 1..={EXCEL_MAX_ROWS}"
+        ));
+    }
+    if end_col > EXCEL_MAX_COLS {
+        return Err(format!(
+            "cell block ends at column {end_col}, outside Excel's valid range 1..={EXCEL_MAX_COLS}"
+        ));
+    }
+    Ok(())
+}
+
+fn actual_block_dimensions<T>(rows: &[Vec<T>]) -> (usize, usize) {
+    let height = rows
+        .iter()
+        .rposition(|row| !row.is_empty())
+        .map_or(0, |index| index + 1);
+    let width = rows.iter().map(Vec::len).max().unwrap_or(0);
+    (height, width)
+}
+
+fn formula_block_dimensions(rows: &[Vec<String>]) -> (usize, usize) {
+    let width = rows.iter().map(Vec::len).max().unwrap_or(0);
+    if width == 0 {
+        (0, 0)
+    } else {
+        (rows.len(), width)
+    }
+}
+
 fn decode_payload<T: DeserializeOwned>(
     payload: *const u8,
     len: usize,
@@ -202,6 +271,14 @@ pub unsafe extern "C" fn fz_workbook_set_cell_value(
         }
         return;
     }
+    if let Err(e) = checked_excel_coordinates(row, col, None) {
+        if !status.is_null() {
+            unsafe {
+                *status = fz_status::error(e);
+            }
+        }
+        return;
+    }
 
     let opaque = unsafe { &*(wb.0 as *mut OpaqueWorkbook) };
     let sheet_str = unsafe { CStr::from_ptr(sheet).to_string_lossy() };
@@ -259,6 +336,14 @@ pub unsafe extern "C" fn fz_workbook_set_cell_formula(
         }
         return;
     }
+    if let Err(e) = checked_excel_coordinates(row, col, None) {
+        if !status.is_null() {
+            unsafe {
+                *status = fz_status::error(e);
+            }
+        }
+        return;
+    }
 
     let opaque = unsafe { &*(wb.0 as *mut OpaqueWorkbook) };
     let sheet_str = unsafe { CStr::from_ptr(sheet).to_string_lossy() };
@@ -290,6 +375,14 @@ pub unsafe extern "C" fn fz_workbook_get_cell_formula(
         if !status.is_null() {
             unsafe {
                 *status = fz_status::error("invalid arguments".to_string());
+            }
+        }
+        return fz_buffer::empty();
+    }
+    if let Err(e) = checked_excel_coordinates(row, col, None) {
+        if !status.is_null() {
+            unsafe {
+                *status = fz_status::error(e);
             }
         }
         return fz_buffer::empty();
@@ -334,6 +427,14 @@ pub unsafe extern "C" fn fz_workbook_get_cell_value(
         if !status.is_null() {
             unsafe {
                 *status = fz_status::error("invalid arguments".to_string());
+            }
+        }
+        return fz_buffer::empty();
+    }
+    if let Err(e) = checked_excel_coordinates(row, col, None) {
+        if !status.is_null() {
+            unsafe {
+                *status = fz_status::error(e);
             }
         }
         return fz_buffer::empty();
@@ -485,6 +586,16 @@ pub unsafe extern "C" fn fz_workbook_evaluate_cells(
             return fz_buffer::empty();
         }
     };
+    for target in &targets {
+        if let Err(e) = checked_excel_coordinates(target.row, target.col, None) {
+            if !status.is_null() {
+                unsafe {
+                    *status = fz_status::error(e);
+                }
+            }
+            return fz_buffer::empty();
+        }
+    }
 
     let mut sheets: BTreeSet<&str> = BTreeSet::new();
     for target in &targets {
@@ -809,6 +920,16 @@ pub unsafe extern "C" fn fz_workbook_set_values(
             return;
         }
     };
+    if let Err(e) =
+        checked_excel_coordinates(start_row, start_col, Some(actual_block_dimensions(&values)))
+    {
+        if !status.is_null() {
+            unsafe {
+                *status = fz_status::error(e);
+            }
+        }
+        return;
+    }
 
     let opaque = unsafe { &*(wb.0 as *mut OpaqueWorkbook) };
     let sheet_str = unsafe { CStr::from_ptr(sheet).to_string_lossy() };
@@ -858,6 +979,18 @@ pub unsafe extern "C" fn fz_workbook_set_formulas(
             return;
         }
     };
+    if let Err(e) = checked_excel_coordinates(
+        start_row,
+        start_col,
+        Some(formula_block_dimensions(&formulas)),
+    ) {
+        if !status.is_null() {
+            unsafe {
+                *status = fz_status::error(e);
+            }
+        }
+        return;
+    }
 
     let opaque = unsafe { &*(wb.0 as *mut OpaqueWorkbook) };
     let sheet_str = unsafe { CStr::from_ptr(sheet).to_string_lossy() };
@@ -873,5 +1006,22 @@ pub unsafe extern "C" fn fz_workbook_set_formulas(
         unsafe {
             *status = fz_status::ok();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_excel_coordinates_cover_limits_and_extents() {
+        assert!(checked_excel_coordinates(0, 1, None).is_err());
+        assert!(checked_excel_coordinates(EXCEL_MAX_ROWS, EXCEL_MAX_COLS, None).is_ok());
+        assert!(checked_excel_coordinates(EXCEL_MAX_ROWS + 1, 1, None).is_err());
+        assert!(checked_excel_coordinates(1, EXCEL_MAX_COLS + 1, None).is_err());
+        assert!(checked_excel_coordinates(EXCEL_MAX_ROWS, 1, Some((2, 1))).is_err());
+        assert!(checked_excel_coordinates(1, EXCEL_MAX_COLS, Some((1, 2))).is_err());
+        assert!(checked_excel_coordinates(1, 1, Some((usize::MAX, 1))).is_err());
+        assert!(checked_excel_coordinates(1, 1, Some((1, usize::MAX))).is_err());
     }
 }

--- a/crates/formualizer-cffi/tests/ffi_guardrails.rs
+++ b/crates/formualizer-cffi/tests/ffi_guardrails.rs
@@ -1,6 +1,473 @@
 use formualizer_cffi::*;
 use std::ffi::CString;
+use std::process::Command;
 use std::ptr;
+
+unsafe fn clear_status(status: &mut fz_status) {
+    let error = std::mem::replace(&mut status.error, fz_buffer::empty());
+    unsafe {
+        fz_buffer_free(error);
+    }
+}
+
+#[test]
+fn invalid_coordinate_subprocess() {
+    if std::env::var_os("FORMUALIZER_CFFI_COORDINATE_CHILD").is_some() {
+        unsafe {
+            let mut status = fz_status::ok();
+            let wb = fz_workbook_create(&mut status);
+            let sheet = CString::new("Sheet1").unwrap();
+            fz_workbook_add_sheet(wb, sheet.as_ptr(), &mut status);
+            let value = "{\"Number\":1.0}";
+            fz_workbook_set_cell_value(
+                wb,
+                sheet.as_ptr(),
+                1,
+                1,
+                value.as_ptr(),
+                value.len(),
+                fz_encoding_format::FZ_ENCODING_JSON,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+            let values = "[[{\"Number\":1.0}],[{\"Number\":2.0}]]";
+            fz_workbook_set_values(
+                wb,
+                sheet.as_ptr(),
+                1_048_576,
+                1,
+                values.as_ptr(),
+                values.len(),
+                fz_encoding_format::FZ_ENCODING_JSON,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            clear_status(&mut status);
+            fz_workbook_free(wb);
+        }
+        return;
+    }
+
+    let status = Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("invalid_coordinate_subprocess")
+        .env("FORMUALIZER_CFFI_COORDINATE_CHILD", "1")
+        .status()
+        .unwrap();
+    assert!(status.success(), "coordinate child exited with {status}");
+}
+
+#[test]
+fn coordinate_boundaries_are_checked_atomically() {
+    unsafe {
+        let mut status = fz_status::ok();
+        let wb = fz_workbook_create(&mut status);
+        let sheet = CString::new("Sheet1").unwrap();
+        fz_workbook_add_sheet(wb, sheet.as_ptr(), &mut status);
+
+        let value = "{\"Number\":7.0}";
+        fz_workbook_set_cell_value(
+            wb,
+            sheet.as_ptr(),
+            1,
+            1,
+            value.as_ptr(),
+            value.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        for &(row, col) in &[(0, 1), (1_048_576 + 1, 1), (1, 0), (1, 16_384 + 1)] {
+            let cell = fz_workbook_get_cell_value(
+                wb,
+                sheet.as_ptr(),
+                row,
+                col,
+                fz_encoding_format::FZ_ENCODING_JSON,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            fz_buffer_free(cell);
+            clear_status(&mut status);
+
+            let formula = fz_workbook_get_cell_formula(wb, sheet.as_ptr(), row, col, &mut status);
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            fz_buffer_free(formula);
+            clear_status(&mut status);
+
+            fz_workbook_set_cell_value(
+                wb,
+                sheet.as_ptr(),
+                row,
+                col,
+                value.as_ptr(),
+                value.len(),
+                fz_encoding_format::FZ_ENCODING_JSON,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            clear_status(&mut status);
+
+            let formula = CString::new("=1").unwrap();
+            fz_workbook_set_cell_formula(
+                wb,
+                sheet.as_ptr(),
+                row,
+                col,
+                formula.as_ptr(),
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            clear_status(&mut status);
+
+            let targets = format!("[{{\"sheet\":\"Sheet1\",\"row\":{row},\"col\":{col}}}]");
+            let evaluated = fz_workbook_evaluate_cells(
+                wb,
+                targets.as_ptr(),
+                targets.len(),
+                fz_encoding_format::FZ_ENCODING_JSON,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            fz_buffer_free(evaluated);
+            clear_status(&mut status);
+        }
+
+        for &(row, col) in &[(1_048_576, 16_384), (1_048_576, 1), (1, 16_384)] {
+            let cell = fz_workbook_get_cell_value(
+                wb,
+                sheet.as_ptr(),
+                row,
+                col,
+                fz_encoding_format::FZ_ENCODING_JSON,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+            fz_buffer_free(cell);
+        }
+
+        let values = "[[{\"Number\":1.0}],[{\"Number\":2.0}]]";
+        fz_workbook_set_values(
+            wb,
+            sheet.as_ptr(),
+            1_048_576,
+            1,
+            values.as_ptr(),
+            values.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        clear_status(&mut status);
+
+        let formulas = "[[\"=1\",\"=2\"],[\"=3\",\"=4\"]]";
+        fz_workbook_set_formulas(
+            wb,
+            sheet.as_ptr(),
+            1,
+            16_384,
+            formulas.as_ptr(),
+            formulas.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        clear_status(&mut status);
+
+        let cell = fz_workbook_get_cell_value(
+            wb,
+            sheet.as_ptr(),
+            1,
+            1,
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let bytes = std::slice::from_raw_parts(cell.data, cell.len);
+        assert!(std::str::from_utf8(bytes).unwrap().contains("7"));
+        fz_buffer_free(cell);
+        fz_workbook_free(wb);
+    }
+}
+
+#[test]
+fn ragged_block_extents_match_mutated_cells() {
+    unsafe {
+        let mut status = fz_status::ok();
+        let wb = fz_workbook_create(&mut status);
+        let sheet = CString::new("Sheet1").unwrap();
+        fz_workbook_add_sheet(wb, sheet.as_ptr(), &mut status);
+
+        let anchor = "{\"Number\":7.0}";
+        fz_workbook_set_cell_value(
+            wb,
+            sheet.as_ptr(),
+            1,
+            1,
+            anchor.as_ptr(),
+            anchor.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let final_row = 1_048_576;
+        let trailing_values = "[[{\"Number\":11.0}],[]]";
+        fz_workbook_set_values(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            1,
+            trailing_values.as_ptr(),
+            trailing_values.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let final_value = fz_workbook_get_cell_value(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            1,
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let final_value_bytes = std::slice::from_raw_parts(final_value.data, final_value.len);
+        assert!(
+            std::str::from_utf8(final_value_bytes)
+                .unwrap()
+                .contains("11")
+        );
+        fz_buffer_free(final_value);
+
+        let value_dimensions = fz_workbook_sheet_dimensions(
+            wb,
+            sheet.as_ptr(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let value_dimensions_bytes =
+            std::slice::from_raw_parts(value_dimensions.data, value_dimensions.len).to_vec();
+        fz_buffer_free(value_dimensions);
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&value_dimensions_bytes).unwrap(),
+            serde_json::json!({"rows": final_row, "cols": 1})
+        );
+
+        let seed_formula = "[[\"=13\"]]";
+        fz_workbook_set_formulas(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            2,
+            seed_formula.as_ptr(),
+            seed_formula.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let dimensions_before = fz_workbook_sheet_dimensions(
+            wb,
+            sheet.as_ptr(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let dimensions_before_bytes =
+            std::slice::from_raw_parts(dimensions_before.data, dimensions_before.len).to_vec();
+        fz_buffer_free(dimensions_before);
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&dimensions_before_bytes).unwrap(),
+            serde_json::json!({"rows": final_row, "cols": 2})
+        );
+
+        let trailing_formulas = "[[\"=19\"],[]]";
+        fz_workbook_set_formulas(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            2,
+            trailing_formulas.as_ptr(),
+            trailing_formulas.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        clear_status(&mut status);
+
+        let dimensions_after = fz_workbook_sheet_dimensions(
+            wb,
+            sheet.as_ptr(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let dimensions_after_bytes =
+            std::slice::from_raw_parts(dimensions_after.data, dimensions_after.len).to_vec();
+        fz_buffer_free(dimensions_after);
+        assert_eq!(dimensions_after_bytes, dimensions_before_bytes);
+
+        let final_formula =
+            fz_workbook_get_cell_formula(wb, sheet.as_ptr(), final_row, 2, &mut status);
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let final_formula_bytes = std::slice::from_raw_parts(final_formula.data, final_formula.len);
+        assert_eq!(std::str::from_utf8(final_formula_bytes).unwrap(), "=13");
+        fz_buffer_free(final_formula);
+
+        let leading_values = "[[],[{\"Number\":17.0}]]";
+        fz_workbook_set_values(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            1,
+            leading_values.as_ptr(),
+            leading_values.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        clear_status(&mut status);
+
+        let leading_formulas = "[[],[\"=19\"]]";
+        fz_workbook_set_formulas(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            2,
+            leading_formulas.as_ptr(),
+            leading_formulas.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        clear_status(&mut status);
+
+        let preserved_value = fz_workbook_get_cell_value(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            1,
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let preserved_value_bytes =
+            std::slice::from_raw_parts(preserved_value.data, preserved_value.len);
+        assert!(
+            std::str::from_utf8(preserved_value_bytes)
+                .unwrap()
+                .contains("11")
+        );
+        fz_buffer_free(preserved_value);
+
+        let preserved_formula =
+            fz_workbook_get_cell_formula(wb, sheet.as_ptr(), final_row, 2, &mut status);
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let preserved_formula_bytes =
+            std::slice::from_raw_parts(preserved_formula.data, preserved_formula.len);
+        assert_eq!(std::str::from_utf8(preserved_formula_bytes).unwrap(), "=13");
+        fz_buffer_free(preserved_formula);
+
+        let interior_values = "[[{\"Number\":21.0}],[],[{\"Number\":23.0}]]";
+        fz_workbook_set_values(
+            wb,
+            sheet.as_ptr(),
+            10,
+            1,
+            interior_values.as_ptr(),
+            interior_values.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let interior_formulas = "[[\"=25\"],[],[\"=27\"]]";
+        fz_workbook_set_formulas(
+            wb,
+            sheet.as_ptr(),
+            10,
+            2,
+            interior_formulas.as_ptr(),
+            interior_formulas.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let empty_values = "[[],[]]";
+        fz_workbook_set_values(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            16_384,
+            empty_values.as_ptr(),
+            empty_values.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let empty_formulas = "[[],[]]";
+        fz_workbook_set_formulas(
+            wb,
+            sheet.as_ptr(),
+            final_row,
+            16_384,
+            empty_formulas.as_ptr(),
+            empty_formulas.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let invalid_empty_values = "[[],[]]";
+        fz_workbook_set_values(
+            wb,
+            sheet.as_ptr(),
+            0,
+            1,
+            invalid_empty_values.as_ptr(),
+            invalid_empty_values.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        clear_status(&mut status);
+
+        let invalid_empty_formulas = "[[],[]]";
+        fz_workbook_set_formulas(
+            wb,
+            sheet.as_ptr(),
+            1,
+            0,
+            invalid_empty_formulas.as_ptr(),
+            invalid_empty_formulas.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        clear_status(&mut status);
+
+        let anchor_value = fz_workbook_get_cell_value(
+            wb,
+            sheet.as_ptr(),
+            1,
+            1,
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        let anchor_bytes = std::slice::from_raw_parts(anchor_value.data, anchor_value.len);
+        assert!(std::str::from_utf8(anchor_bytes).unwrap().contains("7"));
+        fz_buffer_free(anchor_value);
+        fz_workbook_free(wb);
+    }
+}
 
 #[test]
 fn open_xlsx_null_path_reports_error() {


### PR DESCRIPTION
## Summary

- reject zero and out-of-grid CFFI cell coordinates before they reach packed engine coordinates
- reject overflowing rectangular value/formula blocks before any workbook mutation
- preserve distinct ragged-block semantics for literal values and formulas

This is the second independently reproduced correctness defect extracted from @Ocean82's #263. It does not merge or copy the broader PR bundle.

## Root cause

C ABI callers can provide arbitrary `uint32_t` rows and columns. The affected entry points forwarded them into packed zero-based engine coordinates, where an out-of-grid value triggers an assertion. Because the assertion crosses an `extern "C"` boundary, the host process aborts instead of receiving an error status.

A centralized private validator now enforces Excel's exact 1-based limits—1 through 1,048,576 rows and 1 through 16,384 columns—with checked extent arithmetic. Validation runs before workbook access or mutation for single-cell reads/writes, target evaluation, and rectangular value/formula writes.

## Ragged blocks

Literal-value batches touch only actual cells, so their row extent ends at the last non-empty row and trailing empty rows remain harmless. Formula batches currently reserve sheet capacity from the full outer row count whenever any formula exists, so validation intentionally includes that full height. All-empty blocks remain zero-extent no-ops after validating their start coordinate.

Tests pin trailing and leading empty rows, interior gaps, all-empty blocks, last-cell validity, max-plus-one rejection, overflow, unchanged values/formulas, and unchanged sheet dimensions after rejection.

## Validation

- red-before-green subprocess reproduction: current main aborted at packed coordinate construction
- `cargo test -p formualizer-cffi --all-targets`
- CFFI C smoke test: `cffi_smoke: ok`
- `cargo clippy -p formualizer-cffi --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- three adversarial Luna review/fix rounds; final acceptance found no blocker or major issue

## Scope

The ABI and generated header are unchanged. `RangeAddress`, global panic containment, status JSON, parser dialect handling, fallback errors, lock poisoning, Python/WASM validation, Bessel functions, and dependency/generated-file changes remain separate serial tranches.

drafted with love by (agent) Manfred, with approval from Frankie
