### PR TITLE
fix(eval): date arithmetic outside the representable range is a number, not #NUM! (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Arithmetic on a date-typed cell no longer returns `#NUM!` when the result falls outside the representable date range. `Date`/`DateTime` operands keep their temporal tag when the resulting serial is representable, and degrade to a plain number when it is not, instead of manufacturing a numeric-domain error. This most visibly affected `end_date - start_date` accrual expressions whenever the period ran backwards: a perfectly ordinary negative day count became `#NUM!` and propagated through every downstream cell. NaN and infinity operands continue to error. Reported externally with a full reproduction and LibreOffice cross-check. (#310)
+
 ## [0.8.0] - 2026-08-10
 
 ### Engine introspection (new)

--- a/crates/formualizer-eval/src/engine/tests/date_arithmetic_negative_serial.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_arithmetic_negative_serial.rs
@@ -1,0 +1,183 @@
+//! Regression coverage for #310: `Date - Number` yielding a negative serial
+//! returned `#NUM!` instead of the plain number Excel produces.
+//!
+//! Excel has no date type at the formula level. A date cell holds a serial
+//! number carrying a date number format, so `=A1-B1` with `A1 < B1` is just a
+//! negative number. Formualizer keeps a first-class temporal tag so typed date
+//! values survive a round trip, and propagating that tag through `+`/`-` is a
+//! deliberate convenience -- but it must never turn arithmetic Excel performs
+//! happily into a numeric-domain error.
+//!
+//! Each test pins exactly the property it names.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use chrono::NaiveDate;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+/// Serial for 2024-12-01 in the 1900 date system, matching the issue report.
+const DEC_1_2024: f64 = 45627.0;
+
+fn engine_with_date_anchor() -> Engine<TestWorkbook> {
+    let wb = TestWorkbook::new();
+    let mut engine = Engine::new(wb, EvalConfig::default());
+    // A1 holds a genuine Date literal, exactly as an ingested date-formatted
+    // xlsx cell does. This is the trigger: a formula-produced `=DATE(...)`
+    // yields a plain number and never reached the defect.
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            1,
+            LiteralValue::Date(NaiveDate::from_ymd_opt(2024, 12, 1).unwrap()),
+        )
+        .unwrap();
+    engine
+}
+
+fn eval(engine: &mut Engine<TestWorkbook>, formula: &str) -> LiteralValue {
+    engine
+        .set_cell_formula("Sheet1", 10, 10, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_cell("Sheet1", 10, 10).unwrap().unwrap()
+}
+
+#[test]
+fn date_minus_larger_number_returns_negative_number_not_num_error() {
+    let mut engine = engine_with_date_anchor();
+    // 45627 - 45658 = -31, the reporter's headline case.
+    assert_eq!(eval(&mut engine, "=A1-45658"), LiteralValue::Number(-31.0));
+}
+
+#[test]
+fn date_minus_number_at_serial_zero_boundary_stays_representable() {
+    let mut engine = engine_with_date_anchor();
+    // Serial 0 is representable as a date, so the temporal tag is preserved.
+    // This pins the boundary the fix must not move.
+    match eval(&mut engine, "=A1-45627") {
+        LiteralValue::Date(d) => {
+            assert_eq!(d, NaiveDate::from_ymd_opt(1899, 12, 31).unwrap())
+        }
+        other => panic!("expected Date at serial 0, got {other:?}"),
+    }
+}
+
+#[test]
+fn date_minus_number_one_past_serial_zero_degrades_to_number() {
+    let mut engine = engine_with_date_anchor();
+    // Serial -1 is the first unrepresentable value; it must be a plain number.
+    assert_eq!(
+        eval(&mut engine, &format!("=A1-{}", DEC_1_2024 + 1.0)),
+        LiteralValue::Number(-1.0)
+    );
+}
+
+#[test]
+fn date_plus_large_number_beyond_year_9999_degrades_to_number() {
+    let mut engine = engine_with_date_anchor();
+    // Overflow past the representable date range is arithmetic, not failure.
+    assert_eq!(
+        eval(&mut engine, "=A1+1000000000"),
+        LiteralValue::Number(DEC_1_2024 + 1_000_000_000.0)
+    );
+}
+
+#[test]
+fn date_minus_date_remains_a_plain_day_delta_in_both_directions() {
+    let mut engine = engine_with_date_anchor();
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            2,
+            LiteralValue::Date(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+        )
+        .unwrap();
+    assert_eq!(eval(&mut engine, "=B1-A1"), LiteralValue::Number(31.0));
+    // The reverse direction is the negative case, and was never broken because
+    // Date - Date short-circuits to a numeric delta. Pinned so the fix to the
+    // Date - Number path cannot accidentally reroute it.
+    assert_eq!(eval(&mut engine, "=A1-B1"), LiteralValue::Number(-31.0));
+}
+
+#[test]
+fn negative_date_difference_flows_through_the_accrual_idiom() {
+    let mut engine = engine_with_date_anchor();
+    // The real-world shape from the report: a partial-period accrual where the
+    // payment date precedes the anchor. Previously #NUM! poisoned every
+    // downstream cell.
+    match eval(&mut engine, "=(A1-45658)/365") {
+        LiteralValue::Number(n) => assert!(
+            (n - (-31.0 / 365.0)).abs() < 1e-12,
+            "expected -31/365, got {n}"
+        ),
+        other => panic!("expected Number, got {other:?}"),
+    }
+}
+
+#[test]
+fn reporter_max_if_guard_returns_zero_rather_than_propagating_an_error() {
+    let mut engine = engine_with_date_anchor();
+    // Verbatim from the issue: the MAX(...,0) guard is supposed to floor the
+    // negative accrual at zero. An error operand defeats the guard entirely.
+    assert_eq!(
+        eval(
+            &mut engine,
+            "=MAX(IF(YEAR(A1)>2025,A1*0,(A1-45658)/365*0),0)"
+        ),
+        LiteralValue::Number(0.0)
+    );
+}
+
+#[test]
+fn negative_date_difference_is_consumable_by_downstream_functions() {
+    let mut engine = engine_with_date_anchor();
+    // An error is not merely a wrong value: it is uncomposable. Pin that the
+    // result participates in ordinary numeric functions.
+    assert_eq!(
+        eval(&mut engine, "=ABS(A1-45658)"),
+        LiteralValue::Number(31.0)
+    );
+    assert_eq!(
+        eval(&mut engine, "=A1-45658+45658"),
+        LiteralValue::Number(DEC_1_2024)
+    );
+}
+
+#[test]
+fn datetime_minus_number_yielding_negative_serial_degrades_to_number() {
+    // The defect lived in a helper shared by Date and DateTime operands, so the
+    // DateTime path needs its own pin rather than inheriting confidence.
+    let wb = TestWorkbook::new();
+    let mut engine = Engine::new(wb, EvalConfig::default());
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            1,
+            LiteralValue::DateTime(
+                NaiveDate::from_ymd_opt(2024, 12, 1)
+                    .unwrap()
+                    .and_hms_opt(6, 0, 0)
+                    .unwrap(),
+            ),
+        )
+        .unwrap();
+    match eval(&mut engine, "=A1-45658") {
+        LiteralValue::Number(n) => assert!((n - (-30.75)).abs() < 1e-9, "got {n}"),
+        other => panic!("expected Number, got {other:?}"),
+    }
+}
+
+#[test]
+fn nan_and_infinity_operands_still_produce_numeric_errors() {
+    let mut engine = engine_with_date_anchor();
+    // The fix must only reclassify unrepresentable-as-date. Genuine numeric
+    // domain failures keep erroring, so the change cannot be mistaken for
+    // "date arithmetic never errors".
+    match eval(&mut engine, "=A1+(1/0)") {
+        LiteralValue::Error(e) => assert_eq!(e.kind, ExcelErrorKind::Div),
+        other => panic!("expected an error for division by zero, got {other:?}"),
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -9,6 +9,7 @@ mod common;
 mod cross_sheet_named_range_first_cell;
 mod cycle_detection;
 mod database_blank_semantics;
+mod date_arithmetic_negative_serial;
 mod deferred_dirty;
 mod demand_driven;
 mod dependency;

--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -1190,6 +1190,16 @@ impl<'a> Interpreter<'a> {
                 )
             };
 
+            // Excel has no date type at the formula level: `date + number` is
+            // plain numeric addition, and the result only *displays* as a date
+            // because the cell inherits a date number format. We keep the
+            // temporal tag when the result is representable, because that is
+            // what lets typed date values survive a round trip, but a serial no
+            // date can represent is still an ordinary number. Erroring there
+            // invents a numeric-domain failure out of arithmetic Excel performs
+            // without complaint -- notably every negative serial, which the
+            // standard `end_date - start_date` accrual idiom produces whenever
+            // the period runs backwards.
             let serial_to_literal = |serial: f64| -> LiteralValue {
                 match crate::coercion::sanitize_numeric(serial) {
                     Ok(serial) => {
@@ -1201,9 +1211,13 @@ impl<'a> Interpreter<'a> {
                                     DateTime(dt)
                                 }
                             }
-                            Err(e) => Error(e),
+                            // Not representable as a date: degrade to the
+                            // plain serial rather than manufacturing #NUM!.
+                            Err(_) => Number(serial),
                         }
                     }
+                    // NaN and infinity are genuine numeric-domain failures and
+                    // keep their error.
                     Err(e) => Error(e),
                 }
             };


