### PR TITLE
fix(cffi): retain graph fallback errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- CFFI targeted cell evaluation now reports both the targeted graph-preparation error and the distinct full-graph fallback error when both preparation attempts fail.
 - CFFI canonical formula rendering now honors the selected Excel or OpenFormula dialect while retaining canonical Excel output and existing input/output contracts.
 - CFFI status errors now use canonical JSON string escaping, preserving valid round-trippable messages for control characters and other special text.
 - CFFI cell and rectangular block entry points now reject zero, out-of-grid, and overflowing Excel coordinates with a typed status before touching workbook state, preventing packed-coordinate aborts.

--- a/crates/formualizer-cffi/src/workbook.rs
+++ b/crates/formualizer-cffi/src/workbook.rs
@@ -604,12 +604,15 @@ pub unsafe extern "C" fn fz_workbook_evaluate_cells(
     let opaque = unsafe { &*(wb.0 as *mut OpaqueWorkbook) };
     let mut wb_lock = opaque.0.write().unwrap();
 
-    if let Err(e) = wb_lock.prepare_graph_for_sheets(sheets.iter().copied())
-        && wb_lock.prepare_graph_all().is_err()
+    if let Err(targeted_error) = wb_lock.prepare_graph_for_sheets(sheets.iter().copied())
+        && let Err(full_error) = wb_lock.prepare_graph_all()
     {
         if !status.is_null() {
             unsafe {
-                *status = fz_status::error(e.to_string());
+                *status = fz_status::error(format!(
+                    "targeted graph preparation failed: {targeted_error}; \
+full graph preparation fallback failed: {full_error}"
+                ));
             }
         }
         return fz_buffer::empty();

--- a/crates/formualizer-cffi/tests/ffi_guardrails.rs
+++ b/crates/formualizer-cffi/tests/ffi_guardrails.rs
@@ -716,3 +716,101 @@ fn evaluate_cells_allows_null_status_pointer() {
         fz_workbook_free(wb);
     }
 }
+
+#[test]
+fn evaluate_cells_reports_targeted_and_full_preparation_failures() {
+    unsafe {
+        let mut status = fz_status::ok();
+        let mut config = formualizer_workbook::WorkbookConfig::interactive();
+        config.eval.evaluation_budgets.work.max_work_units = Some(0);
+        let workbook = formualizer_workbook::Workbook::new_with_config(config);
+        let opaque = Box::new(OpaqueWorkbook(std::sync::Arc::new(std::sync::RwLock::new(
+            workbook,
+        ))));
+        let wb = fz_workbook_h(Box::into_raw(opaque) as *mut std::ffi::c_void);
+
+        for name in ["Existing", "Target"] {
+            let name = CString::new(name).unwrap();
+            fz_workbook_add_sheet(wb, name.as_ptr(), &mut status);
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        }
+        for (sheet, formula) in [("Existing", "=1"), ("Target", "=2")] {
+            let sheet = CString::new(sheet).unwrap();
+            let formula = CString::new(formula).unwrap();
+            fz_workbook_set_cell_formula(wb, sheet.as_ptr(), 1, 1, formula.as_ptr(), &mut status);
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+        }
+
+        let targets = r#"[{"sheet":"Target","row":1,"col":1}]"#;
+        let result = fz_workbook_evaluate_cells(
+            wb,
+            targets.as_ptr(),
+            targets.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        assert!(result.data.is_null());
+        assert_eq!(result.len, 0);
+        let error = std::slice::from_raw_parts(status.error.data, status.error.len);
+        let error_json: serde_json::Value = serde_json::from_slice(error).unwrap();
+        let message = error_json["message"].as_str().unwrap();
+        let targeted = message.find("targeted graph preparation failed: ").unwrap();
+        let full = message
+            .find("full graph preparation fallback failed: ")
+            .unwrap();
+        assert!(targeted < full);
+        let targeted_message = &message[targeted..full];
+        let full_message = &message[full..];
+        assert!(targeted_message.contains("evaluation resource exhausted: work_units"));
+        assert!(targeted_message.contains("work_units (observed 1, limit 0)"));
+        assert!(!targeted_message.contains("work_units (observed 2, limit 0)"));
+        assert!(full_message.contains("evaluation resource exhausted: work_units"));
+        assert!(full_message.contains("work_units (observed 2, limit 0)"));
+        assert!(!full_message.contains("work_units (observed 1, limit 0)"));
+        let first_message = message.to_string();
+        fz_buffer_free(result);
+        clear_status(&mut status);
+
+        let null_status = fz_workbook_evaluate_cells(
+            wb,
+            targets.as_ptr(),
+            targets.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            ptr::null_mut(),
+        );
+        assert!(null_status.data.is_null());
+        assert_eq!(null_status.len, 0);
+        fz_buffer_free(null_status);
+
+        let repeated = fz_workbook_evaluate_cells(
+            wb,
+            targets.as_ptr(),
+            targets.len(),
+            fz_encoding_format::FZ_ENCODING_JSON,
+            &mut status,
+        );
+        assert_eq!(status.code, fz_status_code::FZ_STATUS_ERROR);
+        assert!(repeated.data.is_null());
+        assert_eq!(repeated.len, 0);
+        let repeated_error = std::slice::from_raw_parts(status.error.data, status.error.len);
+        let repeated_json: serde_json::Value = serde_json::from_slice(repeated_error).unwrap();
+        assert_eq!(
+            repeated_json["message"].as_str(),
+            Some(first_message.as_str())
+        );
+        fz_buffer_free(repeated);
+        clear_status(&mut status);
+
+        for (sheet, expected_formula) in [("Existing", "=1"), ("Target", "=2")] {
+            let sheet = CString::new(sheet).unwrap();
+            let formula = fz_workbook_get_cell_formula(wb, sheet.as_ptr(), 1, 1, &mut status);
+            assert_eq!(status.code, fz_status_code::FZ_STATUS_OK);
+            let formula_bytes = std::slice::from_raw_parts(formula.data, formula.len);
+            assert_eq!(formula_bytes, expected_formula.as_bytes());
+            fz_buffer_free(formula);
+        }
+        clear_status(&mut status);
+        fz_workbook_free(wb);
+    }
+}


### PR DESCRIPTION
## Summary

- retain the targeted graph-preparation error when full preparation fallback also fails
- include the distinct full-fallback error in deterministic source order
- add resource-ledger-based causal coverage for repeated and null-status C callers

This is the sixth independently reproduced correctness defect extracted from @Ocean82's #263. It does not merge the broader PR bundle.

## Root cause

`fz_workbook_evaluate_cells` attempted targeted graph preparation and then one full-graph fallback. When both failed, the second `Result` was reduced to `is_err()`, discarding its error while reporting only the first failure. C callers therefore could not diagnose why the documented fallback failed.

The correction retains both errors as `targeted graph preparation failed: ...; full graph preparation fallback failed: ...`. Successful targeted preparation and successful full fallback continue into evaluation unchanged, and no additional retry is introduced.

## Validation

- deterministic deferred-workbook fixture with valid staged formulas and `max_work_units = 0`
- targeted preparation reports work observation 1; full fallback reports work observation 2
- segment-specific assertions bind each resource error to the correct attempt and source order
- result remains empty and error status remains valid JSON
- null-status and repeated status-bearing calls are safe and deterministic
- exact staged formula sources remain unchanged after every failed attempt
- ordinary successful CFFI evaluation coverage remains green
- focused regression repeated five times
- full CFFI tests with all targets and features
- CFFI smoke, header, ABI symbol/version, and public API checks
- `formualizer-eval`: 2,459 tests passed
- `cargo clippy -p formualizer-cffi --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- two adversarial Luna reviews; the probabilistic first fixture was rejected and replaced, final review accepted with no blocker or major finding

## Scope

The core preparation APIs, retry count, evaluation semantics, dirty/source ownership, ABI, lock poisoning, panic containment, dialect/status serialization, coordinates/ranges, Python/WASM, Bessel functions, dependencies, and generated files are unchanged.

drafted with love by (agent) Manfred, with approval from Frankie
