### PR TITLE
fix(cffi): validate serialized range boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Formualizer will be documented in this file.
 ### Fixed
 
 - CFFI cell and rectangular block entry points now reject zero, out-of-grid, and overflowing Excel coordinates with a typed status before touching workbook state, preventing packed-coordinate aborts.
+- CFFI `RangeAddress` JSON and CBOR boundaries now reject zero, inverted, and out-of-grid ranges before formatting or workbook reads, preventing malformed-bound underflow and out-of-grid materialization.
 - Python `Workbook.undo()` and `redo()` now invalidate the compatibility cell cache before replay, so `Workbook.get_value()` and existing `Sheet` handles immediately reflect authoritative values after successful, failed, or no-op replay without introducing a cache-lock panic.
 - Authoritative FormulaPlane fallback no longer reports a false `#CIRC!` when a statically indexed compressed range contains the formula cell but `INDEX` selects a different cell. Whole-row, whole-column, bounded, omitted-column, zero, negative, and genuine self-selection cases now follow the same reference semantics in Off and authoritative modes.
 - Deferred malformed-formula retries now publish one parse diagnostic per successful ingest event instead of duplicating a source record during authoritative replay; a later distinct ingest of the same malformed source still emits its own diagnostic.

--- a/crates/formualizer-cffi/src/lib.rs
+++ b/crates/formualizer-cffi/src/lib.rs
@@ -102,6 +102,32 @@ pub enum fz_encoding_format {
     FZ_ENCODING_CBOR = 1,
 }
 