### PR DESCRIPTION
Fixes #310.

## What was wrong

Binary `+` and `-` propagate the temporal tag when one operand is a `Date` or `DateTime`, so typed date values survive a round trip. The helper that rebuilt a date from the resulting serial treated an *unrepresentable* serial as a numeric-domain failure and returned `#NUM!`. Every negative result is unrepresentable, so `date - larger_number` always errored.

Excel has no date type at the formula level. A date cell holds a serial carrying a date number format, so arithmetic on it is ordinary arithmetic and the result only *displays* as a date because the cell inherits the format. `45627 - 45658` is `-31` in Excel and LibreOffice alike, and an unrepresentable serial is still a perfectly good number.

## The fix

`serial_to_literal` degrades to `Number(serial)` when the serial cannot be a date, and keeps erroring for NaN and infinity, which are genuine numeric-domain failures.

No currently-successful result changes. Representable serials still return `Date`/`DateTime`, and `Date - Date` was already a numeric day delta. The change strictly converts errors into the values Excel produces.

## Scope of the report

The reporter measured 232 of 2134 output cells diverging from LibreOffice in a real financial model, all downstream of one partial-period accrual expression of the form `(end_date - start_date)/365`, which produces a negative day count whenever the period runs backwards. That idiom is standard in date-driven cash-flow and interest calculations, which is why a narrow-looking defect had such wide blast radius.

