### PR TITLE
fix: coerce date and time text in arithmetic operands (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Arithmetic operators now coerce date, time, and datetime text operands to serial numbers using the workbook's 1900 or 1904 date system, while aggregate, comparison, criteria, `N`, and concatenation text semantics remain unchanged. (#289)
 - Database functions now distinguish explicit empty text from genuinely blank field cells: `DCOUNTA` counts the former, while `DGET` ignores the latter, matching LibreOffice and Excel. (#281)
 - Explicitly omitted function arguments now retain their syntax through parsing and canonical rendering, coerce as Excel empty arguments (`0`, `FALSE`, or empty text by context), and count as numeric zero in aggregates without changing absent optional defaults or blank-reference behavior. (#277)
 - `TEXT` with an empty format string (explicit `""` or an omitted second argument) now returns empty text, matching Excel and LibreOffice; it previously rendered the value as if unformatted. (#277)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
-- Arithmetic operators now coerce date, time, and datetime text operands to serial numbers using the workbook's 1900 or 1904 date system, while aggregate, comparison, criteria, `N`, and concatenation text semantics remain unchanged. (#289)
+- Arithmetic operators now coerce supported en-US date, time, and datetime text operands to serial numbers using the workbook's 1900 or 1904 date system. Two-digit years in slash and English month-name forms use the Excel 29/30 window, ISO dates require a four-digit year, slash dates use month/day/year ordering, and `T` is restricted to ISO datetimes; aggregate, comparison, criteria, `N`, and concatenation text semantics remain unchanged. (#289)
+- `DATEVALUE` and `TIMEVALUE` now use the shared deterministic temporal parsers: two-digit date years use the Excel 29/30 window, surrounding whitespace is accepted, interior slash-date whitespace is rejected, and whitespace around time separators is accepted. `DATEVALUE` retains its pre-existing unambiguous day/month/year and year/month/day slash fallbacks for compatibility. (#289)
+- Date, datetime, time, and duration literals used by `*`, `/`, `^`, unary minus, or `%` now convert under the workbook's selected date system instead of implicitly using the Excel-1900 system. (#289)
 - Database functions now distinguish explicit empty text from genuinely blank field cells: `DCOUNTA` counts the former, while `DGET` ignores the latter, matching LibreOffice and Excel. (#281)
 - Explicitly omitted function arguments now retain their syntax through parsing and canonical rendering, coerce as Excel empty arguments (`0`, `FALSE`, or empty text by context), and count as numeric zero in aggregates without changing absent optional defaults or blank-reference behavior. (#277)
 - `TEXT` with an empty format string (explicit `""` or an omitted second argument) now returns empty text, matching Excel and LibreOffice; it previously rendered the value as if unformatted. (#277)

--- a/crates/formualizer-common/src/date_serial.rs
+++ b/crates/formualizer-common/src/date_serial.rs
@@ -60,6 +60,99 @@ pub fn time_to_fraction(time: &NaiveTime) -> f64 {
     time.num_seconds_from_midnight() as f64 / SECONDS_PER_DAY
 }
 
+/// Parse date text using Formualizer's deterministic spreadsheet convention.
+///
+/// Numeric slash dates prefer month/day/year, with day/month/year retained as
+/// a fallback for unambiguous legacy `DATEVALUE` inputs. Two-digit years use
+/// Excel's fixed window: `00..=29` means 2000 through 2029 and `30..=99`
+/// means 1930 through 1999. Parsing never consults the host locale.
+pub fn parse_excel_date_text(input: &str) -> Option<NaiveDate> {
+    let text = input.trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    if let Some(date) = parse_numeric_slash_date(text) {
+        return Some(date);
+    }
+
+    const FORMATS: &[&str] = &["%Y-%m-%d", "%B %d, %Y", "%b %d, %Y", "%d-%b-%Y", "%d %B %Y"];
+    FORMATS
+        .iter()
+        .find_map(|format| NaiveDate::parse_from_str(text, format).ok())
+}
+
+fn parse_numeric_slash_date(text: &str) -> Option<NaiveDate> {
+    let parts: Vec<&str> = text.split('/').collect();
+    if parts.len() != 3
+        || parts
+            .iter()
+            .any(|part| part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        return None;
+    }
+
+    let first = parts[0].parse::<u32>().ok()?;
+    let second = parts[1].parse::<u32>().ok()?;
+    let third = parts[2].parse::<u32>().ok()?;
+
+    if parts[0].len() == 4 {
+        return NaiveDate::from_ymd_opt(i32::try_from(first).ok()?, second, third);
+    }
+
+    let year = match parts[2].len() {
+        2 if third <= 29 => 2000 + third as i32,
+        2 => 1900 + third as i32,
+        4 => i32::try_from(third).ok()?,
+        _ => return None,
+    };
+
+    NaiveDate::from_ymd_opt(year, first, second)
+        .or_else(|| NaiveDate::from_ymd_opt(year, second, first))
+}
+
+/// Parse time text using fixed 24-hour or English AM/PM formats.
+///
+/// Parsing is deterministic and does not consult the host locale.
+pub fn parse_excel_time_text(input: &str) -> Option<NaiveTime> {
+    let text = input.trim();
+    const FORMATS: &[&str] = &["%H:%M:%S", "%H:%M", "%I:%M:%S %p", "%I:%M %p"];
+    FORMATS
+        .iter()
+        .find_map(|format| NaiveTime::parse_from_str(text, format).ok())
+}
+
+/// Parse a date and time separated by whitespace or `T`.
+///
+/// Date and time components use [`parse_excel_date_text`] and
+/// [`parse_excel_time_text`], so the result is independent of machine locale.
+pub fn parse_excel_datetime_text(input: &str) -> Option<NaiveDateTime> {
+    let text = input.trim();
+    text.char_indices()
+        .filter(|(_, ch)| *ch == 'T' || ch.is_ascii_whitespace())
+        .find_map(|(index, ch)| {
+            let time_start = index + ch.len_utf8();
+            let date = parse_excel_date_text(&text[..index])?;
+            let time = parse_excel_time_text(&text[time_start..])?;
+            Some(date.and_time(time))
+        })
+}
+
+/// Parse spreadsheet date, time, or datetime text and return its serial.
+///
+/// This is the canonical entry point for text operands that need a temporal
+/// serial. Date-bearing results honor the selected workbook date system;
+/// time-only results are fractional days in either system.
+pub fn parse_excel_date_time_text_to_serial_for(system: DateSystem, input: &str) -> Option<f64> {
+    if let Some(datetime) = parse_excel_datetime_text(input) {
+        return Some(datetime_to_serial_for(system, &datetime));
+    }
+    if let Some(date) = parse_excel_date_text(input) {
+        return Some(date_to_serial_for(system, &date));
+    }
+    parse_excel_time_text(input).map(|time| time_to_fraction(&time))
+}
+
 /// Return the final whole-day serial supported by Excel's calendar.
 pub fn max_excel_serial_for(system: DateSystem) -> f64 {
     date_to_serial_for(system, &EXCEL_MAX_DATE)
@@ -385,5 +478,33 @@ mod tests {
     fn time_fraction_is_second_precision() {
         let time = NaiveTime::from_hms_nano_opt(12, 0, 0, 999_999_999).unwrap();
         assert_eq!(time_to_fraction(&time), 0.5);
+    }
+
+    #[test]
+    fn temporal_text_parser_uses_excel_year_window_and_date_system() {
+        assert_eq!(
+            parse_excel_date_time_text_to_serial_for(DateSystem::Excel1900, "1/1/03"),
+            Some(37_622.0)
+        );
+        assert_eq!(
+            parse_excel_date_time_text_to_serial_for(DateSystem::Excel1904, "1/1/03 12:00"),
+            Some(36_160.5)
+        );
+        assert_eq!(parse_excel_date_text("1/1/29"), Some(date(2029, 1, 1)));
+        assert_eq!(parse_excel_date_text("1/1/30"), Some(date(1930, 1, 1)));
+        assert_eq!(
+            parse_excel_date_time_text_to_serial_for(DateSystem::Excel1900, "12:00"),
+            Some(0.5)
+        );
+    }
+
+    #[test]
+    fn temporal_text_parser_rejects_invalid_and_non_dates() {
+        for text in ["2/30/03", "abc", "", "13/13/13", "123-456"] {
+            assert!(
+                parse_excel_date_time_text_to_serial_for(DateSystem::Excel1900, text).is_none(),
+                "{text}"
+            );
+        }
     }
 }

--- a/crates/formualizer-common/src/date_serial.rs
+++ b/crates/formualizer-common/src/date_serial.rs
@@ -60,12 +60,13 @@ pub fn time_to_fraction(time: &NaiveTime) -> f64 {
     time.num_seconds_from_midnight() as f64 / SECONDS_PER_DAY
 }
 
-/// Parse date text using Formualizer's deterministic spreadsheet convention.
+/// Parse date text using Formualizer's deterministic en-US spreadsheet convention.
 ///
-/// Numeric slash dates prefer month/day/year, with day/month/year retained as
-/// a fallback for unambiguous legacy `DATEVALUE` inputs. Two-digit years use
-/// Excel's fixed window: `00..=29` means 2000 through 2029 and `30..=99`
-/// means 1930 through 1999. Parsing never consults the host locale.
+/// Numeric slash dates use month/day/year ordering. Two-digit years in slash
+/// and English month-name forms use Excel's fixed window: `00..=29` means
+/// 2000 through 2029 and `30..=99` means 1930 through 1999. ISO dates require
+/// a four-digit year. Parsing has no locale parameter and never consults the
+/// host locale.
 pub fn parse_excel_date_text(input: &str) -> Option<NaiveDate> {
     let text = input.trim();
     if text.is_empty() {
@@ -76,10 +77,7 @@ pub fn parse_excel_date_text(input: &str) -> Option<NaiveDate> {
         return Some(date);
     }
 
-    const FORMATS: &[&str] = &["%Y-%m-%d", "%B %d, %Y", "%b %d, %Y", "%d-%b-%Y", "%d %B %Y"];
-    FORMATS
-        .iter()
-        .find_map(|format| NaiveDate::parse_from_str(text, format).ok())
+    parse_iso_date(text).or_else(|| parse_month_name_date(text))
 }
 
 fn parse_numeric_slash_date(text: &str) -> Option<NaiveDate> {
@@ -92,47 +90,84 @@ fn parse_numeric_slash_date(text: &str) -> Option<NaiveDate> {
         return None;
     }
 
-    let first = parts[0].parse::<u32>().ok()?;
-    let second = parts[1].parse::<u32>().ok()?;
-    let third = parts[2].parse::<u32>().ok()?;
+    let month = parts[0].parse::<u32>().ok()?;
+    let day = parts[1].parse::<u32>().ok()?;
+    let year = parse_excel_year(parts[2])?;
+    NaiveDate::from_ymd_opt(year, month, day)
+}
 
-    if parts[0].len() == 4 {
-        return NaiveDate::from_ymd_opt(i32::try_from(first).ok()?, second, third);
+fn parse_excel_year(text: &str) -> Option<i32> {
+    let year = text.parse::<i32>().ok()?;
+    match text.len() {
+        2 if year <= 29 => Some(2000 + year),
+        2 => Some(1900 + year),
+        4 => Some(year),
+        _ => None,
     }
+}
 
-    let year = match parts[2].len() {
-        2 if third <= 29 => 2000 + third as i32,
-        2 => 1900 + third as i32,
-        4 => i32::try_from(third).ok()?,
-        _ => return None,
-    };
+fn parse_iso_date(text: &str) -> Option<NaiveDate> {
+    let (year, rest) = text.split_once('-')?;
+    if year.len() != 4 || !year.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let normalized = format!("{}-{rest}", year.parse::<i32>().ok()?);
+    NaiveDate::parse_from_str(&normalized, "%Y-%m-%d").ok()
+}
 
-    NaiveDate::from_ymd_opt(year, first, second)
-        .or_else(|| NaiveDate::from_ymd_opt(year, second, first))
+fn parse_month_name_date(text: &str) -> Option<NaiveDate> {
+    const FORMATS: &[&str] = &["%B %d, %Y", "%b %d, %Y", "%d-%b-%Y"];
+    FORMATS.iter().find_map(|format| {
+        let separator = if *format == "%d-%b-%Y" { '-' } else { ' ' };
+        let (prefix, year_text) = text.rsplit_once(separator)?;
+        let year = parse_excel_year(year_text)?;
+        let normalized = format!("{prefix}{separator}{year:04}");
+        NaiveDate::parse_from_str(&normalized, format).ok()
+    })
 }
 
 /// Parse time text using fixed 24-hour or English AM/PM formats.
 ///
-/// Parsing is deterministic and does not consult the host locale.
+/// Parsing has no locale parameter, uses English AM/PM markers, and never
+/// consults the host locale. ASCII whitespace around separators is ignored.
 pub fn parse_excel_time_text(input: &str) -> Option<NaiveTime> {
     let text = input.trim();
+    let mut normalized = String::with_capacity(text.len());
+    let mut pending_space = false;
+    for ch in text.chars() {
+        if ch.is_ascii_whitespace() {
+            pending_space = true;
+        } else {
+            if pending_space && ch != ':' && !normalized.ends_with(':') && !normalized.is_empty() {
+                normalized.push(' ');
+            }
+            normalized.push(ch);
+            pending_space = false;
+        }
+    }
     const FORMATS: &[&str] = &["%H:%M:%S", "%H:%M", "%I:%M:%S %p", "%I:%M %p"];
     FORMATS
         .iter()
-        .find_map(|format| NaiveTime::parse_from_str(text, format).ok())
+        .find_map(|format| NaiveTime::parse_from_str(&normalized, format).ok())
 }
 
-/// Parse a date and time separated by whitespace or `T`.
+/// Parse an en-US date and time separated by whitespace or an ISO `T`.
 ///
 /// Date and time components use [`parse_excel_date_text`] and
-/// [`parse_excel_time_text`], so the result is independent of machine locale.
-fn parse_excel_datetime_text(input: &str) -> Option<NaiveDateTime> {
+/// [`parse_excel_time_text`]. `T` is accepted only after a four-digit-year ISO
+/// date. There is no locale parameter, and parsing is independent of the host
+/// locale.
+pub fn parse_excel_datetime_text(input: &str) -> Option<NaiveDateTime> {
     let text = input.trim();
     text.char_indices()
         .filter(|(_, ch)| *ch == 'T' || ch.is_ascii_whitespace())
         .find_map(|(index, ch)| {
             let time_start = index + ch.len_utf8();
-            let date = parse_excel_date_text(&text[..index])?;
+            let date = if ch == 'T' {
+                parse_iso_date(&text[..index])?
+            } else {
+                parse_excel_date_text(&text[..index])?
+            };
             let time = parse_excel_time_text(&text[time_start..])?;
             Some(date.and_time(time))
         })
@@ -141,9 +176,10 @@ fn parse_excel_datetime_text(input: &str) -> Option<NaiveDateTime> {
 /// Parse spreadsheet date, time, or datetime text and return its serial.
 ///
 /// This is the canonical entry point for text operands that need a temporal
-/// serial. Date-bearing results honor the selected workbook date system;
-/// time-only results are fractional days in either system.
-pub fn parse_excel_date_time_text_to_serial_for(system: DateSystem, input: &str) -> Option<f64> {
+/// serial. Dates use deterministic en-US month/day/year ordering, with no
+/// locale parameter. Date-bearing results honor the selected workbook date
+/// system; time-only results are fractional days in either system.
+pub fn parse_excel_datetime_text_to_serial_for(system: DateSystem, input: &str) -> Option<f64> {
     if let Some(datetime) = parse_excel_datetime_text(input) {
         return Some(datetime_to_serial_for(system, &datetime));
     }
@@ -483,18 +519,46 @@ mod tests {
     #[test]
     fn temporal_text_parser_uses_excel_year_window_and_date_system() {
         assert_eq!(
-            parse_excel_date_time_text_to_serial_for(DateSystem::Excel1900, "1/1/03"),
+            parse_excel_datetime_text_to_serial_for(DateSystem::Excel1900, "1/1/03"),
             Some(37_622.0)
         );
         assert_eq!(
-            parse_excel_date_time_text_to_serial_for(DateSystem::Excel1904, "1/1/03 12:00"),
+            parse_excel_datetime_text_to_serial_for(DateSystem::Excel1904, "1/1/03 12:00"),
             Some(36_160.5)
         );
-        assert_eq!(parse_excel_date_text("1/1/29"), Some(date(2029, 1, 1)));
-        assert_eq!(parse_excel_date_text("1/1/30"), Some(date(1930, 1, 1)));
+
+        // oracle: lo-verified for every accepted two-digit-year date shape.
+        for (input, expected) in [
+            ("1/1/29", date(2029, 1, 1)),
+            ("1/1/30", date(1930, 1, 1)),
+            ("January 1, 29", date(2029, 1, 1)),
+            ("January 1, 30", date(1930, 1, 1)),
+            ("Jan 1, 29", date(2029, 1, 1)),
+            ("Jan 1, 30", date(1930, 1, 1)),
+            ("1-Jan-29", date(2029, 1, 1)),
+            ("1-Jan-30", date(1930, 1, 1)),
+        ] {
+            assert_eq!(parse_excel_date_text(input), Some(expected), "{input}");
+        }
+
+        // oracle: lo-verified. A short year is not accepted in ISO year position.
+        assert_eq!(parse_excel_date_text("03-01-01"), None);
         assert_eq!(
-            parse_excel_date_time_text_to_serial_for(DateSystem::Excel1900, "12:00"),
+            parse_excel_datetime_text_to_serial_for(DateSystem::Excel1900, "12:00"),
             Some(0.5)
+        );
+    }
+
+    #[test]
+    fn temporal_text_parser_restricts_slash_order_and_t_separator() {
+        // oracle: lo-verified. Arithmetic follows en-US m/d/y, unlike DATEVALUE's
+        // separately retained legacy fallbacks.
+        assert_eq!(parse_excel_date_text("15/01/2003"), None);
+        assert_eq!(parse_excel_date_text("2003/1/1"), None);
+        assert_eq!(parse_excel_datetime_text("1/1/03T12:00"), None);
+        assert_eq!(
+            parse_excel_datetime_text("2003-01-01T12:00"),
+            Some(datetime(2003, 1, 1, 12, 0))
         );
     }
 
@@ -502,7 +566,7 @@ mod tests {
     fn temporal_text_parser_rejects_invalid_and_non_dates() {
         for text in ["2/30/03", "abc", "", "13/13/13", "123-456"] {
             assert!(
-                parse_excel_date_time_text_to_serial_for(DateSystem::Excel1900, text).is_none(),
+                parse_excel_datetime_text_to_serial_for(DateSystem::Excel1900, text).is_none(),
                 "{text}"
             );
         }

--- a/crates/formualizer-common/src/date_serial.rs
+++ b/crates/formualizer-common/src/date_serial.rs
@@ -126,7 +126,7 @@ pub fn parse_excel_time_text(input: &str) -> Option<NaiveTime> {
 ///
 /// Date and time components use [`parse_excel_date_text`] and
 /// [`parse_excel_time_text`], so the result is independent of machine locale.
-pub fn parse_excel_datetime_text(input: &str) -> Option<NaiveDateTime> {
+fn parse_excel_datetime_text(input: &str) -> Option<NaiveDateTime> {
     let text = input.trim();
     text.char_indices()
         .filter(|(_, ch)| *ch == 'T' || ch.is_ascii_whitespace())

--- a/crates/formualizer-eval/src/builtins/datetime/date_value.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/date_value.rs
@@ -9,16 +9,6 @@ use formualizer_common::{
     time_to_fraction,
 };
 
-fn parse_excel_year(text: &str) -> Option<i32> {
-    let year = text.parse::<i32>().ok()?;
-    match text.len() {
-        2 if year <= 29 => Some(2000 + year),
-        2 => Some(1900 + year),
-        4 => Some(year),
-        _ => None,
-    }
-}
-
 fn parse_legacy_datevalue_text(input: &str) -> Option<NaiveDate> {
     let text = input.trim();
     let parts: Vec<&str> = text.split('/').collect();
@@ -27,24 +17,17 @@ fn parse_legacy_datevalue_text(input: &str) -> Option<NaiveDate> {
             .iter()
             .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
     {
-        if parts[0].len() == 4 {
-            return NaiveDate::from_ymd_opt(
-                parts[0].parse::<i32>().ok()?,
-                parts[1].parse::<u32>().ok()?,
-                parts[2].parse::<u32>().ok()?,
-            );
-        }
-        let year = parse_excel_year(parts[2])?;
-        return NaiveDate::from_ymd_opt(
-            year,
-            parts[1].parse::<u32>().ok()?,
-            parts[0].parse::<u32>().ok()?,
-        );
+        let normalized = if parts[0].len() == 4 {
+            format!("{}-{}-{}", parts[0], parts[1], parts[2])
+        } else {
+            format!("{}/{}/{}", parts[1], parts[0], parts[2])
+        };
+        return parse_excel_date_text(&normalized);
     }
 
-    let (prefix, year_text) = text.rsplit_once(' ')?;
-    let year = parse_excel_year(year_text)?;
-    NaiveDate::parse_from_str(&format!("{prefix} {year:04}"), "%d %B %Y").ok()
+    let (day_and_month, year) = text.rsplit_once(' ')?;
+    let (day, month) = day_and_month.split_once(' ')?;
+    parse_excel_date_text(&format!("{month} {day}, {year}"))
 }
 use formualizer_macros::func_caps;
 
@@ -375,6 +358,10 @@ mod tests {
         for (formula, expected) in [
             ("=DATEVALUE(\"15/01/2003\")", 37_636.0),
             ("=DATEVALUE(\"2003/1/1\")", 37_622.0),
+            ("=DATEVALUE(\"15/01/29\")", 47_133.0),
+            ("=DATEVALUE(\"15/01/30\")", 10_973.0),
+            ("=DATEVALUE(\"1 January 29\")", 47_119.0),
+            ("=DATEVALUE(\"1 January 30\")", 10_959.0),
         ] {
             assert_eq!(
                 eval_temporal_value_formula(crate::engine::DateSystem::Excel1900, formula),

--- a/crates/formualizer-eval/src/builtins/datetime/date_value.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/date_value.rs
@@ -3,9 +3,10 @@
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
-use chrono::NaiveDate;
-use formualizer_common::time_to_fraction;
-use formualizer_common::{ExcelError, LiteralValue, date_to_serial_for};
+use formualizer_common::{
+    ExcelError, LiteralValue, date_to_serial_for, parse_excel_date_text, parse_excel_time_text,
+    time_to_fraction,
+};
 use formualizer_macros::func_caps;
 
 /// Parses a date string and returns its date serial number.
@@ -85,25 +86,10 @@ impl Function for DateValueFn {
             }
         };
 
-        // Try common date formats
-        // Excel accepts many formats, we'll support a subset
-        let formats = [
-            "%Y-%m-%d",  // 2024-01-15
-            "%m/%d/%Y",  // 01/15/2024
-            "%d/%m/%Y",  // 15/01/2024
-            "%Y/%m/%d",  // 2024/01/15
-            "%B %d, %Y", // January 15, 2024
-            "%b %d, %Y", // Jan 15, 2024
-            "%d-%b-%Y",  // 15-Jan-2024
-            "%d %B %Y",  // 15 January 2024
-        ];
-
-        for fmt in &formats {
-            if let Ok(date) = NaiveDate::parse_from_str(&date_text, fmt) {
-                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-                    date_to_serial_for(system, &date),
-                )));
-            }
+        if let Some(date) = parse_excel_date_text(&date_text) {
+            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
+                date_to_serial_for(system, &date),
+            )));
         }
 
         Err(ExcelError::new_value()
@@ -186,20 +172,10 @@ impl Function for TimeValueFn {
             }
         };
 
-        // Try common time formats
-        let formats = [
-            "%H:%M:%S",    // 14:30:00
-            "%H:%M",       // 14:30
-            "%I:%M:%S %p", // 02:30:00 PM
-            "%I:%M %p",    // 02:30 PM
-        ];
-
-        for fmt in &formats {
-            if let Ok(time) = chrono::NaiveTime::parse_from_str(&time_text, fmt) {
-                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
-                    time_to_fraction(&time),
-                )));
-            }
+        if let Some(time) = parse_excel_time_text(&time_text) {
+            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
+                time_to_fraction(&time),
+            )));
         }
 
         Err(ExcelError::new_value()

--- a/crates/formualizer-eval/src/builtins/datetime/date_value.rs
+++ b/crates/formualizer-eval/src/builtins/datetime/date_value.rs
@@ -3,10 +3,49 @@
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
+use chrono::NaiveDate;
 use formualizer_common::{
     ExcelError, LiteralValue, date_to_serial_for, parse_excel_date_text, parse_excel_time_text,
     time_to_fraction,
 };
+
+fn parse_excel_year(text: &str) -> Option<i32> {
+    let year = text.parse::<i32>().ok()?;
+    match text.len() {
+        2 if year <= 29 => Some(2000 + year),
+        2 => Some(1900 + year),
+        4 => Some(year),
+        _ => None,
+    }
+}
+
+fn parse_legacy_datevalue_text(input: &str) -> Option<NaiveDate> {
+    let text = input.trim();
+    let parts: Vec<&str> = text.split('/').collect();
+    if parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        if parts[0].len() == 4 {
+            return NaiveDate::from_ymd_opt(
+                parts[0].parse::<i32>().ok()?,
+                parts[1].parse::<u32>().ok()?,
+                parts[2].parse::<u32>().ok()?,
+            );
+        }
+        let year = parse_excel_year(parts[2])?;
+        return NaiveDate::from_ymd_opt(
+            year,
+            parts[1].parse::<u32>().ok()?,
+            parts[0].parse::<u32>().ok()?,
+        );
+    }
+
+    let (prefix, year_text) = text.rsplit_once(' ')?;
+    let year = parse_excel_year(year_text)?;
+    NaiveDate::parse_from_str(&format!("{prefix} {year:04}"), "%d %B %Y").ok()
+}
 use formualizer_macros::func_caps;
 
 /// Parses a date string and returns its date serial number.
@@ -86,7 +125,9 @@ impl Function for DateValueFn {
             }
         };
 
-        if let Some(date) = parse_excel_date_text(&date_text) {
+        if let Some(date) =
+            parse_excel_date_text(&date_text).or_else(|| parse_legacy_datevalue_text(&date_text))
+        {
             return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Number(
                 date_to_serial_for(system, &date),
             )));
@@ -269,18 +310,78 @@ mod tests {
         }
     }
 
-    fn eval_datevalue_formula(system: crate::engine::DateSystem, formula: &str) -> LiteralValue {
+    fn eval_temporal_value_formula(
+        system: crate::engine::DateSystem,
+        formula: &str,
+    ) -> LiteralValue {
         use crate::engine::{Engine, EvalConfig};
         use crate::interpreter::Interpreter;
         use formualizer_parse::parser::parse;
 
-        let wb = TestWorkbook::new().with_function(Arc::new(DateValueFn));
+        let wb = TestWorkbook::new()
+            .with_function(Arc::new(DateValueFn))
+            .with_function(Arc::new(TimeValueFn));
         let engine = Engine::new(wb, EvalConfig::default().with_date_system(system));
         let interpreter = Interpreter::new(&engine, "Sheet1");
         interpreter
             .evaluate_ast(&parse(formula).expect("formula should parse"))
             .expect("formula should evaluate")
             .into_literal()
+    }
+
+    #[test]
+    fn datevalue_and_timevalue_pin_oracle_verified_text_behavior() {
+        use crate::engine::DateSystem;
+        use formualizer_common::ExcelErrorKind;
+
+        let number_cases = [
+            // Two-digit years use the 29/30 window in slash and month-name forms.
+            ("=DATEVALUE(\"1/1/03\")", 37_622.0),
+            ("=DATEVALUE(\"1-Jan-03\")", 37_622.0),
+            // Surrounding and interior whitespace match the LO oracle.
+            ("=DATEVALUE(\" 2003-01-01 \")", 37_622.0),
+            ("=TIMEVALUE(\" 12:00 \")", 0.5),
+            ("=TIMEVALUE(\"12 : 00\")", 0.5),
+        ];
+        for (formula, expected) in number_cases {
+            assert_eq!(
+                eval_temporal_value_formula(DateSystem::Excel1900, formula),
+                LiteralValue::Number(expected),
+                "{formula} (oracle: lo-verified)"
+            );
+        }
+
+        let wb = TestWorkbook::new().with_function(Arc::new(DateValueFn));
+        let ctx = wb.interpreter();
+        let function = ctx.context.get_function("", "DATEVALUE").unwrap();
+        let input = lit(LiteralValue::Text("1/ 15/2003".into()));
+        let error = function
+            .dispatch(
+                &[ArgumentHandle::new(&input, &ctx)],
+                &ctx.function_context(None),
+            )
+            .unwrap_err();
+        assert_eq!(
+            error.kind,
+            ExcelErrorKind::Value,
+            "oracle: lo-verified interior whitespace"
+        );
+    }
+
+    #[test]
+    fn datevalue_retains_preexisting_unambiguous_slash_fallbacks() {
+        // oracle: lo-verified divergence. These shipped DATEVALUE-only forms
+        // remain accepted for compatibility; arithmetic rejects both forms.
+        for (formula, expected) in [
+            ("=DATEVALUE(\"15/01/2003\")", 37_636.0),
+            ("=DATEVALUE(\"2003/1/1\")", 37_622.0),
+        ] {
+            assert_eq!(
+                eval_temporal_value_formula(crate::engine::DateSystem::Excel1900, formula),
+                LiteralValue::Number(expected),
+                "{formula}"
+            );
+        }
     }
 
     /// DATEVALUE emits a serial, so the workbook date system decides the epoch.
@@ -292,7 +393,7 @@ mod tests {
         let parsed = chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
         for system in [DateSystem::Excel1900, DateSystem::Excel1904] {
             assert_eq!(
-                eval_datevalue_formula(system, "=DATEVALUE(\"2024-01-15\")"),
+                eval_temporal_value_formula(system, "=DATEVALUE(\"2024-01-15\")"),
                 LiteralValue::Number(date_to_serial_for(system, &parsed)),
                 "DATEVALUE under {system:?}"
             );

--- a/crates/formualizer-eval/src/coercion.rs
+++ b/crates/formualizer-eval/src/coercion.rs
@@ -67,6 +67,37 @@ pub fn to_number_lenient_with_locale(
     }
 }
 
+/// Numeric coercion for arithmetic operators.
+///
+/// This deliberately extends only the operator boundary: numeric text is
+/// parsed first using the engine's invariant locale, then date/time text is
+/// parsed by `formualizer-common` and encoded in the workbook's date system.
+/// Aggregate arguments, comparisons, criteria, and functions such as `N`
+/// continue to use their existing coercion policies.
+pub fn to_arithmetic_number_with_locale(
+    value: &LiteralValue,
+    loc: &crate::locale::Locale,
+    system: DateSystem,
+) -> Result<f64, ExcelError> {
+    match value {
+        LiteralValue::Text(s) => loc
+            .parse_number_invariant(s)
+            .or_else(|| formualizer_common::parse_excel_date_time_text_to_serial_for(system, s))
+            .ok_or_else(|| {
+                ExcelError::new(ExcelErrorKind::Value)
+                    .with_message(format!("Cannot convert '{s}' to arithmetic operand"))
+            }),
+        LiteralValue::Date(_)
+        | LiteralValue::DateTime(_)
+        | LiteralValue::Time(_)
+        | LiteralValue::Duration(_) => value.as_serial_number_for(system).ok_or_else(|| {
+            ExcelError::new(ExcelErrorKind::Value)
+                .with_message("Cannot convert date/time to arithmetic operand")
+        }),
+        _ => to_number_strict(value),
+    }
+}
+
 /// Logical coercion.
 /// - Accepts Boolean
 /// - Numbers: nonzero → true, zero → false

--- a/crates/formualizer-eval/src/coercion.rs
+++ b/crates/formualizer-eval/src/coercion.rs
@@ -82,7 +82,7 @@ pub(crate) fn to_arithmetic_number_with_locale(
     match value {
         LiteralValue::Text(s) => loc
             .parse_number_invariant(s)
-            .or_else(|| formualizer_common::parse_excel_date_time_text_to_serial_for(system, s))
+            .or_else(|| formualizer_common::parse_excel_datetime_text_to_serial_for(system, s))
             .ok_or_else(|| {
                 ExcelError::new(ExcelErrorKind::Value)
                     .with_message(format!("Cannot convert '{s}' to arithmetic operand"))

--- a/crates/formualizer-eval/src/coercion.rs
+++ b/crates/formualizer-eval/src/coercion.rs
@@ -74,7 +74,7 @@ pub fn to_number_lenient_with_locale(
 /// parsed by `formualizer-common` and encoded in the workbook's date system.
 /// Aggregate arguments, comparisons, criteria, and functions such as `N`
 /// continue to use their existing coercion policies.
-pub fn to_arithmetic_number_with_locale(
+pub(crate) fn to_arithmetic_number_with_locale(
     value: &LiteralValue,
     loc: &crate::locale::Locale,
     system: DateSystem,

--- a/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
@@ -101,6 +101,11 @@ fn date_time_text_arithmetic_oracle_table() {
             Expected::Number(36_160.5),
         ),
         (
+            "=\"1-Jan-03\"+0",
+            Expected::Number(37_622.0),
+            Expected::Number(36_160.0),
+        ),
+        (
             "=ISNUMBER(\"1/1/03\"+0)",
             Expected::Boolean(true),
             Expected::Boolean(true),

--- a/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
@@ -1,0 +1,171 @@
+use crate::engine::{DateSystem, Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+#[derive(Clone, Copy, Debug)]
+enum Expected {
+    Number(f64),
+    Boolean(bool),
+    Text(&'static str),
+    Error(ExcelErrorKind),
+}
+
+fn eval_formula(system: DateSystem, formula: &str) -> LiteralValue {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_date_system(system),
+    );
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+        .get_cell_value("Sheet1", 1, 1)
+        .unwrap_or(LiteralValue::Empty)
+}
+
+fn assert_expected(system: DateSystem, formula: &str, oracle: &str, expected: Expected) {
+    let actual = eval_formula(system, formula);
+    match expected {
+        Expected::Number(value) => {
+            assert_eq!(actual, LiteralValue::Number(value), "{formula} ({oracle})")
+        }
+        Expected::Boolean(value) => {
+            assert_eq!(actual, LiteralValue::Boolean(value), "{formula} ({oracle})")
+        }
+        Expected::Text(value) => assert_eq!(
+            actual,
+            LiteralValue::Text(value.to_string()),
+            "{formula} ({oracle})"
+        ),
+        Expected::Error(kind) => match actual {
+            LiteralValue::Error(error) => assert_eq!(error.kind, kind, "{formula} ({oracle})"),
+            other => panic!("{formula} ({oracle}): expected {kind:?}, got {other:?}"),
+        },
+    }
+}
+
+#[test]
+fn date_time_text_arithmetic_oracle_table() {
+    let cases = [
+        ("=\"1/1/03\"-\"6/01/2002\"", Expected::Number(214.0)),
+        ("=\"1/1/2003\"-\"6/1/2002\"", Expected::Number(214.0)),
+        ("=\"1/1/03\"+0", Expected::Number(37_622.0)),
+        ("=-\"1/1/03\"", Expected::Number(-37_622.0)),
+        ("=\"1/1/03\"*1", Expected::Number(37_622.0)),
+        ("=\"1/1/03\"/1", Expected::Number(37_622.0)),
+        ("=\"1/1/03\"^1", Expected::Number(37_622.0)),
+        ("=\"1/1/03\"%", Expected::Number(376.22)),
+        ("=\"12:00\"-\"6:00\"", Expected::Number(0.25)),
+        ("=\"1/1/03 12:00\"+0", Expected::Number(37_622.5)),
+        ("=ISNUMBER(\"1/1/03\"+0)", Expected::Boolean(true)),
+    ];
+
+    for (formula, expected) in cases {
+        assert_expected(
+            DateSystem::Excel1900,
+            formula,
+            "oracle: lo-verified",
+            expected,
+        );
+    }
+}
+
+#[test]
+fn date_text_arithmetic_honors_workbook_date_system() {
+    let cases = [
+        (
+            DateSystem::Excel1900,
+            "=\"1/1/03\"+0",
+            Expected::Number(37_622.0),
+        ),
+        (
+            DateSystem::Excel1904,
+            "=\"1/1/03\"+0",
+            Expected::Number(36_160.0),
+        ),
+        (
+            DateSystem::Excel1900,
+            "=\"1/1/03 12:00\"+0",
+            Expected::Number(37_622.5),
+        ),
+        (
+            DateSystem::Excel1904,
+            "=\"1/1/03 12:00\"+0",
+            Expected::Number(36_160.5),
+        ),
+        (
+            DateSystem::Excel1900,
+            "=\"1/1/29\"+0",
+            Expected::Number(47_119.0),
+        ),
+        (
+            DateSystem::Excel1904,
+            "=\"1/1/29\"+0",
+            Expected::Number(45_657.0),
+        ),
+        (
+            DateSystem::Excel1900,
+            "=\"1/1/30\"+0",
+            Expected::Number(10_959.0),
+        ),
+        (
+            DateSystem::Excel1904,
+            "=\"1/1/30\"+0",
+            Expected::Number(9_497.0),
+        ),
+    ];
+
+    for (system, formula, expected) in cases {
+        assert_expected(system, formula, "oracle: lo-verified", expected);
+    }
+}
+
+#[test]
+fn invalid_date_time_text_remains_value_error() {
+    let cases = [
+        "=\"2/30/03\"+0",
+        "=\"abc\"+0",
+        "=\"\"+0",
+        "=\"13/13/13\"+0",
+        "=\"123-456\"+0",
+    ];
+
+    for system in [DateSystem::Excel1900, DateSystem::Excel1904] {
+        for formula in cases {
+            assert_expected(
+                system,
+                formula,
+                "oracle: lo-verified",
+                Expected::Error(ExcelErrorKind::Value),
+            );
+        }
+    }
+}
+
+#[test]
+fn non_arithmetic_text_semantics_are_unchanged() {
+    let cases = [
+        ("=\"5\"+\"3\"", Expected::Number(8.0)),
+        ("=\"5\"-\"3\"", Expected::Number(2.0)),
+        (
+            "=SUM(\"1/1/03\",\"1\")",
+            Expected::Error(ExcelErrorKind::Value),
+        ),
+        ("=N(\"1/1/03\")", Expected::Number(0.0)),
+        ("=T(\"1/1/03\")", Expected::Text("1/1/03")),
+        ("=\"1/1/03\"&\"\"", Expected::Text("1/1/03")),
+        ("=+\"1/1/03\"", Expected::Text("1/1/03")),
+        ("=\"1/1/03\"=37622", Expected::Boolean(false)),
+    ];
+
+    for (formula, expected) in cases {
+        assert_expected(
+            DateSystem::Excel1900,
+            formula,
+            "oracle: lo-verified",
+            expected,
+        );
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
@@ -49,52 +49,82 @@ fn assert_expected(system: DateSystem, formula: &str, oracle: &str, expected: Ex
 #[test]
 fn date_time_text_arithmetic_oracle_table() {
     let cases = [
-        ("=\"1/1/03\"-\"6/01/2002\"", Expected::Number(214.0)),
-        ("=\"1/1/2003\"-\"6/1/2002\"", Expected::Number(214.0)),
-        ("=\"1/1/03\"+0", Expected::Number(37_622.0)),
-        ("=-\"1/1/03\"", Expected::Number(-37_622.0)),
-        ("=\"1/1/03\"*1", Expected::Number(37_622.0)),
-        ("=\"1/1/03\"/1", Expected::Number(37_622.0)),
-        ("=\"1/1/03\"^1", Expected::Number(37_622.0)),
-        ("=\"1/1/03\"%", Expected::Number(376.22)),
-        ("=\"12:00\"-\"6:00\"", Expected::Number(0.25)),
-        ("=\"1/1/03 12:00\"+0", Expected::Number(37_622.5)),
-        ("=ISNUMBER(\"1/1/03\"+0)", Expected::Boolean(true)),
+        (
+            "=\"1/1/03\"-\"6/01/2002\"",
+            Expected::Number(214.0),
+            Expected::Number(214.0),
+        ),
+        (
+            "=\"1/1/2003\"-\"6/1/2002\"",
+            Expected::Number(214.0),
+            Expected::Number(214.0),
+        ),
+        (
+            "=\"1/1/03\"+0",
+            Expected::Number(37_622.0),
+            Expected::Number(36_160.0),
+        ),
+        (
+            "=-\"1/1/03\"",
+            Expected::Number(-37_622.0),
+            Expected::Number(-36_160.0),
+        ),
+        (
+            "=\"1/1/03\"*1",
+            Expected::Number(37_622.0),
+            Expected::Number(36_160.0),
+        ),
+        (
+            "=\"1/1/03\"/1",
+            Expected::Number(37_622.0),
+            Expected::Number(36_160.0),
+        ),
+        (
+            "=\"1/1/03\"^1",
+            Expected::Number(37_622.0),
+            Expected::Number(36_160.0),
+        ),
+        (
+            "=\"1/1/03\"%",
+            Expected::Number(376.22),
+            Expected::Number(361.6),
+        ),
+        (
+            "=\"12:00\"-\"6:00\"",
+            Expected::Number(0.25),
+            Expected::Number(0.25),
+        ),
+        (
+            "=\"1/1/03 12:00\"+0",
+            Expected::Number(37_622.5),
+            Expected::Number(36_160.5),
+        ),
+        (
+            "=ISNUMBER(\"1/1/03\"+0)",
+            Expected::Boolean(true),
+            Expected::Boolean(true),
+        ),
     ];
 
-    for (formula, expected) in cases {
+    for (formula, expected_1900, expected_1904) in cases {
         assert_expected(
             DateSystem::Excel1900,
             formula,
             "oracle: lo-verified",
-            expected,
+            expected_1900,
+        );
+        assert_expected(
+            DateSystem::Excel1904,
+            formula,
+            "oracle: lo-verified",
+            expected_1904,
         );
     }
 }
 
 #[test]
-fn date_text_arithmetic_honors_workbook_date_system() {
+fn two_digit_year_window_honors_workbook_date_system() {
     let cases = [
-        (
-            DateSystem::Excel1900,
-            "=\"1/1/03\"+0",
-            Expected::Number(37_622.0),
-        ),
-        (
-            DateSystem::Excel1904,
-            "=\"1/1/03\"+0",
-            Expected::Number(36_160.0),
-        ),
-        (
-            DateSystem::Excel1900,
-            "=\"1/1/03 12:00\"+0",
-            Expected::Number(37_622.5),
-        ),
-        (
-            DateSystem::Excel1904,
-            "=\"1/1/03 12:00\"+0",
-            Expected::Number(36_160.5),
-        ),
         (
             DateSystem::Excel1900,
             "=\"1/1/29\"+0",
@@ -160,12 +190,9 @@ fn non_arithmetic_text_semantics_are_unchanged() {
         ("=\"1/1/03\"=37622", Expected::Boolean(false)),
     ];
 
-    for (formula, expected) in cases {
-        assert_expected(
-            DateSystem::Excel1900,
-            formula,
-            "oracle: lo-verified",
-            expected,
-        );
+    for system in [DateSystem::Excel1900, DateSystem::Excel1904] {
+        for (formula, expected) in cases {
+            assert_expected(system, formula, "oracle: lo-verified", expected);
+        }
     }
 }

--- a/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_text_arithmetic.rs
@@ -1,5 +1,6 @@
 use crate::engine::{DateSystem, Engine, EvalConfig};
 use crate::test_workbook::TestWorkbook;
+use chrono::NaiveDate;
 use formualizer_common::{ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
 
@@ -123,32 +124,31 @@ fn date_time_text_arithmetic_oracle_table() {
 }
 
 #[test]
-fn two_digit_year_window_honors_workbook_date_system() {
+fn two_digit_year_window_honors_workbook_date_system_for_every_accepted_format() {
     let cases = [
-        (
-            DateSystem::Excel1900,
-            "=\"1/1/29\"+0",
-            Expected::Number(47_119.0),
-        ),
-        (
-            DateSystem::Excel1904,
-            "=\"1/1/29\"+0",
-            Expected::Number(45_657.0),
-        ),
-        (
-            DateSystem::Excel1900,
-            "=\"1/1/30\"+0",
-            Expected::Number(10_959.0),
-        ),
-        (
-            DateSystem::Excel1904,
-            "=\"1/1/30\"+0",
-            Expected::Number(9_497.0),
-        ),
+        ("=\"1/1/29\"+0", 47_119.0, 45_657.0),
+        ("=\"1/1/30\"+0", 10_959.0, 9_497.0),
+        ("=\"January 1, 29\"+0", 47_119.0, 45_657.0),
+        ("=\"January 1, 30\"+0", 10_959.0, 9_497.0),
+        ("=\"Jan 1, 29\"+0", 47_119.0, 45_657.0),
+        ("=\"Jan 1, 30\"+0", 10_959.0, 9_497.0),
+        ("=\"1-Jan-29\"+0", 47_119.0, 45_657.0),
+        ("=\"1-Jan-30\"+0", 10_959.0, 9_497.0),
     ];
 
-    for (system, formula, expected) in cases {
-        assert_expected(system, formula, "oracle: lo-verified", expected);
+    for (formula, expected_1900, expected_1904) in cases {
+        assert_expected(
+            DateSystem::Excel1900,
+            formula,
+            "oracle: lo-verified",
+            Expected::Number(expected_1900),
+        );
+        assert_expected(
+            DateSystem::Excel1904,
+            formula,
+            "oracle: lo-verified",
+            Expected::Number(expected_1904),
+        );
     }
 }
 
@@ -160,6 +160,10 @@ fn invalid_date_time_text_remains_value_error() {
         "=\"\"+0",
         "=\"13/13/13\"+0",
         "=\"123-456\"+0",
+        "=\"03-01-01\"+0",
+        "=\"15/01/2003\"+0",
+        "=\"2003/1/1\"+0",
+        "=\"1/1/03T12:00\"+0",
     ];
 
     for system in [DateSystem::Excel1900, DateSystem::Excel1904] {
@@ -172,6 +176,59 @@ fn invalid_date_time_text_remains_value_error() {
             );
         }
     }
+}
+
+#[test]
+fn date_typed_arithmetic_uses_the_1904_workbook_system() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_date_system(DateSystem::Excel1904),
+    );
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            1,
+            LiteralValue::Date(NaiveDate::from_ymd_opt(2003, 1, 1).unwrap()),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=A1*1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=A1%").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(36_160.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(361.6))
+    );
+}
+
+#[test]
+fn known_comparison_and_criteria_divergences_remain_pinned() {
+    // Formualizer currently type-orders text below numbers here; LO returns FALSE.
+    // The comparison-coercion divergence is tracked separately from #289.
+    assert_expected(
+        DateSystem::Excel1900,
+        "=\"1/1/03\"<37623",
+        "oracle: lo-verified divergence",
+        Expected::Boolean(true),
+    );
+
+    // Formualizer does not date-coerce COUNTIF criteria here; LO returns 1.
+    // The criteria-coercion divergence is tracked separately from #289.
+    assert_expected(
+        DateSystem::Excel1900,
+        "=COUNTIF({37622},\"1/1/03\")",
+        "oracle: lo-verified divergence",
+        Expected::Number(0.0),
+    );
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -76,6 +76,7 @@ mod spill_semantics_101;
 mod date_arithmetic_ops;
 mod date_function_duration_cells;
 mod date_math_parity;
+mod date_text_arithmetic;
 mod edate_eomonth_engine;
 
 mod hardening_503;

--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -1144,7 +1144,11 @@ impl<'a> Interpreter<'a> {
     where
         F: Fn(f64) -> f64,
     {
-        match crate::coercion::to_number_lenient_with_locale(&v, &self.context.locale()) {
+        match crate::coercion::to_arithmetic_number_with_locale(
+            &v,
+            &self.context.locale(),
+            self.context.date_system(),
+        ) {
             Ok(n) => match crate::coercion::sanitize_numeric(f(n)) {
                 Ok(n2) => Ok(LiteralValue::Number(n2)),
                 Err(e) => Ok(LiteralValue::Error(e)),
@@ -1223,7 +1227,11 @@ impl<'a> Interpreter<'a> {
             };
 
             let to_num = |v: &LiteralValue| -> Result<f64, ExcelError> {
-                crate::coercion::to_number_lenient_with_locale(v, &self.context.locale())
+                crate::coercion::to_arithmetic_number_with_locale(
+                    v,
+                    &self.context.locale(),
+                    date_system,
+                )
             };
 
             let serial_to_literal = |serial: f64| -> LiteralValue {
@@ -1351,8 +1359,16 @@ impl<'a> Interpreter<'a> {
         F: Fn(f64, f64) -> f64 + Copy,
     {
         self.broadcast_apply(left, right, |l, r| {
-            let a = crate::coercion::to_number_lenient_with_locale(&l, &self.context.locale());
-            let b = crate::coercion::to_number_lenient_with_locale(&r, &self.context.locale());
+            let a = crate::coercion::to_arithmetic_number_with_locale(
+                &l,
+                &self.context.locale(),
+                self.context.date_system(),
+            );
+            let b = crate::coercion::to_arithmetic_number_with_locale(
+                &r,
+                &self.context.locale(),
+                self.context.date_system(),
+            );
             match (a, b) {
                 (Ok(a), Ok(b)) => match crate::coercion::sanitize_numeric(f(a, b)) {
                     Ok(n2) => Ok(LiteralValue::Number(n2)),
@@ -1365,8 +1381,16 @@ impl<'a> Interpreter<'a> {
 
     fn divide(&self, left: LiteralValue, right: LiteralValue) -> Result<LiteralValue, ExcelError> {
         self.broadcast_apply(left, right, |l, r| {
-            let ln = crate::coercion::to_number_lenient_with_locale(&l, &self.context.locale());
-            let rn = crate::coercion::to_number_lenient_with_locale(&r, &self.context.locale());
+            let ln = crate::coercion::to_arithmetic_number_with_locale(
+                &l,
+                &self.context.locale(),
+                self.context.date_system(),
+            );
+            let rn = crate::coercion::to_arithmetic_number_with_locale(
+                &r,
+                &self.context.locale(),
+                self.context.date_system(),
+            );
             let (a, b) = match (ln, rn) {
                 (Ok(a), Ok(b)) => (a, b),
                 (Err(e), _) | (_, Err(e)) => return Ok(LiteralValue::Error(e)),
@@ -1385,8 +1409,16 @@ impl<'a> Interpreter<'a> {
 
     fn power(&self, left: LiteralValue, right: LiteralValue) -> Result<LiteralValue, ExcelError> {
         self.broadcast_apply(left, right, |l, r| {
-            let ln = crate::coercion::to_number_lenient_with_locale(&l, &self.context.locale());
-            let rn = crate::coercion::to_number_lenient_with_locale(&r, &self.context.locale());
+            let ln = crate::coercion::to_arithmetic_number_with_locale(
+                &l,
+                &self.context.locale(),
+                self.context.date_system(),
+            );
+            let rn = crate::coercion::to_arithmetic_number_with_locale(
+                &r,
+                &self.context.locale(),
+                self.context.date_system(),
+            );
             let (a, b) = match (ln, rn) {
                 (Ok(a), Ok(b)) => (a, b),
                 (Err(e), _) | (_, Err(e)) => return Ok(LiteralValue::Error(e)),

--- a/public-api/formualizer-common.txt
+++ b/public-api/formualizer-common.txt
@@ -347,6 +347,9 @@ pub fn formualizer_common::date_serial::date_to_serial_for(formualizer_common::D
 pub fn formualizer_common::date_serial::datetime_to_serial(&chrono::naive::datetime::NaiveDateTime) -> f64
 pub fn formualizer_common::date_serial::datetime_to_serial_for(formualizer_common::DateSystem, &chrono::naive::datetime::NaiveDateTime) -> f64
 pub fn formualizer_common::date_serial::max_excel_serial_for(formualizer_common::DateSystem) -> f64
+pub fn formualizer_common::date_serial::parse_excel_date_text(&str) -> core::option::Option<chrono::naive::date::NaiveDate>
+pub fn formualizer_common::date_serial::parse_excel_date_time_text_to_serial_for(formualizer_common::DateSystem, &str) -> core::option::Option<f64>
+pub fn formualizer_common::date_serial::parse_excel_time_text(&str) -> core::option::Option<chrono::naive::time::NaiveTime>
 pub fn formualizer_common::date_serial::serial_to_datetime(f64) -> chrono::naive::datetime::NaiveDateTime
 pub fn formualizer_common::date_serial::time_to_fraction(&chrono::naive::time::NaiveTime) -> f64
 pub fn formualizer_common::date_serial::try_serial_to_date_for(formualizer_common::DateSystem, f64) -> core::result::Result<chrono::naive::date::NaiveDate, formualizer_common::ExcelError>
@@ -1415,6 +1418,9 @@ pub fn formualizer_common::datetime_to_serial(&chrono::naive::datetime::NaiveDat
 pub fn formualizer_common::datetime_to_serial_for(formualizer_common::DateSystem, &chrono::naive::datetime::NaiveDateTime) -> f64
 pub fn formualizer_common::max_excel_serial_for(formualizer_common::DateSystem) -> f64
 pub fn formualizer_common::parse_a1_1based(&str) -> core::result::Result<(u32, u32, bool, bool), formualizer_common::A1ParseError>
+pub fn formualizer_common::parse_excel_date_text(&str) -> core::option::Option<chrono::naive::date::NaiveDate>
+pub fn formualizer_common::parse_excel_date_time_text_to_serial_for(formualizer_common::DateSystem, &str) -> core::option::Option<f64>
+pub fn formualizer_common::parse_excel_time_text(&str) -> core::option::Option<chrono::naive::time::NaiveTime>
 pub fn formualizer_common::serial_to_datetime(f64) -> chrono::naive::datetime::NaiveDateTime
 pub fn formualizer_common::serial_to_datetime(f64) -> chrono::naive::datetime::NaiveDateTime
 pub fn formualizer_common::time_to_fraction(&chrono::naive::time::NaiveTime) -> f64

--- a/public-api/formualizer-common.txt
+++ b/public-api/formualizer-common.txt
@@ -348,7 +348,8 @@ pub fn formualizer_common::date_serial::datetime_to_serial(&chrono::naive::datet
 pub fn formualizer_common::date_serial::datetime_to_serial_for(formualizer_common::DateSystem, &chrono::naive::datetime::NaiveDateTime) -> f64
 pub fn formualizer_common::date_serial::max_excel_serial_for(formualizer_common::DateSystem) -> f64
 pub fn formualizer_common::date_serial::parse_excel_date_text(&str) -> core::option::Option<chrono::naive::date::NaiveDate>
-pub fn formualizer_common::date_serial::parse_excel_date_time_text_to_serial_for(formualizer_common::DateSystem, &str) -> core::option::Option<f64>
+pub fn formualizer_common::date_serial::parse_excel_datetime_text(&str) -> core::option::Option<chrono::naive::datetime::NaiveDateTime>
+pub fn formualizer_common::date_serial::parse_excel_datetime_text_to_serial_for(formualizer_common::DateSystem, &str) -> core::option::Option<f64>
 pub fn formualizer_common::date_serial::parse_excel_time_text(&str) -> core::option::Option<chrono::naive::time::NaiveTime>
 pub fn formualizer_common::date_serial::serial_to_datetime(f64) -> chrono::naive::datetime::NaiveDateTime
 pub fn formualizer_common::date_serial::time_to_fraction(&chrono::naive::time::NaiveTime) -> f64
@@ -1419,7 +1420,8 @@ pub fn formualizer_common::datetime_to_serial_for(formualizer_common::DateSystem
 pub fn formualizer_common::max_excel_serial_for(formualizer_common::DateSystem) -> f64
 pub fn formualizer_common::parse_a1_1based(&str) -> core::result::Result<(u32, u32, bool, bool), formualizer_common::A1ParseError>
 pub fn formualizer_common::parse_excel_date_text(&str) -> core::option::Option<chrono::naive::date::NaiveDate>
-pub fn formualizer_common::parse_excel_date_time_text_to_serial_for(formualizer_common::DateSystem, &str) -> core::option::Option<f64>
+pub fn formualizer_common::parse_excel_datetime_text(&str) -> core::option::Option<chrono::naive::datetime::NaiveDateTime>
+pub fn formualizer_common::parse_excel_datetime_text_to_serial_for(formualizer_common::DateSystem, &str) -> core::option::Option<f64>
 pub fn formualizer_common::parse_excel_time_text(&str) -> core::option::Option<chrono::naive::time::NaiveTime>
 pub fn formualizer_common::serial_to_datetime(f64) -> chrono::naive::datetime::NaiveDateTime
 pub fn formualizer_common::serial_to_datetime(f64) -> chrono::naive::datetime::NaiveDateTime


### PR DESCRIPTION
Fixes #289.

Date and time text used as an arithmetic operand returned `#VALUE!` instead of coercing to a serial number, so `="1/1/03"-"6/01/2002"` errored where Excel and LibreOffice return `214`. Numeric text such as `="5"+"3"` already coerced correctly, so the gap was specific to temporal text recognition.

This was the largest single divergence source found by the corpus parity runner: one Enron workbook contributed 690 of 1,066 measured divergences through exactly this pattern. Date arithmetic on text literals is common in real financial models, which made a silent `#VALUE!` unusually costly.

Temporal text parsing is now centralized in `formualizer-common`, keeping date-serial ownership in one place, and a crate-private helper applies it to exactly the arithmetic operators: binary `+`, `-`, `*`, `/`, `^`, unary minus, and percent. Unary plus remains an identity operator because LibreOffice and Excel return the original text there. One shared year policy governs every accepted shape: exact two-digit years use Excel's window (`29` to 2029, `30` to 1930), exact four-digit years are literal, and ISO dates require four digits so a short ISO year is rejected rather than silently interpreted. Serial conversion honours the workbook date system, so 1904 results are exactly 1462 days lower, and typed `Date`/`DateTime`/`Time`/`Duration` operands now convert through the workbook system too instead of an implicit 1900 assumption.

Containment was verified by a 102-formula differential against the base revision in both date systems: comparisons, criteria matching, aggregates, logical coercion, general function arguments, and lookup coercion are byte-identical, `SUM("1/1/03","1")` remains `#VALUE!` because aggregates skip text, `N`/`T`/concatenation are unchanged, and text stored in a cell behaves identically to a text literal. Invalid input stays `#VALUE!`, including `"2/30/03"`, `"13/13/13"`, `"abc"`, and empty text.

The refactor also corrected long-standing `DATEVALUE` and `TIMEVALUE` behavior that the previous eval-local parser got wrong: `DATEVALUE("1/1/03")` and `DATEVALUE("1-Jan-03")` returned a year-3 serial near `-692864` and now return `37622`, surrounding whitespace is accepted, and interior whitespace in `"1/ 15/2003"` is now correctly rejected. Shipped leniency that Excel does not share, specifically `DATEVALUE("15/01/2003")` and `DATEVALUE("2003/1/1")`, is deliberately retained for compatibility, isolated to `DATEVALUE` so arithmetic stays strict, and pinned as a documented divergence. All of these changes are disclosed in the CHANGELOG.

Behavior is enforced by hardcoded tables tagged with LibreOffice 24.2.7 oracle provenance, covering both date systems, every accepted format at the two-digit-year boundary, the invalid set, and negative controls proving numeric-string and aggregate behavior did not move. Two known divergences that belong to other coercion domains are pinned at their current values with comments so they cannot drift silently, and are tracked separately in #291; remaining unsupported temporal shapes are tracked in #290.

An independent adversarial review of the first implementation found a blocker and three majors, all fixed here: two-digit-year windowing had applied only to slash dates, so `="1-Jan-03"+0` produced a silently wrong serial roughly 1,900 years off where the base revision had failed loudly; a day/month fallback had become reachable from arithmetic and accepted dates the oracle rejects; and the `DATEVALUE`/`TIMEVALUE` and typed-date changes were undisclosed and untested. The public parsing API was also renamed and completed while `formualizer-common` remains unpublished.

Validation: full workspace tests, clippy, fmt, and public API snapshots pass; snapshot drift is limited to the four intended parsing entry points; no version bump.

drafted with love by (agent) Manfred, with approval from Frankie