+pub(crate) const EXCEL_MAX_ROWS: u32 = 1_048_576;
+pub(crate) const EXCEL_MAX_COLS: u32 = 16_384;
+
+/// Validate a range after it crosses the CFFI serialization boundary.
+pub(crate) fn validate_cffi_range(addr: &formualizer_common::RangeAddress) -> Result<(), String> {
+    if addr.start_row == 0 || addr.start_col == 0 || addr.end_row == 0 || addr.end_col == 0 {
+        return Err("range bounds must be 1-based".to_string());
+    }
+    if addr.start_row > addr.end_row || addr.start_col > addr.end_col {
+        return Err("range bounds must be ordered: start <= end".to_string());
+    }
+    if addr.end_row > EXCEL_MAX_ROWS {
+        return Err(format!(
+            "range ends at row {}, outside Excel's valid range 1..={EXCEL_MAX_ROWS}",
+            addr.end_row
+        ));
+    }
+    if addr.end_col > EXCEL_MAX_COLS {
+        return Err(format!(
+            "range ends at column {}, outside Excel's valid range 1..={EXCEL_MAX_COLS}",
+            addr.end_col
+        ));
+    }
+    Ok(())
+}
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct fz_parse_options {
@@ -336,6 +362,7 @@ pub unsafe extern "C" fn fz_common_parse_range_a1(
         let (er, ec, _, _) = coord::parse_a1_1based(end_str).map_err(|e| e.to_string())?;
 
         let addr = RangeAddress::new(sheet, sr, sc, er, ec).map_err(|e| e.to_string())?;
+        crate::validate_cffi_range(&addr)?;
 
         match format {
             fz_encoding_format::FZ_ENCODING_JSON => {
@@ -397,6 +424,7 @@ pub unsafe extern "C" fn fz_common_format_range_a1(
                 ciborium::from_reader(payload).map_err(|e| e.to_string())?
             }
         };
+        crate::validate_cffi_range(&addr)?;
 
         let start_col =
             coord::col_letters_from_1based(addr.start_col).map_err(|e| e.to_string())?;

--- a/crates/formualizer-cffi/src/workbook.rs
+++ b/crates/formualizer-cffi/src/workbook.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::missing_safety_doc)]
 
-use crate::{fz_buffer, fz_encoding_format, fz_status};
+use crate::{
+    EXCEL_MAX_COLS, EXCEL_MAX_ROWS, fz_buffer, fz_encoding_format, fz_status, validate_cffi_range,
+};
 
 use formualizer_common::{LiteralValue, RangeAddress};
 use formualizer_workbook::{
@@ -38,9 +40,6 @@ struct CffiCellTarget {
     row: u32,
     col: u32,
 }
-
-const EXCEL_MAX_ROWS: u32 = 1_048_576;
-const EXCEL_MAX_COLS: u32 = 16_384;
 
 /// Validate a 1-based cell or block before it reaches the workbook engine.
 fn checked_excel_coordinates(
@@ -864,6 +863,14 @@ pub unsafe extern "C" fn fz_workbook_read_range(
             return fz_buffer::empty();
         }
     };
+    if let Err(e) = validate_cffi_range(&addr) {
+        if !status.is_null() {
+            unsafe {
+                *status = fz_status::error(e);
+            }
+        }
+        return fz_buffer::empty();
+    }
 
     let opaque = unsafe { &*(wb.0 as *mut OpaqueWorkbook) };
     let wb_lock = opaque.0.read().unwrap();

--- a/crates/formualizer-cffi/tests/range_address_guardrails.rs
+++ b/crates/formualizer-cffi/tests/range_address_guardrails.rs
@@ -1,0 +1,264 @@
+use formualizer_cffi::*;
+use serde::Serialize;
+use std::process::Command;
+
+#[derive(Serialize)]
+struct RawRangeAddress {
+    sheet: String,
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+fn payload(range: &RawRangeAddress, format: fz_encoding_format) -> Vec<u8> {
+    match format {
+        fz_encoding_format::FZ_ENCODING_JSON => serde_json::to_vec(range).unwrap(),
+        fz_encoding_format::FZ_ENCODING_CBOR => {
+            let mut bytes = Vec::new();
+            ciborium::into_writer(range, &mut bytes).unwrap();
+            bytes
+        }
+    }
+}
+
+unsafe fn clear_status(status: &mut fz_status) {
+    let error = std::mem::replace(&mut status.error, fz_buffer::empty());
+    unsafe {
+        fz_buffer_free(error);
+    }
+}
+
+#[test]
+fn malformed_range_payloads_are_subprocess_safe() {
+    const CHILD_ENV: &str = "FORMUALIZER_CFFI_RANGE_CHILD";
+    const CASES: usize = 12;
+
+    if let Some(case) = std::env::var_os(CHILD_ENV) {
+        let case: usize = case.to_str().unwrap().parse().unwrap();
+        let cases = [
+            (0, 1, 1, 1),
+            (1, 0, 1, 1),
+            (2, 1, 1, 1),
+            (1, 2, 1, 1),
+            (1_048_577, 1, 1_048_577, 1),
+            (1, 16_385, 1, 16_385),
+        ];
+        let (start_row, start_col, end_row, end_col) = cases[case / 2];
+        let range = RawRangeAddress {
+            sheet: "Sheet1".to_string(),
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+        };
+        let format = if case.is_multiple_of(2) {
+            fz_encoding_format::FZ_ENCODING_JSON
+        } else {
+            fz_encoding_format::FZ_ENCODING_CBOR
+        };
+        let bytes = payload(&range, format);
+
+        unsafe {
+            let mut status = fz_status::ok();
+            let wb = fz_workbook_create(&mut status);
+            let common =
+                fz_common_format_range_a1(bytes.as_ptr(), bytes.len(), format, &mut status);
+            let common_failed = status.code == fz_status_code::FZ_STATUS_ERROR;
+            assert_eq!(common.len, 0);
+            assert!(common.data.is_null());
+            fz_buffer_free(common);
+            clear_status(&mut status);
+
+            let read = fz_workbook_read_range(wb, bytes.as_ptr(), bytes.len(), format, &mut status);
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            assert_eq!(read.len, 0);
+            assert!(common_failed);
+            assert!(read.data.is_null());
+            fz_buffer_free(read);
+            clear_status(&mut status);
+            fz_workbook_free(wb);
+        }
+        return;
+    }
+
+    for case in 0..CASES {
+        let child = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("malformed_range_payloads_are_subprocess_safe")
+            .env(CHILD_ENV, case.to_string())
+            .status()
+            .unwrap();
+        assert!(child.success(), "range case {case} exited with {child}");
+    }
+}
+
+#[test]
+fn valid_last_cell_and_invalid_ranges_preserve_workbook_state() {
+    unsafe {
+        let mut status = fz_status::ok();
+        let wb = fz_workbook_create(&mut status);
+        let sheet = std::ffi::CString::new("Sheet1").unwrap();
+        fz_workbook_add_sheet(wb, sheet.as_ptr(), &mut status);
+        let value = b"{\"Number\":7.0}";
+        fz_workbook_set_cell_value(
+            wb,
+            sheet.as_ptr(),
+            1,
+            1,
+            value.as_ptr(),
+            value.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+
+        let last = RawRangeAddress {
+            sheet: "Sheet1".to_string(),
+            start_row: 1_048_576,
+            start_col: 16_384,
+            end_row: 1_048_576,
+            end_col: 16_384,
+        };
+        let invalid = RawRangeAddress {
+            sheet: "Sheet1".to_string(),
+            start_row: 0,
+            start_col: 1,
+            end_row: 1,
+            end_col: 1,
+        };
+        let anchor = RawRangeAddress {
+            sheet: "Sheet1".to_string(),
+            start_row: 1,
+            start_col: 1,
+            end_row: 1,
+            end_col: 1,
+        };
+
+        for format in [
+            fz_encoding_format::FZ_ENCODING_JSON,
+            fz_encoding_format::FZ_ENCODING_CBOR,
+        ] {
+            let last_payload = payload(&last, format);
+            let formatted = fz_common_format_range_a1(
+                last_payload.as_ptr(),
+                last_payload.len(),
+                format,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+            let formatted_bytes = std::slice::from_raw_parts(formatted.data, formatted.len);
+            assert_eq!(formatted_bytes, b"Sheet1!XFD1048576");
+            fz_buffer_free(formatted);
+
+            let last_read = fz_workbook_read_range(
+                wb,
+                last_payload.as_ptr(),
+                last_payload.len(),
+                format,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+            assert!(!last_read.data.is_null());
+            fz_buffer_free(last_read);
+
+            let invalid_payload = payload(&invalid, format);
+            let invalid_common = fz_common_format_range_a1(
+                invalid_payload.as_ptr(),
+                invalid_payload.len(),
+                format,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            assert_eq!(invalid_common.len, 0);
+            assert!(invalid_common.data.is_null());
+            fz_buffer_free(invalid_common);
+            clear_status(&mut status);
+
+            let invalid_read = fz_workbook_read_range(
+                wb,
+                invalid_payload.as_ptr(),
+                invalid_payload.len(),
+                format,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+            assert_eq!(invalid_read.len, 0);
+            assert!(invalid_read.data.is_null());
+            fz_buffer_free(invalid_read);
+            clear_status(&mut status);
+
+            let no_status_common = fz_common_format_range_a1(
+                invalid_payload.as_ptr(),
+                invalid_payload.len(),
+                format,
+                std::ptr::null_mut(),
+            );
+            assert_eq!(no_status_common.len, 0);
+            assert!(no_status_common.data.is_null());
+            fz_buffer_free(no_status_common);
+            let no_status_read = fz_workbook_read_range(
+                wb,
+                invalid_payload.as_ptr(),
+                invalid_payload.len(),
+                format,
+                std::ptr::null_mut(),
+            );
+            assert_eq!(no_status_read.len, 0);
+            assert!(no_status_read.data.is_null());
+            fz_buffer_free(no_status_read);
+
+            let anchor_payload = payload(&anchor, format);
+            let anchor_read = fz_workbook_read_range(
+                wb,
+                anchor_payload.as_ptr(),
+                anchor_payload.len(),
+                format,
+                &mut status,
+            );
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+            let anchor_bytes = std::slice::from_raw_parts(anchor_read.data, anchor_read.len);
+            let values: Vec<Vec<formualizer_common::LiteralValue>> = match format {
+                fz_encoding_format::FZ_ENCODING_JSON => {
+                    serde_json::from_slice(anchor_bytes).unwrap()
+                }
+                fz_encoding_format::FZ_ENCODING_CBOR => {
+                    ciborium::from_reader(anchor_bytes).unwrap()
+                }
+            };
+            assert_eq!(
+                values,
+                vec![vec![formualizer_common::LiteralValue::Number(7.0)]]
+            );
+            fz_buffer_free(anchor_read);
+        }
+        fz_workbook_free(wb);
+    }
+}
+
+#[test]
+fn parse_range_rejects_out_of_grid_and_accepts_last_cell() {
+    unsafe {
+        for format in [
+            fz_encoding_format::FZ_ENCODING_JSON,
+            fz_encoding_format::FZ_ENCODING_CBOR,
+        ] {
+            for input in ["Sheet1!A0", "Sheet1!A1048577", "Sheet1!XFE1"] {
+                let input = std::ffi::CString::new(input).unwrap();
+                let mut status = fz_status::ok();
+                let buffer = fz_common_parse_range_a1(input.as_ptr(), format, &mut status);
+                assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+                assert_eq!(buffer.len, 0);
+                assert!(buffer.data.is_null());
+                fz_buffer_free(buffer);
+                clear_status(&mut status);
+            }
+
+            let input = std::ffi::CString::new("Sheet1!XFD1048576").unwrap();
+            let mut status = fz_status::ok();
+            let buffer = fz_common_parse_range_a1(input.as_ptr(), format, &mut status);
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+            fz_buffer_free(buffer);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- validate serialized CFFI `RangeAddress` values before formatting or workbook access
- reject zero, inverted, and out-of-grid JSON/CBOR ranges with typed status errors
- preserve the released common Rust API and all valid C ABI behavior

This is the third independently reproduced correctness defect extracted from @Ocean82's #263. It does not merge the broader PR bundle.

## Root cause

`RangeAddress::new` checks 1-based ordered bounds, but JSON and CBOR deserialize the type's public fields directly. C callers could therefore supply values that bypassed the constructor. Formatting and workbook reads then reached coordinate subtraction, width/height, or range materialization with malformed bounds.

A private CFFI validator now enforces non-empty ordered ranges inside Excel's exact 1,048,576-row by 16,384-column grid. Validation runs before formatting, width/height conversion, workbook locking, or materialization.

## Covered entry points

- `fz_common_parse_range_a1`
- `fz_common_format_range_a1`
- `fz_workbook_read_range`

There is no RangeAddress-based C write ABI. Cell and rectangular write coordinates were handled separately in #267.

## Validation

- red-before-green malformed JSON/CBOR subprocess reproduction
- zero, inverted, max-plus-one, and valid `XFD1048576` cases
- null-status and typed empty-buffer behavior
- anchor-value preservation after rejected reads
- full `cargo test -p formualizer-cffi`
- CFFI C smoke test
- `cargo clippy -p formualizer-cffi --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- adversarial Luna review found no runtime blocker after changelog wording was narrowed

## Scope

This does not impose a materialization budget on legally bounded large ranges and does not change public `RangeAddress` methods. Global panic containment, status JSON, parser dialect handling, fallback errors, lock poisoning, Python/WASM validation, Bessel functions, dependencies, and generated files remain separate serial tranches.

drafted with love by (agent) Manfred, with approval from Frankie
