### PR TITLE
fix: distinguish omitted function arguments from explicit empty text (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Formualizer will be documented in this file.
 ### Fixed
 
 - Explicitly omitted function arguments now retain their syntax through parsing and canonical rendering, coerce as Excel empty arguments (`0`, `FALSE`, or empty text by context), and count as numeric zero in aggregates without changing absent optional defaults or blank-reference behavior. (#277)
+- `TEXT` with an empty format string (explicit `""` or an omitted second argument) now returns empty text, matching Excel and LibreOffice; it previously rendered the value as if unformatted. (#277)
 - Restored the released `formualizer_eval::builtins::datetime` conversion helpers and sparse-sheet constructor compatibility paths, including explicit 1904 date-system handling. The eval decode wrappers retain released 0.7.1 component-clamping and negative-fraction behavior; as an intentional safety deviation, infinities and chrono date/duration overflow now return typed `#NUM!` instead of panicking. (#259)
 
 - CFFI targeted cell evaluation now reports both the targeted graph-preparation error and the distinct full-graph fallback error when both preparation attempts fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Formualizer will be documented in this file.
 
 #### Parser/SDK 3.0 preparation
 
+- `ASTNodeType` adds the `Omitted` variant for explicitly omitted function-argument slots. Exhaustive Rust matches and AST projections must handle the new node; it remains distinct from empty text and blank-cell values. (#277)
 - `formualizer-common` and `formualizer-parse` now share version 3.0.0. The major records the removal of the four 2.0 token-vector/classifier `Parser` constructors in favor of source strings, `TokenStream`, and `ParserBuilder`; the deleted token-vector parser is not restored. See `docs/parser-sdk-3-migration.md`. (#257)
 - Reported error/outcome vocabularies (`ExcelErrorKind`, resource and staleness reasons, `ExcelErrorExtra`, common coordinate/address/value errors, `RecoveryAction`, and `ParsingError`) are now non-exhaustive. Downstream output mappings use deliberate future fallbacks, while caller-supplied/core enums remain exhaustive. Serde unknown variants remain a separate wire-compatibility concern. (#257)
 - Restored the inexpensive legacy `formualizer_common::value::{datetime_to_serial, serial_to_datetime}` paths as forwarding reexports; the root and `date_serial` paths remain available. (#257)
@@ -50,6 +51,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Explicitly omitted function arguments now retain their syntax through parsing and canonical rendering, coerce as Excel empty arguments (`0`, `FALSE`, or empty text by context), and count as numeric zero in aggregates without changing absent optional defaults or blank-reference behavior. (#277)
 - Restored the released `formualizer_eval::builtins::datetime` conversion helpers and sparse-sheet constructor compatibility paths, including explicit 1904 date-system handling. The eval decode wrappers retain released 0.7.1 component-clamping and negative-fraction behavior; as an intentional safety deviation, infinities and chrono date/duration overflow now return typed `#NUM!` instead of panicking. (#259)
 
 - CFFI targeted cell evaluation now reports both the targeted graph-preparation error and the distinct full-graph fallback error when both preparation attempts fail.

--- a/bindings/python/src/ast.rs
+++ b/bindings/python/src/ast.rs
@@ -104,6 +104,7 @@ impl PyASTNode {
     fn node_type(&self) -> String {
         match &self.inner.node_type {
             ASTNodeType::Literal(_) => "Literal".to_string(),
+            ASTNodeType::Omitted => "Omitted".to_string(),
             ASTNodeType::Reference { .. } => "Reference".to_string(),
             ASTNodeType::UnaryOp { .. } => "UnaryOp".to_string(),
             ASTNodeType::BinaryOp { .. } => "BinaryOp".to_string(),
@@ -184,6 +185,7 @@ impl PyASTNode {
                     self.format_literal_value(value)
                 )
             }
+            ASTNodeType::Omitted => format!("{indent_str}Omitted"),
             ASTNodeType::Reference { original, .. } => {
                 format!("{indent_str}Reference({original})")
             }
@@ -307,6 +309,7 @@ impl PyASTNode {
                 dict.set_item("value", self.literal_value_to_py(py, value))
                     .unwrap();
             }
+            ASTNodeType::Omitted => {}
             ASTNodeType::Reference { original, .. } => {
                 dict.set_item("reference", original).unwrap();
             }

--- a/bindings/python/tests/test_formula_printing.py
+++ b/bindings/python/tests/test_formula_printing.py
@@ -10,7 +10,7 @@ def test_parse_projects_omitted_argument_distinctly():
     ast = fz.parse("=IFERROR(A1,)")
     assert ast.children()[1].node_type() == "Omitted"
     assert ast.children()[1].get_literal_value() is None
-    assert ast.to_formula() == "=IFERROR(A1, )"
+    assert ast.to_formula() == "=IFERROR(A1,)"
 
 
 def test_workbook_evaluates_omitted_iferror_fallback_as_zero():

--- a/bindings/python/tests/test_formula_printing.py
+++ b/bindings/python/tests/test_formula_printing.py
@@ -6,6 +6,21 @@ def test_parse_to_formula_quotes_text():
     assert ast.to_formula() == '=SUMIFS(A:A, B:B, "*Parking*")'
 
 
+def test_parse_projects_omitted_argument_distinctly():
+    ast = fz.parse("=IFERROR(A1,)")
+    assert ast.children()[1].node_type() == "Omitted"
+    assert ast.children()[1].get_literal_value() is None
+    assert ast.to_formula() == "=IFERROR(A1, )"
+
+
+def test_workbook_evaluates_omitted_iferror_fallback_as_zero():
+    wb = fz.Workbook()
+    wb.add_sheet("S")
+    wb.set_formula("S", 1, 1, "=IFERROR(1/0,)")
+    wb.evaluate_all()
+    assert wb.get_value("S", 1, 1) == 0
+
+
 def test_workbook_get_formula_roundtrips_text():
     wb = fz.Workbook()
     wb.add_sheet("S")

--- a/bindings/wasm/src/ast.rs
+++ b/bindings/wasm/src/ast.rs
@@ -35,6 +35,10 @@ pub enum ASTNodeData {
         #[serde(flatten)]
         source: NodeSourceData,
     },
+    Omitted {
+        #[serde(flatten)]
+        source: NodeSourceData,
+    },
     Reference {
         reference: ReferenceData,
         #[serde(flatten)]
@@ -211,6 +215,7 @@ impl ASTNodeData {
                     source,
                 },
             },
+            ASTNodeType::Omitted => ASTNodeData::Omitted { source },
             ASTNodeType::Reference {
                 original,
                 reference,
@@ -345,6 +350,7 @@ impl ASTNode {
             ASTNodeData::Number { .. } => "number".to_string(),
             ASTNodeData::Text { .. } => "text".to_string(),
             ASTNodeData::Boolean { .. } => "boolean".to_string(),
+            ASTNodeData::Omitted { .. } => "omitted".to_string(),
             ASTNodeData::Reference { .. } => "reference".to_string(),
             ASTNodeData::Function { .. } => "function".to_string(),
             ASTNodeData::BinaryOp { .. } => "binaryOp".to_string(),

--- a/crates/formualizer-bench-core/src/bin/scan-formula-templates.rs
+++ b/crates/formualizer-bench-core/src/bin/scan-formula-templates.rs
@@ -798,6 +798,7 @@ fn canonical_ast(
 ) -> String {
     match &ast.node_type {
         ASTNodeType::Literal(value) => format!("LIT:{:?}", value_kind(value)),
+        ASTNodeType::Omitted => "OMITTED".to_string(),
         ASTNodeType::Reference { reference, .. } => {
             canonical_reference(reference, anchor_row, anchor_col, labels)
         }

--- a/crates/formualizer-cffi/src/parse.rs
+++ b/crates/formualizer-cffi/src/parse.rs
@@ -25,6 +25,10 @@ pub enum CffiASTNode {
         #[serde(skip_serializing_if = "Option::is_none")]
         span: Option<[usize; 2]>,
     },
+    Omitted {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        span: Option<[usize; 2]>,
+    },
     Error {
         kind: String,
         message: Option<String>,
@@ -120,6 +124,7 @@ impl CffiASTNode {
                     span,
                 },
             },
+            ASTNodeType::Omitted => CffiASTNode::Omitted { span },
             ASTNodeType::Reference {
                 original,
                 reference,

--- a/crates/formualizer-eval/src/builtins/lookup/core.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/core.rs
@@ -183,19 +183,23 @@ impl Function for MatchFn {
         }
         let mut match_type = 1.0; // default
         if args.len() >= 3 {
-            let mt_val = args[2].value()?.into_literal();
-            if let LiteralValue::Error(e) = mt_val {
-                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
-            }
-            match mt_val {
-                LiteralValue::Number(n) => match_type = n,
-                LiteralValue::Int(i) => match_type = i as f64,
-                LiteralValue::Text(s) => {
-                    if let Ok(n) = s.parse::<f64>() {
-                        match_type = n;
-                    }
+            if args[2].is_omitted() {
+                match_type = 0.0;
+            } else {
+                let mt_val = args[2].value()?.into_literal();
+                if let LiteralValue::Error(e) = mt_val {
+                    return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
                 }
-                _ => {}
+                match mt_val {
+                    LiteralValue::Number(n) => match_type = n,
+                    LiteralValue::Int(i) => match_type = i as f64,
+                    LiteralValue::Text(s) => {
+                        if let Ok(n) = s.parse::<f64>() {
+                            match_type = n;
+                        }
+                    }
+                    _ => {}
+                }
             }
         }
         let mt = if match_type > 0.0 {

--- a/crates/formualizer-eval/src/builtins/lookup/core.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/core.rs
@@ -183,6 +183,7 @@ impl Function for MatchFn {
         }
         let mut match_type = 1.0; // default
         if args.len() >= 3 {
+            // Defensive: value() currently materializes omission as Number(0), so this is redundant.
             if args[2].is_omitted() {
                 match_type = 0.0;
             } else {

--- a/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
@@ -628,6 +628,7 @@ impl Function for XMatchFn {
         }
 
         let match_mode = if args.len() >= 3 {
+            // Defensive: value() currently materializes omission as Number(0), so this is redundant.
             if args[2].is_omitted() {
                 0
             } else {

--- a/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
@@ -628,10 +628,14 @@ impl Function for XMatchFn {
         }
 
         let match_mode = if args.len() >= 3 {
-            match args[2].value()?.into_literal() {
-                LiteralValue::Int(i) => i,
-                LiteralValue::Number(n) => n as i64,
-                _ => 0,
+            if args[2].is_omitted() {
+                0
+            } else {
+                match args[2].value()?.into_literal() {
+                    LiteralValue::Int(i) => i,
+                    LiteralValue::Number(n) => n as i64,
+                    _ => 0,
+                }
             }
         } else {
             0

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -223,6 +223,8 @@ impl Function for IndexFn {
             Ok(r) => r,
             Err(_) => return None,
         };
+        // Defensive: value() currently materializes omitted indexes as Number(0), so these
+        // row/column checks are redundant while documenting whole-row/column intent.
         let position = if args[1].is_omitted() {
             0
         } else {
@@ -367,6 +369,8 @@ impl Function for IndexFn {
                 LiteralValue::Array(rows) => rows,
                 other => vec![vec![other]],
             };
+            // Defensive: value() currently materializes omitted indexes as Number(0), so these
+            // row/column checks are redundant while documenting whole-row/column intent.
             let index = if args[1].is_omitted() {
                 0
             } else {

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -223,22 +223,30 @@ impl Function for IndexFn {
             Ok(r) => r,
             Err(_) => return None,
         };
-        let position = match args[1].value() {
-            Ok(cv) => match cv.into_literal() {
-                LiteralValue::Number(n) => n as i64,
-                LiteralValue::Int(i) => i,
-                _ => return Some(Err(ExcelError::new(ExcelErrorKind::Value))),
-            },
-            Err(e) => return Some(Err(e)),
-        };
-        let explicit_col = if args.len() >= 3 {
-            Some(match args[2].value() {
+        let position = if args[1].is_omitted() {
+            0
+        } else {
+            match args[1].value() {
                 Ok(cv) => match cv.into_literal() {
                     LiteralValue::Number(n) => n as i64,
                     LiteralValue::Int(i) => i,
                     _ => return Some(Err(ExcelError::new(ExcelErrorKind::Value))),
                 },
                 Err(e) => return Some(Err(e)),
+            }
+        };
+        let explicit_col = if args.len() >= 3 {
+            Some(if args[2].is_omitted() {
+                0
+            } else {
+                match args[2].value() {
+                    Ok(cv) => match cv.into_literal() {
+                        LiteralValue::Number(n) => n as i64,
+                        LiteralValue::Int(i) => i,
+                        _ => return Some(Err(ExcelError::new(ExcelErrorKind::Value))),
+                    },
+                    Err(e) => return Some(Err(e)),
+                }
             })
         } else {
             None
@@ -359,25 +367,33 @@ impl Function for IndexFn {
                 LiteralValue::Array(rows) => rows,
                 other => vec![vec![other]],
             };
-            let index = match args[1].value()?.into_literal() {
-                LiteralValue::Number(n) => n as i64,
-                LiteralValue::Int(i) => i,
-                _ => {
-                    return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
-                        ExcelError::new(ExcelErrorKind::Value),
-                    )));
-                }
-            };
-
-            // Optional explicit column_num (third argument).
-            let explicit_col = if args.len() >= 3 {
-                Some(match args[2].value()?.into_literal() {
+            let index = if args[1].is_omitted() {
+                0
+            } else {
+                match args[1].value()?.into_literal() {
                     LiteralValue::Number(n) => n as i64,
                     LiteralValue::Int(i) => i,
                     _ => {
                         return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
                             ExcelError::new(ExcelErrorKind::Value),
                         )));
+                    }
+                }
+            };
+
+            // Optional explicit column_num (third argument).
+            let explicit_col = if args.len() >= 3 {
+                Some(if args[2].is_omitted() {
+                    0
+                } else {
+                    match args[2].value()?.into_literal() {
+                        LiteralValue::Number(n) => n as i64,
+                        LiteralValue::Int(i) => i,
+                        _ => {
+                            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                                ExcelError::new(ExcelErrorKind::Value),
+                            )));
+                        }
                     }
                 })
             } else {
@@ -582,7 +598,7 @@ impl Function for OffsetFn {
 
         let nsr = (sr as i64) + dr;
         let nsc = (sc as i64) + dc;
-        let height = if args.len() >= 4 {
+        let height = if args.len() >= 4 && !args[3].is_omitted() {
             match args[3].value() {
                 Ok(cv) => match cv.into_literal() {
                     LiteralValue::Number(n) => n as i64,
@@ -594,7 +610,7 @@ impl Function for OffsetFn {
         } else {
             (er as i64) - (sr as i64) + 1
         };
-        let width = if args.len() >= 5 {
+        let width = if args.len() >= 5 && !args[4].is_omitted() {
             match args[4].value() {
                 Ok(cv) => match cv.into_literal() {
                     LiteralValue::Number(n) => n as i64,

--- a/crates/formualizer-eval/src/builtins/text/array_text.rs
+++ b/crates/formualizer-eval/src/builtins/text/array_text.rs
@@ -4,7 +4,7 @@
 //! VALUETOTEXT: Converts a value to text representation
 //! ARRAYTOTEXT: Converts an array to text representation
 
-use super::super::utils::collapse_if_scalar;
+use super::{super::utils::collapse_if_scalar, scalar_text_value};
 use crate::args::{ArgSchema, ShapeKind};
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
@@ -42,7 +42,7 @@ fn coerce_text(v: &LiteralValue) -> String {
 
 /// Get delimiters from an argument (can be single value or array)
 fn get_delimiters(arg: &ArgumentHandle<'_, '_>) -> Result<Vec<String>, ExcelError> {
-    let cv = arg.value()?;
+    let cv = arg.value_for_text()?;
     match cv {
         CalcValue::Scalar(v) => match v {
             LiteralValue::Error(e) => Err(e),
@@ -293,7 +293,7 @@ impl Function for TextSplitFn {
         ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
         // Get text to split
-        let text_val = scalar_like_value(&args[0])?;
+        let text_val = scalar_text_value(&args[0])?;
         let text = match text_val {
             LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
             other => coerce_text(&other),
@@ -305,7 +305,7 @@ impl Function for TextSplitFn {
         // Get optional row delimiters
         let row_delimiters = if args.len() > 2 {
             // Check if row_delimiter argument is provided and not omitted
-            let val = scalar_like_value(&args[2])?;
+            let val = scalar_text_value(&args[2])?;
             match val {
                 LiteralValue::Empty => vec![],
                 LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
@@ -545,7 +545,7 @@ impl Function for ValueToTextFn {
         _ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
         // Get value
-        let value = scalar_like_value(&args[0])?;
+        let value = scalar_text_value(&args[0])?;
 
         // Get format (0=concise, 1=strict)
         let format = if args.len() > 1 {
@@ -702,7 +702,7 @@ impl Function for ArrayToTextFn {
             }
             result
         } else {
-            let cv = args[0].value()?;
+            let cv = args[0].value_for_text()?;
             match cv.into_literal() {
                 LiteralValue::Array(arr) => arr,
                 LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),

--- a/crates/formualizer-eval/src/builtins/text/char_code_rept.rs
+++ b/crates/formualizer-eval/src/builtins/text/char_code_rept.rs
@@ -1,6 +1,9 @@
 //! CHAR, CODE, REPT text functions
 
-use super::super::utils::{ARG_ANY_ONE, ARG_ANY_TWO, coerce_num};
+use super::{
+    super::utils::{ARG_ANY_ONE, ARG_ANY_TWO, coerce_num},
+    scalar_text_value,
+};
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
@@ -199,7 +202,7 @@ impl Function for CodeFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         _: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
-        let v = scalar_like_value(&args[0])?;
+        let v = scalar_text_value(&args[0])?;
         let s = match v {
             LiteralValue::Text(t) => t,
             LiteralValue::Empty => {
@@ -330,7 +333,7 @@ impl Function for AscFn {
                 ExcelError::new_value(),
             )));
         }
-        let v = scalar_like_value(&args[0])?;
+        let v = scalar_text_value(&args[0])?;
         let s = match v {
             LiteralValue::Text(t) => t,
             LiteralValue::Empty => String::new(),
@@ -401,7 +404,7 @@ impl Function for ReptFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         _: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
-        let text_val = scalar_like_value(&args[0])?;
+        let text_val = scalar_text_value(&args[0])?;
         let count_val = scalar_like_value(&args[1])?;
 
         let text = match text_val {

--- a/crates/formualizer-eval/src/builtins/text/extended.rs
+++ b/crates/formualizer-eval/src/builtins/text/extended.rs
@@ -1,6 +1,9 @@
 //! Extended text functions: CLEAN, UNICHAR, UNICODE, TEXTBEFORE, TEXTAFTER, TEXTSPLIT, DOLLAR, FIXED
 
-use super::super::utils::{ARG_ANY_ONE, coerce_num};
+use super::{
+    super::utils::{ARG_ANY_ONE, coerce_num},
+    scalar_text_value,
+};
 use crate::args::{ArgSchema, ShapeKind};
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
@@ -99,7 +102,7 @@ impl Function for CleanFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         _: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
-        let v = scalar_like_value(&args[0])?;
+        let v = scalar_text_value(&args[0])?;
         let text = match v {
             LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
             other => coerce_text(&other),
@@ -261,7 +264,7 @@ impl Function for UnicodeFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         _: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
-        let v = scalar_like_value(&args[0])?;
+        let v = scalar_text_value(&args[0])?;
         let text = match v {
             LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
             other => coerce_text(&other),
@@ -378,13 +381,13 @@ impl Function for TextBeforeFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         _: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
-        let v1 = scalar_like_value(&args[0])?;
+        let v1 = scalar_text_value(&args[0])?;
         let text = match v1 {
             LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
             other => coerce_text(&other),
         };
 
-        let v2 = scalar_like_value(&args[1])?;
+        let v2 = scalar_text_value(&args[1])?;
         let delimiter = match v2 {
             LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
             other => coerce_text(&other),
@@ -509,13 +512,13 @@ impl Function for TextAfterFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         _: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
-        let v1 = scalar_like_value(&args[0])?;
+        let v1 = scalar_text_value(&args[0])?;
         let text = match v1 {
             LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
             other => coerce_text(&other),
         };
 
-        let v2 = scalar_like_value(&args[1])?;
+        let v2 = scalar_text_value(&args[1])?;
         let delimiter = match v2 {
             LiteralValue::Error(e) => return Ok(CalcValue::Scalar(LiteralValue::Error(e))),
             other => coerce_text(&other),

--- a/crates/formualizer-eval/src/builtins/text/find_search_exact.rs
+++ b/crates/formualizer-eval/src/builtins/text/find_search_exact.rs
@@ -1,4 +1,4 @@
-use super::super::utils::ARG_ANY_ONE;
+use super::{super::utils::ARG_ANY_ONE, scalar_text_value};
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
@@ -16,7 +16,7 @@ fn scalar_like_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, Excel
 }
 
 fn to_text<'a, 'b>(a: &ArgumentHandle<'a, 'b>) -> Result<String, ExcelError> {
-    let v = scalar_like_value(a)?;
+    let v = scalar_text_value(a)?;
     Ok(match v {
         LiteralValue::Text(s) => s,
         LiteralValue::Empty => String::new(),

--- a/crates/formualizer-eval/src/builtins/text/len_left_right.rs
+++ b/crates/formualizer-eval/src/builtins/text/len_left_right.rs
@@ -1,4 +1,4 @@
-use super::super::utils::ARG_ANY_ONE;
+use super::{super::utils::ARG_ANY_ONE, scalar_text_value};
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
@@ -74,7 +74,7 @@ impl Function for LenFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         _: &dyn FunctionContext<'b>,
     ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
-        let v = scalar_like_value(&args[0])?;
+        let v = scalar_text_value(&args[0])?;
         let count = match v {
             LiteralValue::Text(s) => s.chars().count() as i64,
             LiteralValue::Empty => 0,
@@ -154,7 +154,7 @@ impl Function for LeftFn {
                 ExcelError::new_value(),
             )));
         }
-        let s_val = scalar_like_value(&args[0])?;
+        let s_val = scalar_text_value(&args[0])?;
         let s = match s_val {
             LiteralValue::Text(t) => t,
             LiteralValue::Empty => String::new(),
@@ -248,7 +248,7 @@ impl Function for RightFn {
                 ExcelError::new_value(),
             )));
         }
-        let s_val = scalar_like_value(&args[0])?;
+        let s_val = scalar_text_value(&args[0])?;
         let s = match s_val {
             LiteralValue::Text(t) => t,
             LiteralValue::Empty => String::new(),

--- a/crates/formualizer-eval/src/builtins/text/mid_sub_replace.rs
+++ b/crates/formualizer-eval/src/builtins/text/mid_sub_replace.rs
@@ -1,4 +1,4 @@
-use super::super::utils::ARG_ANY_ONE;
+use super::{super::utils::ARG_ANY_ONE, scalar_text_value};
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
@@ -300,7 +300,7 @@ impl Function for ReplaceFn {
 }
 
 fn to_text<'a, 'b>(arg: &ArgumentHandle<'a, 'b>) -> Result<String, ExcelError> {
-    let v = scalar_like_value(arg)?;
+    let v = scalar_text_value(arg)?;
     Ok(match v {
         LiteralValue::Text(s) => s,
         LiteralValue::Empty => String::new(),

--- a/crates/formualizer-eval/src/builtins/text/mod.rs
+++ b/crates/formualizer-eval/src/builtins/text/mod.rs
@@ -4,6 +4,19 @@
 //! CHAR, CODE, REPT, CLEAN, UNICHAR, UNICODE, TEXTBEFORE, TEXTAFTER, DOLLAR, FIXED
 //! TEXTSPLIT, VALUETOTEXT, ARRAYTOTEXT (array text functions)
 
+use crate::traits::{ArgumentHandle, CalcValue};
+use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
+
+fn scalar_text_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, ExcelError> {
+    Ok(match arg.value_for_text()? {
+        CalcValue::Scalar(value) => value,
+        CalcValue::Range(view) => view.get_cell(0, 0),
+        CalcValue::Callable(_) => LiteralValue::Error(
+            ExcelError::new(ExcelErrorKind::Calc).with_message("LAMBDA value must be invoked"),
+        ),
+    })
+}
+
 mod array_text; // TEXTSPLIT, VALUETOTEXT, ARRAYTOTEXT
 mod byte; // FINDB, LEFTB, LENB, MIDB, REPLACEB, RIGHTB, SEARCHB
 mod char_code_rept; // CHAR, CODE, REPT

--- a/crates/formualizer-eval/src/builtins/text/trim_case_concat.rs
+++ b/crates/formualizer-eval/src/builtins/text/trim_case_concat.rs
@@ -26,6 +26,9 @@ static TEXTJOIN_ARGS: LazyLock<Vec<ArgSchema>> = LazyLock::new(|| {
 const MAX_CONCAT_RESULT_CHARS: usize = 32_767;
 
 fn scalar_like_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, ExcelError> {
+    if arg.is_omitted() {
+        return Ok(LiteralValue::Text(String::new()));
+    }
     Ok(match arg.value()? {
         crate::traits::CalcValue::Scalar(v) => v,
         crate::traits::CalcValue::Range(rv) => rv.get_cell(0, 0),
@@ -65,6 +68,9 @@ fn literal_to_text(v: &LiteralValue) -> Result<String, ExcelError> {
 }
 
 fn legacy_scalar_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, ExcelError> {
+    if arg.is_omitted() {
+        return Ok(LiteralValue::Text(String::new()));
+    }
     Ok(match arg.value()? {
         crate::traits::CalcValue::Scalar(LiteralValue::Array(rows)) => rows
             .first()
@@ -99,6 +105,9 @@ fn for_each_expanded_value(
     arg: &ArgumentHandle<'_, '_>,
     visitor: &mut dyn FnMut(&LiteralValue) -> Result<(), ExcelError>,
 ) -> Result<(), ExcelError> {
+    if arg.is_omitted() {
+        return visitor(&LiteralValue::Text(String::new()));
+    }
     match arg.resolve_once()? {
         ResolvedArgument::Range(view) | ResolvedArgument::Value(CalcValue::Range(view)) => {
             view.for_each_cell(visitor)

--- a/crates/formualizer-eval/src/builtins/text/trim_case_concat.rs
+++ b/crates/formualizer-eval/src/builtins/text/trim_case_concat.rs
@@ -1,7 +1,7 @@
 use super::{super::utils::ARG_ANY_ONE, scalar_text_value};
 use crate::args::{ArgSchema, ShapeKind};
 use crate::function::Function;
-use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
+use crate::traits::{ArgumentHandle, CalcValue, FunctionContext, ResolvedArgument};
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_macros::func_caps;
 use std::sync::LazyLock;
@@ -99,9 +99,12 @@ fn for_each_expanded_value(
     arg: &ArgumentHandle<'_, '_>,
     visitor: &mut dyn FnMut(&LiteralValue) -> Result<(), ExcelError>,
 ) -> Result<(), ExcelError> {
-    match arg.value_for_text()? {
-        CalcValue::Range(view) => view.for_each_cell(visitor),
-        CalcValue::Scalar(LiteralValue::Array(rows)) => {
+    match arg.resolve_once_for_text()? {
+        ResolvedArgument::Range(view) | ResolvedArgument::Value(CalcValue::Range(view)) => {
+            view.for_each_cell(visitor)
+        }
+        ResolvedArgument::ReferenceError(error) => visitor(&LiteralValue::Error(error)),
+        ResolvedArgument::Value(CalcValue::Scalar(LiteralValue::Array(rows))) => {
             for row in &rows {
                 for value in row {
                     visitor(value)?;
@@ -109,8 +112,8 @@ fn for_each_expanded_value(
             }
             Ok(())
         }
-        CalcValue::Scalar(value) => visitor(&value),
-        CalcValue::Callable(_) => visitor(&LiteralValue::Error(
+        ResolvedArgument::Value(CalcValue::Scalar(value)) => visitor(&value),
+        ResolvedArgument::Value(CalcValue::Callable(_)) => visitor(&LiteralValue::Error(
             ExcelError::new(ExcelErrorKind::Calc).with_message("LAMBDA value must be invoked"),
         )),
     }

--- a/crates/formualizer-eval/src/builtins/text/trim_case_concat.rs
+++ b/crates/formualizer-eval/src/builtins/text/trim_case_concat.rs
@@ -1,7 +1,7 @@
-use super::super::utils::ARG_ANY_ONE;
+use super::{super::utils::ARG_ANY_ONE, scalar_text_value};
 use crate::args::{ArgSchema, ShapeKind};
 use crate::function::Function;
-use crate::traits::{ArgumentHandle, CalcValue, FunctionContext, ResolvedArgument};
+use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_macros::func_caps;
 use std::sync::LazyLock;
@@ -26,9 +26,6 @@ static TEXTJOIN_ARGS: LazyLock<Vec<ArgSchema>> = LazyLock::new(|| {
 const MAX_CONCAT_RESULT_CHARS: usize = 32_767;
 
 fn scalar_like_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, ExcelError> {
-    if arg.is_omitted() {
-        return Ok(LiteralValue::Text(String::new()));
-    }
     Ok(match arg.value()? {
         crate::traits::CalcValue::Scalar(v) => v,
         crate::traits::CalcValue::Range(rv) => rv.get_cell(0, 0),
@@ -39,7 +36,7 @@ fn scalar_like_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, Excel
 }
 
 fn to_text<'a, 'b>(a: &ArgumentHandle<'a, 'b>) -> Result<String, ExcelError> {
-    literal_to_text(&scalar_like_value(a)?)
+    literal_to_text(&scalar_text_value(a)?)
 }
 
 fn literal_to_text(v: &LiteralValue) -> Result<String, ExcelError> {
@@ -68,10 +65,7 @@ fn literal_to_text(v: &LiteralValue) -> Result<String, ExcelError> {
 }
 
 fn legacy_scalar_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, ExcelError> {
-    if arg.is_omitted() {
-        return Ok(LiteralValue::Text(String::new()));
-    }
-    Ok(match arg.value()? {
+    Ok(match arg.value_for_text()? {
         crate::traits::CalcValue::Scalar(LiteralValue::Array(rows)) => rows
             .first()
             .and_then(|row| row.first())
@@ -105,15 +99,9 @@ fn for_each_expanded_value(
     arg: &ArgumentHandle<'_, '_>,
     visitor: &mut dyn FnMut(&LiteralValue) -> Result<(), ExcelError>,
 ) -> Result<(), ExcelError> {
-    if arg.is_omitted() {
-        return visitor(&LiteralValue::Text(String::new()));
-    }
-    match arg.resolve_once()? {
-        ResolvedArgument::Range(view) | ResolvedArgument::Value(CalcValue::Range(view)) => {
-            view.for_each_cell(visitor)
-        }
-        ResolvedArgument::ReferenceError(error) => visitor(&LiteralValue::Error(error)),
-        ResolvedArgument::Value(CalcValue::Scalar(LiteralValue::Array(rows))) => {
+    match arg.value_for_text()? {
+        CalcValue::Range(view) => view.for_each_cell(visitor),
+        CalcValue::Scalar(LiteralValue::Array(rows)) => {
             for row in &rows {
                 for value in row {
                     visitor(value)?;
@@ -121,8 +109,8 @@ fn for_each_expanded_value(
             }
             Ok(())
         }
-        ResolvedArgument::Value(CalcValue::Scalar(value)) => visitor(&value),
-        ResolvedArgument::Value(CalcValue::Callable(_)) => visitor(&LiteralValue::Error(
+        CalcValue::Scalar(value) => visitor(&value),
+        CalcValue::Callable(_) => visitor(&LiteralValue::Error(
             ExcelError::new(ExcelErrorKind::Calc).with_message("LAMBDA value must be invoked"),
         )),
     }

--- a/crates/formualizer-eval/src/builtins/text/value_text.rs
+++ b/crates/formualizer-eval/src/builtins/text/value_text.rs
@@ -1,4 +1,4 @@
-use super::super::utils::ARG_ANY_ONE;
+use super::{super::utils::ARG_ANY_ONE, scalar_text_value};
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
@@ -16,7 +16,7 @@ fn scalar_like_value(arg: &ArgumentHandle<'_, '_>) -> Result<LiteralValue, Excel
 }
 
 fn to_text<'a, 'b>(a: &ArgumentHandle<'a, 'b>) -> Result<String, ExcelError> {
-    let v = scalar_like_value(a)?;
+    let v = scalar_text_value(a)?;
     Ok(match v {
         LiteralValue::Text(s) => s,
         LiteralValue::Empty => String::new(),
@@ -298,6 +298,11 @@ impl Function for TextFn {
             return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
         }
         let fmt = to_text(&args[1])?;
+        if fmt.is_empty() {
+            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Text(
+                String::new(),
+            )));
+        }
         let num = match val {
             LiteralValue::Number(f) => f,
             LiteralValue::Int(i) => i as f64,

--- a/crates/formualizer-eval/src/engine/arena/ast.rs
+++ b/crates/formualizer-eval/src/engine/arena/ast.rs
@@ -318,7 +318,7 @@ impl AstArena {
     }
 
     /// Insert an explicitly omitted argument node.
-    pub fn insert_omitted(&mut self) -> AstNodeId {
+    pub(crate) fn insert_omitted(&mut self) -> AstNodeId {
         self.insert(AstNodeData::Omitted)
     }
 

--- a/crates/formualizer-eval/src/engine/arena/ast.rs
+++ b/crates/formualizer-eval/src/engine/arena/ast.rs
@@ -43,6 +43,9 @@ pub enum AstNodeData {
     /// Literal value
     Literal(ValueRef),
 
+    /// Explicitly omitted function argument.
+    Omitted,
+
     /// Cell or range reference
     Reference {
         original_id: StringId,    // Original reference string
@@ -312,6 +315,11 @@ impl AstArena {
     /// Insert a literal node
     pub fn insert_literal(&mut self, value: ValueRef) -> AstNodeId {
         self.insert(AstNodeData::Literal(value))
+    }
+
+    /// Insert an explicitly omitted argument node.
+    pub fn insert_omitted(&mut self) -> AstNodeId {
+        self.insert(AstNodeData::Omitted)
     }
 
     /// Insert a reference node

--- a/crates/formualizer-eval/src/engine/arena/canonical.rs
+++ b/crates/formualizer-eval/src/engine/arena/canonical.rs
@@ -39,6 +39,7 @@ const KIND_UNARY: u8 = 3;
 const KIND_BINARY: u8 = 4;
 const KIND_FUNCTION: u8 = 5;
 const KIND_ARRAY: u8 = 6;
+const KIND_OMITTED: u8 = 7;
 
 const REF_CELL: u8 = 1;
 const REF_RANGE: u8 = 2;
@@ -81,6 +82,7 @@ pub(crate) fn compute_node_metadata(
             hasher.mix_u8(KIND_LITERAL);
             hasher.mix_u32(value.as_raw());
         }
+        AstNodeData::Omitted => hasher.mix_u8(KIND_OMITTED),
         AstNodeData::Reference {
             original_id,
             ref_type,

--- a/crates/formualizer-eval/src/engine/arena/data_store.rs
+++ b/crates/formualizer-eval/src/engine/arena/data_store.rs
@@ -372,7 +372,7 @@ impl DataStore {
                         stack.extend(elems.iter().rev().copied());
                     }
                 }
-                super::ast::AstNodeData::Literal(_) => {}
+                super::ast::AstNodeData::Literal(_) | super::ast::AstNodeData::Omitted => {}
             }
         }
         false
@@ -385,6 +385,8 @@ impl DataStore {
                 let value_ref = self.store_value(lit.clone());
                 self.asts.insert_literal(value_ref)
             }
+
+            ASTNodeType::Omitted => self.asts.insert_omitted(),
 
             ASTNodeType::Reference {
                 original,
@@ -601,6 +603,8 @@ impl DataStore {
                 let lit = self.retrieve_value(*value_ref);
                 ASTNodeType::Literal(lit)
             }
+
+            AstNodeData::Omitted => ASTNodeType::Omitted,
 
             AstNodeData::Reference {
                 original_id,

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -6754,7 +6754,7 @@ where
                     Self::collect_planning_function_requests(cell, requests);
                 }
             }
-            ASTNodeType::Literal(_) | ASTNodeType::Reference { .. } => {}
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted | ASTNodeType::Reference { .. } => {}
         }
     }
 
@@ -9385,7 +9385,7 @@ where
                     | ReferenceType::Range3D { .. },
                 ..
             } => Some(crate::engine::OpaqueReason::UnresolvedCrossSheetBinding),
-            ASTNodeType::Literal(_) | ASTNodeType::Reference { .. } => None,
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted | ASTNodeType::Reference { .. } => None,
         }
     }
 
@@ -9544,7 +9544,8 @@ where
                         | ReferenceType::Range { sheet: None, .. },
                     ..
                 }
-                | ASTNodeType::Literal(_) => (true, false),
+                | ASTNodeType::Literal(_)
+                | ASTNodeType::Omitted => (true, false),
                 ASTNodeType::Call { .. } | ASTNodeType::Reference { .. } => (false, false),
             }
         }
@@ -12285,7 +12286,7 @@ where
                 Self::ast_contains_function(left) || Self::ast_contains_function(right)
             }
             ASTNodeType::Array(rows) => rows.iter().flatten().any(Self::ast_contains_function),
-            ASTNodeType::Literal(_) | ASTNodeType::Reference { .. } => false,
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted | ASTNodeType::Reference { .. } => false,
         }
     }
 
@@ -12696,6 +12697,7 @@ where
                         ASTNodeType::Literal(value)
                     }
                     ASTNodeType::Literal(value) => ASTNodeType::Literal(value.clone()),
+                    ASTNodeType::Omitted => ASTNodeType::Omitted,
                     ASTNodeType::Reference {
                         original,
                         reference,
@@ -14075,6 +14077,7 @@ where
                         ASTNodeType::Literal(value)
                     }
                     ASTNodeType::Literal(value) => ASTNodeType::Literal(value.clone()),
+                    ASTNodeType::Omitted => ASTNodeType::Omitted,
                     ASTNodeType::Reference {
                         original,
                         reference,

--- a/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
@@ -377,7 +377,8 @@ impl DependencyGraph {
                     )?;
                 }
             }
-            super::super::arena::ast::AstNodeData::Literal(_) => {}
+            super::super::arena::ast::AstNodeData::Literal(_)
+            | super::super::arena::ast::AstNodeData::Omitted => {}
         }
         Ok(())
     }
@@ -700,7 +701,7 @@ impl DependencyGraph {
                     )?;
                 }
             }
-            ASTNodeType::Literal(_) => {}
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted => {}
         }
         Ok(())
     }

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -2350,7 +2350,7 @@ impl DependencyGraph {
                 }
                 Ok(rewritten)
             }
-            ASTNodeType::Literal(_) => Ok(false),
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted => Ok(false),
         }
     }
 

--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -292,7 +292,9 @@ impl DependencyGraph {
                             kind.merge(visit(graph, item, dependent, range_sheet, range, None))
                         })
                 }
-                ASTNodeType::Literal(_) | ASTNodeType::Reference { .. } => RangeSelfUse::NoMatch,
+                ASTNodeType::Literal(_) | ASTNodeType::Omitted | ASTNodeType::Reference { .. } => {
+                    RangeSelfUse::NoMatch
+                }
             }
         }
 

--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -332,7 +332,7 @@ impl<'a> IngestPipeline<'a> {
             ASTNodeType::Call { callee, args } => {
                 self.ast_is_volatile(callee) || args.iter().any(|arg| self.ast_is_volatile(arg))
             }
-            ASTNodeType::Literal(_) | ASTNodeType::Reference { .. } => false,
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted | ASTNodeType::Reference { .. } => false,
         }
     }
 
@@ -446,7 +446,7 @@ impl<'a> IngestPipeline<'a> {
                 }
                 Ok(())
             }
-            ASTNodeType::Literal(_) => Ok(()),
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted => Ok(()),
         }
     }
 
@@ -662,7 +662,7 @@ impl<'a> IngestPipeline<'a> {
                 }
                 Ok(rewritten)
             }
-            ASTNodeType::Literal(_) => Ok(false),
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted => Ok(false),
         }
     }
 
@@ -892,7 +892,7 @@ fn compute_read_projections(
         in_function_arg: bool,
     ) -> Result<(), ProjectionFallbackReason> {
         match &ast.node_type {
-            ASTNodeType::Literal(_) => {
+            ASTNodeType::Literal(_) | ASTNodeType::Omitted => {
                 if matches!(
                     context,
                     AnalyzerContext::Value | AnalyzerContext::CriteriaExpressionArg
@@ -1261,6 +1261,7 @@ fn compute_tree_metadata(
                 AstNodeData::Literal(canonical_literal_value_ref(value.clone())),
                 Vec::new(),
             ),
+            ASTNodeType::Omitted => (AstNodeData::Omitted, Vec::new()),
             ASTNodeType::Reference {
                 original,
                 reference,
@@ -1513,7 +1514,7 @@ fn normalize_node_for_canonical_metadata(
     placement: CellRef,
 ) {
     match node {
-        AstNodeData::Literal(_) => {}
+        AstNodeData::Literal(_) | AstNodeData::Omitted => {}
         AstNodeData::Reference { ref_type, .. } => normalize_reference_axes(ref_type, placement),
         AstNodeData::UnaryOp { .. }
         | AstNodeData::BinaryOp { .. }

--- a/crates/formualizer-eval/src/engine/plan.rs
+++ b/crates/formualizer-eval/src/engine/plan.rs
@@ -155,7 +155,7 @@ fn collect_references_arena(
                     }
                 }
             }
-            AstNodeData::Literal(_) => {}
+            AstNodeData::Literal(_) | AstNodeData::Omitted => {}
         }
     }
 

--- a/crates/formualizer-eval/src/engine/tests/iferror_ifna_lazy.rs
+++ b/crates/formualizer-eval/src/engine/tests/iferror_ifna_lazy.rs
@@ -53,6 +53,15 @@ fn ifna_catches_only_na() {
 }
 
 #[test]
+fn iferror_distinguishes_omitted_fallback_from_empty_text() {
+    assert_eq!(eval_formula("=IFERROR(1/0,)"), LiteralValue::Number(0.0));
+    assert_eq!(
+        eval_formula("=IFERROR(1/0,\"\")"),
+        LiteralValue::Text(String::new())
+    );
+}
+
+#[test]
 fn iferror_text_and_number_passthrough() {
     assert_eq!(
         eval_formula("=IFERROR(\"ok\",\"fb\")"),

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -140,6 +140,7 @@ mod indirect;
 mod info_reference_context;
 mod let_lambda;
 mod offset_dynamic;
+mod omitted_arguments;
 mod open_ended_bounds_caps;
 mod overlay_compaction;
 mod region_lock;

--- a/crates/formualizer-eval/src/engine/tests/omitted_arguments.rs
+++ b/crates/formualizer-eval/src/engine/tests/omitted_arguments.rs
@@ -184,6 +184,11 @@ fn omitted_argument_oracle_table() {
         ),
         ("=EXACT(,)", "oracle: lo-verified", Expected::Boolean(true)),
         ("=TEXT(1,)", "oracle: lo-verified", Expected::Text("")),
+        (
+            "=TEXT(1,\"\")",
+            "oracle: lo-verified explicit-empty control",
+            Expected::Text(""),
+        ),
         ("=REPT(,2)", "oracle: lo-verified", Expected::Text("")),
         (
             "=SUBSTITUTE(\"abc\",\"b\",,)",

--- a/crates/formualizer-eval/src/engine/tests/omitted_arguments.rs
+++ b/crates/formualizer-eval/src/engine/tests/omitted_arguments.rs
@@ -1,0 +1,359 @@
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug)]
+enum Expected {
+    Number(f64),
+    Boolean(bool),
+    Text(&'static str),
+    Error(ExcelErrorKind),
+}
+
+fn eval_formula(formula: &str) -> LiteralValue {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+        .get_cell_value("Sheet1", 1, 1)
+        .unwrap_or(LiteralValue::Empty)
+}
+
+fn assert_expected(formula: &str, oracle: &str, expected: Expected) {
+    let actual = eval_formula(formula);
+    match expected {
+        Expected::Number(value) => {
+            assert_eq!(actual, LiteralValue::Number(value), "{formula} ({oracle})")
+        }
+        Expected::Boolean(value) => {
+            assert_eq!(actual, LiteralValue::Boolean(value), "{formula} ({oracle})")
+        }
+        Expected::Text(value) => assert_eq!(
+            actual,
+            LiteralValue::Text(value.to_string()),
+            "{formula} ({oracle})"
+        ),
+        Expected::Error(kind) => match actual {
+            LiteralValue::Error(error) => assert_eq!(error.kind, kind, "{formula} ({oracle})"),
+            other => panic!("{formula} ({oracle}): expected {kind:?}, got {other:?}"),
+        },
+    }
+}
+
+#[test]
+fn omitted_argument_oracle_table() {
+    // Each row is tagged with its evidence source from issue #277's oracle table.
+    let cases = [
+        (
+            "=IFERROR(1/0,)",
+            "oracle: lo-verified",
+            Expected::Number(0.0),
+        ),
+        (
+            "=IFERROR(1/0,\"\")",
+            "oracle: lo-verified",
+            Expected::Text(""),
+        ),
+        ("=IF(TRUE,,5)", "oracle: lo-verified", Expected::Number(0.0)),
+        (
+            "=IF(FALSE,5,)",
+            "oracle: lo-verified",
+            Expected::Number(0.0),
+        ),
+        (
+            "=CHOOSE(1,,5)",
+            "oracle: lo-verified",
+            Expected::Number(0.0),
+        ),
+        ("=SUM(1,)", "oracle: lo-verified", Expected::Number(1.0)),
+        ("=MAX(-5,)", "oracle: lo-verified", Expected::Number(0.0)),
+        ("=MIN(5,)", "oracle: lo-verified", Expected::Number(0.0)),
+        ("=AVERAGE(2,)", "oracle: lo-verified", Expected::Number(1.0)),
+        ("=PRODUCT(2,)", "oracle: lo-verified", Expected::Number(0.0)),
+        ("=COUNT(1,)", "oracle: lo-verified", Expected::Number(2.0)),
+        ("=COUNTA(1,)", "oracle: lo-verified", Expected::Number(2.0)),
+        (
+            "=AND(TRUE,)",
+            "oracle: lo-verified",
+            Expected::Boolean(false),
+        ),
+        ("=OR(TRUE,)", "oracle: lo-verified", Expected::Boolean(true)),
+        (
+            "=OR(FALSE,)",
+            "oracle: lo-verified",
+            Expected::Boolean(false),
+        ),
+        ("=ROUND(1.6,)", "oracle: lo-verified", Expected::Number(2.0)),
+        (
+            "=ROUNDUP(1.1,)",
+            "oracle: lo-verified",
+            Expected::Number(2.0),
+        ),
+        (
+            "=MOD(5,)",
+            "oracle: lo-verified",
+            Expected::Error(ExcelErrorKind::Div),
+        ),
+        ("=POWER(2,)", "oracle: lo-verified", Expected::Number(1.0)),
+        ("=LEFT(\"abc\",)", "oracle: lo-verified", Expected::Text("")),
+        (
+            "=RIGHT(\"abc\",)",
+            "oracle: lo-verified",
+            Expected::Text(""),
+        ),
+        (
+            "=MID(\"abc\",,2)",
+            "oracle: lo-verified",
+            Expected::Error(ExcelErrorKind::Value),
+        ),
+        ("=REPT(\"x\",)", "oracle: lo-verified", Expected::Text("")),
+        (
+            "=FIND(\"a\",\"abc\",)",
+            "oracle: lo-verified",
+            Expected::Error(ExcelErrorKind::Value),
+        ),
+        (
+            "=CONCATENATE(\"a\",)",
+            "oracle: lo-verified",
+            Expected::Text("a"),
+        ),
+        (
+            "=MATCH(2,{1,2,3},)",
+            "oracle: lo-verified",
+            Expected::Number(2.0),
+        ),
+        (
+            "=INDEX({1,2;3,4},,2)",
+            "oracle: lo-verified",
+            Expected::Number(2.0),
+        ),
+        ("=IFS(TRUE,)", "oracle: uniform-rule", Expected::Number(0.0)),
+        (
+            "=SWITCH(1,1,)",
+            "oracle: uniform-rule",
+            Expected::Number(0.0),
+        ),
+        (
+            "=CONCAT(\"a\",)",
+            "oracle: uniform-rule",
+            Expected::Text("a"),
+        ),
+        (
+            "=TEXTJOIN(\",\",TRUE,\"a\",)",
+            "oracle: uniform-rule",
+            Expected::Text("a"),
+        ),
+        (
+            "=XMATCH(2,{1,2,3},)",
+            "oracle: uniform-rule",
+            Expected::Number(2.0),
+        ),
+        (
+            "=IFNA(NA(),)",
+            "oracle: uniform-rule",
+            Expected::Number(0.0),
+        ),
+    ];
+
+    for (formula, oracle, expected) in cases {
+        assert_expected(formula, oracle, expected);
+    }
+}
+
+#[test]
+fn lazy_branch_omission_remains_distinct_from_explicit_empty_text() {
+    assert_eq!(eval_formula("=IF(TRUE,,)"), LiteralValue::Number(0.0));
+    assert_eq!(
+        eval_formula("=IF(TRUE,\"\",)"),
+        LiteralValue::Text(String::new())
+    );
+}
+
+#[test]
+fn omitted_arguments_remain_distinct_from_blank_references() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, formula) in [
+        (1, "=COUNT(1,A100)"),
+        (2, "=COUNT(1,)"),
+        (3, "=AVERAGE(2,A100)"),
+        (4, "=AVERAGE(2,)"),
+    ] {
+        engine
+            .set_cell_formula("Sheet1", row, 1, parse(formula).unwrap())
+            .unwrap();
+    }
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(1.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 1),
+        Some(LiteralValue::Number(2.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 3, 1),
+        Some(LiteralValue::Number(2.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 4, 1),
+        Some(LiteralValue::Number(1.0))
+    );
+}
+
+#[test]
+fn absent_text_default_remains_distinct_from_omission() {
+    assert_eq!(
+        eval_formula("=LEFT(\"abc\")"),
+        LiteralValue::Text("a".into())
+    );
+    assert_eq!(
+        eval_formula("=LEFT(\"abc\",)"),
+        LiteralValue::Text(String::new())
+    );
+}
+
+#[test]
+fn omitted_lazy_branch_does_not_evaluate_the_unselected_error() {
+    assert_eq!(eval_formula("=IF(FALSE,1/0,)"), LiteralValue::Number(0.0));
+    assert_eq!(eval_formula("=IF(TRUE,,1/0)"), LiteralValue::Number(0.0));
+}
+
+#[test]
+fn offset_omitted_dimensions_retain_source_dimensions() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, col, value) in [(1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)] {
+        engine
+            .set_cell_value("Sheet1", row, col, LiteralValue::Int(value))
+            .unwrap();
+    }
+    for (row, formula) in [
+        (1, "=SUM(OFFSET(A1:B2,0,0,,))"),
+        (2, "=SUM(OFFSET(A1:B2,0,0,2,2))"),
+        (3, "=SUM(OFFSET(A1:B2,0,0,0,0))"),
+    ] {
+        engine
+            .set_cell_formula("Sheet1", row, 4, parse(formula).unwrap())
+            .unwrap();
+    }
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 4),
+        Some(LiteralValue::Number(10.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 4),
+        Some(LiteralValue::Number(10.0))
+    );
+    assert!(matches!(
+        engine.get_cell_value("Sheet1", 3, 4),
+        Some(LiteralValue::Error(error)) if error.kind == ExcelErrorKind::Ref
+    ));
+}
+
+#[test]
+fn match_absent_and_omitted_use_different_modes() {
+    let absent = eval_formula("=MATCH(2,{2,1,3})");
+    let omitted = eval_formula("=MATCH(2,{2,1,3},)");
+    assert_eq!(omitted, LiteralValue::Number(1.0));
+    assert_ne!(absent, omitted);
+}
+
+fn ingest_omitted_formula_set(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_formula_plane_mode(mode),
+    );
+    let formulas = [
+        "=SUM(1,)",
+        "=IF(TRUE,,5)",
+        "=ROUND(1.6,)",
+        "=CONCATENATE(\"a\",)",
+    ];
+    let mut records = Vec::new();
+    for (column, formula) in formulas.iter().enumerate() {
+        for row in 1..=20 {
+            let ast = parse(formula).unwrap();
+            let ast_id = engine.intern_formula_ast(&ast);
+            records.push(FormulaIngestRecord::new(
+                row,
+                column as u32 + 1,
+                ast_id,
+                Some(Arc::<str>::from(*formula)),
+            ));
+        }
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", records)])
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+#[test]
+fn formula_plane_omitted_argument_values_match_legacy_evaluation() {
+    let legacy = ingest_omitted_formula_set(FormulaPlaneMode::Off);
+    let formula_plane = ingest_omitted_formula_set(FormulaPlaneMode::AuthoritativeExperimental);
+    assert!(
+        formula_plane
+            .baseline_stats()
+            .formula_plane_active_span_count
+            > 0
+    );
+    for row in 1..=20 {
+        for col in 1..=4 {
+            assert_eq!(
+                formula_plane.get_cell_value("Sheet1", row, col),
+                legacy.get_cell_value("Sheet1", row, col),
+                "FormulaPlane mismatch at ({row}, {col})"
+            );
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OmissionProbeFn;
+
+impl crate::function::Function for OmissionProbeFn {
+    fn name(&self) -> &'static str {
+        "ISSUE277_OMISSION_PROBE"
+    }
+
+    fn variadic(&self) -> bool {
+        true
+    }
+
+    fn eval<'a, 'b, 'c>(
+        &self,
+        args: &'c [crate::traits::ArgumentHandle<'a, 'b>],
+        _ctx: &dyn crate::traits::FunctionContext<'b>,
+    ) -> Result<crate::traits::CalcValue<'b>, formualizer_common::ExcelError> {
+        let omitted = args.iter().filter(|arg| arg.is_omitted()).count() as i64;
+        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(
+            args.len() as i64 * 100 + omitted,
+        )))
+    }
+}
+
+#[test]
+fn custom_functions_can_observe_omission_without_conflating_other_states() {
+    crate::function_registry::register_function(Arc::new(OmissionProbeFn));
+    assert_eq!(
+        eval_formula("=ISSUE277_OMISSION_PROBE()"),
+        LiteralValue::Number(0.0)
+    );
+    assert_eq!(
+        eval_formula("=ISSUE277_OMISSION_PROBE(\"\")"),
+        LiteralValue::Number(100.0)
+    );
+    assert_eq!(
+        eval_formula("=ISSUE277_OMISSION_PROBE(,)"),
+        LiteralValue::Number(202.0)
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/omitted_arguments.rs
+++ b/crates/formualizer-eval/src/engine/tests/omitted_arguments.rs
@@ -159,10 +159,83 @@ fn omitted_argument_oracle_table() {
             "oracle: uniform-rule",
             Expected::Number(0.0),
         ),
+        (
+            "=REPLACE(\"abc\",1,1,)",
+            "oracle: lo-verified",
+            Expected::Text("bc"),
+        ),
+        (
+            "=SUBSTITUTE(\"a0b\",\"0\",)",
+            "oracle: lo-verified",
+            Expected::Text("ab"),
+        ),
+        (
+            "=SUBSTITUTE(\"a0b\",,\"x\")",
+            "oracle: lo-verified",
+            Expected::Text("a0b"),
+        ),
+        ("=LEFT(,2)", "oracle: lo-verified", Expected::Text("")),
+        ("=RIGHT(,2)", "oracle: lo-verified", Expected::Text("")),
+        ("=MID(,1,2)", "oracle: lo-verified", Expected::Text("")),
+        (
+            "=EXACT(\"\",)",
+            "oracle: lo-verified",
+            Expected::Boolean(true),
+        ),
+        ("=EXACT(,)", "oracle: lo-verified", Expected::Boolean(true)),
+        ("=TEXT(1,)", "oracle: lo-verified", Expected::Text("")),
+        ("=REPT(,2)", "oracle: lo-verified", Expected::Text("")),
+        (
+            "=SUBSTITUTE(\"abc\",\"b\",,)",
+            "oracle: lo-verified",
+            Expected::Error(ExcelErrorKind::Value),
+        ),
+        (
+            "=FIND(,\"abc\")",
+            "oracle: uniform-rule",
+            Expected::Number(1.0),
+        ),
+        (
+            "=FIND(\"\",\"abc\")",
+            "oracle: uniform-rule explicit-empty control",
+            Expected::Number(1.0),
+        ),
+        (
+            "=SEARCH(,\"abc\")",
+            "oracle: uniform-rule",
+            Expected::Number(1.0),
+        ),
+        (
+            "=SEARCH(\"\",\"abc\")",
+            "oracle: uniform-rule explicit-empty control",
+            Expected::Number(1.0),
+        ),
+        (
+            "=VALUE(,)",
+            "oracle: uniform-rule",
+            Expected::Error(ExcelErrorKind::Value),
+        ),
+        ("=LEFT(0,2)", "negative control", Expected::Text("0")),
+        (
+            "=EXACT(\"\",0)",
+            "negative control",
+            Expected::Boolean(false),
+        ),
     ];
 
     for (formula, oracle, expected) in cases {
         assert_expected(formula, oracle, expected);
+    }
+}
+
+#[test]
+fn omitted_find_text_matches_explicit_empty_text() {
+    for name in ["FIND", "SEARCH"] {
+        assert_eq!(
+            eval_formula(&format!("={name}(,\"abc\")")),
+            eval_formula(&format!("={name}(\"\",\"abc\")")),
+            "{name} must apply the same text coercion to omission and explicit empty text"
+        );
     }
 }
 

--- a/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
+++ b/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
@@ -720,7 +720,7 @@ impl SummaryAnalyzer {
         in_function_arg: bool,
     ) -> bool {
         match expr {
-            CanonicalExpr::Literal(_) => matches!(
+            CanonicalExpr::Literal(_) | CanonicalExpr::Omitted => matches!(
                 context,
                 AnalyzerContext::Value | AnalyzerContext::CriteriaExpressionArg
             ),

--- a/crates/formualizer-eval/src/formula_plane/placement.rs
+++ b/crates/formualizer-eval/src/formula_plane/placement.rs
@@ -1156,7 +1156,7 @@ pub(crate) fn commit_prepared_family(
 pub(crate) fn value_ref_slot_descriptors(expr: &CanonicalExpr) -> Vec<ValueRefSlotDescriptor> {
     fn walk(expr: &CanonicalExpr, out: &mut Vec<ValueRefSlotDescriptor>, preorder: &mut u32) {
         match expr {
-            CanonicalExpr::Literal(_) => {}
+            CanonicalExpr::Literal(_) | CanonicalExpr::Omitted => {}
             CanonicalExpr::Reference { context, reference } => {
                 let slot_context = match context {
                     super::template_canonical::CanonicalReferenceContext::Value => {
@@ -1677,7 +1677,7 @@ pub(crate) fn build_template_slot_map(
                     *next = next.saturating_add(1);
                 }
             }
-            AstNodeData::Reference { .. } => {}
+            AstNodeData::Reference { .. } | AstNodeData::Omitted => {}
             AstNodeData::UnaryOp { expr_id, .. } => walk(*expr_id, data_store, next, out),
             AstNodeData::BinaryOp {
                 left_id, right_id, ..
@@ -1734,7 +1734,7 @@ fn residual_relative_axes(expr: &CanonicalExpr) -> (bool, bool) {
 
     fn walk(expr: &CanonicalExpr, row: &mut bool, col: &mut bool) {
         match expr {
-            CanonicalExpr::Literal(_) => {}
+            CanonicalExpr::Literal(_) | CanonicalExpr::Omitted => {}
             CanonicalExpr::Reference { context, reference } => {
                 let slot_context = match context {
                     super::template_canonical::CanonicalReferenceContext::Value => {

--- a/crates/formualizer-eval/src/formula_plane/span_eval.rs
+++ b/crates/formualizer-eval/src/formula_plane/span_eval.rs
@@ -1046,7 +1046,7 @@ fn validate_relocatable_arena_ast(
         .get_node(node_id)
         .ok_or(SpanEvalError::UnsupportedReferenceRelocation)?;
     match node {
-        AstNodeData::Literal(_) => Ok(()),
+        AstNodeData::Literal(_) | AstNodeData::Omitted => Ok(()),
         AstNodeData::Reference { ref_type, .. } => validate_relocatable_compact_reference(ref_type),
         AstNodeData::UnaryOp { expr_id, .. } => {
             validate_relocatable_arena_ast(*expr_id, data_store)

--- a/crates/formualizer-eval/src/formula_plane/structural.rs
+++ b/crates/formualizer-eval/src/formula_plane/structural.rs
@@ -26,6 +26,7 @@ pub fn relocate_ast_for_template_placement(
 ) -> Result<ASTNode, ExcelError> {
     let node_type = match &ast.node_type {
         ASTNodeType::Literal(value) => ASTNodeType::Literal(value.clone()),
+        ASTNodeType::Omitted => ASTNodeType::Omitted,
         ASTNodeType::Reference {
             original,
             reference,

--- a/crates/formualizer-eval/src/formula_plane/template_canonical.rs
+++ b/crates/formualizer-eval/src/formula_plane/template_canonical.rs
@@ -89,6 +89,7 @@ impl FormulaTemplateKey {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum CanonicalExpr {
     Literal(CanonicalLiteral),
+    Omitted,
     Reference {
         context: CanonicalReferenceContext,
         reference: CanonicalReference,
@@ -525,6 +526,7 @@ impl Canonicalizer<'_> {
                 }
                 CanonicalExpr::Literal(self.canonicalize_literal(value))
             }
+            ASTNodeType::Omitted => CanonicalExpr::Omitted,
             ASTNodeType::Reference {
                 original,
                 reference,
@@ -1123,6 +1125,7 @@ fn write_parameterized_expr_key_inner(
     parameterize_literals: bool,
 ) {
     match expr {
+        CanonicalExpr::Omitted => out.push_str("omitted"),
         CanonicalExpr::Literal(value)
             if parameterize_literals && !matches!(value, CanonicalLiteral::Array(_)) =>
         {
@@ -1203,6 +1206,7 @@ fn write_parameterized_expr_key_inner(
 
 fn write_expr_key(expr: &CanonicalExpr, out: &mut String) {
     match expr {
+        CanonicalExpr::Omitted => out.push_str("omitted"),
         CanonicalExpr::Literal(value) => {
             out.push_str("lit(");
             write_literal_key(value, out);

--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -257,7 +257,8 @@ impl<'a> Interpreter<'a> {
             | ASTNodeType::UnaryOp { .. }
             | ASTNodeType::BinaryOp { .. }
             | ASTNodeType::Call { .. }
-            | ASTNodeType::Literal(_) => Err(ExcelError::new(ExcelErrorKind::Ref)
+            | ASTNodeType::Literal(_)
+            | ASTNodeType::Omitted => Err(ExcelError::new(ExcelErrorKind::Ref)
                 .with_message("Expression cannot be used as a reference")),
         }
     }
@@ -465,6 +466,7 @@ impl<'a> Interpreter<'a> {
                     data_store.retrieve_value(*vref),
                 ))
             }
+            AstNodeData::Omitted => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0))),
             AstNodeData::Reference { ref_type, .. } => {
                 if self.local_env.is_empty()
                     && let CompactRefType::Cell {
@@ -789,6 +791,7 @@ impl<'a> Interpreter<'a> {
     ) -> Result<crate::traits::CalcValue<'a>, ExcelError> {
         match &node.node_type {
             ASTNodeType::Literal(v) => Ok(crate::traits::CalcValue::Scalar(v.clone())),
+            ASTNodeType::Omitted => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0))),
             ASTNodeType::Reference { reference, .. } => self.eval_ast_reference_to_calc(reference),
             ASTNodeType::UnaryOp { op, expr } => self
                 .eval_unary(op, expr)
@@ -810,6 +813,7 @@ impl<'a> Interpreter<'a> {
     ) -> Result<crate::traits::CalcValue<'a>, ExcelError> {
         match &node.node_type {
             ASTNodeType::Literal(v) => Ok(crate::traits::CalcValue::Scalar(v.clone())),
+            ASTNodeType::Omitted => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0))),
             ASTNodeType::Reference { reference, .. } => self.eval_ast_reference_to_calc(reference),
             ASTNodeType::UnaryOp { op, expr } => {
                 // For now, reuse existing unary implementation (which recurses).

--- a/crates/formualizer-eval/src/planner.rs
+++ b/crates/formualizer-eval/src/planner.rs
@@ -146,7 +146,7 @@ impl<'a> Planner<'a> {
 
         // Basic structure & cost estimation (very rough)
         let (cost, has_range, dims, fanout) = match &ast.node_type {
-            Literal(_) => (
+            Literal(_) | Omitted => (
                 NodeCost {
                     est_nanos: 50,
                     cells: 0,

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -339,6 +339,16 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         }
     }
 
+    pub(crate) fn resolve_once_for_text(&self) -> Result<ResolvedArgument<'b>, ExcelError> {
+        if self.is_omitted() {
+            Ok(ResolvedArgument::Value(crate::traits::CalcValue::Scalar(
+                LiteralValue::Text(String::new()),
+            )))
+        } else {
+            self.resolve_once()
+        }
+    }
+
     fn compute_value(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
         match &self.expr {
             ArgumentExpr::Ast(node) => match &node.node_type {

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -324,12 +324,27 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
             .clone()
     }
 
+    /// Resolves a scalar that is about to be coerced to text.
+    ///
+    /// Omitted arguments materialize as numeric zero through `value()`, which is
+    /// correct for Any/numeric consumers and aggregates. Text consumers must use
+    /// this boundary so omission becomes empty text without changing explicit 0.
+    pub(crate) fn value_for_text(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+        if self.is_omitted() {
+            Ok(crate::traits::CalcValue::Scalar(LiteralValue::Text(
+                String::new(),
+            )))
+        } else {
+            self.value()
+        }
+    }
+
     fn compute_value(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
         match &self.expr {
             ArgumentExpr::Ast(node) => match &node.node_type {
                 ASTNodeType::Literal(v) => Ok(crate::traits::CalcValue::Scalar(v.clone())),
                 // With no schema-level text policy, Number(0) is the neutral Any-policy
-                // materialization. Text consumers use `is_omitted` when empty text differs.
+                // materialization. Text consumers resolve through `value_for_text`.
                 ASTNodeType::Omitted => {
                     Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0)))
                 }

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -305,6 +305,19 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         }
     }
 
+    /// Returns whether this handle represents an explicitly omitted argument slot.
+    ///
+    /// This is false for absent arguments, explicit empty text, and blank references.
+    pub fn is_omitted(&self) -> bool {
+        match &self.expr {
+            ArgumentExpr::Ast(node) => matches!(node.node_type, ASTNodeType::Omitted),
+            ArgumentExpr::Arena { id, data_store, .. } => matches!(
+                data_store.get_node(*id),
+                Some(crate::engine::arena::AstNodeData::Omitted)
+            ),
+        }
+    }
+
     pub fn value(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
         self.cached_value
             .get_or_init(|| self.compute_value())
@@ -313,19 +326,30 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
 
     fn compute_value(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
         match &self.expr {
-            ArgumentExpr::Ast(node) => {
-                if let ASTNodeType::Literal(ref v) = node.node_type {
-                    return Ok(crate::traits::CalcValue::Scalar(v.clone()));
+            ArgumentExpr::Ast(node) => match &node.node_type {
+                ASTNodeType::Literal(v) => Ok(crate::traits::CalcValue::Scalar(v.clone())),
+                // With no schema-level text policy, Number(0) is the neutral Any-policy
+                // materialization. Text consumers use `is_omitted` when empty text differs.
+                ASTNodeType::Omitted => {
+                    Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0)))
                 }
-                self.interp.evaluate_ast(node)
-            }
+                _ => self.interp.evaluate_ast(node),
+            },
             ArgumentExpr::Arena {
                 id,
                 data_store,
                 sheet_registry,
-            } => self
-                .interp
-                .evaluate_arena_ast(*id, data_store, sheet_registry),
+            } => {
+                if matches!(
+                    data_store.get_node(*id),
+                    Some(crate::engine::arena::AstNodeData::Omitted)
+                ) {
+                    Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0)))
+                } else {
+                    self.interp
+                        .evaluate_arena_ast(*id, data_store, sheet_registry)
+                }
+            }
         }
     }
 
@@ -335,17 +359,27 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
     ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
         let scoped = self.interp.with_local_env(env);
         match &self.expr {
-            ArgumentExpr::Ast(node) => {
-                if let ASTNodeType::Literal(ref v) = node.node_type {
-                    return Ok(crate::traits::CalcValue::Scalar(v.clone()));
+            ArgumentExpr::Ast(node) => match &node.node_type {
+                ASTNodeType::Literal(v) => Ok(crate::traits::CalcValue::Scalar(v.clone())),
+                ASTNodeType::Omitted => {
+                    Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0)))
                 }
-                scoped.evaluate_ast(node)
-            }
+                _ => scoped.evaluate_ast(node),
+            },
             ArgumentExpr::Arena {
                 id,
                 data_store,
                 sheet_registry,
-            } => scoped.evaluate_arena_ast(*id, data_store, sheet_registry),
+            } => {
+                if matches!(
+                    data_store.get_node(*id),
+                    Some(crate::engine::arena::AstNodeData::Omitted)
+                ) {
+                    Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(0.0)))
+                } else {
+                    scoped.evaluate_arena_ast(*id, data_store, sheet_registry)
+                }
+            }
         }
     }
 

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -1677,6 +1677,11 @@ impl ReferenceType {
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub enum ASTNodeType {
     Literal(LiteralValue),
+    /// An explicitly omitted function argument slot.
+    ///
+    /// This node is only valid as a direct argument of a [`Function`](Self::Function)
+    /// or [`Call`](Self::Call) node.
+    Omitted,
     Reference {
         original: String, // Original reference string (preserved for display/debugging)
         reference: ReferenceType, // Parsed reference
@@ -1707,6 +1712,7 @@ impl Display for ASTNodeType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ASTNodeType::Literal(value) => write!(f, "Literal({value})"),
+            ASTNodeType::Omitted => write!(f, "Omitted"),
             ASTNodeType::Reference { reference, .. } => write!(f, "Reference({reference:?})"),
             ASTNodeType::UnaryOp { op, expr } => write!(f, "UnaryOp({op}, {expr})"),
             ASTNodeType::BinaryOp { op, left, right } => {
@@ -1776,6 +1782,7 @@ impl ASTNode {
                 hasher.write(&[1]); // Discriminant for Literal
                 value.hash(hasher);
             }
+            ASTNodeType::Omitted => hasher.write(&[8]),
             ASTNodeType::Reference { reference, .. } => {
                 hasher.write(&[2]); // Discriminant for Reference
                 reference.hash(hasher);
@@ -1908,7 +1915,7 @@ impl ASTNode {
                         }
                     }
                 }
-                ASTNodeType::Literal(_) => {}
+                ASTNodeType::Literal(_) | ASTNodeType::Omitted => {}
             }
         }
     }
@@ -2290,7 +2297,7 @@ impl<'a> Iterator for RefIter<'a> {
                         }
                     }
                 }
-                ASTNodeType::Literal(_) => {}
+                ASTNodeType::Literal(_) | ASTNodeType::Omitted => {}
             }
         }
         None
@@ -2811,7 +2818,8 @@ impl Parser {
 
         self.in_call_args_depth += 1;
         let result = (|| -> Result<Vec<ASTNode>, ParserError> {
-            args.push(self.parse_expression()?);
+            let mut expecting_argument = true;
+            let mut saw_argument = false;
             loop {
                 self.skip_whitespace();
                 if self.position >= self.tokens.len() {
@@ -2820,16 +2828,35 @@ impl Parser {
                         position: Some(self.position),
                     });
                 }
+
                 let token = &self.tokens[self.position];
                 let is_separator = (token.token_type == TokenType::Sep
                     && token.subtype == TokenSubType::Arg)
                     || (token.token_type == TokenType::OpInfix && self.span_value(token) == ",");
-                if is_separator {
+                let is_close =
+                    token.token_type == TokenType::Paren && token.subtype == TokenSubType::Close;
+
+                if expecting_argument {
+                    if is_close {
+                        if saw_argument {
+                            args.push(ASTNode::new(ASTNodeType::Omitted, None));
+                        }
+                        self.position += 1;
+                        return Ok(std::mem::take(&mut args));
+                    }
+                    if is_separator {
+                        args.push(ASTNode::new(ASTNodeType::Omitted, None));
+                        saw_argument = true;
+                        self.position += 1;
+                    } else {
+                        args.push(self.parse_expression()?);
+                        saw_argument = true;
+                        expecting_argument = false;
+                    }
+                } else if is_separator {
                     self.position += 1;
-                    args.push(self.parse_expression()?);
-                } else if token.token_type == TokenType::Paren
-                    && token.subtype == TokenSubType::Close
-                {
+                    expecting_argument = true;
+                } else if is_close {
                     self.position += 1;
                     return Ok(std::mem::take(&mut args));
                 } else {
@@ -2856,59 +2883,46 @@ impl Parser {
             return Ok(args);
         }
 
-        self.skip_whitespace();
-        if self.position < self.tokens.len()
-            && self.tokens[self.position].token_type == TokenType::Sep
-            && self.tokens[self.position].subtype == TokenSubType::Arg
-        {
-            args.push(ASTNode::new(
-                ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                None,
-            ));
-        } else {
-            args.push(self.parse_expression()?);
-        }
-
-        while self.position < self.tokens.len() {
+        let mut expecting_argument = true;
+        let mut saw_argument = false;
+        loop {
             self.skip_whitespace();
             if self.position >= self.tokens.len() {
-                break;
+                return Err(ParserError {
+                    message: "Unterminated function argument list".to_string(),
+                    position: Some(self.position),
+                });
             }
 
             let token = &self.tokens[self.position];
-            if token.token_type == TokenType::Sep && token.subtype == TokenSubType::Arg {
-                self.position += 1;
-                self.skip_whitespace();
-                if self.position < self.tokens.len() {
-                    let next_token = &self.tokens[self.position];
-                    if next_token.token_type == TokenType::Sep
-                        && next_token.subtype == TokenSubType::Arg
-                    {
-                        args.push(ASTNode::new(
-                            ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                            None,
-                        ));
-                    } else if next_token.token_type == TokenType::Func
-                        && next_token.subtype == TokenSubType::Close
-                    {
-                        args.push(ASTNode::new(
-                            ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                            None,
-                        ));
-                        self.position += 1;
-                        break;
-                    } else {
-                        args.push(self.parse_expression()?);
+            let is_separator =
+                token.token_type == TokenType::Sep && token.subtype == TokenSubType::Arg;
+            let is_close =
+                token.token_type == TokenType::Func && token.subtype == TokenSubType::Close;
+
+            if expecting_argument {
+                if is_close {
+                    if saw_argument {
+                        args.push(ASTNode::new(ASTNodeType::Omitted, None));
                     }
-                } else {
-                    args.push(ASTNode::new(
-                        ASTNodeType::Literal(LiteralValue::Text("".to_string())),
-                        None,
-                    ));
+                    self.position += 1;
+                    return Ok(args);
                 }
-            } else if token.token_type == TokenType::Func && token.subtype == TokenSubType::Close {
+                if is_separator {
+                    args.push(ASTNode::new(ASTNodeType::Omitted, None));
+                    saw_argument = true;
+                    self.position += 1;
+                } else {
+                    args.push(self.parse_expression()?);
+                    saw_argument = true;
+                    expecting_argument = false;
+                }
+            } else if is_separator {
                 self.position += 1;
-                break;
+                expecting_argument = true;
+            } else if is_close {
+                self.position += 1;
+                return Ok(args);
             } else {
                 return Err(ParserError {
                     message: format!("Expected ',' or ')' in function arguments, got {token:?}"),
@@ -2916,8 +2930,6 @@ impl Parser {
                 });
             }
         }
-
-        Ok(args)
     }
 
     fn parse_array(&mut self) -> Result<ASTNode, ParserError> {

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -126,6 +126,20 @@ fn pretty_child(
     }
 }
 
+fn pretty_print_arguments(args: &[ASTNode]) -> String {
+    let mut rendered = String::new();
+    for (index, arg) in args.iter().enumerate() {
+        if index > 0 {
+            rendered.push(',');
+            if !matches!(arg.node_type, ASTNodeType::Omitted) {
+                rendered.push(' ');
+            }
+        }
+        rendered.push_str(&pretty_print_node(arg));
+    }
+    rendered
+}
+
 fn pretty_print_node(ast: &ASTNode) -> String {
     match &ast.node_type {
         ASTNodeType::Literal(value) => match value {
@@ -167,12 +181,7 @@ fn pretty_print_node(ast: &ASTNode) -> String {
             }
         }
         ASTNodeType::Function { name, args } => {
-            let args_str = args
-                .iter()
-                .map(pretty_print_node)
-                .collect::<Vec<String>>()
-                .join(", ");
-
+            let args_str = pretty_print_arguments(args);
             format!("{}({})", name.to_uppercase(), args_str)
         }
         ASTNodeType::Call { callee, args } => {
@@ -184,11 +193,7 @@ fn pretty_print_node(ast: &ASTNode) -> String {
                 ASTNodeType::Function { .. } | ASTNodeType::Call { .. } => callee_str,
                 _ => format!("({callee_str})"),
             };
-            let args_str = args
-                .iter()
-                .map(pretty_print_node)
-                .collect::<Vec<String>>()
-                .join(", ");
+            let args_str = pretty_print_arguments(args);
             format!("{callee_rendered}({args_str})")
         }
         ASTNodeType::Array(rows) => {

--- a/crates/formualizer-parse/src/pretty.rs
+++ b/crates/formualizer-parse/src/pretty.rs
@@ -136,6 +136,7 @@ fn pretty_print_node(ast: &ASTNode) -> String {
             }
             _ => format!("{value}"),
         },
+        ASTNodeType::Omitted => String::new(),
         ASTNodeType::Reference { reference, .. } => reference.normalise(),
         ASTNodeType::UnaryOp { op, expr } => {
             let inner = pretty_print_node(expr);

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -631,7 +631,7 @@ mod tests {
 
         let nested = parse_formula("=IF(TRUE,IFERROR(1/0,),2)").unwrap();
         let rendered = crate::pretty::canonical_formula(&nested);
-        assert_eq!(rendered, "=IF(true, IFERROR(1 / 0, ), 2)");
+        assert_eq!(rendered, "=IF(true, IFERROR(1 / 0,), 2)");
         assert_eq!(
             parse_formula(&rendered).unwrap().fingerprint(),
             nested.fingerprint()

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -557,32 +557,31 @@ mod tests {
             panic!("Expected Function node");
         }
 
-        // Test with multiple optional arguments - some specified, some not
+        // Explicitly omitted arguments remain distinct from explicit empty text.
         let ast = parse_formula("=IFERROR(A1/B1,)").unwrap();
         if let ASTNodeType::Function { name, args } = &ast.node_type {
             assert_eq!(name, "IFERROR");
             assert_eq!(args.len(), 2);
-            // Second argument should be an empty string
-            if let ASTNodeType::Literal(LiteralValue::Text(text)) = &args[1].node_type {
-                assert_eq!(text, "");
-            } else {
-                panic!("Expected empty text literal for omitted argument");
-            }
+            assert!(matches!(args[1].node_type, ASTNodeType::Omitted));
         } else {
             panic!("Expected Function node");
         }
+
+        let ast = parse_formula("=IFERROR(A1/B1,\"\")").unwrap();
+        let ASTNodeType::Function { args, .. } = &ast.node_type else {
+            panic!("Expected Function node");
+        };
+        assert!(matches!(
+            &args[1].node_type,
+            ASTNodeType::Literal(LiteralValue::Text(text)) if text.is_empty()
+        ));
 
         // Test skipping middle arguments
         let ast = parse_formula("=IF(A1>0,,C1)").unwrap();
         if let ASTNodeType::Function { name, args } = ast.node_type {
             assert_eq!(name, "IF");
             assert_eq!(args.len(), 3);
-            // Middle argument should be empty
-            if let ASTNodeType::Literal(LiteralValue::Text(text)) = &args[1].node_type {
-                assert_eq!(text, "");
-            } else {
-                panic!("Expected empty text literal for omitted middle argument");
-            }
+            assert!(matches!(args[1].node_type, ASTNodeType::Omitted));
         } else {
             panic!("Expected Function node");
         }
@@ -592,17 +591,8 @@ mod tests {
         if let ASTNodeType::Function { name, args } = ast.node_type {
             assert_eq!(name, "IF");
             assert_eq!(args.len(), 3);
-            // Both optional arguments should be empty
-            if let ASTNodeType::Literal(LiteralValue::Text(text)) = &args[1].node_type {
-                assert_eq!(text, "");
-            } else {
-                panic!("Expected empty text literal for second argument");
-            }
-            if let ASTNodeType::Literal(LiteralValue::Text(text)) = &args[2].node_type {
-                assert_eq!(text, "");
-            } else {
-                panic!("Expected empty text literal for third argument");
-            }
+            assert!(matches!(args[1].node_type, ASTNodeType::Omitted));
+            assert!(matches!(args[2].node_type, ASTNodeType::Omitted));
         } else {
             panic!("Expected Function node");
         }
@@ -612,20 +602,55 @@ mod tests {
         if let ASTNodeType::Function { name, args } = ast.node_type {
             assert_eq!(name, "CHOOSE");
             assert_eq!(args.len(), 6);
-            // Check the empty arguments (3rd and 5th)
-            if let ASTNodeType::Literal(LiteralValue::Text(text)) = &args[2].node_type {
-                assert_eq!(text, "");
-            } else {
-                panic!("Expected empty text literal for third argument");
-            }
-            if let ASTNodeType::Literal(LiteralValue::Text(text)) = &args[4].node_type {
-                assert_eq!(text, "");
-            } else {
-                panic!("Expected empty text literal for fifth argument");
-            }
+            assert!(matches!(args[2].node_type, ASTNodeType::Omitted));
+            assert!(matches!(args[4].node_type, ASTNodeType::Omitted));
         } else {
             panic!("Expected Function node");
         }
+    }
+
+    #[test]
+    fn test_omitted_argument_shapes_round_trip_and_fingerprint() {
+        for (formula, omitted_positions) in [
+            ("=IF(TRUE,,5)", vec![1]),
+            ("=SUM(1,)", vec![1]),
+            ("=SUM(1,,)", vec![1, 2]),
+            ("=SUM(1, )", vec![1]),
+        ] {
+            let ast = parse_formula(formula).unwrap();
+            let ASTNodeType::Function { args, .. } = &ast.node_type else {
+                panic!("Expected Function node for {formula}");
+            };
+            for position in omitted_positions {
+                assert!(
+                    matches!(args[position].node_type, ASTNodeType::Omitted),
+                    "argument {position} was not omitted in {formula}"
+                );
+            }
+        }
+
+        let nested = parse_formula("=IF(TRUE,IFERROR(1/0,),2)").unwrap();
+        let rendered = crate::pretty::canonical_formula(&nested);
+        assert_eq!(rendered, "=IF(true, IFERROR(1 / 0, ), 2)");
+        assert_eq!(
+            parse_formula(&rendered).unwrap().fingerprint(),
+            nested.fingerprint()
+        );
+
+        let omitted = parse_formula("=IFERROR(A1,)").unwrap();
+        let empty_text = parse_formula("=IFERROR(A1,\"\")").unwrap();
+        assert_ne!(omitted.fingerprint(), empty_text.fingerprint());
+        assert_ne!(
+            crate::pretty::canonical_formula(&omitted),
+            crate::pretty::canonical_formula(&empty_text)
+        );
+
+        let call = parse_formula("=LAMBDA(x,y,x)(1,)").unwrap();
+        let ASTNodeType::Call { args, .. } = call.node_type else {
+            panic!("Expected immediate call node");
+        };
+        assert_eq!(args.len(), 2);
+        assert!(matches!(args[1].node_type, ASTNodeType::Omitted));
     }
 
     #[test]

--- a/crates/formualizer-parse/tests/parser_differential.rs
+++ b/crates/formualizer-parse/tests/parser_differential.rs
@@ -6,9 +6,9 @@
 
 use std::str::FromStr;
 
+use formualizer_parse::parse;
 use formualizer_parse::parser::{ASTNode, ASTNodeType, BatchParser, Parser};
 use formualizer_parse::tokenizer::TokenStream;
-use formualizer_parse::{LiteralValue, parse};
 
 fn ast_eq(a: &ASTNode, b: &ASTNode) -> bool {
     if a.node_type == b.node_type {
@@ -216,10 +216,7 @@ fn leading_empty_argument_followed_by_argument_parses() {
         ASTNodeType::Function { name, args } => {
             assert_eq!(name, "VLOOKUP");
             assert_eq!(args.len(), 4);
-            assert!(matches!(
-                &args[0].node_type,
-                ASTNodeType::Literal(LiteralValue::Text(s)) if s.is_empty()
-            ));
+            assert!(matches!(&args[0].node_type, ASTNodeType::Omitted));
         }
         other => panic!("expected Function, got {other:?}"),
     }
@@ -231,10 +228,10 @@ fn comma_only_empty_arguments_preserve_arity() {
     match ast.node_type {
         ASTNodeType::Function { args, .. } => {
             assert_eq!(args.len(), 2);
-            assert!(args.iter().all(|arg| matches!(
-                &arg.node_type,
-                ASTNodeType::Literal(LiteralValue::Text(s)) if s.is_empty()
-            )));
+            assert!(
+                args.iter()
+                    .all(|arg| matches!(&arg.node_type, ASTNodeType::Omitted))
+            );
         }
         other => panic!("expected Function, got {other:?}"),
     }

--- a/crates/formualizer-workbook/tests/json_omitted_arguments.rs
+++ b/crates/formualizer-workbook/tests/json_omitted_arguments.rs
@@ -10,12 +10,7 @@ fn json_round_trip_preserves_omitted_argument_formula_and_value() {
     let mut adapter = JsonAdapter::new();
     adapter.create_sheet("Sheet1").unwrap();
     adapter
-        .write_cell(
-            "Sheet1",
-            1,
-            1,
-            CellData::from_formula("=IFERROR(1/0,)"),
-        )
+        .write_cell("Sheet1", 1, 1, CellData::from_formula("=IFERROR(1/0,)"))
         .unwrap();
     adapter.set_dimensions("Sheet1", Some((1, 1)));
 

--- a/crates/formualizer-workbook/tests/json_omitted_arguments.rs
+++ b/crates/formualizer-workbook/tests/json_omitted_arguments.rs
@@ -20,7 +20,7 @@ fn json_round_trip_preserves_omitted_argument_formula_and_value() {
         .expect("bytes destination");
     let serialized = String::from_utf8(bytes.clone()).unwrap();
     assert!(serialized.contains("=IFERROR(1/0,)"));
-    assert!(!serialized.contains("omitted"));
+    assert!(!serialized.to_ascii_lowercase().contains("omitted"));
 
     let mut reopened = JsonAdapter::open_bytes(bytes).unwrap();
     let cell = reopened.read_cell("Sheet1", 1, 1).unwrap().unwrap();

--- a/crates/formualizer-workbook/tests/json_omitted_arguments.rs
+++ b/crates/formualizer-workbook/tests/json_omitted_arguments.rs
@@ -1,0 +1,40 @@
+use formualizer_common::LiteralValue;
+use formualizer_eval::engine::ingest::EngineLoadStream;
+use formualizer_eval::engine::{Engine, EvalConfig};
+use formualizer_eval::test_workbook::TestWorkbook;
+use formualizer_workbook::traits::SaveDestination;
+use formualizer_workbook::{CellData, JsonAdapter, SpreadsheetReader, SpreadsheetWriter};
+
+#[test]
+fn json_round_trip_preserves_omitted_argument_formula_and_value() {
+    let mut adapter = JsonAdapter::new();
+    adapter.create_sheet("Sheet1").unwrap();
+    adapter
+        .write_cell(
+            "Sheet1",
+            1,
+            1,
+            CellData::from_formula("=IFERROR(1/0,)"),
+        )
+        .unwrap();
+    adapter.set_dimensions("Sheet1", Some((1, 1)));
+
+    let bytes = adapter
+        .save_to(SaveDestination::Bytes)
+        .unwrap()
+        .expect("bytes destination");
+    let serialized = String::from_utf8(bytes.clone()).unwrap();
+    assert!(serialized.contains("=IFERROR(1/0,)"));
+    assert!(!serialized.contains("omitted"));
+
+    let mut reopened = JsonAdapter::open_bytes(bytes).unwrap();
+    let cell = reopened.read_cell("Sheet1", 1, 1).unwrap().unwrap();
+    assert_eq!(cell.formula.as_deref(), Some("=IFERROR(1/0,)"));
+
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    reopened.stream_into_engine(&mut engine).unwrap();
+    assert_eq!(
+        engine.evaluate_cell("Sheet1", 1, 1).unwrap(),
+        Some(LiteralValue::Number(0.0))
+    );
+}

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -346,6 +346,7 @@ pub formualizer_eval::engine::arena::ast::AstNodeData::Function::args_count: u16
 pub formualizer_eval::engine::arena::ast::AstNodeData::Function::args_offset: u32
 pub formualizer_eval::engine::arena::ast::AstNodeData::Function::name_id: formualizer_eval::engine::arena::string_interner::StringId
 pub formualizer_eval::engine::arena::ast::AstNodeData::Literal(formualizer_eval::engine::arena::value_ref::ValueRef)
+pub formualizer_eval::engine::arena::ast::AstNodeData::Omitted
 pub formualizer_eval::engine::arena::ast::AstNodeData::Reference
 pub formualizer_eval::engine::arena::ast::AstNodeData::Reference::original_id: formualizer_eval::engine::arena::string_interner::StringId
 pub formualizer_eval::engine::arena::ast::AstNodeData::Reference::ref_type: formualizer_eval::engine::arena::ast::CompactRefType
@@ -733,6 +734,7 @@ pub formualizer_eval::engine::arena::AstNodeData::Function::args_count: u16
 pub formualizer_eval::engine::arena::AstNodeData::Function::args_offset: u32
 pub formualizer_eval::engine::arena::AstNodeData::Function::name_id: formualizer_eval::engine::arena::string_interner::StringId
 pub formualizer_eval::engine::arena::AstNodeData::Literal(formualizer_eval::engine::arena::value_ref::ValueRef)
+pub formualizer_eval::engine::arena::AstNodeData::Omitted
 pub formualizer_eval::engine::arena::AstNodeData::Reference
 pub formualizer_eval::engine::arena::AstNodeData::Reference::original_id: formualizer_eval::engine::arena::string_interner::StringId
 pub formualizer_eval::engine::arena::AstNodeData::Reference::ref_type: formualizer_eval::engine::arena::ast::CompactRefType
@@ -8547,6 +8549,7 @@ pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::as_reference_or_eval(&s
 pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::ast(&self) -> &formualizer_parse::parser::ASTNode
 pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::current_env(&self) -> formualizer_eval::interpreter::LocalEnv
 pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::inline_array_literal(&self) -> core::result::Result<core::option::Option<alloc::vec::Vec<alloc::vec::Vec<formualizer_common::value::LiteralValue>>>, formualizer_common::error::ExcelError>
+pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::is_omitted(&self) -> bool
 pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::lazy_values_owned(&'a self) -> core::result::Result<alloc::boxed::Box<(dyn core::iter::traits::iterator::Iterator<Item = formualizer_common::value::LiteralValue> + 'a)>, formualizer_common::error::ExcelError>
 pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::matches_kind(&self, formualizer_common::function::ArgKind) -> core::result::Result<bool, formualizer_common::error::ExcelError>
 pub fn formualizer_eval::traits::ArgumentHandle<'a, 'b>::range(&self) -> core::result::Result<alloc::boxed::Box<dyn formualizer_eval::traits::Range>, formualizer_common::error::ExcelError>

--- a/public-api/formualizer-parse.txt
+++ b/public-api/formualizer-parse.txt
@@ -17,6 +17,7 @@ pub formualizer_parse::parser::ASTNodeType::Function
 pub formualizer_parse::parser::ASTNodeType::Function::args: alloc::vec::Vec<formualizer_parse::parser::ASTNode>
 pub formualizer_parse::parser::ASTNodeType::Function::name: alloc::string::String
 pub formualizer_parse::parser::ASTNodeType::Literal(formualizer_common::value::LiteralValue)
+pub formualizer_parse::parser::ASTNodeType::Omitted
 pub formualizer_parse::parser::ASTNodeType::Reference
 pub formualizer_parse::parser::ASTNodeType::Reference::original: alloc::string::String
 pub formualizer_parse::parser::ASTNodeType::Reference::reference: formualizer_parse::parser::ReferenceType
@@ -695,6 +696,7 @@ pub formualizer_parse::ASTNodeType::Function
 pub formualizer_parse::ASTNodeType::Function::args: alloc::vec::Vec<formualizer_parse::parser::ASTNode>
 pub formualizer_parse::ASTNodeType::Function::name: alloc::string::String
 pub formualizer_parse::ASTNodeType::Literal(formualizer_common::value::LiteralValue)
+pub formualizer_parse::ASTNodeType::Omitted
 pub formualizer_parse::ASTNodeType::Reference
 pub formualizer_parse::ASTNodeType::Reference::original: alloc::string::String
 pub formualizer_parse::ASTNodeType::Reference::reference: formualizer_parse::parser::ReferenceType


### PR DESCRIPTION
Fixes #277.

The parser lowered explicitly omitted argument slots (`=IFERROR(A1/B1,)`, `=IF(TRUE,,5)`) to `Literal(Text(""))`, byte-identical to an explicit `""`. The distinction was destroyed at parse time, so numeric fallbacks silently became text, strict coercion policies returned spurious `#VALUE!` (`=SUM(1,)`, `=ROUND(1.6,)`, `=AND(TRUE,)`, `=MATCH(2,{1,2,3},)`), aggregates mis-counted (`=MAX(-5,)` returned `-5` instead of `0`, `=COUNT(1,)` returned `1` instead of `2`), and canonical rendering rewrote `IFERROR(x,)` into `IFERROR(x,"")`.

Design: the parser carries representation only; the engine carries all semantics. A new `ASTNodeType::Omitted` (mirrored as `AstNodeData::Omitted` and `CanonicalExpr::Omitted` in the evaluator arena and FormulaPlane) preserves omission through parsing, pretty-printing, fingerprinting, and structural relocation. At evaluation, omission materializes per context: numeric/logical/Any consumers see `0`/`FALSE` via ordinary `value()`, text consumers route through a central crate-private `ArgumentHandle::value_for_text()` boundary that lowers omission to empty text, and aggregates count an omitted slot as numeric zero. `ArgumentHandle::is_omitted()` is public for functions that must see omission before materialization: OFFSET retains source dimensions for omitted height/width, and MATCH/XMATCH/INDEX treat explicit omission as exact-mode/index zero distinctly from absence.

Three states remain observably distinct throughout: absent optional arguments keep their existing schema defaults, explicitly omitted slots follow Excel empty-argument coercion, and explicit `""` behaves exactly as before. Blank-cell `LiteralValue::Empty` semantics are untouched, and aggregates still ignore blank references while counting omitted slots (`=COUNT(1,A100)` with blank `A100` is `1`; `=COUNT(1,)` is `2`). No `LiteralValue` variant was added and no omission sentinel crosses value, persistence, Python/WASM/CFFI value, or SheetPort boundaries; the parse-AST projections in Python/WASM/CFFI expose an explicit omitted node.

Behavior is enforced by a hardcoded 50-case oracle table (`crates/formualizer-eval/src/engine/tests/omitted_arguments.rs`) with per-row provenance tags: `lo-verified` rows were confirmed against LibreOffice 24.2.7 headless recalculation, `uniform-rule` rows follow Excel-documented empty-argument coercion where LibreOffice itself diverges or could not evaluate, plus explicit-empty and negative controls (`=LEFT(0,2)` stays `"0"`, `=EXACT("",0)` stays `FALSE`). One deliberate adjacent correction: `TEXT` with an empty format string (explicit or omitted) now returns empty text, matching Excel and LibreOffice; the previous behavior rendered the value unformatted and would have made omission and explicit `""` diverge.

Known boundary: immediate LAMBDA/IIFE calls now parse omitted slots, but runtime `Call` evaluation was already unimplemented (`#N/IMPL`) at the base revision, so omitted-parameter binding is observable only at the parser level. This is the same pre-existing gap that blocks `ISOMITTED` (#238).

This is a breaking change for the unpublished parser 3.0 line: exhaustive matches on `ASTNodeType` must handle `Omitted`. Public API drift is limited to `ASTNodeType::Omitted`, `AstNodeData::Omitted`, and `ArgumentHandle::is_omitted()`. Process: implementation and a separate fix pass were both preceded by an independent adversarial read-only review, whose single major finding (numeric zero leaking as `"0"` into text contexts outside the concat family) was fixed centrally and pinned with additional LibreOffice-verified oracle rows. Validation: full workspace tests 3320 passed / 0 failed, clippy and fmt clean, all 8 public API snapshots pass, Python wheel and touched tests pass, JSON workbook round trip preserves `=IFERROR(A1,)` exactly. No version bump; FormulaPlane default unchanged.

drafted with love by (agent) Manfred, with approval from Frankie
