### PR TITLE
fix(api): restore released date helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Restored the released `formualizer_eval::builtins::datetime` conversion helpers and sparse-sheet constructor compatibility paths, including explicit 1904 date-system handling. The eval decode wrappers retain released 0.7.1 component-clamping and negative-fraction behavior; as an intentional safety deviation, infinities and chrono date/duration overflow now return typed `#NUM!` instead of panicking. (#259)
+
 - CFFI targeted cell evaluation now reports both the targeted graph-preparation error and the distinct full-graph fallback error when both preparation attempts fail.
 - CFFI canonical formula rendering now honors the selected Excel or OpenFormula dialect while retaining canonical Excel output and existing input/output contracts.
 - CFFI status errors now use canonical JSON string escaping, preserving valid round-trippable messages for control characters and other special text.

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -3361,7 +3361,18 @@ impl ArrowSheet {
     /// Columns start with no materialized chunks; callers can populate only touched
     /// column/chunk pairs via `set_sparse_overlay_value`. Missing chunks remain
     /// observable as empty cells through scalar and range reads.
-    pub fn new_sparse(
+    pub fn new_sparse(sheet_name: &str, ncols: usize, nrows: usize, chunk_rows: usize) -> Self {
+        Self::new_sparse_with_date_system(
+            sheet_name,
+            ncols,
+            nrows,
+            chunk_rows,
+            crate::engine::DateSystem::Excel1900,
+        )
+    }
+
+    /// Create a sparse sheet using an explicitly selected workbook date system.
+    pub fn new_sparse_with_date_system(
         sheet_name: &str,
         ncols: usize,
         nrows: usize,
@@ -4681,6 +4692,37 @@ mod tests {
     use chrono::{Datelike, Timelike};
 
     #[test]
+    fn sparse_constructor_defaults_to_excel_1900_and_decodes_excel_1904() {
+        let date = chrono::NaiveDate::from_ymd_opt(1904, 1, 1).unwrap();
+        let datetime = date.and_hms_opt(12, 0, 0).unwrap();
+
+        let mut default_sheet = ArrowSheet::new_sparse("Default", 1, 1, 16);
+        assert_eq!(
+            default_sheet.date_system,
+            crate::engine::DateSystem::Excel1900
+        );
+        default_sheet.set_sparse_overlay_value(0, 0, OverlayValue::DateTime(1462.5));
+        assert_eq!(
+            default_sheet.get_cell_value(0, 0),
+            LiteralValue::DateTime(datetime)
+        );
+
+        let mut excel_1904 = ArrowSheet::new_sparse_with_date_system(
+            "1904",
+            1,
+            1,
+            16,
+            crate::engine::DateSystem::Excel1904,
+        );
+        assert_eq!(excel_1904.date_system, crate::engine::DateSystem::Excel1904);
+        excel_1904.set_sparse_overlay_value(0, 0, OverlayValue::DateTime(0.5));
+        assert_eq!(
+            excel_1904.get_cell_value(0, 0),
+            LiteralValue::DateTime(datetime)
+        );
+    }
+
+    #[test]
     fn datetime_lanes_round_trip_the_sheet_date_system() {
         let date = chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
         let datetime = date.and_hms_opt(12, 30, 0).unwrap();
@@ -4701,7 +4743,7 @@ mod tests {
             assert_eq!(view.get_cell(0, 0), values[0]);
             assert_eq!(view.get_cell(0, 1), values[1]);
 
-            let mut sparse = ArrowSheet::new_sparse("Sparse", 1, 1, 16, system);
+            let mut sparse = ArrowSheet::new_sparse_with_date_system("Sparse", 1, 1, 16, system);
             sparse.set_sparse_overlay_value(
                 0,
                 0,

--- a/crates/formualizer-eval/src/builtins/datetime/date_time.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/date_time.rs
@@ -1,24 +1,12 @@
 //! DATE and TIME functions
 
+use super::serial::create_date_normalized;
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
-use chrono::{NaiveDate, NaiveTime};
+use chrono::NaiveTime;
 use formualizer_common::{ExcelError, LiteralValue, date_to_serial_for, time_to_fraction};
 use formualizer_macros::func_caps;
-
-/// Create a date from year, month, and day using Excel normalization.
-fn create_date_normalized(year: i32, month: i32, day: i32) -> Result<NaiveDate, ExcelError> {
-    let total_months = (year * 12) + month - 1;
-    let normalized_year = total_months / 12;
-    let normalized_month = (total_months % 12) + 1;
-    let first_of_month = NaiveDate::from_ymd_opt(normalized_year, normalized_month as u32, 1)
-        .ok_or_else(ExcelError::new_num)?;
-
-    first_of_month
-        .checked_add_signed(chrono::TimeDelta::days((day - 1) as i64))
-        .ok_or_else(ExcelError::new_num)
-}
 
 fn coerce_to_int(arg: &ArgumentHandle) -> Result<i32, ExcelError> {
     let v = arg.value()?.into_literal();

--- a/crates/formualizer-eval/src/builtins/datetime/mod.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/mod.rs
@@ -9,6 +9,7 @@ mod date_parts;
 mod date_time;
 mod date_value;
 mod edate_eomonth;
+mod serial;
 mod today_now;
 mod weekday_workday;
 
@@ -16,6 +17,7 @@ pub use date_parts::*;
 pub use date_time::*;
 pub use date_value::*;
 pub use edate_eomonth::*;
+pub use serial::*;
 pub use today_now::*;
 pub use weekday_workday::*;
 

--- a/crates/formualizer-eval/src/builtins/datetime/serial.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/serial.rs
@@ -1,0 +1,135 @@
+//! Compatibility date-serial helpers retained at the released eval path.
+//!
+//! The checked conversion APIs in `formualizer-common` are the canonical
+//! production conversion path. The decode helpers here intentionally keep the
+//! component-wise behavior released in 0.7.1, including its handling of
+//! negative fractional serials and rounded near-midnight times. This is an
+//! eval-local compatibility adapter, not a second canonical conversion API.
+
+use chrono::{Days, NaiveDate, NaiveDateTime, NaiveTime};
+use formualizer_common::{DateSystem, ExcelError};
+
+const EXCEL_1900_EPOCH: NaiveDate = NaiveDate::from_ymd_opt(1899, 12, 31).unwrap();
+const EXCEL_1904_EPOCH: NaiveDate = NaiveDate::from_ymd_opt(1904, 1, 1).unwrap();
+const SECONDS_PER_DAY: f64 = 86_400.0;
+
+fn checked_add_days(date: NaiveDate, days: i64) -> Result<NaiveDate, ExcelError> {
+    if days >= 0 {
+        date.checked_add_days(Days::new(days as u64))
+    } else {
+        date.checked_sub_days(Days::new(days.unsigned_abs()))
+    }
+    .ok_or_else(ExcelError::new_num)
+}
+
+fn legacy_time(serial: f64) -> Result<NaiveTime, ExcelError> {
+    // This deliberately clamps components instead of carrying 24:00 into the
+    // next date: 0.999995... was observable as 23:00:00 in 0.7.1.
+    let total_seconds = (serial.fract() * SECONDS_PER_DAY).round() as u32;
+    let hours = total_seconds / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+    let seconds = total_seconds % 60;
+    NaiveTime::from_hms_opt(hours.min(23), minutes.min(59), seconds.min(59))
+        .ok_or_else(ExcelError::new_num)
+}
+
+fn legacy_excel_1900_date(serial: f64) -> Result<NaiveDate, ExcelError> {
+    if serial.is_infinite() {
+        return Err(ExcelError::new_num());
+    }
+
+    // Keep the old truncation-before-validation behavior: -0.25 and NaN both
+    // truncate/cast to zero and therefore decode to the epoch date, while
+    // negative whole serials remain #NUM.
+    let serial_int = serial.trunc();
+    if serial_int < 0.0 {
+        return Err(ExcelError::new_num());
+    }
+    let serial_int = serial_int as i64;
+    if serial_int == 60 {
+        return Ok(NaiveDate::from_ymd_opt(1900, 2, 28).unwrap());
+    }
+    let offset = if serial_int < 60 {
+        serial_int
+    } else {
+        serial_int - 1
+    };
+    checked_add_days(EXCEL_1900_EPOCH, offset)
+}
+
+/// Convert a serial to a representable Excel-1900 date.
+pub fn serial_to_date(serial: f64) -> Result<NaiveDate, ExcelError> {
+    legacy_excel_1900_date(serial)
+}
+
+/// Convert a date to an Excel-1900 serial.
+pub fn date_to_serial(date: &NaiveDate) -> f64 {
+    formualizer_common::date_to_serial_for(DateSystem::Excel1900, date)
+}
+
+/// Convert a date to a serial in the selected date system.
+pub fn date_to_serial_for(system: DateSystem, date: &NaiveDate) -> f64 {
+    formualizer_common::date_to_serial_for(system, date)
+}
+
+/// Convert a datetime to an Excel-1900 serial.
+pub fn datetime_to_serial(datetime: &NaiveDateTime) -> f64 {
+    formualizer_common::datetime_to_serial_for(DateSystem::Excel1900, datetime)
+}
+
+/// Convert a datetime to a serial in the selected date system.
+pub fn datetime_to_serial_for(system: DateSystem, datetime: &NaiveDateTime) -> f64 {
+    formualizer_common::datetime_to_serial_for(system, datetime)
+}
+
+/// Convert an Excel-1900 serial to a representable datetime.
+///
+/// This preserves the released component-clamping behavior. Unlike the
+/// released implementation, infinities and date arithmetic overflow return
+/// `#NUM!` rather than panicking.
+pub fn serial_to_datetime(serial: f64) -> Result<NaiveDateTime, ExcelError> {
+    let date = legacy_excel_1900_date(serial)?;
+    Ok(NaiveDateTime::new(date, legacy_time(serial)?))
+}
+
+/// Convert a serial to a representable datetime in the selected date system.
+///
+/// The Excel-1900 and Excel-1904 branches retain the released eval helper's
+/// component-wise decode behavior. Infinities and chrono date overflow are
+/// hardened to typed `#NUM!` errors.
+pub fn serial_to_datetime_for(
+    system: DateSystem,
+    serial: f64,
+) -> Result<NaiveDateTime, ExcelError> {
+    if serial.is_infinite() {
+        return Err(ExcelError::new_num());
+    }
+    match system {
+        DateSystem::Excel1900 => serial_to_datetime(serial),
+        DateSystem::Excel1904 => {
+            if serial.is_nan() {
+                return Err(ExcelError::new_num());
+            }
+            let days = serial.trunc() as i64;
+            let date = checked_add_days(EXCEL_1904_EPOCH, days)?;
+            Ok(NaiveDateTime::new(date, legacy_time(serial)?))
+        }
+    }
+}
+
+/// Convert a time to a fractional day.
+pub fn time_to_fraction(time: &NaiveTime) -> f64 {
+    formualizer_common::time_to_fraction(time)
+}
+
+/// Create a date using the normalization behavior released in 0.7.1.
+pub fn create_date_normalized(year: i32, month: i32, day: i32) -> Result<NaiveDate, ExcelError> {
+    let total_months = (year * 12) + month - 1;
+    let normalized_year = total_months / 12;
+    let normalized_month = (total_months % 12) + 1;
+    let first_of_month = NaiveDate::from_ymd_opt(normalized_year, normalized_month as u32, 1)
+        .ok_or_else(ExcelError::new_num)?;
+    first_of_month
+        .checked_add_signed(chrono::TimeDelta::days((day - 1) as i64))
+        .ok_or_else(ExcelError::new_num)
+}

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -156,12 +156,13 @@ impl<'a> CalcValue<'a> {
                     rv.get_cell(0, 0)
                 } else {
                     let mut data = Vec::with_capacity(rows);
-                    // Use a simple materialization loop for now
-                    // In the future, this should be optimized.
-                    let _ = rv.for_each_row(&mut |row| {
-                        data.push(row.to_vec());
-                        Ok(())
-                    });
+                    for row_idx in 0..rows {
+                        let mut row = Vec::with_capacity(cols);
+                        for col_idx in 0..cols {
+                            row.push(rv.get_cell(row_idx, col_idx));
+                        }
+                        data.push(row);
+                    }
                     LiteralValue::Array(data)
                 }
             }

--- a/crates/formualizer-eval/tests/api_compat_datetime.rs
+++ b/crates/formualizer-eval/tests/api_compat_datetime.rs
@@ -1,0 +1,213 @@
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use formualizer_common::{DateSystem, ExcelErrorKind, LiteralValue};
+use formualizer_eval::builtins::datetime::{
+    create_date_normalized, date_to_serial, date_to_serial_for, datetime_to_serial,
+    datetime_to_serial_for, serial_to_date, serial_to_datetime, serial_to_datetime_for,
+    time_to_fraction,
+};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).unwrap()
+}
+
+fn datetime(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> NaiveDateTime {
+    date(year, month, day)
+        .and_hms_opt(hour, minute, second)
+        .unwrap()
+}
+
+fn assert_num<T>(result: Result<T, formualizer_common::ExcelError>) {
+    match result {
+        Ok(_) => panic!("expected #NUM!"),
+        Err(error) => assert_eq!(error.kind, ExcelErrorKind::Num),
+    }
+}
+
+#[test]
+fn released_decode_wrappers_keep_hardcoded_excel_1900_behavior() {
+    assert_eq!(serial_to_date(0.0).unwrap(), date(1899, 12, 31));
+    assert_eq!(serial_to_date(59.0).unwrap(), date(1900, 2, 28));
+    assert_eq!(serial_to_date(60.0).unwrap(), date(1900, 2, 28));
+    assert_eq!(serial_to_date(61.0).unwrap(), date(1900, 3, 1));
+    assert_eq!(serial_to_date(-0.25).unwrap(), date(1899, 12, 31));
+    assert_eq!(serial_to_date(-0.0).unwrap(), date(1899, 12, 31));
+    assert_eq!(serial_to_date(f64::NAN).unwrap(), date(1899, 12, 31));
+
+    assert_eq!(
+        serial_to_datetime(0.0).unwrap(),
+        datetime(1899, 12, 31, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime(-0.25).unwrap(),
+        datetime(1899, 12, 31, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime(-0.0).unwrap(),
+        datetime(1899, 12, 31, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime(f64::NAN).unwrap(),
+        datetime(1899, 12, 31, 0, 0, 0)
+    );
+    for serial in [-1.0, -2.0, -1.25] {
+        assert_num(serial_to_date(serial));
+        assert_num(serial_to_datetime(serial));
+    }
+
+    let near_midnight = 86_399.4 / 86_400.0;
+    let rounded_to_midnight = 86_399.6 / 86_400.0;
+    assert_eq!(
+        serial_to_datetime(59.0 + near_midnight).unwrap(),
+        datetime(1900, 2, 28, 23, 59, 59)
+    );
+    assert_eq!(
+        serial_to_datetime(59.0 + rounded_to_midnight).unwrap(),
+        datetime(1900, 2, 28, 23, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime(60.0 + rounded_to_midnight).unwrap(),
+        datetime(1900, 2, 28, 23, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime(61.0 + near_midnight).unwrap(),
+        datetime(1900, 3, 1, 23, 59, 59)
+    );
+    assert_eq!(
+        serial_to_datetime(61.0 + rounded_to_midnight).unwrap(),
+        datetime(1900, 3, 1, 23, 0, 0)
+    );
+}
+
+#[test]
+fn released_decode_wrappers_keep_hardcoded_excel_1904_behavior() {
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, -1.25).unwrap(),
+        datetime(1903, 12, 31, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, -1.0).unwrap(),
+        datetime(1903, 12, 31, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, -0.25).unwrap(),
+        datetime(1904, 1, 1, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, -0.0).unwrap(),
+        datetime(1904, 1, 1, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 0.0).unwrap(),
+        datetime(1904, 1, 1, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 59.0).unwrap(),
+        datetime(1904, 2, 29, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 60.0).unwrap(),
+        datetime(1904, 3, 1, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 61.0).unwrap(),
+        datetime(1904, 3, 2, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 59.0 + 86_399.4 / 86_400.0).unwrap(),
+        datetime(1904, 2, 29, 23, 59, 59)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 59.0 + 86_399.6 / 86_400.0).unwrap(),
+        datetime(1904, 2, 29, 23, 0, 0)
+    );
+    assert_num(serial_to_datetime_for(DateSystem::Excel1904, f64::NAN));
+}
+
+#[test]
+fn decode_wrappers_support_chrono_year_9999_and_10000_and_harden_overflow() {
+    assert_eq!(
+        serial_to_datetime(2_958_465.0).unwrap(),
+        datetime(9999, 12, 31, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime(2_958_466.0).unwrap(),
+        datetime(10000, 1, 1, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 2_957_003.0).unwrap(),
+        datetime(9999, 12, 31, 0, 0, 0)
+    );
+    assert_eq!(
+        serial_to_datetime_for(DateSystem::Excel1904, 2_957_004.0).unwrap(),
+        datetime(10000, 1, 1, 0, 0, 0)
+    );
+
+    for serial in [f64::INFINITY, f64::NEG_INFINITY, f64::MAX, f64::MIN] {
+        assert_num(serial_to_date(serial));
+        assert_num(serial_to_datetime(serial));
+        assert_num(serial_to_datetime_for(DateSystem::Excel1900, serial));
+        assert_num(serial_to_datetime_for(DateSystem::Excel1904, serial));
+    }
+}
+
+#[test]
+fn released_encode_helpers_and_normalization_remain_public() {
+    let _: fn(f64) -> Result<NaiveDate, formualizer_common::ExcelError> = serial_to_date;
+    let _: fn(&NaiveDate) -> f64 = date_to_serial;
+    let _: fn(f64) -> Result<NaiveDateTime, formualizer_common::ExcelError> = serial_to_datetime;
+    let _: fn(&NaiveDateTime) -> f64 = datetime_to_serial;
+    let _: fn(DateSystem, &NaiveDate) -> f64 = date_to_serial_for;
+    let _: fn(DateSystem, &NaiveDateTime) -> f64 = datetime_to_serial_for;
+    let _: fn(DateSystem, f64) -> Result<NaiveDateTime, formualizer_common::ExcelError> =
+        serial_to_datetime_for;
+    let _: fn(&NaiveTime) -> f64 = time_to_fraction;
+    let _: fn(i32, i32, i32) -> Result<NaiveDate, formualizer_common::ExcelError> =
+        create_date_normalized;
+
+    let noon_1900 = datetime(1900, 3, 1, 12, 0, 0);
+    let noon_1904 = datetime(1904, 1, 1, 12, 0, 0);
+    assert_eq!(date_to_serial(&date(1900, 3, 1)), 61.0);
+    assert_eq!(datetime_to_serial(&noon_1900), 61.5);
+    assert_eq!(
+        date_to_serial_for(DateSystem::Excel1904, &date(1904, 1, 1)),
+        0.0
+    );
+    assert_eq!(
+        datetime_to_serial_for(DateSystem::Excel1904, &noon_1904),
+        0.5
+    );
+    assert_eq!(
+        time_to_fraction(&NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+        0.5
+    );
+    assert_eq!(
+        create_date_normalized(2024, 13, 5).unwrap(),
+        date(2025, 1, 5)
+    );
+    assert_eq!(
+        create_date_normalized(2024, 0, 15).unwrap(),
+        date(2023, 12, 15)
+    );
+    assert_num(create_date_normalized(0, 0, 1));
+}
+
+#[test]
+fn sparse_public_constructors_decode_hardcoded_1900_and_1904_serials() {
+    use formualizer_eval::arrow_store::{ArrowSheet, OverlayValue};
+
+    let expected = datetime(1904, 1, 1, 12, 0, 0);
+    let mut excel_1900 = ArrowSheet::new_sparse("1900", 1, 1, 16);
+    excel_1900.set_sparse_overlay_value(0, 0, OverlayValue::DateTime(1462.5));
+    assert_eq!(
+        excel_1900.get_cell_value(0, 0),
+        LiteralValue::DateTime(expected)
+    );
+
+    let mut excel_1904 =
+        ArrowSheet::new_sparse_with_date_system("1904", 1, 1, 16, DateSystem::Excel1904);
+    excel_1904.set_sparse_overlay_value(0, 0, OverlayValue::DateTime(0.5));
+    assert_eq!(
+        excel_1904.get_cell_value(0, 0),
+        LiteralValue::DateTime(expected)
+    );
+}

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -349,7 +349,7 @@ impl CalamineAdapter {
             row_started: false,
         });
         let mut sparse = force_sparse_from_start.then(|| {
-            formualizer_eval::arrow_store::ArrowSheet::new_sparse(
+            formualizer_eval::arrow_store::ArrowSheet::new_sparse_with_date_system(
                 sheet,
                 dims_cols,
                 dims_rows,

--- a/crates/formualizer-workbook/src/backends/json.rs
+++ b/crates/formualizer-workbook/src/backends/json.rs
@@ -738,13 +738,14 @@ where
                 engine.workbook_load_limits(),
             );
             let asheet = if sparse_initial {
-                let mut asheet = formualizer_eval::arrow_store::ArrowSheet::new_sparse(
-                    name,
-                    cols,
-                    rows,
-                    chunk_rows,
-                    engine.config.date_system,
-                );
+                let mut asheet =
+                    formualizer_eval::arrow_store::ArrowSheet::new_sparse_with_date_system(
+                        name,
+                        cols,
+                        rows,
+                        chunk_rows,
+                        engine.config.date_system,
+                    );
                 for cell in &sheet.cells {
                     if cell.formula.is_some() {
                         continue;

--- a/crates/formualizer-workbook/src/backends/umya.rs
+++ b/crates/formualizer-workbook/src/backends/umya.rs
@@ -1267,8 +1267,13 @@ where
                 engine.workbook_load_limits(),
             );
             let asheet = if sparse_initial {
-                let mut asheet =
-                    ArrowSheet::new_sparse(n, cols, rows, chunk_rows, engine.config.date_system);
+                let mut asheet = ArrowSheet::new_sparse_with_date_system(
+                    n,
+                    cols,
+                    rows,
+                    chunk_rows,
+                    engine.config.date_system,
+                );
                 for ((row, col), cd) in &sheet_data.cells {
                     if cd.formula.is_some() {
                         continue;

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -143,7 +143,8 @@ pub fn formualizer_eval::arrow_store::ArrowSheet::get_cell_value(&self, usize, u
 pub fn formualizer_eval::arrow_store::ArrowSheet::insert_columns(&mut self, usize, usize)
 pub fn formualizer_eval::arrow_store::ArrowSheet::insert_rows(&mut self, usize, usize)
 pub fn formualizer_eval::arrow_store::ArrowSheet::maybe_compact_chunk(&mut self, usize, usize, usize, usize) -> usize
-pub fn formualizer_eval::arrow_store::ArrowSheet::new_sparse(&str, usize, usize, usize, formualizer_common::value::DateSystem) -> Self
+pub fn formualizer_eval::arrow_store::ArrowSheet::new_sparse(&str, usize, usize, usize) -> Self
+pub fn formualizer_eval::arrow_store::ArrowSheet::new_sparse_with_date_system(&str, usize, usize, usize, formualizer_common::value::DateSystem) -> Self
 pub fn formualizer_eval::arrow_store::ArrowSheet::range_view(&self, usize, usize, usize, usize) -> formualizer_eval::engine::range_view::RangeView<'_>
 pub fn formualizer_eval::arrow_store::ArrowSheet::set_sparse_overlay_value(&mut self, usize, usize, formualizer_eval::arrow_store::OverlayValue) -> isize
 pub fn formualizer_eval::arrow_store::ArrowSheet::shape(&self) -> alloc::vec::Vec<formualizer_eval::arrow_store::ColumnShape>
@@ -912,7 +913,16 @@ pub fn formualizer_eval::builtins::datetime::YearFracFn::namespace(&self) -> &'s
 pub fn formualizer_eval::builtins::datetime::YearFracFn::semantic_contract(&self, usize) -> core::option::Option<formualizer_eval::function_contract::FunctionSemanticContract>
 pub fn formualizer_eval::builtins::datetime::YearFracFn::variadic(&self) -> bool
 pub fn formualizer_eval::builtins::datetime::YearFracFn::volatile(&self) -> bool
+pub fn formualizer_eval::builtins::datetime::create_date_normalized(i32, i32, i32) -> core::result::Result<chrono::naive::date::NaiveDate, formualizer_common::error::ExcelError>
+pub fn formualizer_eval::builtins::datetime::date_to_serial(&chrono::naive::date::NaiveDate) -> f64
+pub fn formualizer_eval::builtins::datetime::date_to_serial_for(formualizer_common::value::DateSystem, &chrono::naive::date::NaiveDate) -> f64
+pub fn formualizer_eval::builtins::datetime::datetime_to_serial(&chrono::naive::datetime::NaiveDateTime) -> f64
+pub fn formualizer_eval::builtins::datetime::datetime_to_serial_for(formualizer_common::value::DateSystem, &chrono::naive::datetime::NaiveDateTime) -> f64
 pub fn formualizer_eval::builtins::datetime::register_builtins()
+pub fn formualizer_eval::builtins::datetime::serial_to_date(f64) -> core::result::Result<chrono::naive::date::NaiveDate, formualizer_common::error::ExcelError>
+pub fn formualizer_eval::builtins::datetime::serial_to_datetime(f64) -> core::result::Result<chrono::naive::datetime::NaiveDateTime, formualizer_common::error::ExcelError>
+pub fn formualizer_eval::builtins::datetime::serial_to_datetime_for(formualizer_common::value::DateSystem, f64) -> core::result::Result<chrono::naive::datetime::NaiveDateTime, formualizer_common::error::ExcelError>
+pub fn formualizer_eval::builtins::datetime::time_to_fraction(&chrono::naive::time::NaiveTime) -> f64
 pub mod formualizer_eval::builtins::engineering
 pub struct formualizer_eval::builtins::engineering::BesselIFn
 impl core::fmt::Debug for formualizer_eval::builtins::engineering::BesselIFn


### PR DESCRIPTION
## Summary

- restore the nine released `formualizer_eval::builtins::datetime` helper paths while keeping canonical production conversion in `formualizer-common`
- restore four-argument `ArrowSheet::new_sparse` as the Excel-1900 convenience and add explicit `new_sparse_with_date_system`
- preserve released finite/NaN/negative-fraction and component-clamping compatibility behavior, while returning typed `#NUM!` instead of panicking on infinities or chrono overflow
- materialize `CalcValue::Range` directly instead of discarding a vacuous callback `Result`
- add hardcoded public-path regressions and reviewed public API snapshot changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p formualizer-eval --test api_compat_datetime`
- `cargo test -p formualizer-eval --lib` — 2460 passed, 12 ignored
- `cargo check -p formualizer-workbook --all-features --tests`
- `scripts/public-api.sh check formualizer-eval`
- controlled negative mutations proved the datetime compatibility and sparse date-system assertions fail when routing is changed
- two fresh adversarial reviews; final review reported no blockers or major findings

Closes the compatibility/conversion tranche of #259; the remaining surface, extensibility, and package/freeze tranches stay serial.

drafted with love by (agent) Manfred, with approval from Frankie