### PR TITLE
fix(eval): structural deletes invalidate compressed open-range readers (#306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
-- Row and column deletion now recalculates formulas that read affected whole-column, whole-row, or other compressed open ranges, instead of returning stale pre-deletion values while reporting them as current. (#306)
+- Row and column deletion now recalculates formulas that read affected whole-column, whole-row, or other compressed open ranges, instead of returning stale pre-deletion values while reporting them as current. Insertion still does not invalidate position-sensitive open-range readers such as `MATCH` and `INDEX`; that pre-existing gap is tracked separately. (#306)
 - Arithmetic on a date-typed cell no longer returns `#NUM!` when the result falls outside the representable date range. `Date`/`DateTime` operands keep their temporal tag when the resulting serial is representable, and degrade to a plain number when it is not, instead of manufacturing a numeric-domain error. This most visibly affected `end_date - start_date` accrual expressions whenever the period ran backwards: a perfectly ordinary negative day count became `#NUM!` and propagated through every downstream cell. NaN and infinity operands continue to error. Reported externally with a full reproduction and LibreOffice cross-check. (#310)
 
 ## [0.8.0] - 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Row and column deletion now recalculates formulas that read affected whole-column, whole-row, or other compressed open ranges, instead of returning stale pre-deletion values while reporting them as current. (#306)
 - Arithmetic on a date-typed cell no longer returns `#NUM!` when the result falls outside the representable date range. `Date`/`DateTime` operands keep their temporal tag when the resulting serial is representable, and degrade to a plain number when it is not, instead of manufacturing a numeric-domain error. This most visibly affected `end_date - start_date` accrual expressions whenever the period ran backwards: a perfectly ordinary negative day count became `#NUM!` and propagated through every downstream cell. NaN and infinity operands continue to error. Reported externally with a full reproduction and LibreOffice cross-check. (#310)
 
 ## [0.8.0] - 2026-08-10

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -1014,7 +1014,7 @@ impl<'g> VertexEditor<'g> {
             .compressed_range_dependents_intersecting_deleted_rows(
                 sheet_id,
                 start,
-                start.saturating_add(count).saturating_sub(1),
+                start.saturating_add(count).saturating_sub(1).max(start),
             );
         self.graph.mark_dirty_many(&range_dependents);
 
@@ -1266,7 +1266,7 @@ impl<'g> VertexEditor<'g> {
             .compressed_range_dependents_intersecting_deleted_columns(
                 sheet_id,
                 start,
-                start.saturating_add(count).saturating_sub(1),
+                start.saturating_add(count).saturating_sub(1).max(start),
             );
         self.graph.mark_dirty_many(&range_dependents);
 

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -1009,6 +1009,14 @@ impl<'g> VertexEditor<'g> {
                 coord.row() >= start && coord.row() < start + count
             })
             .collect();
+        let range_dependents = self
+            .graph
+            .compressed_range_dependents_intersecting_deleted_rows(
+                sheet_id,
+                start,
+                start.saturating_add(count).saturating_sub(1),
+            );
+        self.graph.mark_dirty_many(&range_dependents);
 
         for id in vertices_to_delete {
             self.remove_vertex(id)?;
@@ -1253,6 +1261,14 @@ impl<'g> VertexEditor<'g> {
                 coord.col() >= start && coord.col() < start + count
             })
             .collect();
+        let range_dependents = self
+            .graph
+            .compressed_range_dependents_intersecting_deleted_columns(
+                sheet_id,
+                start,
+                start.saturating_add(count).saturating_sub(1),
+            );
+        self.graph.mark_dirty_many(&range_dependents);
 
         for id in vertices_to_delete {
             self.remove_vertex(id)?;

--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -35,7 +35,9 @@ impl DependencyGraph {
                     .any(|range| {
                         let range_sheet_id = match range.sheet {
                             SharedSheetLocator::Id(id) => id,
-                            _ => self.get_vertex_sheet_id(dependent),
+                            // Formula analysis normalizes ingested locators to Id, so this
+                            // fallback is unreachable today; match the sibling query semantics.
+                            _ => sheet_id,
                         };
                         let range_start = range.start_row.map(|bound| bound.index).unwrap_or(0);
                         let range_end = range.end_row.map(|bound| bound.index).unwrap_or(u32::MAX);
@@ -62,7 +64,9 @@ impl DependencyGraph {
                     .any(|range| {
                         let range_sheet_id = match range.sheet {
                             SharedSheetLocator::Id(id) => id,
-                            _ => self.get_vertex_sheet_id(dependent),
+                            // Formula analysis normalizes ingested locators to Id, so this
+                            // fallback is unreachable today; match the sibling query semantics.
+                            _ => sheet_id,
                         };
                         let range_start = range.start_col.map(|bound| bound.index).unwrap_or(0);
                         let range_end = range.end_col.map(|bound| bound.index).unwrap_or(u32::MAX);

--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -21,6 +21,60 @@ impl RangeSelfUse {
 }
 
 impl DependencyGraph {
+    pub(crate) fn compressed_range_dependents_intersecting_deleted_rows(
+        &self,
+        sheet_id: SheetId,
+        start_row: u32,
+        end_row: u32,
+    ) -> Vec<VertexId> {
+        self.formula_to_range_deps
+            .iter()
+            .filter_map(|(&dependent, ranges)| {
+                ranges
+                    .iter()
+                    .any(|range| {
+                        let range_sheet_id = match range.sheet {
+                            SharedSheetLocator::Id(id) => id,
+                            _ => self.get_vertex_sheet_id(dependent),
+                        };
+                        let range_start = range.start_row.map(|bound| bound.index).unwrap_or(0);
+                        let range_end = range.end_row.map(|bound| bound.index).unwrap_or(u32::MAX);
+                        range_sheet_id == sheet_id
+                            && range_start <= end_row
+                            && range_end >= start_row
+                    })
+                    .then_some(dependent)
+            })
+            .collect()
+    }
+
+    pub(crate) fn compressed_range_dependents_intersecting_deleted_columns(
+        &self,
+        sheet_id: SheetId,
+        start_col: u32,
+        end_col: u32,
+    ) -> Vec<VertexId> {
+        self.formula_to_range_deps
+            .iter()
+            .filter_map(|(&dependent, ranges)| {
+                ranges
+                    .iter()
+                    .any(|range| {
+                        let range_sheet_id = match range.sheet {
+                            SharedSheetLocator::Id(id) => id,
+                            _ => self.get_vertex_sheet_id(dependent),
+                        };
+                        let range_start = range.start_col.map(|bound| bound.index).unwrap_or(0);
+                        let range_end = range.end_col.map(|bound| bound.index).unwrap_or(u32::MAX);
+                        range_sheet_id == sheet_id
+                            && range_start <= end_col
+                            && range_end >= start_col
+                    })
+                    .then_some(dependent)
+            })
+            .collect()
+    }
+
     /// Visit compressed-range formula dependents covering one cell without
     /// materializing the stripe union used by dirty propagation.
     ///

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_inspect_parity.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_inspect_parity.rs
@@ -608,16 +608,15 @@ fn structural_insert_conservative_staleness_is_documented_and_converges_after_ev
 }
 
 #[test]
-fn structural_delete_legacy_whole_column_staleness_bug_is_pinned_for_issue_306() {
+fn structural_delete_whole_column_values_match_fresh_formula_and_formula_plane_for_issue_306() {
     let (mut off, mut authoritative) = build_pair(7);
     off.delete_rows(SHEET, 60, 1).unwrap();
     authoritative.delete_rows(SHEET, 60, 1).unwrap();
     off.evaluate_all().unwrap();
     authoritative.evaluate_all().unwrap();
 
-    // Known engine bug #306: legacy delete_rows fails to dirty existing
-    // whole-column readers. The authoritative value is confirmed by a freshly
-    // authored legacy formula over the post-delete data.
+    // Confirm both authorities against a freshly authored formula over the
+    // post-delete data.
     for engine in [&mut off, &mut authoritative] {
         engine
             .set_cell_formula(SHEET, 1, 20, parse("=SUM($B:$B)+A1+7").unwrap())
@@ -640,11 +639,11 @@ fn structural_delete_legacy_whole_column_staleness_bug_is_pinned_for_issue_306()
         .inspect_cell(&address(1, 20), &SnapshotOptions::default())
         .unwrap()
         .cell;
-    assert_eq!(legacy.value, Some(LiteralValue::Number(16_520.0)));
+    assert_eq!(legacy.value, Some(LiteralValue::Number(16_400.0)));
     assert_eq!(plane.value, Some(LiteralValue::Number(16_400.0)));
     assert_eq!(legacy_oracle.value, plane_oracle.value);
+    assert_eq!(legacy.value, legacy_oracle.value);
     assert_eq!(plane.value, plane_oracle.value);
-    assert_ne!(legacy.value, legacy_oracle.value);
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/issue_306_structural_delete_dirty.rs
+++ b/crates/formualizer-eval/src/engine/tests/issue_306_structural_delete_dirty.rs
@@ -1,0 +1,364 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::engine::graph::editor::undo_engine::UndoEngine;
+use crate::engine::{
+    ChangeLog, Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::function::{FnCaps, Function};
+use crate::test_workbook::TestWorkbook;
+use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
+use formualizer_common::{ExcelError, LiteralValue};
+use formualizer_parse::parse;
+
+const SHEET: &str = "Model";
+const FORMULA_ROWS: u32 = 120;
+
+fn issue_fixture() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=FORMULA_ROWS + 8 {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(f64::from(row)))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, row, 2, LiteralValue::Number(f64::from(row * 2)))
+            .unwrap();
+    }
+
+    let mut records = Vec::with_capacity(FORMULA_ROWS as usize);
+    for row in 1..=FORMULA_ROWS {
+        let formula = format!("=SUM($B:$B)+A{row}+7");
+        let ast_id = engine.intern_formula_ast(&parse(&formula).unwrap());
+        records.push(FormulaIngestRecord::new(
+            row,
+            4,
+            ast_id,
+            Some(Arc::<str>::from(formula)),
+        ));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, records)])
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+fn number(engine: &Engine<TestWorkbook>, row: u32, col: u32) -> f64 {
+    match engine.get_cell_value(SHEET, row, col) {
+        Some(LiteralValue::Number(value)) => value,
+        value => panic!("expected number at {SHEET}!R{row}C{col}, got {value:?}"),
+    }
+}
+
+#[test]
+fn delete_rows_recomputes_really_ingested_whole_column_readers_for_issue_306() {
+    let mut engine = issue_fixture();
+    assert_eq!(number(&engine, 1, 4), 16_520.0);
+
+    engine.delete_rows(SHEET, 60, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(number(&engine, 1, 4), 16_400.0);
+}
+
+#[test]
+fn delete_columns_recomputes_whole_row_readers() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    engine
+        .set_cell_value(SHEET, 1, 1, LiteralValue::Number(1.0))
+        .unwrap();
+    for col in 1..=FORMULA_ROWS + 8 {
+        engine
+            .set_cell_value(SHEET, 2, col, LiteralValue::Number(f64::from(col * 2)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula(SHEET, 1, 4, parse("=SUM($2:$2)+A1+7").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(number(&engine, 1, 4), 16_520.0);
+
+    engine.delete_columns(SHEET, 60, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(number(&engine, 1, 4), 16_400.0);
+}
+
+#[test]
+fn delete_rows_keeps_bounded_range_recalculation_correct() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=FORMULA_ROWS {
+        engine
+            .set_cell_value(SHEET, row, 1, LiteralValue::Number(f64::from(row)))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, row, 2, LiteralValue::Number(f64::from(row * 2)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula(SHEET, 1, 4, parse("=SUM(B1:B120)+A1+7").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(number(&engine, 1, 4), 14_528.0);
+
+    engine.delete_rows(SHEET, 60, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(number(&engine, 1, 4), 14_408.0);
+}
+
+#[test]
+fn delete_rows_outside_bounded_read_region_does_not_change_result() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=30 {
+        engine
+            .set_cell_value("Data", row, 2, LiteralValue::Number(f64::from(row)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula(SHEET, 1, 1, parse("=SUM(Data!B10:B20)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(number(&engine, 1, 1), 165.0);
+
+    engine.delete_rows("Data", 25, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(number(&engine, 1, 1), 165.0);
+}
+
+fn cross_sheet_whole_column_fixture() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=FORMULA_ROWS + 8 {
+        engine
+            .set_cell_value("Data", row, 2, LiteralValue::Number(f64::from(row * 2)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula(SHEET, 1, 1, parse("=SUM(Data!$B:$B)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+#[test]
+fn delete_rows_at_first_and_last_bounded_range_boundaries_remain_correct() {
+    for (row, expected) in [(10, 155.0), (20, 145.0)] {
+        let mut engine = Engine::new(
+            TestWorkbook::new(),
+            EvalConfig::default().with_parallel(false),
+        );
+        for data_row in 1..=30 {
+            engine
+                .set_cell_value(
+                    "Data",
+                    data_row,
+                    2,
+                    LiteralValue::Number(f64::from(data_row)),
+                )
+                .unwrap();
+        }
+        engine
+            .set_cell_formula(SHEET, 1, 1, parse("=SUM(Data!B10:B20)").unwrap())
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        assert_eq!(number(&engine, 1, 1), 165.0);
+
+        engine.delete_rows("Data", row, 1).unwrap();
+        engine.evaluate_all().unwrap();
+
+        assert_eq!(number(&engine, 1, 1), expected, "deleted row {row}");
+    }
+}
+
+#[test]
+fn delete_rows_recomputes_whole_column_reader_after_multi_row_delete() {
+    let mut engine = cross_sheet_whole_column_fixture();
+    assert_eq!(number(&engine, 1, 1), 16_512.0);
+
+    engine.delete_rows("Data", 60, 3).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(number(&engine, 1, 1), 16_146.0);
+}
+
+#[test]
+fn delete_rows_recomputes_whole_column_reader_at_first_and_last_populated_boundaries() {
+    for (row, expected) in [(1, 16_510.0), (FORMULA_ROWS + 8, 16_256.0)] {
+        let mut engine = cross_sheet_whole_column_fixture();
+        engine.delete_rows("Data", row, 1).unwrap();
+        engine.evaluate_all().unwrap();
+        assert_eq!(number(&engine, 1, 1), expected, "deleted row {row}");
+    }
+}
+
+#[derive(Debug)]
+struct CountFn {
+    name: &'static str,
+    calls: Arc<AtomicUsize>,
+}
+
+impl Function for CountFn {
+    fn caps(&self) -> FnCaps {
+        FnCaps::PURE
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn eval<'a, 'b, 'c>(
+        &self,
+        _args: &'c [ArgumentHandle<'a, 'b>],
+        _ctx: &dyn FunctionContext<'b>,
+    ) -> Result<CalcValue<'b>, ExcelError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(CalcValue::Scalar(LiteralValue::Number(0.0)))
+    }
+}
+
+#[test]
+fn delete_rows_recomputes_only_formulas_depending_on_deleted_region() {
+    let affected_calls = Arc::new(AtomicUsize::new(0));
+    let unaffected_calls = Arc::new(AtomicUsize::new(0));
+    let workbook = TestWorkbook::new()
+        .with_function(Arc::new(CountFn {
+            name: "ISSUE306_AFFECTED",
+            calls: Arc::clone(&affected_calls),
+        }))
+        .with_function(Arc::new(CountFn {
+            name: "ISSUE306_UNAFFECTED",
+            calls: Arc::clone(&unaffected_calls),
+        }));
+    let mut engine = Engine::new(workbook, EvalConfig::default().with_parallel(false));
+    for row in 1..=100 {
+        engine
+            .set_cell_value(SHEET, row, 2, LiteralValue::Number(f64::from(row)))
+            .unwrap();
+        engine
+            .set_cell_value(SHEET, row, 26, LiteralValue::Number(f64::from(row)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula(
+            SHEET,
+            1,
+            4,
+            parse("=ISSUE306_AFFECTED()+SUM($B:$B)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            SHEET,
+            1,
+            5,
+            parse("=ISSUE306_UNAFFECTED()+SUM(Z1:Z10)").unwrap(),
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(affected_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(unaffected_calls.load(Ordering::SeqCst), 1);
+
+    engine.delete_rows(SHEET, 60, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(affected_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(unaffected_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn legacy_delete_rows_matches_formula_plane_authority_on_issue_306_fixture() {
+    let build = |mode| {
+        let mut engine = Engine::new(
+            TestWorkbook::new(),
+            EvalConfig::default()
+                .with_formula_plane_mode(mode)
+                .with_parallel(false),
+        );
+        for row in 1..=FORMULA_ROWS + 8 {
+            engine
+                .set_cell_value(SHEET, row, 1, LiteralValue::Number(f64::from(row)))
+                .unwrap();
+            engine
+                .set_cell_value(SHEET, row, 2, LiteralValue::Number(f64::from(row * 2)))
+                .unwrap();
+        }
+        let mut records = Vec::with_capacity(FORMULA_ROWS as usize);
+        for row in 1..=FORMULA_ROWS {
+            let formula = format!("=SUM($B:$B)+A{row}+7");
+            let ast_id = engine.intern_formula_ast(&parse(&formula).unwrap());
+            records.push(FormulaIngestRecord::new(
+                row,
+                4,
+                ast_id,
+                Some(Arc::<str>::from(formula)),
+            ));
+        }
+        engine
+            .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, records)])
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        engine
+    };
+    let mut legacy = build(FormulaPlaneMode::Off);
+    let mut authoritative = build(FormulaPlaneMode::AuthoritativeExperimental);
+    assert_eq!(
+        authoritative
+            .baseline_stats()
+            .formula_plane_active_span_count,
+        1
+    );
+
+    for engine in [&mut legacy, &mut authoritative] {
+        engine.delete_rows(SHEET, 60, 1).unwrap();
+        engine.evaluate_all().unwrap();
+    }
+
+    assert_eq!(number(&legacy, 1, 4), 16_400.0);
+    assert_eq!(number(&legacy, 1, 4), number(&authoritative, 1, 4));
+}
+
+#[test]
+fn undo_of_logged_delete_restores_whole_column_reader_value() {
+    let mut engine = issue_fixture();
+    let sheet_id = engine.sheet_id(SHEET).unwrap();
+    let mut log = ChangeLog::new();
+    engine
+        .edit_with_logger(&mut log, |editor| editor.delete_rows(sheet_id, 59, 1))
+        .unwrap()
+        .unwrap();
+    engine
+        .sheet_store_mut()
+        .sheet_mut(SHEET)
+        .unwrap()
+        .delete_rows(59, 1);
+    engine.evaluate_all().unwrap();
+    assert_eq!(number(&engine, 1, 4), 16_400.0);
+
+    {
+        let sheet = engine.sheet_store_mut().sheet_mut(SHEET).unwrap();
+        sheet.insert_rows(59, 1);
+        sheet.set_sparse_overlay_value(59, 0, crate::arrow_store::OverlayValue::Number(60.0));
+        sheet.set_sparse_overlay_value(59, 1, crate::arrow_store::OverlayValue::Number(120.0));
+    }
+    let mut undo = UndoEngine::new();
+    engine.undo_logged(&mut undo, &mut log).unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(number(&engine, 1, 4), 16_520.0);
+}

--- a/crates/formualizer-eval/src/engine/tests/issue_306_structural_delete_dirty.rs
+++ b/crates/formualizer-eval/src/engine/tests/issue_306_structural_delete_dirty.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::engine::graph::editor::undo_engine::UndoEngine;
+use crate::engine::inspect::{SnapshotOptions, Staleness};
 use crate::engine::{
     ChangeLog, Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
 };
@@ -248,18 +249,22 @@ fn delete_rows_recomputes_only_formulas_depending_on_deleted_region() {
     let mut engine = Engine::new(workbook, EvalConfig::default().with_parallel(false));
     for row in 1..=100 {
         engine
-            .set_cell_value(SHEET, row, 2, LiteralValue::Number(f64::from(row)))
+            .set_cell_value("Data", row, 2, LiteralValue::Number(f64::from(row)))
             .unwrap();
-        engine
-            .set_cell_value(SHEET, row, 26, LiteralValue::Number(f64::from(row)))
-            .unwrap();
+    }
+    for row in 1..=12 {
+        for col in 21..=26 {
+            engine
+                .set_cell_value("Data", row, col, LiteralValue::Number(f64::from(row)))
+                .unwrap();
+        }
     }
     engine
         .set_cell_formula(
             SHEET,
             1,
             4,
-            parse("=ISSUE306_AFFECTED()+SUM($B:$B)").unwrap(),
+            parse("=ISSUE306_AFFECTED()+SUM(Data!$B:$B)").unwrap(),
         )
         .unwrap();
     engine
@@ -267,14 +272,16 @@ fn delete_rows_recomputes_only_formulas_depending_on_deleted_region() {
             SHEET,
             1,
             5,
-            parse("=ISSUE306_UNAFFECTED()+SUM(Z1:Z10)").unwrap(),
+            // Area 72 exceeds the default expansion limit (64), so this is a
+            // compressed registration on the edited sheet, disjoint from row 60.
+            parse("=ISSUE306_UNAFFECTED()+SUM(Data!U1:Z12)").unwrap(),
         )
         .unwrap();
     engine.evaluate_all().unwrap();
     assert_eq!(affected_calls.load(Ordering::SeqCst), 1);
     assert_eq!(unaffected_calls.load(Ordering::SeqCst), 1);
 
-    engine.delete_rows(SHEET, 60, 1).unwrap();
+    engine.delete_rows("Data", 60, 1).unwrap();
     engine.evaluate_all().unwrap();
 
     assert_eq!(affected_calls.load(Ordering::SeqCst), 2);
@@ -361,4 +368,314 @@ fn undo_of_logged_delete_restores_whole_column_reader_value() {
     engine.evaluate_all().unwrap();
 
     assert_eq!(number(&engine, 1, 4), 16_520.0);
+}
+
+fn out_formula_vertex(engine: &Engine<TestWorkbook>, row: u32) -> crate::engine::vertex::VertexId {
+    *engine
+        .graph
+        .get_vertex_id_for_address(&engine.graph.make_cell_ref("Out", row, 1))
+        .expect("formula vertex")
+}
+
+fn assert_exact_vertices(
+    engine: &Engine<TestWorkbook>,
+    mut actual: Vec<crate::engine::vertex::VertexId>,
+    expected_rows: &[u32],
+) {
+    let mut expected = expected_rows
+        .iter()
+        .map(|&row| out_formula_vertex(engine, row))
+        .collect::<Vec<_>>();
+    actual.sort_unstable();
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn compressed_delete_queries_select_exact_shape_and_boundary_matrix() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    engine
+        .set_cell_value("Data", 1, 1, LiteralValue::Number(1.0))
+        .unwrap();
+    engine
+        .set_cell_value("Other", 1, 1, LiteralValue::Number(1.0))
+        .unwrap();
+
+    // Every range below is compressed. Formulas live on Out so Data references
+    // also cover the cross-sheet-positive case; rows 8 and 9 are the negative case.
+    let cases = [
+        "=SUM(Data!$B:$B)",
+        "=SUM(Data!$2:$2)",
+        "=SUM(Data!B:B65)",
+        "=SUM(Data!B66:B)",
+        "=SUM(Data!Z1:Z65)",
+        "=SUM(Data!Z100:Z300)",
+        "=SUM(Data!U1:Z12)",
+        "=SUM(Other!$B:$B)",
+        "=SUM(Other!Z1:Z65)",
+        "=SUM(Data!$AH:$AN)",
+    ];
+    for (index, formula) in cases.into_iter().enumerate() {
+        engine
+            .set_cell_formula("Out", index as u32 + 1, 1, parse(formula).unwrap())
+            .unwrap();
+    }
+
+    let data = engine.sheet_id("Data").unwrap();
+    // Row windows touch each finite range's exact upper and lower boundaries,
+    // and include whole-column, multi-column-open, half-open, and bounded shapes.
+    for (start, end, expected_rows) in [
+        (0, 0, vec![1, 3, 5, 7, 10]),
+        (64, 64, vec![1, 3, 5, 10]),
+        (65, 65, vec![1, 4, 10]),
+        (64, 66, vec![1, 3, 4, 5, 10]),
+        (349, 349, vec![1, 4, 10]),
+    ] {
+        assert_exact_vertices(
+            &engine,
+            engine
+                .graph
+                .compressed_range_dependents_intersecting_deleted_rows(data, start, end),
+            &expected_rows,
+        );
+    }
+
+    // Column windows likewise pin both inclusive boundaries and exact exclusion
+    // immediately outside the referenced interval.
+    for (start, end, expected_rows) in [
+        (0, 0, vec![2]),
+        (1, 1, vec![1, 2, 3, 4]),
+        (25, 25, vec![2, 5, 6, 7]),
+        (33, 39, vec![2, 10]),
+        (51, 51, vec![2]),
+    ] {
+        assert_exact_vertices(
+            &engine,
+            engine
+                .graph
+                .compressed_range_dependents_intersecting_deleted_columns(data, start, end),
+            &expected_rows,
+        );
+    }
+}
+
+#[test]
+fn half_open_upper_boundary_delete_recomputes_against_fresh_oracle() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=200 {
+        engine
+            .set_cell_value("Data", row, 2, LiteralValue::Number(f64::from(row)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Out", 1, 1, parse("=SUM(Data!B:B65)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Out", 1, 1),
+        Some(LiteralValue::Number(2_145.0))
+    );
+
+    engine.delete_rows("Data", 65, 1).unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+        .set_cell_formula("Out", 1, 2, parse("=SUM(Data!B:B65)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    // The fully bounded analogue is dirtied by ReferenceAdjuster, masking this
+    // boundary. This half-open shape leaves its AST unchanged, so only the query
+    // pins the inclusive range_end == deleted-start overlap.
+    assert_eq!(
+        engine.get_cell_value("Out", 1, 1),
+        Some(LiteralValue::Number(2_146.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Out", 1, 1),
+        engine.get_cell_value("Out", 1, 2)
+    );
+}
+
+#[test]
+fn delete_rows_marks_open_range_reader_dirty_before_recalculation() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=200 {
+        engine
+            .set_cell_value("Data", row, 2, LiteralValue::Number(f64::from(row)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Out", 1, 1, parse("=SUM(Data!$B:$B)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    engine.delete_rows("Data", 65, 1).unwrap();
+
+    let inspected = engine
+        .inspect_cell(
+            &formualizer_common::CellAddress::new("Out", 1, 1).unwrap(),
+            &SnapshotOptions::default(),
+        )
+        .unwrap()
+        .cell;
+    assert_eq!(inspected.value, Some(LiteralValue::Number(20_100.0)));
+    assert_eq!(inspected.staleness, Staleness::Dirty);
+}
+
+#[test]
+fn unrelated_sheet_deletes_do_not_recompute_open_range_readers_on_either_axis() {
+    let row_calls = Arc::new(AtomicUsize::new(0));
+    let col_calls = Arc::new(AtomicUsize::new(0));
+    let workbook = TestWorkbook::new()
+        .with_function(Arc::new(CountFn {
+            name: "ISSUE306_OTHER_SHEET_ROW",
+            calls: Arc::clone(&row_calls),
+        }))
+        .with_function(Arc::new(CountFn {
+            name: "ISSUE306_OTHER_SHEET_COL",
+            calls: Arc::clone(&col_calls),
+        }));
+    let mut engine = Engine::new(workbook, EvalConfig::default().with_parallel(false));
+    for index in 1..=100 {
+        for sheet in ["Data", "Other"] {
+            engine
+                .set_cell_value(sheet, index, 2, LiteralValue::Number(f64::from(index)))
+                .unwrap();
+            engine
+                .set_cell_value(sheet, 2, index, LiteralValue::Number(f64::from(index)))
+                .unwrap();
+        }
+    }
+    engine
+        .set_cell_formula(
+            "Out",
+            1,
+            1,
+            parse("=ISSUE306_OTHER_SHEET_ROW()+SUM(Data!$B:$B)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Out",
+            2,
+            1,
+            parse("=ISSUE306_OTHER_SHEET_COL()+SUM(Data!$2:$2)").unwrap(),
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(row_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(col_calls.load(Ordering::SeqCst), 1);
+
+    engine.delete_rows("Other", 60, 1).unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(row_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(col_calls.load(Ordering::SeqCst), 1);
+
+    engine.delete_columns("Other", 60, 1).unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(row_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(col_calls.load(Ordering::SeqCst), 1);
+}
+
+// Pre-existing on main; follow-up #XXX tracks position-sensitive open-range
+// readers that insertion leaves current over stale values.
+#[test]
+#[ignore = "pending insert open-range invalidation follow-up #XXX"]
+fn insert_rows_dirties_match_over_whole_column() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=200 {
+        engine
+            .set_cell_value("Data", row, 2, LiteralValue::Number(f64::from(row * 10)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Out", 1, 1, parse("=MATCH(500,Data!$B:$B,0)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.insert_rows("Data", 2, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    let inspected = engine
+        .inspect_cell(
+            &formualizer_common::CellAddress::new("Out", 1, 1).unwrap(),
+            &SnapshotOptions::default(),
+        )
+        .unwrap()
+        .cell;
+    assert_eq!(inspected.staleness, Staleness::Current);
+    assert_eq!(inspected.value, Some(LiteralValue::Number(51.0)));
+}
+
+// Pre-existing on main; follow-up #XXX tracks this insertion invalidation gap.
+#[test]
+#[ignore = "pending insert open-range invalidation follow-up #XXX"]
+fn insert_rows_dirties_index_over_whole_column() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for row in 1..=200 {
+        engine
+            .set_cell_value("Data", row, 2, LiteralValue::Number(f64::from(row * 10)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Out", 1, 1, parse("=INDEX(Data!$B:$B,7)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.insert_rows("Data", 2, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    let inspected = engine
+        .inspect_cell(
+            &formualizer_common::CellAddress::new("Out", 1, 1).unwrap(),
+            &SnapshotOptions::default(),
+        )
+        .unwrap()
+        .cell;
+    assert_eq!(inspected.staleness, Staleness::Current);
+    assert_eq!(inspected.value, Some(LiteralValue::Number(60.0)));
+}
+
+// Pre-existing on main; follow-up #XXX tracks the symmetric column case.
+#[test]
+#[ignore = "pending insert open-range invalidation follow-up #XXX"]
+fn insert_columns_dirties_index_over_whole_row() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    );
+    for col in 1..=200 {
+        engine
+            .set_cell_value("Data", 2, col, LiteralValue::Number(f64::from(200 + col)))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Out", 1, 1, parse("=INDEX(Data!$2:$2,7)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.insert_columns("Data", 3, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    let inspected = engine
+        .inspect_cell(
+            &formualizer_common::CellAddress::new("Out", 1, 1).unwrap(),
+            &SnapshotOptions::default(),
+        )
+        .unwrap()
+        .cell;
+    assert_eq!(inspected.staleness, Staleness::Current);
+    assert_eq!(inspected.value, Some(LiteralValue::Number(206.0)));
 }

--- a/crates/formualizer-eval/src/engine/tests/issue_306_structural_delete_dirty.rs
+++ b/crates/formualizer-eval/src/engine/tests/issue_306_structural_delete_dirty.rs
@@ -586,10 +586,10 @@ fn unrelated_sheet_deletes_do_not_recompute_open_range_readers_on_either_axis() 
     assert_eq!(col_calls.load(Ordering::SeqCst), 1);
 }
 
-// Pre-existing on main; follow-up #XXX tracks position-sensitive open-range
+// Pre-existing on main; follow-up #313 tracks position-sensitive open-range
 // readers that insertion leaves current over stale values.
 #[test]
-#[ignore = "pending insert open-range invalidation follow-up #XXX"]
+#[ignore = "pending insert open-range invalidation follow-up #313"]
 fn insert_rows_dirties_match_over_whole_column() {
     let mut engine = Engine::new(
         TestWorkbook::new(),
@@ -618,9 +618,9 @@ fn insert_rows_dirties_match_over_whole_column() {
     assert_eq!(inspected.value, Some(LiteralValue::Number(51.0)));
 }
 
-// Pre-existing on main; follow-up #XXX tracks this insertion invalidation gap.
+// Pre-existing on main; follow-up #313 tracks this insertion invalidation gap.
 #[test]
-#[ignore = "pending insert open-range invalidation follow-up #XXX"]
+#[ignore = "pending insert open-range invalidation follow-up #313"]
 fn insert_rows_dirties_index_over_whole_column() {
     let mut engine = Engine::new(
         TestWorkbook::new(),
@@ -649,9 +649,9 @@ fn insert_rows_dirties_index_over_whole_column() {
     assert_eq!(inspected.value, Some(LiteralValue::Number(60.0)));
 }
 
-// Pre-existing on main; follow-up #XXX tracks the symmetric column case.
+// Pre-existing on main; follow-up #313 tracks the symmetric column case.
 #[test]
-#[ignore = "pending insert open-range invalidation follow-up #XXX"]
+#[ignore = "pending insert open-range invalidation follow-up #313"]
 fn insert_columns_dirties_index_over_whole_row() {
     let mut engine = Engine::new(
         TestWorkbook::new(),

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -68,6 +68,7 @@ mod engine_atomic_actions_618;
 
 mod index_unbounded_ranges;
 mod infinite_ranges;
+mod issue_306_structural_delete_dirty;
 mod spill_atomic;
 mod spill_basic;
 mod spill_config_defaults;


### PR DESCRIPTION
Fixes #306.

## What was wrong

`delete_rows` and `delete_columns` did not invalidate compressed open-range readers, so the legacy engine — the default configuration — served stale values after an ordinary structural delete, with no error and no staleness signal.

On the issue's fixture, `D1` continued to report `16520` after the row supplying `120` was deleted, where the correct value is `16400`. `inspect_cell` reported `Staleness::Current` over that stale value, because the engine genuinely believed it had no pending work.

## Mechanism

Compressed ranges are not ordinary per-cell edges. They live in `formula_to_range_deps` and the stripe indexes, and ordinary value mutation reaches them through `mark_dirty_many`. The delete path never entered that propagation: `remove_vertex` captured only direct graph-edge dependents, and a whole-column reader has no per-cell edge to the deleted cell. `move_vertex` did not repair it either, being direct-edge-only. Finally the AST of `$B:$B` is unchanged by a row deletion, so reference adjustment did not dirty it.

Bounded ranges converged for a different reason, which is why this stayed hidden: `ReferenceAdjuster` contracts a bounded row range on row deletion, the AST changes, and the formula is dirtied as a side effect. A whole-column range has no row bounds to contract, so it reported no AST change.

## The fix

Two exact axis-overlap queries over the existing compressed dependency registrations, called from `delete_rows`/`delete_columns` and fed into the existing `mark_dirty_many` propagation so genuine downstream dependents are covered too.

This is not global invalidation. A row delete selects only compressed references on the edited sheet whose row interval intersects the deleted interval. The scan is linear in the number of compressed registrations, not in worksheet cells.

Collection happens before vertices are deleted and shifted. That ordering is defensive rather than required — review confirmed that moving it after the delete loop, and after the entire reference-adjustment pass, produces identical results on all 31 structural-edit shapes tested.

## Verification

Adversarial review checked 31 structural-edit shapes against a fresh-formula oracle, on both this branch and `main`:

| build | mismatches |
|---|---|
| `main` @ `ad2a40d8` | 16 of 31 |
| this branch | 3 of 31, all pre-existing insert cases that also fail on `main` |

The branch is correct on 28 of 28 delete cases, where `main` is wrong on 13 of them. Exact query selection is correct on 10 of 10 shape and window combinations across both axes. Cross-sheet works in both directions, deleted readers leave no tombstoned registrations, and the `Staleness::Current`-over-stale-value symptom is resolved.

Review found the code correct and the evidence insufficient: 10 of 21 reviewer-authored mutants survived the original suite, including one that replaced the overlap query with blanket invalidation of every compressed registration in the workbook and still passed the test named `delete_rows_recomputes_only_formulas_depending_on_deleted_region`. That test was vacuous — its `SUM(Z1:Z10)` control has area 10, below the default `range_expansion_limit` of 64, so it expands to per-cell edges and never enters the map the new query iterates. The control is now `SUM(Data!U1:Z12)`, area 72, genuinely compressed and genuinely disjoint.

The fix pass added a direct exact-set assertion over both queries across ten shape and window combinations, an end-to-end case for the inclusive upper boundary using the half-open `B:B65` shape — the only shape that distinguishes it, since `ReferenceAdjuster` masks the fully bounded analogue — a staleness assertion, and cross-sheet negative coverage on both axes. All seven non-equivalent survivors are now killed. M11, M18, M19, and M22 are genuinely equivalent mutants and were deliberately not chased; no test was distorted to distinguish them.

Self-falsification: reverting only the production integration fails 9 of the focused tests. The survivors are bounded and disjoint controls, which were already correct before this change.

Full workspace suite, fmt, and clippy pass.

## Known limitations, both recorded rather than hidden

**Insertion is still affected** for position-sensitive readers, and the original build report's argument that insert converges was wrong. It holds for order-invariant aggregates and fails for ordinal ones: after `insert_rows`, `MATCH(500,Data!$B:$B,0)` returns 50 where the answer is 51, and `INDEX(Data!$B:$B,7)` returns 70 where the answer is 60, while `SUM` over the same range is correctly unchanged. This is pre-existing on `main` and out of scope here. Filed as #313 and pinned by three `#[ignore]`d tests carrying the observed and required values.

**The conservative selection costs real work.** The row query ignores the range's column interval, so open-range readers over columns with no data near the deletion are invalidated even though no recomputation can change their value. Measured at 6.3x end-to-end with 1,000 such readers and 12.8x with 4,000. Structural-edit cost alone rises 2.6% when nothing can match and 29% when everything matches but the target columns are empty. Filed as #314 with the measurements and a concrete narrowing direction. Not optimised here: conservative and slow beats fast and stale, and a correctness patch is the wrong place to take that risk.

drafted with love by (agent) Manfred, with approval from Frankie
