### PR TITLE
test: AST↔edge parity invariant harness — four pinned engine defects (#301–#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to Formualizer will be documented in this file.
 ### Testing / internal
 
 - Added a fixed-seed AST-to-edge parity harness covering structural edits, compressed ranges, symbol vertices, dirty propagation, and mutation-tested edge-maintenance failures.
+- Pinned a fourth AST-to-edge finding, `AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID`: a default-sheet row or column insert shifts a workbook-name vertex off its `Sheet1!$A$1` home onto an addressable cell, so references resolved afterwards bind to the name vertex instead of the cell. The campaign carve-out for default-sheet inserts is narrowed to that shape, restoring formula and value overwrite coverage on the default sheet.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ All notable changes to Formualizer will be documented in this file.
 - Narrowed the published eval API to stable table metadata, reference-adjustment conveniences, builtin loading/date compatibility helpers, and opaque Formula Plane descriptors; test-only helpers now require the non-default `test-support` feature. (#259)
 - Upgraded Calamine-backed XLSX loading to Calamine 0.36 and a single-pass value/formula metadata stream, preserving formula-only worksheet dimensions, cached-value semantics, load limits, shared-formula relocation, and malformed-family fallback.
 
+### Testing / internal
+
+- Added a fixed-seed AST-to-edge parity harness covering structural edits, compressed ranges, symbol vertices, dirty propagation, and mutation-tested edge-maintenance failures.
+
 ### Fixed
 
 - Whole-surface ranges whose cell count overflows `u32` are now always kept as compressed range dependencies instead of panicking or attempting expansion.

--- a/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
+++ b/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
@@ -445,6 +445,9 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
     let mut undo = UndoEngine::new();
     let mut can_redo = false;
     let mut stats = CampaignStats::default();
+    // Default-sheet inserts are covered, but later overwriting a formula shifted by one exposes a
+    // separate unpinned interaction. Keep those vertices out of subsequent formula/value writes.
+    let mut shifted_formulas = BTreeSet::new();
 
     for operation in 0..campaign.operations {
         let force_redo = can_redo && rng.gen_bool(0.4);
@@ -455,9 +458,39 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
         }
 
         let choice = rng.gen_range(0..100);
-        let sheet = random_sheet(&mut rng, &sheets).to_string();
-        let row = rng.gen_range(1..=MAX_ROW);
-        let col = rng.gen_range(1..=MAX_COL);
+        let mut sheet = random_sheet(&mut rng, &sheets).to_string();
+        let mut row = rng.gen_range(1..=MAX_ROW);
+        let mut col = rng.gen_range(1..=MAX_COL);
+        let selected = CellRef::new(
+            engine.sheet_id(&sheet).unwrap(),
+            Coord::from_excel(row, col, true, true),
+        );
+        if engine
+            .graph
+            .get_vertex_for_cell(&selected)
+            .is_some_and(|vertex| shifted_formulas.contains(&vertex))
+        {
+            'replacement: for candidate_sheet in &sheets {
+                for candidate_row in 1..=MAX_ROW {
+                    for candidate_col in 1..=MAX_COL {
+                        let candidate = CellRef::new(
+                            engine.sheet_id(candidate_sheet).unwrap(),
+                            Coord::from_excel(candidate_row, candidate_col, true, true),
+                        );
+                        if engine
+                            .graph
+                            .get_vertex_for_cell(&candidate)
+                            .is_none_or(|vertex| !shifted_formulas.contains(&vertex))
+                        {
+                            sheet = candidate_sheet.clone();
+                            row = candidate_row;
+                            col = candidate_col;
+                            break 'replacement;
+                        }
+                    }
+                }
+            }
+        }
 
         match choice {
             _ if force_redo => {}
@@ -486,19 +519,17 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 can_redo = false;
             }
             30..=40 => {
-                let active_symbol_edge = engine
-                    .graph
-                    .formula_vertices()
-                    .into_iter()
-                    .any(|formula| !ast_shape(&engine.graph, formula).shape.symbols.is_empty());
-                let edit_sheet = if sheet == "Sheet1" && active_symbol_edge {
-                    "Sheet2"
-                } else {
-                    &sheet
-                };
+                if sheet == "Sheet1" {
+                    shifted_formulas.extend(engine.graph.formula_vertices().into_iter().filter(
+                        |formula| {
+                            engine.graph.get_vertex_sheet_id(*formula)
+                                == engine.sheet_id("Sheet1").unwrap()
+                        },
+                    ));
+                }
                 engine
                     .action_with_logger(&mut log, "campaign-insert-rows", |action| {
-                        action.insert_rows(edit_sheet, row, 1).map(|_| ())
+                        action.insert_rows(&sheet, row, 1).map(|_| ())
                     })
                     .unwrap();
                 reset_history(&mut log, &mut undo, &mut can_redo);
@@ -509,19 +540,17 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 reset_history(&mut log, &mut undo, &mut can_redo);
             }
             52..=61 => {
-                let active_symbol_edge = engine
-                    .graph
-                    .formula_vertices()
-                    .into_iter()
-                    .any(|formula| !ast_shape(&engine.graph, formula).shape.symbols.is_empty());
-                let edit_sheet = if sheet == "Sheet1" && active_symbol_edge {
-                    "Sheet2"
-                } else {
-                    &sheet
-                };
+                if sheet == "Sheet1" {
+                    shifted_formulas.extend(engine.graph.formula_vertices().into_iter().filter(
+                        |formula| {
+                            engine.graph.get_vertex_sheet_id(*formula)
+                                == engine.sheet_id("Sheet1").unwrap()
+                        },
+                    ));
+                }
                 engine
                     .action_with_logger(&mut log, "campaign-insert-columns", |action| {
-                        action.insert_columns(edit_sheet, col, 1).map(|_| ())
+                        action.insert_columns(&sheet, col, 1).map(|_| ())
                     })
                     .unwrap();
                 reset_history(&mut log, &mut undo, &mut can_redo);
@@ -532,7 +561,12 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 reset_history(&mut log, &mut undo, &mut can_redo);
             }
             72..=79 => {
-                let formulas = engine.graph.formula_vertices();
+                let formulas: Vec<_> = engine
+                    .graph
+                    .formula_vertices()
+                    .into_iter()
+                    .filter(|formula| !shifted_formulas.contains(formula))
+                    .collect();
                 if let Some(formula) = formulas.get(rng.gen_range(0..formulas.len().max(1))) {
                     let target = engine.graph.get_cell_ref(*formula).unwrap();
                     let target_sheet = engine.graph.sheet_name(target.sheet_id).to_string();

--- a/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
+++ b/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
@@ -1,0 +1,833 @@
+//! AST-to-edge parity invariant harness for the engine's dual-write seam.
+//!
+//! The invariant is: for every formula vertex, the semantic references in its current retained
+//! AST (classified by `engine::refs`) are represented by exactly the formula's outgoing graph
+//! dependencies. A cell is represented by a direct edge (including an empty placeholder), a
+//! finite range at or below `range_expansion_limit` by one edge per cell, a larger or open range
+//! by one compressed range dependency backed by the stripe indexes, and a name or table by an
+//! edge to its resolving vertex. Exact parity matters in both directions: a missing dependency can
+//! leave a value silently stale, while a phantom dependency causes spurious recalculation.
+//!
+//! The structural checker compares those representations after edit operations. The behavioral
+//! checker independently mutates sampled AST-referenced cells through `Engine`, requires the
+//! formula to become dirty, and undoes the mutation through the changelog. Structural failures
+//! diagnose the representation; behavioral failures are the scheduling ground truth. If only one
+//! fails, its panic reports both the formula and sampled cell so the disagreement is actionable.
+//!
+//! Campaign seeds are fixed constants below. They are intentionally not persisted: a failure
+//! prints its seed and operation index, which is enough to replay the deterministic campaign while
+//! keeping the repository free of generated failure corpora.
+
+use std::collections::BTreeSet;
+
+use rand::{Rng, SeedableRng, rngs::SmallRng};
+
+use crate::engine::graph::editor::undo_engine::UndoEngine;
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::refs::{DeclaredSheet, LocalBindingStyle, SemanticReference};
+use crate::engine::{ChangeLog, DependencyGraph, Engine, EvalConfig, VertexId, VertexKind};
+use crate::reference::{CellRef, Coord, RangeRef, SharedRangeRef, SharedSheetLocator};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelError, LiteralValue};
+use formualizer_parse::parser::parse;
+
+const MAX_ROW: u32 = 10;
+const MAX_COL: u32 = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct RangeKey {
+    sheet_id: u16,
+    start_row: Option<u32>,
+    start_col: Option<u32>,
+    end_row: Option<u32>,
+    end_col: Option<u32>,
+}
+
+impl RangeKey {
+    fn contains(self, cell: CellRef) -> bool {
+        self.sheet_id == cell.sheet_id
+            && self.start_row.is_none_or(|start| cell.coord.row() >= start)
+            && self.end_row.is_none_or(|end| cell.coord.row() <= end)
+            && self.start_col.is_none_or(|start| cell.coord.col() >= start)
+            && self.end_col.is_none_or(|end| cell.coord.col() <= end)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DependencyShape {
+    cells: BTreeSet<CellRef>,
+    ranges: BTreeSet<RangeKey>,
+    symbols: BTreeSet<VertexId>,
+}
+
+struct AstShapeContext<'a> {
+    graph: &'a DependencyGraph,
+    formula: VertexId,
+    formula_cell: CellRef,
+    shape: DependencyShape,
+    behavioral_cells: BTreeSet<CellRef>,
+}
+
+fn no_local_bindings(_: &AstShapeContext<'_>, _: &str, _: usize) -> LocalBindingStyle {
+    LocalBindingStyle::None
+}
+
+fn resolve_sheet(
+    graph: &DependencyGraph,
+    declared: DeclaredSheet<'_>,
+    current_sheet: u16,
+) -> Option<u16> {
+    match declared {
+        DeclaredSheet::Current => Some(current_sheet),
+        DeclaredSheet::Name(name) => graph.sheet_id(name),
+    }
+}
+
+fn range_key(
+    graph: &DependencyGraph,
+    range: crate::engine::refs::RangeReference<'_>,
+    current_sheet: u16,
+) -> Option<RangeKey> {
+    Some(RangeKey {
+        sheet_id: resolve_sheet(graph, range.sheet, current_sheet)?,
+        start_row: range.start_row.map(|row| row.saturating_sub(1)),
+        start_col: range.start_col.map(|col| col.saturating_sub(1)),
+        end_row: range.end_row.map(|row| row.saturating_sub(1)),
+        end_col: range.end_col.map(|col| col.saturating_sub(1)),
+    })
+}
+
+fn sample_cells_in_range(key: RangeKey) -> [CellRef; 2] {
+    let start_row = key.start_row.unwrap_or(0);
+    let start_col = key.start_col.unwrap_or(0);
+    let end_row = key.end_row.unwrap_or(start_row.saturating_add(MAX_ROW - 1));
+    let end_col = key.end_col.unwrap_or(start_col.saturating_add(MAX_COL - 1));
+    [
+        CellRef::new(
+            key.sheet_id,
+            Coord::new(start_row.min(end_row), start_col.min(end_col), true, true),
+        ),
+        CellRef::new(
+            key.sheet_id,
+            Coord::new(end_row.max(start_row), end_col.max(start_col), true, true),
+        ),
+    ]
+}
+
+fn collect_ast_reference(
+    context: &mut AstShapeContext<'_>,
+    reference: SemanticReference<'_>,
+) -> Result<(), ExcelError> {
+    match reference {
+        SemanticReference::Cell(cell) => {
+            if let Some(sheet_id) =
+                resolve_sheet(context.graph, cell.sheet, context.formula_cell.sheet_id)
+            {
+                let target =
+                    CellRef::new(sheet_id, Coord::from_excel(cell.row, cell.col, true, true));
+                context.shape.cells.insert(target);
+                if target != context.formula_cell {
+                    context.behavioral_cells.insert(target);
+                }
+            }
+        }
+        SemanticReference::FiniteRange(range) => {
+            let Some(key) = range_key(context.graph, range, context.formula_cell.sheet_id) else {
+                return Ok(());
+            };
+            if range.is_reversed() {
+                return Ok(());
+            }
+            if range.saturating_area().unwrap_or(u64::MAX)
+                <= context.graph.range_expansion_limit() as u64
+            {
+                let (start_row, start_col, end_row, end_col) = range
+                    .finite_bounds()
+                    .expect("finite reference must have finite bounds");
+                for row in start_row..=end_row {
+                    for col in start_col..=end_col {
+                        let target =
+                            CellRef::new(key.sheet_id, Coord::from_excel(row, col, true, true));
+                        context.shape.cells.insert(target);
+                        if target != context.formula_cell {
+                            context.behavioral_cells.insert(target);
+                        }
+                    }
+                }
+            } else {
+                context.shape.ranges.insert(key);
+                context.behavioral_cells.extend(
+                    sample_cells_in_range(key)
+                        .into_iter()
+                        .filter(|sample| *sample != context.formula_cell),
+                );
+                if key.contains(context.formula_cell) {
+                    context.shape.cells.insert(context.formula_cell);
+                }
+            }
+        }
+        SemanticReference::OpenRange(range) => {
+            let Some(key) = range_key(context.graph, range, context.formula_cell.sheet_id) else {
+                return Ok(());
+            };
+            context.shape.ranges.insert(key);
+            context.behavioral_cells.extend(
+                sample_cells_in_range(key)
+                    .into_iter()
+                    .filter(|sample| *sample != context.formula_cell),
+            );
+            if key.contains(context.formula_cell) {
+                context.shape.cells.insert(context.formula_cell);
+            }
+        }
+        SemanticReference::Name(name) => {
+            if let Some(named) = context
+                .graph
+                .resolve_name_entry(name, context.formula_cell.sheet_id)
+            {
+                context.shape.symbols.insert(named.vertex);
+            }
+        }
+        SemanticReference::Table(table) => {
+            if let Some(entry) = context.graph.resolve_table_entry(&table.name) {
+                context.shape.symbols.insert(entry.vertex);
+            }
+        }
+        SemanticReference::ExternalSource(_)
+        | SemanticReference::ThreeDimensional(_)
+        | SemanticReference::Unsupported(_) => {}
+    }
+    Ok(())
+}
+
+fn ast_shape(graph: &DependencyGraph, formula: VertexId) -> AstShapeContext<'_> {
+    let formula_cell = graph
+        .get_cell_ref(formula)
+        .expect("formula vertex must have a cell address");
+    let ast = graph
+        .get_formula(formula)
+        .expect("formula vertex must retain its AST");
+    let mut context = AstShapeContext {
+        graph,
+        formula,
+        formula_cell,
+        shape: DependencyShape::default(),
+        behavioral_cells: BTreeSet::new(),
+    };
+    crate::engine::refs::visit_tree_references(
+        &ast,
+        &mut context,
+        no_local_bindings,
+        collect_ast_reference,
+    )
+    .expect("retained formula reference collection must succeed");
+    context
+}
+
+fn actual_range_key(
+    graph: &DependencyGraph,
+    formula_sheet: u16,
+    range: &SharedRangeRef<'static>,
+) -> Option<RangeKey> {
+    let sheet_id = match &range.sheet {
+        SharedSheetLocator::Id(id) => *id,
+        SharedSheetLocator::Current => formula_sheet,
+        SharedSheetLocator::Name(name) => graph.sheet_id(name.as_ref())?,
+    };
+    Some(RangeKey {
+        sheet_id,
+        start_row: range.start_row.map(|bound| bound.index),
+        start_col: range.start_col.map(|bound| bound.index),
+        end_row: range.end_row.map(|bound| bound.index),
+        end_col: range.end_col.map(|bound| bound.index),
+    })
+}
+
+fn graph_shape(graph: &DependencyGraph, formula: VertexId) -> DependencyShape {
+    let formula_sheet = graph.get_vertex_sheet_id(formula);
+    let mut shape = DependencyShape::default();
+    for dependency in graph.get_dependencies(formula) {
+        match graph.get_vertex_kind(dependency) {
+            VertexKind::Cell
+            | VertexKind::Empty
+            | VertexKind::FormulaScalar
+            | VertexKind::FormulaArray => {
+                shape.cells.insert(
+                    graph
+                        .get_cell_ref(dependency)
+                        .expect("cell-like dependency must have an address"),
+                );
+            }
+            VertexKind::NamedScalar
+            | VertexKind::NamedArray
+            | VertexKind::Table
+            | VertexKind::External
+            | VertexKind::InfiniteRange
+            | VertexKind::Range => {
+                shape.symbols.insert(dependency);
+            }
+        }
+    }
+    if let Some(ranges) = graph.get_range_dependencies(formula) {
+        shape.ranges.extend(
+            ranges
+                .iter()
+                .filter_map(|range| actual_range_key(graph, formula_sheet, range)),
+        );
+    }
+    shape
+}
+
+fn assert_structural_parity(engine: &Engine<TestWorkbook>, seed: u64, operation: usize) {
+    for formula in engine.graph.formula_vertices() {
+        let expected = ast_shape(&engine.graph, formula);
+        let actual = graph_shape(&engine.graph, formula);
+        assert_eq!(
+            actual,
+            expected.shape,
+            "AST/edge structural divergence: seed={seed:#x} operation={operation} formula={} vertex={formula:?}",
+            engine.graph.to_a1(expected.formula_cell),
+        );
+    }
+}
+
+fn behavior_pairs(engine: &Engine<TestWorkbook>) -> Vec<(VertexId, CellRef)> {
+    let mut pairs = Vec::new();
+    for formula in engine.graph.formula_vertices() {
+        let expected = ast_shape(&engine.graph, formula);
+        pairs.extend(expected.behavioral_cells.into_iter().filter_map(|cell| {
+            let existing = engine.graph.get_vertex_for_cell(&cell)?;
+            let sheet = engine.graph.sheet_name(cell.sheet_id);
+            let value = engine.get_cell_value(sheet, cell.coord.row() + 1, cell.coord.col() + 1);
+            (engine.graph.get_vertex_kind(existing) == VertexKind::Cell
+                && value.is_some_and(|value| value != LiteralValue::Empty))
+            .then_some((formula, cell))
+        }));
+    }
+    pairs
+}
+
+fn assert_behavioral_parity(
+    engine: &mut Engine<TestWorkbook>,
+    seed: u64,
+    operation: usize,
+    sample_limit: usize,
+) {
+    let pairs = behavior_pairs(engine);
+    if pairs.is_empty() {
+        return;
+    }
+    let start = (seed as usize ^ operation.wrapping_mul(0x9e37)) % pairs.len();
+    for offset in 0..sample_limit.min(pairs.len()) {
+        let (formula, referenced_cell) = pairs[(start + offset) % pairs.len()];
+        if !engine.graph.vertex_exists(formula) {
+            continue;
+        }
+        let sheet = engine
+            .graph
+            .sheet_name(referenced_cell.sheet_id)
+            .to_string();
+        let row = referenced_cell.coord.row() + 1;
+        let col = referenced_cell.coord.col() + 1;
+        let formulas = engine.graph.formula_vertices();
+        engine.graph.clear_dirty_flags(&formulas);
+
+        let mut probe_log = ChangeLog::new();
+        let marker = LiteralValue::Number(seed as f64 + operation as f64 + offset as f64 + 0.5);
+        engine
+            .action_with_logger(&mut probe_log, "ast-edge-behavior-probe", |action| {
+                action.set_cell_value(&sheet, row, col, marker)
+            })
+            .expect("behavioral probe mutation must succeed");
+        assert!(
+            engine.graph.vertex_exists(formula) && engine.graph.is_dirty(formula),
+            "AST/edge behavioral divergence: seed={seed:#x} operation={operation} formula={formula:?} referenced_cell={} (structural checker passed)",
+            engine.graph.to_a1(referenced_cell),
+        );
+
+        let mut probe_undo = UndoEngine::new();
+        engine
+            .undo_logged(&mut probe_undo, &mut probe_log)
+            .expect("behavioral probe undo must succeed");
+        assert_structural_parity(engine, seed, operation);
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Campaign {
+    seed: u64,
+    operations: usize,
+    expansion_limit: usize,
+    assert_every: usize,
+    behavior_samples: usize,
+}
+
+fn random_sheet<'a>(rng: &mut SmallRng, sheets: &'a [String]) -> &'a str {
+    &sheets[rng.gen_range(0..sheets.len())]
+}
+
+fn random_formula(rng: &mut SmallRng, sheets: &[String], current_sheet: &str) -> String {
+    let row1 = rng.gen_range(1..=MAX_ROW);
+    let row2 = rng.gen_range(row1..=MAX_ROW);
+    let col1 = rng.gen_range(1..=MAX_COL);
+    let other = random_sheet(rng, sheets);
+    let col_letter = Coord::col_to_letters(col1 - 1);
+    match rng.gen_range(0..8) {
+        0 => format!("={col_letter}{row1}+1"),
+        1 => format!("=SUM(A{row1}:B{row2})"),
+        2 => "=SUM(A1:H10)".to_string(),
+        3 => "=SUM(A:A)".to_string(),
+        4 if other != current_sheet => format!("='{other}'!{col_letter}{row1}*2"),
+        5 if other != current_sheet => format!("=SUM('{other}'!A{row1}:B{row2})"),
+        6 => "=Tracked+1".to_string(),
+        _ => format!("={col_letter}{row1}+SUM(C1:C{row2})"),
+    }
+}
+
+fn reset_history(log: &mut ChangeLog, undo: &mut UndoEngine, can_redo: &mut bool) {
+    log.clear();
+    *undo = UndoEngine::new();
+    *can_redo = false;
+}
+
+fn run_campaign(campaign: Campaign) {
+    let config = EvalConfig::default().with_range_expansion_limit(campaign.expansion_limit);
+    let mut engine = Engine::new(TestWorkbook::new(), config);
+    let mut sheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
+    engine.add_sheet("Sheet2").unwrap();
+    for sheet in &sheets {
+        for row in 1..=MAX_ROW {
+            for col in 1..=MAX_COL {
+                engine
+                    .set_cell_value(
+                        sheet,
+                        row,
+                        col,
+                        LiteralValue::Number(f64::from(row * MAX_COL + col)),
+                    )
+                    .unwrap();
+            }
+        }
+    }
+    let tracked_sheet = engine.sheet_id("Sheet1").unwrap();
+    engine
+        .define_name(
+            "Tracked",
+            NamedDefinition::Cell(CellRef::new(
+                tracked_sheet,
+                Coord::from_excel(2, 1, true, true),
+            )),
+            NameScope::Workbook,
+        )
+        .unwrap();
+
+    let mut rng = SmallRng::seed_from_u64(campaign.seed);
+    let mut log = ChangeLog::new();
+    let mut undo = UndoEngine::new();
+    let mut can_redo = false;
+
+    for operation in 0..campaign.operations {
+        let choice = rng.gen_range(0..100);
+        let sheet = random_sheet(&mut rng, &sheets).to_string();
+        let row = rng.gen_range(1..=MAX_ROW);
+        let col = rng.gen_range(1..=MAX_COL);
+
+        match choice {
+            0..=13 => {
+                engine
+                    .action_with_logger(&mut log, "campaign-set-value", |action| {
+                        action.set_cell_value(
+                            &sheet,
+                            row,
+                            col,
+                            LiteralValue::Number(rng.gen_range(-100.0..100.0)),
+                        )
+                    })
+                    .unwrap();
+                undo = UndoEngine::new();
+                can_redo = false;
+            }
+            14..=29 => {
+                let formula = random_formula(&mut rng, &sheets, &sheet);
+                engine
+                    .action_with_logger(&mut log, "campaign-set-formula", |action| {
+                        action.set_cell_formula(&sheet, row, col, parse(&formula).unwrap())
+                    })
+                    .unwrap();
+                undo = UndoEngine::new();
+                can_redo = false;
+            }
+            30..=40 => {
+                let edit_sheet = if sheet == "Sheet1" { "Sheet2" } else { &sheet };
+                engine
+                    .action_with_logger(&mut log, "campaign-insert-rows", |action| {
+                        action.insert_rows(edit_sheet, row, 1).map(|_| ())
+                    })
+                    .unwrap();
+                reset_history(&mut log, &mut undo, &mut can_redo);
+            }
+            41..=51 => {
+                let delete_sheet = if sheet == "Sheet1" { "Sheet2" } else { &sheet };
+                engine.delete_rows(delete_sheet, row, 1).unwrap();
+                reset_history(&mut log, &mut undo, &mut can_redo);
+            }
+            52..=61 => {
+                let edit_sheet = if sheet == "Sheet1" { "Sheet2" } else { &sheet };
+                engine
+                    .action_with_logger(&mut log, "campaign-insert-columns", |action| {
+                        action.insert_columns(edit_sheet, col, 1).map(|_| ())
+                    })
+                    .unwrap();
+                reset_history(&mut log, &mut undo, &mut can_redo);
+            }
+            62..=71 => {
+                let delete_sheet = if sheet == "Sheet1" { "Sheet2" } else { &sheet };
+                engine.delete_columns(delete_sheet, col, 1).unwrap();
+                reset_history(&mut log, &mut undo, &mut can_redo);
+            }
+            72..=79 => {
+                let formulas = engine.graph.formula_vertices();
+                if let Some(formula) = formulas.get(rng.gen_range(0..formulas.len().max(1))) {
+                    let target = engine.graph.get_cell_ref(*formula).unwrap();
+                    let target_sheet = engine.graph.sheet_name(target.sheet_id).to_string();
+                    engine
+                        .action_with_logger(&mut log, "campaign-delete-formula", |action| {
+                            action.set_cell_value(
+                                &target_sheet,
+                                target.coord.row() + 1,
+                                target.coord.col() + 1,
+                                LiteralValue::Empty,
+                            )
+                        })
+                        .unwrap();
+                    undo = UndoEngine::new();
+                    can_redo = false;
+                }
+            }
+            80..=85 => {
+                let target = CellRef::new(
+                    engine.sheet_id(&sheet).unwrap(),
+                    Coord::from_excel(row, col, true, true),
+                );
+                log.begin_compound("campaign-redefine-name".to_string());
+                engine
+                    .update_name_with_logger(
+                        &mut log,
+                        "Tracked",
+                        NamedDefinition::Cell(target),
+                        NameScope::Workbook,
+                    )
+                    .unwrap();
+                log.end_compound();
+                undo = UndoEngine::new();
+                can_redo = false;
+            }
+            86..=89 if sheets.len() < 3 => {
+                let name = format!("Sheet{}", sheets.len() + 1);
+                engine.add_sheet(&name).unwrap();
+                for seed_row in 1..=MAX_ROW {
+                    for seed_col in 1..=MAX_COL {
+                        engine
+                            .set_cell_value(
+                                &name,
+                                seed_row,
+                                seed_col,
+                                LiteralValue::Number(f64::from(seed_row * MAX_COL + seed_col)),
+                            )
+                            .unwrap();
+                    }
+                }
+                sheets.push(name);
+                reset_history(&mut log, &mut undo, &mut can_redo);
+            }
+            90..=95 if !log.is_empty() => {
+                engine.undo_logged(&mut undo, &mut log).unwrap();
+                can_redo = true;
+            }
+            96..=99 if can_redo => {
+                engine.redo_logged(&mut undo, &mut log).unwrap();
+                can_redo = false;
+            }
+            _ => {
+                engine
+                    .set_cell_value(&sheet, row, col, LiteralValue::Number(operation as f64))
+                    .unwrap();
+                reset_history(&mut log, &mut undo, &mut can_redo);
+            }
+        }
+
+        if (operation + 1) % campaign.assert_every == 0 || operation + 1 == campaign.operations {
+            assert_structural_parity(&engine, campaign.seed, operation);
+            assert_behavioral_parity(
+                &mut engine,
+                campaign.seed,
+                operation,
+                campaign.behavior_samples,
+            );
+        }
+    }
+}
+
+// T2 finding AST_EDGE_UNDO_STRUCTURAL_ADJUSTMENT: see the matching T2 worker-report entry.
+// Undo moves the referenced cell edge back but leaves the cross-sheet AST at its inserted-row
+// coordinate, splitting scheduling from evaluation.
+#[test]
+#[ignore = "known T2 divergence: undoing row insertion leaves adjusted AST and edge split"]
+fn undoing_row_insertion_restores_cross_sheet_ast_and_edge_together() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.add_sheet("Sheet2").unwrap();
+    engine
+        .set_cell_formula("Sheet1", 6, 4, parse("='Sheet2'!B6*2").unwrap())
+        .unwrap();
+    let mut log = ChangeLog::new();
+    engine
+        .action_with_logger(&mut log, "insert-row", |action| {
+            action.insert_rows("Sheet2", 1, 1).map(|_| ())
+        })
+        .unwrap();
+    assert_structural_parity(&engine, 0xc0de_0007, 0);
+
+    let mut undo = UndoEngine::new();
+    engine.undo_logged(&mut undo, &mut log).unwrap();
+
+    assert_structural_parity(&engine, 0xc0de_0007, 1);
+}
+
+// T2 finding AST_EDGE_UNRELATED_DELETE_NAME: see the matching entry in the T2 worker report.
+// Deleting a column on the default sheet removes a workbook-name vertex and strands formulas on
+// other sheets, even when the name resolves to a cell on another sheet.
+#[test]
+#[ignore = "known T2 divergence: unrelated default-sheet delete drops a name edge"]
+fn deleting_unrelated_default_sheet_column_preserves_cross_sheet_name_edge() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.add_sheet("Sheet2").unwrap();
+    let target = CellRef::new(
+        engine.sheet_id("Sheet2").unwrap(),
+        Coord::from_excel(2, 6, true, true),
+    );
+    engine
+        .define_name(
+            "Tracked",
+            NamedDefinition::Cell(target),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet2", 10, 6, parse("=Tracked+1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(1.0))
+        .unwrap();
+    assert_structural_parity(&engine, 0xc0de_0006, 0);
+
+    engine.delete_columns("Sheet1", 1, 1).unwrap();
+
+    assert_structural_parity(&engine, 0xc0de_0006, 1);
+}
+
+// T2 finding AST_EDGE_UNDO_EMPTY_PLACEHOLDER: see the matching entry in the T2 worker report.
+// Undo removes a referenced empty placeholder instead of restoring its dependency role.
+#[test]
+#[ignore = "known T2 divergence: undoing a write to a referenced empty placeholder drops its edge"]
+fn undoing_value_write_to_referenced_empty_placeholder_preserves_formula_edge() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 4, 4, parse("=C6+1").unwrap())
+        .unwrap();
+    assert_structural_parity(&engine, 0xc0de_0005, 0);
+
+    let mut log = ChangeLog::new();
+    engine
+        .action_with_logger(&mut log, "write-placeholder", |action| {
+            action.set_cell_value("Sheet1", 6, 3, LiteralValue::Number(7.0))
+        })
+        .unwrap();
+    let mut undo = UndoEngine::new();
+    engine.undo_logged(&mut undo, &mut log).unwrap();
+
+    assert_structural_parity(&engine, 0xc0de_0005, 1);
+}
+
+#[test]
+fn randomized_structural_edits_keep_ast_and_graph_dependencies_exact() {
+    let campaigns = [
+        Campaign {
+            seed: 0xa57e_d9e0_0000_0000,
+            operations: 50,
+            expansion_limit: 0,
+            assert_every: 1,
+            behavior_samples: 1,
+        },
+        Campaign {
+            seed: 0xa57e_d9e0_0000_0001,
+            operations: 60,
+            expansion_limit: 1,
+            assert_every: 1,
+            behavior_samples: 1,
+        },
+        Campaign {
+            seed: 0xa57e_d9e0_0000_0010,
+            operations: 120,
+            expansion_limit: 16,
+            assert_every: 10,
+            behavior_samples: 2,
+        },
+        Campaign {
+            seed: 0xa57e_d9e0_0000_0040,
+            operations: 160,
+            expansion_limit: 64,
+            assert_every: 10,
+            behavior_samples: 2,
+        },
+    ];
+    for campaign in campaigns {
+        run_campaign(campaign);
+    }
+}
+
+#[test]
+fn changelog_undo_and_redo_formula_overwrite_preserve_ast_edge_parity() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=A1+1").unwrap())
+        .unwrap();
+    let mut log = ChangeLog::new();
+    engine
+        .action_with_logger(&mut log, "overwrite-formula", |action| {
+            action.set_cell_formula("Sheet1", 1, 2, parse("=C1+1").unwrap())
+        })
+        .unwrap();
+    assert_structural_parity(&engine, 0xc0de_0008, 0);
+
+    let mut undo = UndoEngine::new();
+    engine.undo_logged(&mut undo, &mut log).unwrap();
+    assert_structural_parity(&engine, 0xc0de_0008, 1);
+    engine.redo_logged(&mut undo, &mut log).unwrap();
+    assert_structural_parity(&engine, 0xc0de_0008, 2);
+}
+
+#[test]
+fn row_and_column_adjustment_keeps_compressed_ranges_in_ast_edge_parity() {
+    let config = EvalConfig::default().with_range_expansion_limit(0);
+    let mut engine = Engine::new(TestWorkbook::new(), config);
+    engine
+        .set_cell_formula("Sheet1", 1, 8, parse("=SUM(A2:F9)").unwrap())
+        .unwrap();
+    assert_structural_parity(&engine, 0xc0de_0001, 0);
+
+    engine.insert_rows("Sheet1", 2, 1).unwrap();
+    assert_structural_parity(&engine, 0xc0de_0001, 1);
+    assert_behavioral_parity(&mut engine, 0xc0de_0001, 1, 2);
+
+    engine.delete_rows("Sheet1", 5, 1).unwrap();
+    assert_structural_parity(&engine, 0xc0de_0001, 2);
+    engine.insert_columns("Sheet1", 2, 1).unwrap();
+    assert_structural_parity(&engine, 0xc0de_0001, 3);
+    engine.delete_columns("Sheet1", 4, 1).unwrap();
+    assert_structural_parity(&engine, 0xc0de_0001, 4);
+    assert_behavioral_parity(&mut engine, 0xc0de_0001, 4, 2);
+}
+
+#[test]
+fn deleting_referenced_row_and_column_turns_ast_to_ref_without_phantom_edges() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=A2").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 3, 1, parse("=C3").unwrap())
+        .unwrap();
+
+    engine.delete_rows("Sheet1", 2, 1).unwrap();
+    engine.delete_columns("Sheet1", 3, 1).unwrap();
+    assert_structural_parity(&engine, 0xc0de_0002, 2);
+
+    for formula in engine.graph.formula_vertices() {
+        let ast = engine.graph.get_formula(formula).unwrap();
+        assert!(
+            formualizer_parse::pretty::canonical_formula(&ast).contains("#REF!"),
+            "deleted direct reference must be retained as #REF!: {ast:?}",
+        );
+        assert!(
+            engine.graph.get_dependencies(formula).is_empty()
+                && engine
+                    .graph
+                    .get_range_dependencies(formula)
+                    .is_none_or(Vec::is_empty),
+            "#REF! formula must not retain phantom graph dependencies",
+        );
+    }
+}
+
+#[test]
+fn sheet_addition_then_adjustment_keeps_unqualified_edges_on_the_formula_sheet() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.add_sheet("Sheet2").unwrap();
+    engine
+        .set_cell_value("Sheet1", 2, 1, LiteralValue::Number(1.0))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet2", 2, 1, LiteralValue::Number(2.0))
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet2", 1, 2, parse("=A2").unwrap())
+        .unwrap();
+    engine.insert_rows("Sheet2", 2, 1).unwrap();
+
+    assert_structural_parity(&engine, 0xc0de_0003, 1);
+    assert_behavioral_parity(&mut engine, 0xc0de_0003, 1, 1);
+}
+
+#[test]
+fn names_and_tables_are_exact_symbol_vertices_and_dirty_their_dependents() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    let sheet_id = engine.sheet_id("Sheet1").unwrap();
+    let named_cell = CellRef::new(sheet_id, Coord::from_excel(2, 1, true, true));
+    engine
+        .define_name(
+            "Tracked",
+            NamedDefinition::Cell(named_cell),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .define_table(
+            "Sales",
+            RangeRef::new(
+                CellRef::new(sheet_id, Coord::from_excel(1, 3, true, true)),
+                CellRef::new(sheet_id, Coord::from_excel(3, 4, true, true)),
+            ),
+            true,
+            vec!["Item".into(), "Amount".into()],
+            false,
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            6,
+            parse("=Tracked+SUM(Sales[Amount])").unwrap(),
+        )
+        .unwrap();
+
+    assert_structural_parity(&engine, 0xc0de_0004, 0);
+    let formula = engine.graph.formula_vertices()[0];
+    let formulas = engine.graph.formula_vertices();
+    engine.graph.clear_dirty_flags(&formulas);
+    engine
+        .set_cell_value("Sheet1", 2, 1, LiteralValue::Number(4.0))
+        .unwrap();
+    assert!(
+        engine.graph.is_dirty(formula),
+        "name target must dirty formula"
+    );
+    engine.graph.clear_dirty_flags(&formulas);
+    engine
+        .set_cell_value("Sheet1", 2, 4, LiteralValue::Number(8.0))
+        .unwrap();
+    assert!(
+        engine.graph.is_dirty(formula),
+        "table cell must dirty formula"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
+++ b/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
@@ -867,9 +867,10 @@ fn range_area_equal_to_expansion_limit_uses_direct_edges() {
     engine
         .set_cell_formula("Sheet1", 1, 8, parse("=SUM(A2:B9)").unwrap())
         .unwrap();
+    engine.insert_rows("Sheet1", 1, 1).unwrap();
 
-    assert_structural_parity(&engine, 0xc0de_0010, 0);
-    assert_behavioral_parity(&mut engine, 0xc0de_0010, 0, 2);
+    assert_structural_parity(&engine, 0xc0de_0010, 1);
+    assert_behavioral_parity(&mut engine, 0xc0de_0010, 1, 2);
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
+++ b/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
@@ -4,15 +4,23 @@
 //! AST (classified by `engine::refs`) are represented by exactly the formula's outgoing graph
 //! dependencies. A cell is represented by a direct edge (including an empty placeholder), a
 //! finite range at or below `range_expansion_limit` by one edge per cell, a larger or open range
-//! by one compressed range dependency backed by the stripe indexes, and a name or table by an
-//! edge to its resolving vertex. Exact parity matters in both directions: a missing dependency can
-//! leave a value silently stale, while a phantom dependency causes spurious recalculation.
+//! by one compressed range dependency, and a name or table by an edge to its resolving vertex.
+//! `get_range_dependencies` exposes a stored pre-stripe copy, so stripe-index integrity is covered
+//! behaviorally rather than by the structural comparison. Exact parity matters in both directions:
+//! a missing dependency can leave a value silently stale, while a phantom dependency causes
+//! spurious recalculation.
 //!
 //! The structural checker compares those representations after edit operations. The behavioral
 //! checker independently mutates sampled AST-referenced cells through `Engine`, requires the
 //! formula to become dirty, and undoes the mutation through the changelog. Structural failures
 //! diagnose the representation; behavioral failures are the scheduling ground truth. If only one
 //! fails, its panic reports both the formula and sampled cell so the disagreement is actionable.
+//! Campaigns deliberately use this dirty-flag proxy as their oracle and never call `evaluate_all`;
+//! value-level consequences are pinned in the dedicated ignored finding tests.
+//!
+//! The missing-edge direction silently contributes an empty expected set for unresolvable sheets,
+//! names, or tables; reversed ranges; and external, three-dimensional, or unsupported references.
+//! It is therefore vacuous for those references, while the phantom-edge direction remains covered.
 //!
 //! Campaign seeds are fixed constants below. They are intentionally not persisted: a failure
 //! prints its seed and operation index, which is enough to replay the deterministic campaign while
@@ -323,6 +331,10 @@ fn assert_behavioral_parity(
         if !engine.graph.vertex_exists(formula) {
             continue;
         }
+        let formula_cell = engine
+            .graph
+            .get_cell_ref(formula)
+            .expect("formula vertex must retain its address during a value probe");
         let sheet = engine
             .graph
             .sheet_name(referenced_cell.sheet_id)
@@ -341,7 +353,8 @@ fn assert_behavioral_parity(
             .expect("behavioral probe mutation must succeed");
         assert!(
             engine.graph.vertex_exists(formula) && engine.graph.is_dirty(formula),
-            "AST/edge behavioral divergence: seed={seed:#x} operation={operation} formula={formula:?} referenced_cell={} (structural checker passed)",
+            "AST/edge behavioral divergence: seed={seed:#x} operation={operation} formula={} referenced_cell={} (structural checker passed)",
+            engine.graph.to_a1(formula_cell),
             engine.graph.to_a1(referenced_cell),
         );
 
@@ -360,6 +373,12 @@ struct Campaign {
     expansion_limit: usize,
     assert_every: usize,
     behavior_samples: usize,
+}
+
+#[derive(Default)]
+struct CampaignStats {
+    undo: usize,
+    redo: usize,
 }
 
 fn random_sheet<'a>(rng: &mut SmallRng, sheets: &'a [String]) -> &'a str {
@@ -390,7 +409,7 @@ fn reset_history(log: &mut ChangeLog, undo: &mut UndoEngine, can_redo: &mut bool
     *can_redo = false;
 }
 
-fn run_campaign(campaign: Campaign) {
+fn run_campaign(campaign: Campaign) -> CampaignStats {
     let config = EvalConfig::default().with_range_expansion_limit(campaign.expansion_limit);
     let mut engine = Engine::new(TestWorkbook::new(), config);
     let mut sheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
@@ -425,14 +444,23 @@ fn run_campaign(campaign: Campaign) {
     let mut log = ChangeLog::new();
     let mut undo = UndoEngine::new();
     let mut can_redo = false;
+    let mut stats = CampaignStats::default();
 
     for operation in 0..campaign.operations {
+        let force_redo = can_redo && rng.gen_bool(0.4);
+        if force_redo {
+            engine.redo_logged(&mut undo, &mut log).unwrap();
+            can_redo = false;
+            stats.redo += 1;
+        }
+
         let choice = rng.gen_range(0..100);
         let sheet = random_sheet(&mut rng, &sheets).to_string();
         let row = rng.gen_range(1..=MAX_ROW);
         let col = rng.gen_range(1..=MAX_COL);
 
         match choice {
+            _ if force_redo => {}
             0..=13 => {
                 engine
                     .action_with_logger(&mut log, "campaign-set-value", |action| {
@@ -458,7 +486,16 @@ fn run_campaign(campaign: Campaign) {
                 can_redo = false;
             }
             30..=40 => {
-                let edit_sheet = if sheet == "Sheet1" { "Sheet2" } else { &sheet };
+                let active_symbol_edge = engine
+                    .graph
+                    .formula_vertices()
+                    .into_iter()
+                    .any(|formula| !ast_shape(&engine.graph, formula).shape.symbols.is_empty());
+                let edit_sheet = if sheet == "Sheet1" && active_symbol_edge {
+                    "Sheet2"
+                } else {
+                    &sheet
+                };
                 engine
                     .action_with_logger(&mut log, "campaign-insert-rows", |action| {
                         action.insert_rows(edit_sheet, row, 1).map(|_| ())
@@ -472,7 +509,16 @@ fn run_campaign(campaign: Campaign) {
                 reset_history(&mut log, &mut undo, &mut can_redo);
             }
             52..=61 => {
-                let edit_sheet = if sheet == "Sheet1" { "Sheet2" } else { &sheet };
+                let active_symbol_edge = engine
+                    .graph
+                    .formula_vertices()
+                    .into_iter()
+                    .any(|formula| !ast_shape(&engine.graph, formula).shape.symbols.is_empty());
+                let edit_sheet = if sheet == "Sheet1" && active_symbol_edge {
+                    "Sheet2"
+                } else {
+                    &sheet
+                };
                 engine
                     .action_with_logger(&mut log, "campaign-insert-columns", |action| {
                         action.insert_columns(edit_sheet, col, 1).map(|_| ())
@@ -543,10 +589,12 @@ fn run_campaign(campaign: Campaign) {
             90..=95 if !log.is_empty() => {
                 engine.undo_logged(&mut undo, &mut log).unwrap();
                 can_redo = true;
+                stats.undo += 1;
             }
             96..=99 if can_redo => {
                 engine.redo_logged(&mut undo, &mut log).unwrap();
                 can_redo = false;
+                stats.redo += 1;
             }
             _ => {
                 engine
@@ -566,16 +614,21 @@ fn run_campaign(campaign: Campaign) {
             );
         }
     }
+    stats
 }
 
 // T2 finding AST_EDGE_UNDO_STRUCTURAL_ADJUSTMENT: see the matching T2 worker-report entry.
-// Undo moves the referenced cell edge back but leaves the cross-sheet AST at its inserted-row
-// coordinate, splitting scheduling from evaluation.
+// Undo leaves populated data shifted, restores the AST to B6, and mis-restores its edge to B5.
 #[test]
-#[ignore = "known T2 divergence: undoing row insertion leaves adjusted AST and edge split"]
-fn undoing_row_insertion_restores_cross_sheet_ast_and_edge_together() {
+#[ignore = "known T2 divergence: undoing populated row insertion leaves data shifted and edge above AST"]
+fn undoing_populated_row_insertion_restores_data_ast_and_edge_together() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
     engine.add_sheet("Sheet2").unwrap();
+    for row in 1..=8 {
+        engine
+            .set_cell_value("Sheet2", row, 2, LiteralValue::Number(f64::from(row * 10)))
+            .unwrap();
+    }
     engine
         .set_cell_formula("Sheet1", 6, 4, parse("='Sheet2'!B6*2").unwrap())
         .unwrap();
@@ -585,50 +638,100 @@ fn undoing_row_insertion_restores_cross_sheet_ast_and_edge_together() {
             action.insert_rows("Sheet2", 1, 1).map(|_| ())
         })
         .unwrap();
-    assert_structural_parity(&engine, 0xc0de_0007, 0);
+    assert_structural_parity(&engine, 0x0adc_0303, 0);
 
     let mut undo = UndoEngine::new();
     engine.undo_logged(&mut undo, &mut log).unwrap();
 
-    assert_structural_parity(&engine, 0xc0de_0007, 1);
+    let shifted_values: Vec<_> = (2..=9)
+        .map(|row| engine.get_cell_value("Sheet2", row, 2))
+        .collect();
+    let expected_shifted_values: Vec<_> = (1..=8)
+        .map(|row| Some(LiteralValue::Number(f64::from(row * 10))))
+        .collect();
+    assert_eq!(shifted_values, expected_shifted_values);
+
+    let formula = engine.graph.formula_vertices()[0];
+    let ast = ast_shape(&engine.graph, formula);
+    let actual = graph_shape(&engine.graph, formula);
+    let sheet2 = engine.sheet_id("Sheet2").unwrap();
+    let b5 = CellRef::new(sheet2, Coord::from_excel(5, 2, true, true));
+    let b6 = CellRef::new(sheet2, Coord::from_excel(6, 2, true, true));
+    assert_eq!(actual.cells, BTreeSet::from([b5]));
+    assert_eq!(ast.shape.cells, BTreeSet::from([b6]));
+    let structural_failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_structural_parity(&engine, 0x0adc_0303, 1);
+    }));
+    assert!(
+        structural_failure.is_err(),
+        "the structural checker must detect the B5/B6 split"
+    );
+
+    engine.graph.mark_vertex_dirty(formula);
+    engine.evaluate_all().unwrap();
+    let evaluated = engine.get_cell_value("Sheet1", 6, 4);
+    eprintln!(
+        "AST_EDGE_UNDO_STRUCTURAL_ADJUSTMENT: values B2:B9={shifted_values:?}; edge=Sheet2!B5; AST=Sheet2!B6; D6={evaluated:?}; correct D6=120"
+    );
+    assert_eq!(
+        evaluated,
+        Some(LiteralValue::Number(120.0)),
+        "undo must restore the data and evaluate Sheet1!D6 from the restored Sheet2!B6 value"
+    );
 }
 
 // T2 finding AST_EDGE_UNRELATED_DELETE_NAME: see the matching entry in the T2 worker report.
-// Deleting a column on the default sheet removes a workbook-name vertex and strands formulas on
-// other sheets, even when the name resolves to a cell on another sheet.
+// GitHub issue #302's review extension covers both default-sheet row and column deletes. Either
+// shape removes a workbook-name edge and strands formulas on another sheet.
 #[test]
-#[ignore = "known T2 divergence: unrelated default-sheet delete drops a name edge"]
-fn deleting_unrelated_default_sheet_column_preserves_cross_sheet_name_edge() {
-    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
-    engine.add_sheet("Sheet2").unwrap();
-    let target = CellRef::new(
-        engine.sheet_id("Sheet2").unwrap(),
-        Coord::from_excel(2, 6, true, true),
+#[ignore = "known T2 divergence: unrelated default-sheet row or column delete drops a name edge"]
+fn deleting_unrelated_default_sheet_row_or_column_preserves_cross_sheet_name_edge() {
+    fn dependencies_after_delete(delete_row: bool) -> usize {
+        let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+        engine.add_sheet("Sheet2").unwrap();
+        let target = CellRef::new(
+            engine.sheet_id("Sheet2").unwrap(),
+            Coord::from_excel(2, 6, true, true),
+        );
+        engine
+            .define_name(
+                "Tracked",
+                NamedDefinition::Cell(target),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        engine
+            .set_cell_formula("Sheet2", 10, 6, parse("=Tracked+1").unwrap())
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(1.0))
+            .unwrap();
+        assert_structural_parity(&engine, 0xc0de_0006, 0);
+        if delete_row {
+            engine.delete_rows("Sheet1", 1, 1).unwrap();
+        } else {
+            engine.delete_columns("Sheet1", 1, 1).unwrap();
+        }
+        engine
+            .graph
+            .get_dependencies(engine.graph.formula_vertices()[0])
+            .len()
+    }
+
+    let after_column_delete = dependencies_after_delete(false);
+    let after_row_delete = dependencies_after_delete(true);
+    assert_eq!(after_column_delete, 0);
+    assert_eq!(after_row_delete, 0);
+    assert!(
+        after_column_delete > 0 && after_row_delete > 0,
+        "default-sheet row and column deletes must both preserve the cross-sheet name edge"
     );
-    engine
-        .define_name(
-            "Tracked",
-            NamedDefinition::Cell(target),
-            NameScope::Workbook,
-        )
-        .unwrap();
-    engine
-        .set_cell_formula("Sheet2", 10, 6, parse("=Tracked+1").unwrap())
-        .unwrap();
-    engine
-        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(1.0))
-        .unwrap();
-    assert_structural_parity(&engine, 0xc0de_0006, 0);
-
-    engine.delete_columns("Sheet1", 1, 1).unwrap();
-
-    assert_structural_parity(&engine, 0xc0de_0006, 1);
 }
 
 // T2 finding AST_EDGE_UNDO_EMPTY_PLACEHOLDER: see the matching entry in the T2 worker report.
-// Undo removes a referenced empty placeholder instead of restoring its dependency role.
+// GitHub issue #301's review extension confirms that redo also fails to rebuild the edge.
 #[test]
-#[ignore = "known T2 divergence: undoing a write to a referenced empty placeholder drops its edge"]
+#[ignore = "known T2 divergence: undo and redo of an empty-placeholder write drop its edge"]
 fn undoing_value_write_to_referenced_empty_placeholder_preserves_formula_edge() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
     engine
@@ -644,8 +747,24 @@ fn undoing_value_write_to_referenced_empty_placeholder_preserves_formula_edge() 
         .unwrap();
     let mut undo = UndoEngine::new();
     engine.undo_logged(&mut undo, &mut log).unwrap();
+    let formula = engine.graph.formula_vertices()[0];
+    assert!(engine.graph.get_dependencies(formula).is_empty());
 
-    assert_structural_parity(&engine, 0xc0de_0005, 1);
+    engine.redo_logged(&mut undo, &mut log).unwrap();
+    let dependencies_after_redo = engine.graph.get_dependencies(formula);
+    assert!(dependencies_after_redo.is_empty());
+    let formulas = engine.graph.formula_vertices();
+    engine.graph.clear_dirty_flags(&formulas);
+    engine
+        .set_cell_value("Sheet1", 6, 3, LiteralValue::Number(555.0))
+        .unwrap();
+    assert!(!engine.graph.is_dirty(formula));
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.get_cell_value("Sheet1", 4, 4), None);
+    assert!(
+        !dependencies_after_redo.is_empty(),
+        "redo must rebuild the C6 edge so a later C6 write dirties and evaluates D4"
+    );
 }
 
 #[test]
@@ -680,9 +799,22 @@ fn randomized_structural_edits_keep_ast_and_graph_dependencies_exact() {
             behavior_samples: 2,
         },
     ];
-    for campaign in campaigns {
-        run_campaign(campaign);
-    }
+    let stats = campaigns
+        .into_iter()
+        .fold(CampaignStats::default(), |mut total, campaign| {
+            let campaign_stats = run_campaign(campaign);
+            total.undo += campaign_stats.undo;
+            total.redo += campaign_stats.redo;
+            total
+        });
+    eprintln!(
+        "campaign history operations realized: undo={} redo={}",
+        stats.undo, stats.redo
+    );
+    assert!(
+        stats.redo > 0,
+        "default campaigns must realize at least one redo operation"
+    );
 }
 
 #[test]
@@ -726,6 +858,18 @@ fn row_and_column_adjustment_keeps_compressed_ranges_in_ast_edge_parity() {
     engine.delete_columns("Sheet1", 4, 1).unwrap();
     assert_structural_parity(&engine, 0xc0de_0001, 4);
     assert_behavioral_parity(&mut engine, 0xc0de_0001, 4, 2);
+}
+
+#[test]
+fn range_area_equal_to_expansion_limit_uses_direct_edges() {
+    let config = EvalConfig::default().with_range_expansion_limit(16);
+    let mut engine = Engine::new(TestWorkbook::new(), config);
+    engine
+        .set_cell_formula("Sheet1", 1, 8, parse("=SUM(A2:B9)").unwrap())
+        .unwrap();
+
+    assert_structural_parity(&engine, 0xc0de_0010, 0);
+    assert_behavioral_parity(&mut engine, 0xc0de_0010, 0, 2);
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
+++ b/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
@@ -22,6 +22,15 @@
 //! names, or tables; reversed ranges; and external, three-dimensional, or unsupported references.
 //! It is therefore vacuous for those references, while the phantom-edge direction remains covered.
 //!
+//! Pinned T2 findings, each an `#[ignore]`d test asserting the intended invariant and failing on
+//! the live divergence: `AST_EDGE_UNDO_STRUCTURAL_ADJUSTMENT` (undo of a populated row insert
+//! leaves data shifted and the edge one row above the AST reference),
+//! `AST_EDGE_UNRELATED_DELETE_NAME` (a default-sheet row or column delete drops a cross-sheet
+//! workbook-name edge), `AST_EDGE_UNDO_EMPTY_PLACEHOLDER` (undo and redo of a write to a
+//! referenced empty placeholder drop its edge), and `AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID`
+//! (a default-sheet insert shifts a name vertex onto an addressable cell, so later references to
+//! that address bind to the name vertex instead of the cell).
+//!
 //! Campaign seeds are fixed constants below. They are intentionally not persisted: a failure
 //! prints its seed and operation index, which is enough to replay the deterministic campaign while
 //! keeping the repository free of generated failure corpora.
@@ -403,6 +412,38 @@ fn random_formula(rng: &mut SmallRng, sheets: &[String], current_sheet: &str) ->
     }
 }
 
+/// The workbook name's vertex physically occupies a cell on the default sheet. A default-sheet
+/// insert at or above that cell shifts the vertex onto an addressable grid cell, after which any
+/// later reference to that address binds to the name vertex instead of the cell — finding
+/// `AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID`, pinned by
+/// `default_sheet_insertion_keeps_the_name_vertex_off_the_addressable_grid`. Campaigns keep their
+/// default-sheet inserts strictly below and to the right of the name vertex so they exercise the
+/// healthy shape; every other default-sheet edit, including formula and value overwrite of shifted
+/// formulas, stays in play.
+fn insert_clear_of_name_vertex(
+    engine: &Engine<TestWorkbook>,
+    sheet: &str,
+    row: u32,
+    col: u32,
+) -> (u32, u32) {
+    let Some(sheet_id) = engine.sheet_id(sheet) else {
+        return (row, col);
+    };
+    let Some(named) = engine.graph.resolve_name_entry("Tracked", sheet_id) else {
+        return (row, col);
+    };
+    let Some(anchor) = engine.graph.get_cell_ref(named.vertex) else {
+        return (row, col);
+    };
+    if anchor.sheet_id != sheet_id {
+        return (row, col);
+    }
+    (
+        row.max(anchor.coord.row() + 2),
+        col.max(anchor.coord.col() + 2),
+    )
+}
+
 fn reset_history(log: &mut ChangeLog, undo: &mut UndoEngine, can_redo: &mut bool) {
     log.clear();
     *undo = UndoEngine::new();
@@ -445,9 +486,6 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
     let mut undo = UndoEngine::new();
     let mut can_redo = false;
     let mut stats = CampaignStats::default();
-    // Default-sheet inserts are covered, but later overwriting a formula shifted by one exposes a
-    // separate unpinned interaction. Keep those vertices out of subsequent formula/value writes.
-    let mut shifted_formulas = BTreeSet::new();
 
     for operation in 0..campaign.operations {
         let force_redo = can_redo && rng.gen_bool(0.4);
@@ -458,39 +496,9 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
         }
 
         let choice = rng.gen_range(0..100);
-        let mut sheet = random_sheet(&mut rng, &sheets).to_string();
-        let mut row = rng.gen_range(1..=MAX_ROW);
-        let mut col = rng.gen_range(1..=MAX_COL);
-        let selected = CellRef::new(
-            engine.sheet_id(&sheet).unwrap(),
-            Coord::from_excel(row, col, true, true),
-        );
-        if engine
-            .graph
-            .get_vertex_for_cell(&selected)
-            .is_some_and(|vertex| shifted_formulas.contains(&vertex))
-        {
-            'replacement: for candidate_sheet in &sheets {
-                for candidate_row in 1..=MAX_ROW {
-                    for candidate_col in 1..=MAX_COL {
-                        let candidate = CellRef::new(
-                            engine.sheet_id(candidate_sheet).unwrap(),
-                            Coord::from_excel(candidate_row, candidate_col, true, true),
-                        );
-                        if engine
-                            .graph
-                            .get_vertex_for_cell(&candidate)
-                            .is_none_or(|vertex| !shifted_formulas.contains(&vertex))
-                        {
-                            sheet = candidate_sheet.clone();
-                            row = candidate_row;
-                            col = candidate_col;
-                            break 'replacement;
-                        }
-                    }
-                }
-            }
-        }
+        let sheet = random_sheet(&mut rng, &sheets).to_string();
+        let row = rng.gen_range(1..=MAX_ROW);
+        let col = rng.gen_range(1..=MAX_COL);
 
         match choice {
             _ if force_redo => {}
@@ -519,17 +527,10 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 can_redo = false;
             }
             30..=40 => {
-                if sheet == "Sheet1" {
-                    shifted_formulas.extend(engine.graph.formula_vertices().into_iter().filter(
-                        |formula| {
-                            engine.graph.get_vertex_sheet_id(*formula)
-                                == engine.sheet_id("Sheet1").unwrap()
-                        },
-                    ));
-                }
+                let (insert_row, _) = insert_clear_of_name_vertex(&engine, &sheet, row, col);
                 engine
                     .action_with_logger(&mut log, "campaign-insert-rows", |action| {
-                        action.insert_rows(&sheet, row, 1).map(|_| ())
+                        action.insert_rows(&sheet, insert_row, 1).map(|_| ())
                     })
                     .unwrap();
                 reset_history(&mut log, &mut undo, &mut can_redo);
@@ -540,17 +541,10 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 reset_history(&mut log, &mut undo, &mut can_redo);
             }
             52..=61 => {
-                if sheet == "Sheet1" {
-                    shifted_formulas.extend(engine.graph.formula_vertices().into_iter().filter(
-                        |formula| {
-                            engine.graph.get_vertex_sheet_id(*formula)
-                                == engine.sheet_id("Sheet1").unwrap()
-                        },
-                    ));
-                }
+                let (_, insert_col) = insert_clear_of_name_vertex(&engine, &sheet, row, col);
                 engine
                     .action_with_logger(&mut log, "campaign-insert-columns", |action| {
-                        action.insert_columns(&sheet, col, 1).map(|_| ())
+                        action.insert_columns(&sheet, insert_col, 1).map(|_| ())
                     })
                     .unwrap();
                 reset_history(&mut log, &mut undo, &mut can_redo);
@@ -561,12 +555,7 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 reset_history(&mut log, &mut undo, &mut can_redo);
             }
             72..=79 => {
-                let formulas: Vec<_> = engine
-                    .graph
-                    .formula_vertices()
-                    .into_iter()
-                    .filter(|formula| !shifted_formulas.contains(formula))
-                    .collect();
+                let formulas = engine.graph.formula_vertices();
                 if let Some(formula) = formulas.get(rng.gen_range(0..formulas.len().max(1))) {
                     let target = engine.graph.get_cell_ref(*formula).unwrap();
                     let target_sheet = engine.graph.sheet_name(target.sheet_id).to_string();
@@ -798,6 +787,131 @@ fn undoing_value_write_to_referenced_empty_placeholder_preserves_formula_edge() 
     assert!(
         !dependencies_after_redo.is_empty(),
         "redo must rebuild the C6 edge so a later C6 write dirties and evaluates D4"
+    );
+}
+
+// T2 finding AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID: see the matching T2 worker-report entry.
+// A workbook name's vertex physically occupies `Sheet1!$A$1` and is deliberately kept out of the
+// cell index while it sits there. A default-sheet insert at or above it shifts the vertex onto an
+// addressable grid cell and publishes it in the cell index, so every reference resolved afterwards
+// binds to the name vertex instead of the cell: a phantom symbol edge plus a missing direct cell
+// edge. No overwrite is involved, and the referring formula need not be one the insert shifted.
+#[test]
+#[ignore = "known T2 divergence: a default-sheet insert shifts a name vertex onto an addressable cell"]
+fn default_sheet_insertion_keeps_the_name_vertex_off_the_addressable_grid() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.add_sheet("Sheet2").unwrap();
+    let sheet1 = engine.sheet_id("Sheet1").unwrap();
+    let sheet2 = engine.sheet_id("Sheet2").unwrap();
+    // The name's target lives on Sheet2, so the default-sheet insert cannot move the target and
+    // every value below is attributable to the vertex placement alone.
+    engine
+        .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(7.0))
+        .unwrap();
+    engine
+        .define_name(
+            "Tracked",
+            NamedDefinition::Cell(CellRef::new(sheet2, Coord::from_excel(4, 4, true, true))),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet2", 1, 1, parse("=Tracked+1").unwrap())
+        .unwrap();
+    assert_structural_parity(&engine, 0xc0de_0007, 0);
+
+    let name_vertex = engine
+        .graph
+        .resolve_name_entry("Tracked", sheet2)
+        .expect("workbook name must resolve")
+        .vertex;
+    let a1 = CellRef::new(sheet1, Coord::from_excel(1, 1, true, true));
+    let a2 = CellRef::new(sheet1, Coord::from_excel(2, 1, true, true));
+    assert_eq!(engine.graph.get_cell_ref(name_vertex), Some(a1));
+    assert_eq!(engine.graph.get_vertex_for_cell(&a1), None);
+
+    engine.insert_rows("Sheet1", 1, 1).unwrap();
+    assert_eq!(engine.graph.get_cell_ref(name_vertex), Some(a2));
+    assert_eq!(engine.graph.get_vertex_for_cell(&a2), Some(name_vertex));
+
+    // A brand-new formula on a cell the insertion never touched, referencing the shifted address.
+    engine
+        .set_cell_formula("Sheet1", 7, 7, parse("=A2+1").unwrap())
+        .unwrap();
+    let referring = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet1, Coord::from_excel(7, 7, true, true)))
+        .expect("the referring formula must exist");
+    let actual = graph_shape(&engine.graph, referring);
+    let expected_cells = {
+        let expected = ast_shape(&engine.graph, referring);
+        assert!(expected.shape.symbols.is_empty());
+        expected.shape.cells.clone()
+    };
+    assert_eq!(actual.symbols, BTreeSet::from([name_vertex]));
+    assert!(actual.cells.is_empty());
+    assert_eq!(expected_cells, BTreeSet::from([a2]));
+    let structural_failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_structural_parity(&engine, 0xc0de_0007, 1);
+    }));
+    assert!(
+        structural_failure.is_err(),
+        "the structural checker must detect the phantom name edge and the missing A2 edge"
+    );
+
+    // Consequence 1: the referring formula is now a dependent of the name, so editing the name's
+    // target spuriously dirties a formula that never mentions the name.
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 7, 7),
+        Some(LiteralValue::Number(1.0))
+    );
+    let formulas = engine.graph.formula_vertices();
+    engine.graph.clear_dirty_flags(&formulas);
+    engine
+        .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(70.0))
+        .unwrap();
+    let spuriously_dirty = engine.graph.is_dirty(referring);
+    assert!(spuriously_dirty);
+    engine.evaluate_all().unwrap();
+
+    // Consequence 2: an ordinary data write at the shifted address overwrites the name's own
+    // vertex, so the name entry now resolves to a plain default-sheet cell.
+    engine
+        .set_cell_value("Sheet1", 2, 1, LiteralValue::Number(500.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(engine.graph.get_vertex_kind(name_vertex), VertexKind::Cell);
+
+    // Consequence 3: deleting the row the hijacked vertex now occupies strands the name, and
+    // `=Tracked+1` stops tracking its own target.
+    engine.delete_rows("Sheet1", 2, 1).unwrap();
+    engine.evaluate_all().unwrap();
+    let tracked_formula = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet2, Coord::from_excel(1, 1, true, true)))
+        .expect("the name-consuming formula must exist");
+    assert!(engine.graph.get_dependencies(tracked_formula).is_empty());
+    let formulas = engine.graph.formula_vertices();
+    engine.graph.clear_dirty_flags(&formulas);
+    engine
+        .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(700.0))
+        .unwrap();
+    assert!(!engine.graph.is_dirty(tracked_formula));
+    engine.evaluate_all().unwrap();
+    let evaluated = engine.get_cell_value("Sheet2", 1, 1);
+    eprintln!(
+        "AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID: name vertex Sheet1!$A$1 -> Sheet1!$A$2; \
+Sheet1!G7 deps={:?} AST cells={:?}; name-target edit dirties Sheet1!G7={spuriously_dirty}; \
+name vertex kind after Sheet1!A2=500 is Cell; Sheet2!A1={evaluated:?}; correct Sheet2!A1=701",
+        actual.symbols, expected_cells,
+    );
+    assert_eq!(
+        evaluated,
+        Some(LiteralValue::Number(701.0)),
+        "a default-sheet insert must not park the name vertex on an addressable cell: \
+Sheet1!G7 must take a direct Sheet1!A2 edge, the name target must not dirty it, and \
+`=Tracked+1` must still recompute from Sheet2!D4"
     );
 }
 

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -1,5 +1,6 @@
 mod active_span_gate_audit;
 mod arena_debug;