Two things worth recording beyond the report. This is **not a 0.8.0 regression** — 0.7.1 reproduces identically, so it is long-standing. And the trigger requires a genuine date-typed value: a formula-produced `=DATE(2024,12,1)` yields a plain number and never reaches the defect, which is why a synthetic function suite would not catch it. It needs an ingested date-formatted cell or a `date` value written through the API.

## Verification

Ten regression tests, each pinning exactly the property it names: the headline negative case, the serial-zero boundary and the first serial past it, year-9999 overflow, `Date - Date` in both directions, the `DateTime` operand path (the defect lived in a helper shared by both, so it does not inherit confidence), the accrual idiom, the reporter's verbatim `MAX(IF(...),0)` guard, composition into downstream functions, and NaN/infinity still erroring.

Reverting the production change fails **seven of the ten**. The three that survive are the controls pinning behaviour the fix must not move: the serial-zero boundary, `Date - Date`, and the numeric-error path. Full workspace test suite passes.

## Deliberately not in this PR

The report's second suggestion — dropping `Date` preservation from `+`/`-` entirely, so `=A1+0` returns a number like Excel — is the more Excel-exact design, and it is worth doing. It also changes currently-successful results and the value types callers receive from egress, which makes it a semver-relevant behaviour change rather than a patch fix. Filed separately so this can ship as 0.8.1 without carrying that decision.

drafted with love by (agent) Manfred, with approval from Frankie
