### PR TITLE
fix: publish blank formula results as numeric zero (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to Formualizer will be documented in this file.
 ### Fixed
 
 - Database functions now distinguish explicit empty text from genuinely blank field cells: `DCOUNTA` counts the former, while `DGET` ignores the latter, matching LibreOffice and Excel. (#281)
+- Formula cells whose final result passes through a truly blank cell now publish numeric `0`, matching Excel and LibreOffice, while direct blank-cell inspection and range semantics remain unchanged. Blank elements in spilled results are likewise published as zero; JSON persistence and Python/WASM value surfaces now expose these computed results as `0` instead of empty/`None`/`null`. (#279)
 - Explicitly omitted function arguments now retain their syntax through parsing and canonical rendering, coerce as Excel empty arguments (`0`, `FALSE`, or empty text by context), and count as numeric zero in aggregates without changing absent optional defaults or blank-reference behavior. (#277)
 - `TEXT` with an empty format string (explicit `""` or an omitted second argument) now returns empty text, matching Excel and LibreOffice; it previously rendered the value as if unformatted. (#277)
 - Restored the released `formualizer_eval::builtins::datetime` conversion helpers and sparse-sheet constructor compatibility paths, including explicit 1904 date-system handling. The eval decode wrappers retain released 0.7.1 component-clamping and negative-fraction behavior; as an intentional safety deviation, infinities and chrono date/duration overflow now return typed `#NUM!` instead of panicking. (#259)

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -17111,7 +17111,8 @@ where
         // If array result, perform spill from the anchor cell
         match result {
             Ok(cv) => {
-                let result_literal = cv.into_literal();
+                let result_literal =
+                    crate::engine::result_finalization::finalize_formula_result(cv.into_literal());
                 match result_literal {
                     LiteralValue::Array(rows) => {
                         // Update kind to FormulaArray for tracking
@@ -22472,7 +22473,9 @@ where
 
         interpreter
             .evaluate_arena_ast(ast_id, self.graph.data_store(), self.graph.sheet_reg())
-            .map(|cv| cv.into_literal())
+            .map(|cv| {
+                crate::engine::result_finalization::finalize_formula_result(cv.into_literal())
+            })
     }
 
     /// Get access to the shared thread pool for parallel evaluation
@@ -24724,7 +24727,11 @@ where
                 let interpreter = Interpreter::new_with_cell(ctx, sheet_name, cell_ref);
                 interpreter
                     .evaluate_arena_ast(ast_id, self.graph.data_store(), self.graph.sheet_reg())
-                    .map(|cv| cv.into_literal())
+                    .map(|cv| {
+                        crate::engine::result_finalization::finalize_formula_result(
+                            cv.into_literal(),
+                        )
+                    })
             }
             VertexKind::NamedScalar | VertexKind::NamedArray => {
                 let named_range = self.graph.named_range_by_vertex(vertex_id).ok_or_else(|| {

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -23,6 +23,7 @@ pub mod plan;
 pub mod range_view;
 pub mod resource_ledger;
 pub mod resource_observability;
+pub(crate) mod result_finalization;
 pub mod row_visibility;
 pub mod scheduler;
 pub mod spill;

--- a/crates/formualizer-eval/src/engine/result_finalization.rs
+++ b/crates/formualizer-eval/src/engine/result_finalization.rs
@@ -1,0 +1,19 @@
+use formualizer_common::LiteralValue;
+
+/// Finalize a formula result immediately before it is published to the grid.
+///
+/// Excel exposes a blank-cell passthrough as numeric zero once it becomes a
+/// formula cell's result. `Number(0.0)` matches the evaluator's existing
+/// coercion results; stored blank cells remain `Empty` because only formula
+/// publication calls this function.
+pub(crate) fn finalize_formula_result(value: LiteralValue) -> LiteralValue {
+    match value {
+        LiteralValue::Empty => LiteralValue::Number(0.0),
+        LiteralValue::Array(rows) => LiteralValue::Array(
+            rows.into_iter()
+                .map(|row| row.into_iter().map(finalize_formula_result).collect())
+                .collect(),
+        ),
+        other => other,
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/blank_formula_results.rs
+++ b/crates/formualizer-eval/src/engine/tests/blank_formula_results.rs
@@ -1,0 +1,367 @@
+use std::sync::Arc;
+
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::test_workbook::TestWorkbook;
+
+#[derive(Clone, Copy, Debug)]
+enum Expected {
+    Number(f64),
+    Boolean(bool),
+    Text(&'static str),
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OracleCase {
+    row: u32,
+    formula: &'static str,
+    oracle: &'static str,
+    expected: Expected,
+}
+
+const ORACLE_CASES: &[OracleCase] = &[
+    OracleCase {
+        row: 1,
+        formula: "=ISBLANK(C1)",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Boolean(true),
+    },
+    OracleCase {
+        row: 2,
+        formula: "=C1&\"x\"",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Text("x"),
+    },
+    OracleCase {
+        row: 3,
+        formula: "=LEN(C1)",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 4,
+        formula: "=C1=0",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Boolean(true),
+    },
+    OracleCase {
+        row: 5,
+        formula: "=C1=\"\"",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Boolean(true),
+    },
+    OracleCase {
+        row: 6,
+        formula: "=T(C1)",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Text(""),
+    },
+    OracleCase {
+        row: 7,
+        formula: "=N(C1)",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 8,
+        formula: "=ISNUMBER(C1)",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Boolean(false),
+    },
+    OracleCase {
+        row: 9,
+        formula: "=COUNT(C1)",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 10,
+        formula: "=COUNTA(C1)",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 11,
+        formula: "=TEXT(C1,\"0\")",
+        oracle: "oracle: lo-verified must-not-change",
+        expected: Expected::Text("0"),
+    },
+    OracleCase {
+        row: 12,
+        formula: "=C1",
+        oracle: "oracle: lo-verified must-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 13,
+        formula: "=+C1",
+        oracle: "oracle: lo-verified must-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 14,
+        formula: "=IF(TRUE,C1,5)",
+        oracle: "oracle: lo-verified must-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 15,
+        formula: "=IFERROR(C1,5)",
+        oracle: "oracle: lo-verified must-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 16,
+        formula: "=CHOOSE(1,C1)",
+        oracle: "oracle: lo-verified must-change",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 17,
+        formula: "=C1",
+        oracle: "oracle: lo-verified chain producer",
+        expected: Expected::Number(0.0),
+    },
+    OracleCase {
+        row: 18,
+        formula: "=ISBLANK(A17)",
+        oracle: "oracle: lo-verified chain consumer",
+        expected: Expected::Boolean(false),
+    },
+    OracleCase {
+        row: 19,
+        formula: "=COUNT(A17)",
+        oracle: "oracle: lo-verified chain consumer",
+        expected: Expected::Number(1.0),
+    },
+    OracleCase {
+        row: 20,
+        formula: "=COUNTA(A17)",
+        oracle: "oracle: lo-verified chain consumer",
+        expected: Expected::Number(1.0),
+    },
+];
+
+fn expected_literal(expected: Expected) -> LiteralValue {
+    match expected {
+        Expected::Number(value) => LiteralValue::Number(value),
+        Expected::Boolean(value) => LiteralValue::Boolean(value),
+        Expected::Text(value) => LiteralValue::Text(value.to_string()),
+    }
+}
+
+#[test]
+fn blank_formula_result_oracle_table() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for case in ORACLE_CASES {
+        engine
+            .set_cell_formula("Sheet1", case.row, 1, parse(case.formula).unwrap())
+            .unwrap();
+    }
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        None,
+        "C1 must remain a truly blank stored cell"
+    );
+    for case in ORACLE_CASES {
+        assert_eq!(
+            engine.get_cell_value("Sheet1", case.row, 1),
+            Some(expected_literal(case.expected)),
+            "{} ({})",
+            case.formula,
+            case.oracle
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PlaneCase {
+    col: u32,
+    formula: fn(u32) -> String,
+    expected: Expected,
+}
+
+fn row_formula(template: &str, row: u32) -> String {
+    template.replace("{row}", &row.to_string())
+}
+
+fn build_plane_engine(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    let cases = plane_cases();
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_formula_plane_mode(mode),
+    );
+    let mut records = Vec::new();
+    for case in &cases {
+        for row in 1..=20 {
+            let formula = (case.formula)(row);
+            let ast = parse(&formula).unwrap();
+            let ast_id = engine.intern_formula_ast(&ast);
+            records.push(FormulaIngestRecord::new(
+                row,
+                case.col,
+                ast_id,
+                Some(Arc::<str>::from(formula)),
+            ));
+        }
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", records)])
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+fn plane_cases() -> [PlaneCase; 20] {
+    [
+        PlaneCase {
+            col: 4,
+            formula: |row| row_formula("=ISBLANK(C{row})", row),
+            expected: Expected::Boolean(true),
+        },
+        PlaneCase {
+            col: 5,
+            formula: |row| row_formula("=C{row}&\"x\"", row),
+            expected: Expected::Text("x"),
+        },
+        PlaneCase {
+            col: 6,
+            formula: |row| row_formula("=LEN(C{row})", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 7,
+            formula: |row| row_formula("=C{row}=0", row),
+            expected: Expected::Boolean(true),
+        },
+        PlaneCase {
+            col: 8,
+            formula: |row| row_formula("=C{row}=\"\"", row),
+            expected: Expected::Boolean(true),
+        },
+        PlaneCase {
+            col: 9,
+            formula: |row| row_formula("=T(C{row})", row),
+            expected: Expected::Text(""),
+        },
+        PlaneCase {
+            col: 10,
+            formula: |row| row_formula("=N(C{row})", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 11,
+            formula: |row| row_formula("=ISNUMBER(C{row})", row),
+            expected: Expected::Boolean(false),
+        },
+        PlaneCase {
+            col: 12,
+            formula: |row| row_formula("=COUNT(C{row})", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 13,
+            formula: |row| row_formula("=COUNTA(C{row})", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 14,
+            formula: |row| row_formula("=TEXT(C{row},\"0\")", row),
+            expected: Expected::Text("0"),
+        },
+        PlaneCase {
+            col: 15,
+            formula: |row| row_formula("=C{row}", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 16,
+            formula: |row| row_formula("=+C{row}", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 17,
+            formula: |row| row_formula("=IF(TRUE,C{row},5)", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 18,
+            formula: |row| row_formula("=IFERROR(C{row},5)", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 19,
+            formula: |row| row_formula("=CHOOSE(1,C{row})", row),
+            expected: Expected::Number(0.0),
+        },
+        PlaneCase {
+            col: 20,
+            formula: |row| row_formula("=ISBLANK(O{row})", row),
+            expected: Expected::Boolean(false),
+        },
+        PlaneCase {
+            col: 21,
+            formula: |row| row_formula("=COUNT(O{row})", row),
+            expected: Expected::Number(1.0),
+        },
+        PlaneCase {
+            col: 22,
+            formula: |row| row_formula("=COUNTA(O{row})", row),
+            expected: Expected::Number(1.0),
+        },
+        PlaneCase {
+            col: 23,
+            formula: |_row| "=$C$1".to_string(),
+            expected: Expected::Number(0.0),
+        },
+    ]
+}
+
+#[test]
+fn formula_plane_blank_result_values_match_off() {
+    let off = build_plane_engine(FormulaPlaneMode::Off);
+    let authoritative = build_plane_engine(FormulaPlaneMode::AuthoritativeExperimental);
+    assert!(
+        authoritative
+            .baseline_stats()
+            .formula_plane_active_span_count
+            > 0
+    );
+
+    for case in plane_cases() {
+        for row in 1..=20 {
+            let expected = Some(expected_literal(case.expected));
+            assert_eq!(off.get_cell_value("Sheet1", row, case.col), expected);
+            assert_eq!(
+                authoritative.get_cell_value("Sheet1", row, case.col),
+                off.get_cell_value("Sheet1", row, case.col),
+                "FormulaPlane mismatch at ({row}, {})",
+                case.col
+            );
+        }
+    }
+}
+
+#[test]
+fn blank_elements_in_spilled_formula_results_finalize_to_zero() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=C1:C2").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    for row in 1..=2 {
+        assert_eq!(
+            engine.get_cell_value("Sheet1", row, 1),
+            Some(LiteralValue::Number(0.0))
+        );
+        assert_eq!(engine.get_cell_value("Sheet1", row, 3), None);
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/dynamic_lookup_arrow.rs
+++ b/crates/formualizer-eval/src/engine/tests/dynamic_lookup_arrow.rs
@@ -38,7 +38,10 @@ fn take_whole_column_returns_single_cell_without_materializing() {
         .unwrap();
 
     engine.evaluate_all().unwrap();
-    assert_eq!(engine.get_cell_value("Sheet1", 1, 3), None);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(0.0))
+    );
 }
 
 #[test]
@@ -53,5 +56,8 @@ fn drop_whole_column_can_return_last_cell_without_materializing() {
         .unwrap();
 
     engine.evaluate_all().unwrap();
-    assert_eq!(engine.get_cell_value("Sheet1", 1, 3), None);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(0.0))
+    );
 }

--- a/crates/formualizer-eval/src/engine/tests/iferror_ifna_lazy.rs
+++ b/crates/formualizer-eval/src/engine/tests/iferror_ifna_lazy.rs
@@ -75,8 +75,9 @@ fn iferror_text_and_number_passthrough() {
 }
 
 #[test]
-fn iferror_blank_value_arg_passes_through_as_empty() {
-    // A1 is blank; IFERROR(A1, 42) yields the blank (Empty), not the fallback.
+fn iferror_blank_value_arg_finalizes_as_zero() {
+    // A1 is blank; IFERROR/IFNA pass it through rather than using the fallback,
+    // then formula-result finalization publishes numeric zero.
     let wb = TestWorkbook::new();
     let mut engine = Engine::new(wb, EvalConfig::default());
     engine
@@ -88,12 +89,7 @@ fn iferror_blank_value_arg_passes_through_as_empty() {
     engine.evaluate_all().unwrap();
     let v = engine.get_cell_value("Sheet1", 1, 2);
     let v2 = engine.get_cell_value("Sheet1", 2, 2);
-    // Blank arg0 is not an error: it passes through as Empty (engine stores
-    // an Empty result as an empty cell), NOT as the fallback.
-    assert!(
-        matches!(v, None | Some(LiteralValue::Empty)),
-        "blank passthrough changed: {v:?}"
-    );
+    assert_eq!(v, Some(LiteralValue::Number(0.0)));
     assert_eq!(v, v2, "IFERROR and IFNA must agree on blank passthrough");
 }
 

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -95,6 +95,7 @@ mod arrow_sparse_compaction;
 mod arrow_sparse_extension;
 mod arrow_sparse_structural_ops;
 mod arrow_sparse_used_bounds;
+mod blank_formula_results;
 mod compressed_range_scheduler;
 mod computed_array_aggregates;
 mod computed_flush;

--- a/crates/formualizer-eval/src/formula_plane/span_eval.rs
+++ b/crates/formualizer-eval/src/formula_plane/span_eval.rs
@@ -292,7 +292,9 @@ impl<'a> SpanEvaluator<'a> {
                 first_writable_placement.col,
             ));
             let value = match interpreter.evaluate_ast(&ast_tree) {
-                Ok(calc) => literal_to_overlay(calc.into_literal(), self.context.date_system()),
+                Ok(calc) => {
+                    formula_result_to_overlay(calc.into_literal(), self.context.date_system())
+                }
                 Err(err) => OverlayValue::Error(map_error_code(err.kind)),
             };
 
@@ -423,7 +425,9 @@ impl<'a> SpanEvaluator<'a> {
                 self.data_store,
                 self.sheet_registry,
             ) {
-                Ok(calc) => literal_to_overlay(calc.into_literal(), self.context.date_system()),
+                Ok(calc) => {
+                    formula_result_to_overlay(calc.into_literal(), self.context.date_system())
+                }
                 Err(err) => OverlayValue::Error(map_error_code(err.kind)),
             }
         } else {
@@ -434,7 +438,9 @@ impl<'a> SpanEvaluator<'a> {
                 self.data_store,
                 self.sheet_registry,
             ) {
-                Ok(calc) => literal_to_overlay(calc.into_literal(), self.context.date_system()),
+                Ok(calc) => {
+                    formula_result_to_overlay(calc.into_literal(), self.context.date_system())
+                }
                 Err(err) => OverlayValue::Error(map_error_code(err.kind)),
             }
         };
@@ -707,7 +713,7 @@ impl<'a> SpanEvaluator<'a> {
             self.data_store,
             self.sheet_registry,
         ) {
-            Ok(calc) => literal_to_overlay(calc.into_literal(), self.context.date_system()),
+            Ok(calc) => formula_result_to_overlay(calc.into_literal(), self.context.date_system()),
             Err(err) => OverlayValue::Error(map_error_code(err.kind)),
         };
         Ok(value)
@@ -1120,6 +1126,16 @@ fn literal_to_overlay(
         LiteralValue::Pending => OverlayValue::Pending,
         LiteralValue::Error(err) => OverlayValue::Error(map_error_code(err.kind)),
     }
+}
+
+fn formula_result_to_overlay(
+    value: LiteralValue,
+    date_system: formualizer_common::DateSystem,
+) -> OverlayValue {
+    literal_to_overlay(
+        crate::engine::result_finalization::finalize_formula_result(value),
+        date_system,
+    )
 }
 
 #[cfg(test)]

--- a/crates/formualizer-eval/src/formula_plane/span_eval.rs
+++ b/crates/formualizer-eval/src/formula_plane/span_eval.rs
@@ -1562,7 +1562,7 @@ mod tests {
     }
 
     #[test]
-    fn span_eval_preserves_explicit_empty_outputs() {
+    fn span_eval_finalizes_explicit_empty_outputs_as_zero() {
         let mut plane = FormulaPlane::default();
         let mut data_store = DataStore::new();
         let sheet_registry = SheetRegistry::new();
@@ -1601,7 +1601,10 @@ mod tests {
 
         assert_eq!(
             cell_values(&buffer),
-            vec![(0, 0, OverlayValue::Empty), (1, 0, OverlayValue::Empty)]
+            vec![
+                (0, 0, OverlayValue::Number(0.0)),
+                (1, 0, OverlayValue::Number(0.0))
+            ]
         );
     }
 


### PR DESCRIPTION
Fixes #279.

Formulas whose final result was a blank-cell passthrough published `LiteralValue::Empty` as the computed cell value, where Excel and LibreOffice publish numeric zero. The blankness also propagated: a cell containing `=C1` (with `C1` blank) was itself treated as blank by downstream `ISBLANK`, `COUNT`, and `COUNTA`, which the LibreOffice chain probes show is wrong at the producing cell, not just at display.

Design: a single shared `finalize_formula_result` at the grid-publication boundary maps a final scalar `Empty` to `Number(0.0)` (arrays element-wise, covering spilled blanks), called from the legacy sequential, parallel/immutable, and SCC/cycle evaluation paths and from all four FormulaPlane overlay conversion sites. Nothing else changes: intra-expression `Empty` coercion, stored truly-blank cells, reference inspection (`ISBLANK(C1)` stays TRUE, `ISBLANK(INDEX(C1:C2,1))` stays TRUE), named-range intermediates, range/criteria semantics, and explicit empty text (`=IF(TRUE,"",5)` stays `""`) are all preserved and pinned.

Behavior is enforced by a 19-row LibreOffice-verified oracle table (11 must-not-change, 5 must-change, 3 chain-consumer rows) asserted under both FormulaPlane Off and authoritative modes with active-span verification. Four pre-existing test pins that codified the old behavior were updated, each individually justified against Excel in review. Computed values surfaced through persistence and bindings change for affected cells (numeric zero instead of empty), noted in the CHANGELOG; truly blank stored cells still round-trip as empty.

An independent adversarial review verified complete finalization coverage across every publication route including demand-driven and cycle paths, confirmed intermediate-array and reference semantics empirically against base, and mutation-tested the finalizer (identity mutation fails seven tests). The review surfaced three pre-existing blank-range aggregation deviations reproduced identically on base, filed separately as #285.

Validation: full workspace tests, clippy, fmt, and public API snapshots pass; no API drift, no schema changes, no version bump.

drafted with love by (agent) Manfred, with approval from Frankie
