### PR TITLE
fix(cffi): serialize error statuses as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- CFFI status errors now use canonical JSON string escaping, preserving valid round-trippable messages for control characters and other special text.
 - CFFI cell and rectangular block entry points now reject zero, out-of-grid, and overflowing Excel coordinates with a typed status before touching workbook state, preventing packed-coordinate aborts.
 - CFFI `RangeAddress` JSON and CBOR boundaries now reject zero, inverted, and out-of-grid ranges before formatting or workbook reads, preventing malformed-bound underflow and out-of-grid materialization.
 - Python `Workbook.undo()` and `redo()` now invalidate the compatibility cell cache before replay, so `Workbook.get_value()` and existing `Sheet` handles immediately reflect authoritative values after successful, failed, or no-op replay without introducing a cache-lock panic.

--- a/crates/formualizer-cffi/src/lib.rs
+++ b/crates/formualizer-cffi/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::ffi::{c_char, c_int};
 
+use serde::Serialize;
 use std::ptr;
 use std::slice;
 
@@ -53,6 +54,11 @@ pub struct fz_status {
     pub error: fz_buffer, // JSON encoded error if code != OK
 }
 
+#[derive(Serialize)]
+struct StatusError<'a> {
+    message: &'a str,
+}
+
 impl fz_status {
     pub fn ok() -> Self {
         fz_status {
@@ -62,10 +68,15 @@ impl fz_status {
     }
 
     pub fn error(msg: String) -> Self {
-        let error_json = format!("{{\"message\": {:?}}}", msg);
+        let error_json = match serde_json::to_vec(&StatusError { message: &msg }) {
+            Ok(json) => json,
+            // String serialization cannot fail, but keep the C boundary total if the
+            // serializer gains a fallible path in the future.
+            Err(_) => br#"{"message":"failed to serialize error"}"#.to_vec(),
+        };
         fz_status {
             code: fz_status_code::FZ_STATUS_ERROR,
-            error: fz_buffer::from_vec(error_json.into_bytes()),
+            error: fz_buffer::from_vec(error_json),
         }
     }
 }

--- a/crates/formualizer-cffi/tests/abi_test.rs
+++ b/crates/formualizer-cffi/tests/abi_test.rs
@@ -79,6 +79,83 @@ fn test_invalid_range() {
 }
 
 #[test]
+fn test_status_error_json_escaping() {
+    let messages = vec![
+        "ordinary existing message".to_string(),
+        "quote: \"; backslash: \\".to_string(),
+        "line one\nline two".to_string(),
+        "unit separator: \u{1f}".to_string(),
+        "delete: \u{7f}".to_string(),
+        "non-ASCII: café 日本語 😀".to_string(),
+        "long message: ".to_string() + &"x".repeat(16_384),
+    ];
+
+    for message in messages {
+        let status = fz_status::error(message.clone());
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+
+        let parsed: serde_json::Value = serde_json::from_slice(&buffer_as_bytes(&status.error))
+            .expect("status error should be valid JSON");
+        assert_eq!(parsed, serde_json::json!({"message": message}));
+        unsafe { fz_buffer_free(status.error) };
+    }
+}
+
+#[test]
+fn test_exported_api_error_is_json() {
+    let options = fz_parse_options {
+        include_spans: false,
+        dialect: fz_formula_dialect::FZ_DIALECT_EXCEL,
+    };
+    let mut status = fz_status::ok();
+
+    let buffer = unsafe {
+        fz_parse_tokenize(
+            std::ptr::null(),
+            options,
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        )
+    };
+    assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+    assert_eq!(buffer.len, 0);
+
+    let parsed: serde_json::Value = serde_json::from_slice(&buffer_as_bytes(&status.error))
+        .expect("exported API status error should be valid JSON");
+    assert_eq!(parsed, serde_json::json!({"message": "formula is null"}));
+    unsafe { fz_buffer_free(status.error) };
+}
+
+#[test]
+fn test_exported_api_error_escapes_control_character() {
+    let input = CString::new("bad\u{1f}").unwrap();
+    let mut status = fz_status::ok();
+
+    let buffer = unsafe {
+        fz_common_parse_range_a1(
+            input.as_ptr(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        )
+    };
+    assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+    assert_eq!(buffer.len, 0);
+
+    let parsed: serde_json::Value = serde_json::from_slice(&buffer_as_bytes(&status.error))
+        .expect("exported API status error should be valid JSON");
+    assert_eq!(
+        parsed,
+        serde_json::json!({
+            "message": "invalid row character `\u{1f}`; expected 0-9"
+        })
+    );
+    unsafe {
+        fz_buffer_free(buffer);
+        fz_buffer_free(status.error);
+    }
+}
+
+#[test]
 fn test_range_roundtrip_cbor() {
     unsafe {
         let range_str = "Sheet1!A1:B2";


### PR DESCRIPTION
## Summary

- serialize CFFI error statuses through `serde_json` rather than Rust Debug formatting
- preserve exact error-message round trips for control characters and Unicode
- pin the behavior through a causal exported C API regression

This is the fourth independently reproduced correctness defect extracted from @Ocean82's #263. It does not merge the broader PR bundle.

## Root cause

`fz_status::error` constructed a value advertised as JSON using `format!("{msg:?}")`. Rust Debug string escapes are not JSON escapes for every character. For example, U+001F is emitted as `\u{1f}`, which causes conforming JSON parsers to reject the entire status payload.

The status now serializes the existing `{ "message": string }` shape with `serde_json`. The fallback is itself static valid JSON and keeps the C boundary total without an unwrap.

## Validation

- exact round trips for quotes, backslashes, newline, U+001F, DEL, non-ASCII, ordinary text, and a 16 KiB message
- causal exported-path regression through `fz_common_parse_range_a1("bad\u001f")`
- full CFFI tests with all targets and features
- CFFI C smoke test
- ABI symbol/version and generated-header checks
- `cargo clippy -p formualizer-cffi --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- final independent Luna acceptance: no blocker or major finding

## Scope

The `fz_status` layout, status codes, ABI signatures, and buffer ownership are unchanged. Global panic containment, parser dialect behavior, fallback evaluation errors, lock poisoning, Python/WASM validation, Bessel functions, dependencies, and generated artifacts remain separate serial tranches.

drafted with love by (agent) Manfred, with approval from Frankie
