### PR TITLE
fix(cffi): honor canonical formula dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- CFFI canonical formula rendering now honors the selected Excel or OpenFormula dialect while retaining canonical Excel output and existing input/output contracts.
 - CFFI status errors now use canonical JSON string escaping, preserving valid round-trippable messages for control characters and other special text.
 - CFFI cell and rectangular block entry points now reject zero, out-of-grid, and overflowing Excel coordinates with a typed status before touching workbook state, preventing packed-coordinate aborts.
 - CFFI `RangeAddress` JSON and CBOR boundaries now reject zero, inverted, and out-of-grid ranges before formatting or workbook reads, preventing malformed-bound underflow and out-of-grid materialization.

--- a/crates/formualizer-cffi/src/lib.rs
+++ b/crates/formualizer-cffi/src/lib.rs
@@ -165,6 +165,34 @@ impl From<fz_formula_dialect> for formualizer_parse::FormulaDialect {
     }
 }
 
+/// Render a formula with the selected dialect while preserving the CFFI
+/// canonical-rendering contract.
+fn cffi_pretty_parse_render(
+    formula: &str,
+    dialect: formualizer_parse::FormulaDialect,
+) -> Result<String, String> {
+    if formula.is_empty() {
+        return Ok(String::new());
+    }
+
+    let needs_equals = !formula.starts_with('=');
+    let formula_to_parse = if needs_equals {
+        format!("={formula}")
+    } else {
+        formula.to_string()
+    };
+
+    let ast = formualizer_parse::parse_with_dialect(&formula_to_parse, dialect)
+        .map_err(|e| e.to_string())?;
+    let pretty_printed = formualizer_parse::pretty_print(&ast);
+
+    if needs_equals {
+        Ok(pretty_printed)
+    } else {
+        Ok(format!("={pretty_printed}"))
+    }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fz_parse_tokenize(
     formula: *const c_char,
@@ -298,7 +326,7 @@ pub unsafe extern "C" fn fz_parse_canonical_formula(
     dialect: fz_formula_dialect,
     status: *mut fz_status,
 ) -> fz_buffer {
-    use formualizer_parse::{FormulaDialect, pretty_parse_render};
+    use formualizer_parse::FormulaDialect;
     use std::ffi::CStr;
 
     if formula.is_null() {
@@ -312,8 +340,7 @@ pub unsafe extern "C" fn fz_parse_canonical_formula(
 
     let input = unsafe { CStr::from_ptr(formula).to_string_lossy() };
 
-    let _ = FormulaDialect::from(dialect);
-    let result: Result<String, String> = pretty_parse_render(&input).map_err(|e| e.to_string());
+    let result = cffi_pretty_parse_render(&input, FormulaDialect::from(dialect));
 
     match result {
         Ok(v) => {

--- a/crates/formualizer-cffi/tests/abi_test.rs
+++ b/crates/formualizer-cffi/tests/abi_test.rs
@@ -723,3 +723,72 @@ fn test_canonical_formula() {
         fz_buffer_free(buffer);
     }
 }
+
+#[test]
+fn test_canonical_formula_uses_openformula_dialect() {
+    let formula = CString::new("=SUM([.A1];[.B1])").unwrap();
+    let mut open_status = fz_status::ok();
+
+    unsafe {
+        let open_buffer = fz_parse_canonical_formula(
+            formula.as_ptr(),
+            fz_formula_dialect::FZ_DIALECT_OPENFORMULA,
+            &mut open_status,
+        );
+        assert_eq!(open_status.code, fz_status_code::FZ_STATUS_OK);
+        let result = String::from_utf8_lossy(std::slice::from_raw_parts(
+            open_buffer.data,
+            open_buffer.len,
+        ));
+        assert_eq!(result, "=SUM(A1, B1)");
+        fz_buffer_free(open_buffer);
+
+        // Excel tokenization cannot parse OpenFormula references/separators.
+        let mut excel_status = fz_status::ok();
+        let excel_buffer = fz_parse_canonical_formula(
+            formula.as_ptr(),
+            fz_formula_dialect::FZ_DIALECT_EXCEL,
+            &mut excel_status,
+        );
+        assert_eq!(excel_status.code, fz_status_code::FZ_STATUS_ERROR);
+        assert_eq!(excel_buffer.len, 0);
+        fz_buffer_free(excel_buffer);
+        assert!(
+            serde_json::from_slice::<serde_json::Value>(&buffer_as_bytes(&excel_status.error))
+                .is_ok()
+        );
+        fz_buffer_free(excel_status.error);
+    }
+}
+
+#[test]
+fn test_canonical_formula_preserves_empty_and_optional_equals_contract() {
+    let empty = CString::new("").unwrap();
+    let without_equals = CString::new("sum([.A1];[.B1])").unwrap();
+
+    unsafe {
+        let mut empty_status = fz_status::ok();
+        let empty_buffer = fz_parse_canonical_formula(
+            empty.as_ptr(),
+            fz_formula_dialect::FZ_DIALECT_OPENFORMULA,
+            &mut empty_status,
+        );
+        assert_eq!(empty_status.code, fz_status_code::FZ_STATUS_OK);
+        assert_eq!(empty_buffer.len, 0);
+        fz_buffer_free(empty_buffer);
+
+        let mut no_equals_status = fz_status::ok();
+        let no_equals_buffer = fz_parse_canonical_formula(
+            without_equals.as_ptr(),
+            fz_formula_dialect::FZ_DIALECT_OPENFORMULA,
+            &mut no_equals_status,
+        );
+        assert_eq!(no_equals_status.code, fz_status_code::FZ_STATUS_OK);
+        let result = String::from_utf8_lossy(std::slice::from_raw_parts(
+            no_equals_buffer.data,
+            no_equals_buffer.len,
+        ));
+        assert_eq!(result, "SUM(A1, B1)");
+        fz_buffer_free(no_equals_buffer);
+    }
+}


### PR DESCRIPTION
## Summary

- make `fz_parse_canonical_formula` parse with its supplied Excel or OpenFormula dialect
- retain the existing canonical Excel output and optional-leading-`=` behavior
- add a causal OpenFormula regression and preserve existing Excel/empty-input contracts

This is the fifth independently reproduced correctness defect extracted from @Ocean82's #263. It does not merge the broader PR bundle.

## Root cause

The exported function converted its `dialect` argument and immediately discarded the result before calling Excel-only `pretty_parse_render`. Consequently valid OpenFormula input such as `=SUM([.A1];[.B1])` failed even when the caller selected `FZ_DIALECT_OPENFORMULA`.

The correction is private to the CFFI boundary. It uses the existing dialect-aware parser and canonical pretty-printer without adding parser API or changing the ABI.

## Validation

- causal OpenFormula success: `=SUM([.A1];[.B1])` becomes `=SUM(A1, B1)`
- the same input is rejected under the Excel dialect
- existing Excel canonicalization remains `=SUM(A1, 10)`
- empty and optional-leading-`=` behavior is preserved
- error statuses remain valid JSON and all returned buffers are freed
- full CFFI tests with all targets and features
- parser test suite
- CFFI C smoke, header, ABI symbol/version, and public API checks
- `cargo clippy -p formualizer-cffi --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent Luna review: accepted with no blocker or major finding

## Scope

Status serialization, panic containment, coordinates and ranges, evaluation fallback errors, lock poisoning, Python/WASM, Bessel functions, dependencies, and generated files are unchanged.

drafted with love by (agent) Manfred, with approval from Frankie