+mod ast_edge_invariant;
 mod cancellation;
 mod change_log;
 mod changelog_replay;

--- a/scripts/mutate-ast-edge-invariant.sh
+++ b/scripts/mutate-ast-edge-invariant.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/formualizer-t2-mutations.XXXXXX")
+target_dir="$root/target/t2-mutations"
+active_worktree=""
+
+cleanup() {
+  if [[ -n "$active_worktree" ]]; then
+    git -C "$root" worktree remove --force "$active_worktree" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+mutate_and_expect_failure() {
+  local label=$1
+  local test_name=$2
+  local mutation=$3
+  local worktree="$tmp/$label"
+
+  git -C "$root" worktree add --detach "$worktree" HEAD >/dev/null
+  active_worktree=$worktree
+  cp "$root/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs" \
+    "$worktree/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs"
+  cp "$root/crates/formualizer-eval/src/engine/tests/mod.rs" \
+    "$worktree/crates/formualizer-eval/src/engine/tests/mod.rs"
+
+  CASE_MUTATION=$mutation python3 - "$worktree" <<'PY'
+import os
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+case = os.environ["CASE_MUTATION"]
+
+if case in {"drop-adjusted-cell-edge", "skip-shifted-range-dependency", "wrong-sheet-after-insert"}:
+    path = root / "crates/formualizer-eval/src/engine/graph/mod.rs"
+    text = path.read_text()
+    if case == "drop-adjusted-cell-edge":
+        old = "        self.add_dependent_edges(id, &new_dependencies);"
+        new = "        let _ = &new_dependencies;"
+    elif case == "skip-shifted-range-dependency":
+        old = "        self.add_range_dependent_edges(id, &new_range_dependencies, sheet_id);"
+        new = "        let _ = &new_range_dependencies;"
+    else:
+        old = "    pub fn update_vertex_formula(&mut self, id: VertexId, ast: ASTNode) -> Result<(), ExcelError> {\n        // Get the sheet_id for this vertex\n        let sheet_id = self.store.sheet_id(id);"
+        new = "    pub fn update_vertex_formula(&mut self, id: VertexId, ast: ASTNode) -> Result<(), ExcelError> {\n        // Mutant: resolve adjusted unqualified references on the wrong sheet.\n        let sheet_id = self.default_sheet_id;"
+else:
+    path = root / "crates/formualizer-eval/src/engine/graph/editor/reference_adjuster.rs"
+    text = path.read_text()
+    old = "                    ReferenceAdjustment::Invalidated => ASTNodeType::Literal(LiteralValue::Error(\n                        ExcelError::new(ExcelErrorKind::Ref),\n                    )),"
+    new = "                    ReferenceAdjustment::Invalidated => return None,"
+
+if text.count(old) != 1:
+    raise SystemExit(f"mutation anchor count for {case}: {text.count(old)}")
+path.write_text(text.replace(old, new, 1))
+PY
+
+  local output="$tmp/$label.log"
+  if CARGO_TARGET_DIR="$target_dir" cargo test \
+      --manifest-path "$worktree/Cargo.toml" \
+      -p formualizer-eval "$test_name" -- --exact >"$output" 2>&1; then
+    echo "NOT CAUGHT: $label" >&2
+    exit 1
+  fi
+  if ! grep -q "test result: FAILED" "$output"; then
+    echo "mutation did not reach a failing test: $label" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+
+  echo "caught: $label"
+  git -C "$root" worktree remove --force "$worktree" >/dev/null
+  active_worktree=""
+}
+
+mutate_and_expect_failure \
+  drop-adjusted-cell-edge \
+  engine::tests::ast_edge_invariant::sheet_addition_then_adjustment_keeps_unqualified_edges_on_the_formula_sheet \
+  drop-adjusted-cell-edge
+mutate_and_expect_failure \
+  skip-shifted-range-dependency \
+  engine::tests::ast_edge_invariant::row_and_column_adjustment_keeps_compressed_ranges_in_ast_edge_parity \
+  skip-shifted-range-dependency
+mutate_and_expect_failure \
+  skip-ref-tombstone-on-delete \
+  engine::tests::ast_edge_invariant::deleting_referenced_row_and_column_turns_ast_to_ref_without_phantom_edges \
+  skip-ref-tombstone-on-delete
+mutate_and_expect_failure \
+  wrong-sheet-after-insert \
+  engine::tests::ast_edge_invariant::sheet_addition_then_adjustment_keeps_unqualified_edges_on_the_formula_sheet \
+  wrong-sheet-after-insert
+
+echo "all 4 AST/edge maintenance mutants caught"


### PR DESCRIPTION
Adds a randomized AST↔edge parity invariant harness guarding the engine's dual-write seam — scheduling reads graph edges while evaluation reads retained ASTs, so any divergence between them produces silently stale or wrong values. Nothing in the existing suite compared the two truths; this harness does, after every operation of seeded structural-edit campaigns.

The invariant: every formula vertex's outgoing dependency representation (direct cell edges, expanded small-range edges, compressed range dependencies, symbol-vertex edges) must exactly match the semantic references of its current retained AST, collected through the reference collector this program consolidated earlier — checked in both directions, so missing edges and phantom edges both fail. A behavioral layer provides ground truth: mutating a referenced cell must dirty the formula. The two layers are complementary by construction and empirically — an adversarial-review mutant corrupting only the stripe indexes was invisible to the structural comparison and caught by the behavioral probe, which is now documented as the stripe-index oracle.

Campaigns run fixed-seed operation mixes (value and formula writes and overwrites, row/column inserts and deletes, formula deletion, name redefinition, sheet addition, logged undo/redo) across expansion limits 0/1/16/64, with realized undo and redo coverage measured rather than assumed, an exact area-equals-expansion-limit boundary case, and a committed mutation script proving the harness catches deliberately broken edge maintenance. Failure messages print seed, operation index, and A1 addresses for direct reproduction.

The harness found four distinct production defects, each minimized, independently confirmed against plain main with concrete wrong values, pinned as an ignored intended-invariant test that fails deterministically, and filed: #301 (undo of a value write to a referenced empty cell drops the dependent edge, and redo does not restore it — stale values), #302 (default-sheet row or column deletion destroys formula-to-name edges because name vertices occupy real default-sheet coordinates — stale values), #303 (undo of a logged row insert leaves cell data unrestored and lands the edge one row above the AST reference — wrong values), and #304 (a default-sheet insert publishes name and table vertices into the cell index, hijacking subsequent address resolution — spurious recompute, silent name destruction, and stale values). Campaign generators exclude exactly the minimized broken shapes, each exclusion documented against its finding id and proven load-bearing: neutralizing an exclusion makes the campaigns fail at the pinned mechanism.

Two review cycles preceded this merge. The adversarial review independently re-derived all findings against plain main, which corrected one mechanism attribution before it could mislead a fix (the original #303 filing described a divergence the engine does not produce; the corrected mechanism is worse than filed), and a follow-up pass corrected a second attribution the same way (#304's collision was initially mistaken for an insert-then-overwrite interaction; the true mechanism requires no overwrite at all). Both corrections are recorded transparently on the issues.

Tests only: production code is untouched, public API snapshots show zero drift, and the full workspace suite, clippy with denied warnings, fmt, and docgen all pass. The four pins are the executable specification for the fixes; each fix should un-ignore its pin and make it green.

drafted with love by (agent) Manfred, with approval from Frankie
