### PR TITLE
fix(eval): temporal values compare as Excel serials in lookups (#316)

### DIFF
--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -9,6 +9,10 @@ use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 /// - Number / Int: numeric
 /// - Text: parsed if it looks numeric (lenient)
 /// - Boolean: TRUE=1, FALSE=0
+/// - Date / DateTime / Time: the Excel serial number. Excel has no date type
+///   at the formula level -- a date cell holds a serial carrying a date number
+///   format -- so a temporal value must order against plain numerics and
+///   against other temporal values exactly as two numbers do.
 /// - Empty: treated as 0
 pub fn value_to_f64_lenient(v: &LiteralValue) -> Option<f64> {
     match v {
@@ -16,6 +20,9 @@ pub fn value_to_f64_lenient(v: &LiteralValue) -> Option<f64> {
         LiteralValue::Int(i) => Some(*i as f64),
         LiteralValue::Text(s) => s.parse::<f64>().ok(),
         LiteralValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+        LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => {
+            v.as_serial_number()
+        }
         LiteralValue::Empty => Some(0.0),
         _ => None,
     }
@@ -354,6 +361,15 @@ pub fn find_exact_index_in_view(
         LiteralValue::Boolean(b) => find_exact_boolean_in_view(view, *b, vertical),
         LiteralValue::Empty => find_exact_empty_in_view(view, vertical),
         LiteralValue::Error(e) => Err(e.clone()),
+        // A temporal needle searches the numeric lane by serial: the arrow
+        // store keeps dates and times as serials under a temporal type tag,
+        // so an exact lookup for a date must not fall through to "no match".
+        LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => {
+            match needle.as_serial_number() {
+                Some(serial) => find_exact_number_in_view(view, serial, vertical),
+                None => Ok(None),
+            }
+        }
         _ => Ok(None),
     }
 }

--- a/crates/formualizer-eval/src/engine/lookup_index_cache.rs
+++ b/crates/formualizer-eval/src/engine/lookup_index_cache.rs
@@ -64,11 +64,14 @@ impl LookupHashKey {
             LiteralValue::Text(s) => Some(Self::Text(s.to_lowercase().into_boxed_str())),
             LiteralValue::Boolean(b) => Some(Self::Boolean(*b)),
             LiteralValue::Empty => Some(Self::Empty),
+            // Temporal values are numbers in Excel: key them by their serial so
+            // an exact lookup finds them whether the needle or the cell (or
+            // both) carry a temporal type rather than a plain numeric.
+            LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => value
+                .as_serial_number()
+                .map(|serial| Self::Number(normalize_f64_bits(serial))),
             LiteralValue::Error(_)
             | LiteralValue::Array(_)
-            | LiteralValue::Date(_)
-            | LiteralValue::DateTime(_)
-            | LiteralValue::Time(_)
             | LiteralValue::Duration(_)
             | LiteralValue::Pending => None,
         }

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -187,3 +187,5 @@ mod scc_iterate;
 mod scc_runtime_cycles;
 mod scc_runtime_property;
 mod short_circuit_dispatch;
+
+mod temporal_lookup_semantics;

--- a/crates/formualizer-eval/src/engine/tests/temporal_lookup_semantics.rs
+++ b/crates/formualizer-eval/src/engine/tests/temporal_lookup_semantics.rs
@@ -1,0 +1,182 @@
+//! Temporal values participate in lookups as ordinary Excel serials.
+//!
+//! Oracle: Microsoft Excel 16.105.3 (Microsoft 365 for Mac), synthetic
+//! workbook, values recalculated in-app (`oracle: excel-verified`).
+//!
+//! Excel has no date type at the formula level: a date cell holds a serial
+//! carrying a date number format. Every lookup family member therefore
+//! compares dates against dates, and against plain numerics, exactly as it
+//! compares two numbers.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use chrono::{NaiveDate, NaiveTime};
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn date(y: i32, m: u32, d: u32) -> LiteralValue {
+    LiteralValue::Date(NaiveDate::from_ymd_opt(y, m, d).unwrap())
+}
+
+/// Serial for 2024-01-01 in the Excel 1900 system.
+const JAN_1_2024: f64 = 45292.0;
+
+/// Column A: date-typed keys 2024-01-01..2024-01-05.
+/// Column B: numeric payload 10..50.
+/// Column C: the same keys written as plain numeric serials.
+/// D1: a date-typed needle cell (2024-01-03).
+fn build_date_engine() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for i in 1..=5u32 {
+        engine
+            .set_cell_value("Sheet1", i, 1, date(2024, 1, i))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", i, 2, LiteralValue::Int((i as i64) * 10))
+            .unwrap();
+        engine
+            .set_cell_value(
+                "Sheet1",
+                i,
+                3,
+                LiteralValue::Number(JAN_1_2024 + (i as f64) - 1.0),
+            )
+            .unwrap();
+    }
+    engine
+        .set_cell_value("Sheet1", 1, 4, date(2024, 1, 3))
+        .unwrap();
+    engine
+}
+
+fn eval(engine: &mut Engine<TestWorkbook>, formula: &str) -> Option<LiteralValue> {
+    engine
+        .set_cell_formula("Sheet1", 1, 10, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.get_cell_value("Sheet1", 1, 10)
+}
+
+fn assert_number(value: Option<LiteralValue>, expected: f64, formula: &str) {
+    match value {
+        Some(LiteralValue::Int(i)) => assert_eq!(i as f64, expected, "{formula}"),
+        Some(LiteralValue::Number(n)) => assert!((n - expected).abs() < 1e-9, "{formula} => {n}"),
+        other => panic!("{formula}: expected {expected}, got {other:?}"),
+    }
+}
+
+/// Excel: `=MATCH(D1,A1:A5,0)` => 3 where D1 and A1:A5 are date cells.
+#[test]
+fn match_exact_finds_a_date_typed_key_with_a_date_typed_needle() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(D1,A1:A5,0)"),
+        3.0,
+        "MATCH(D1,A1:A5,0)",
+    );
+}
+
+/// Excel: `=MATCH(DATE(2024,1,3),A1:A5,0)` => 3. A serial-valued needle must
+/// find a date-typed cell: both sides are the same number in Excel.
+#[test]
+fn match_exact_finds_a_date_typed_key_with_a_serial_needle() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(DATE(2024,1,3),A1:A5,0)"),
+        3.0,
+        "MATCH(DATE(2024,1,3),A1:A5,0)",
+    );
+}
+
+/// Excel: `=MATCH(D1,C1:C5,0)` => 3. The mirror direction — a date-typed
+/// needle against plain numeric serials.
+#[test]
+fn match_exact_finds_a_numeric_serial_with_a_date_typed_needle() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(D1,C1:C5,0)"),
+        3.0,
+        "MATCH(D1,C1:C5,0)",
+    );
+}
+
+/// Excel: `=MATCH(DATE(2024,1,3),A1:A5,1)` => 3 on an ascending date column.
+#[test]
+fn match_approximate_orders_date_typed_keys() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(DATE(2024,1,3),A1:A5,1)"),
+        3.0,
+        "MATCH(DATE(2024,1,3),A1:A5,1)",
+    );
+}
+
+/// Excel: `=MATCH(DATE(2024,1,4)+0.5,A1:A5,1)` => 4. A needle between two
+/// date keys selects the largest key not greater than it, which is only
+/// possible if dates order against non-integral serials.
+#[test]
+fn match_approximate_orders_dates_against_fractional_serials() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(DATE(2024,1,4)+0.5,A1:A5,1)"),
+        4.0,
+        "MATCH(DATE(2024,1,4)+0.5,A1:A5,1)",
+    );
+}
+
+/// Excel: `=VLOOKUP(D1,A1:B5,2,FALSE)` => 30.
+#[test]
+fn vlookup_exact_resolves_a_date_typed_key() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=VLOOKUP(D1,A1:B5,2,FALSE)"),
+        30.0,
+        "VLOOKUP(D1,A1:B5,2,FALSE)",
+    );
+}
+
+/// Excel: `=VLOOKUP(DATE(2024,1,3),A1:B5,2,TRUE)` => 30.
+#[test]
+fn vlookup_approximate_resolves_a_date_typed_key() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=VLOOKUP(DATE(2024,1,3),A1:B5,2,TRUE)"),
+        30.0,
+        "VLOOKUP(DATE(2024,1,3),A1:B5,2,TRUE)",
+    );
+}
+
+/// Control: a date outside the key column is still `#N/A`. Making dates
+/// comparable must not make every date match something.
+/// Excel: `=MATCH(DATE(2024,1,9),A1:A5,0)` => `#N/A`.
+#[test]
+fn match_exact_still_reports_na_for_an_absent_date() {
+    let mut engine = build_date_engine();
+    match eval(&mut engine, "=MATCH(DATE(2024,1,9),A1:A5,0)") {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Na),
+        other => panic!("expected #N/A, got {other:?}"),
+    }
+}
+
+/// A `Time` cell is the fractional part of a serial and orders the same way.
+/// Excel: with A=06:00,12:00,18:00 written as times, `=MATCH(0.5,A1:A3,0)`
+/// => 2 (12:00 is serial fraction 0.5).
+#[test]
+fn match_exact_finds_a_time_typed_key_by_its_serial_fraction() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, hour) in [(1u32, 6u32), (2, 12), (3, 18)] {
+        engine
+            .set_cell_value(
+                "Sheet1",
+                row,
+                1,
+                LiteralValue::Time(NaiveTime::from_hms_opt(hour, 0, 0).unwrap()),
+            )
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(0.5,A1:A3,0)"),
+        2.0,
+        "MATCH(0.5,A1:A3,0)",
+    );
+}


### PR DESCRIPTION
Fixes #316.

## What was wrong

`MATCH`, `VLOOKUP` and `HLOOKUP` could not find or order a `Date`,
`DateTime` or `Time` value. Three independent places refuse the temporal
variants:

- `builtins::lookup::lookup_utils::value_to_f64_lenient` returns `None` for
  them. `cmp_for_lookup` is built on it, so every temporal comparison is
  "incomparable" — which means `MATCH`'s approximate sortedness guard sees an
  unordered vector and returns `#N/A` for a perfectly ordered date column.
- `find_exact_index_in_view` dispatches on the needle's variant and has no
  temporal arm, so a date-typed needle falls through to `Ok(None)`.
- `LookupHashKey::from_literal` returns `None` for them, so the lookup hash
  index can key neither a date needle nor a date cell and the fast exact path
  is unusable.

## Excel behaviour

Excel has no date type at the formula level. A date cell holds a serial and a
date number format; the format is display, not type. So a lookup over dates
is a lookup over numbers, and a date must order against another date, against
a plain serial, and against a fractional serial, exactly as two numbers do.

Measured on Microsoft Excel 16.105.3 (Microsoft 365 for Mac), synthetic
workbook, `A1:A5` = 2024-01-01..05 as dates, `B1:B5` = 10..50, `C1:C5` = the
same dates as plain serials, `D1` = the date 2024-01-03:

| Formula | Excel | main @ `fe7b9111` |
| --- | --- | --- |
| `=MATCH(D1,A1:A5,0)` | 3 | `#N/A` |
| `=MATCH(D1,C1:C5,0)` | 3 | `#N/A` |
| `=MATCH(DATE(2024,1,3),A1:A5,1)` | 3 | `#N/A` |
| `=MATCH(DATE(2024,1,4)+0.5,A1:A5,1)` | 4 | `#N/A` |
| `=VLOOKUP(D1,A1:B5,2,FALSE)` | 30 | `#N/A` |
| `=VLOOKUP(DATE(2024,1,3),A1:B5,2,TRUE)` | 30 | `#N/A` |

The fractional-serial row is the interesting one: it can only come out at 4
if a `Date` and a non-integral number sit on the same number line.

## The fix

All three sites route through `LiteralValue::as_serial_number()`, which
already exists and already implements the 1900-system conversion the rest of
the crate uses.

Nothing that previously matched changes. `as_serial_number` is total over the
three temporal variants, so no case that used to return a position now
returns `#N/A`; the change only converts `#N/A` into the value Excel
produces. Non-temporal values take exactly the paths they took before.

## Scope

Not a regression: the same code is present well before 0.8.0. The trigger
requires a genuine date-typed value — an ingested date-formatted cell, or a
`date` written through the API. A formula-produced `=DATE(2024,1,3)` yields a
plain number and never reaches any of the three sites, which is why the JSON
formula suite does not catch this and why it shows up first on real ingested
workbooks. Any date-keyed schedule — rate tables, amortisation schedules,
period lookups — is affected wholesale rather than at the margin.

## Verification

Nine regression tests in
`crates/formualizer-eval/src/engine/tests/temporal_lookup_semantics.rs`, each
pinned to a measured Excel result. Revert the production change and **six of
the nine fail**. The three that survive are the controls:

- a plain serial needle against date cells (already worked; must keep working),
- a `Time` key found by its serial fraction via the numeric lane,
- an absent date still reporting `#N/A` — making dates comparable must not
  make every date match something.

Gates, run locally on the CI-pinned toolchain (macOS 15, aarch64):

```
cargo +1.93.0 fmt --all -- --check                                  exit 0
cargo +1.93.0 clippy --workspace --exclude formualizer-bench-core \
  --exclude formualizer-python --exclude formualizer-wasm \
  --all-targets --all-features -- -D warnings                       exit 0
cargo +1.93.0 test --workspace --exclude formualizer-bench-core \
  --exclude formualizer-python --exclude formualizer-wasm \
  --all-features --no-fail-fast            3471 passed, 1 failed
```

The single failure is pre-existing and unrelated: the JSON formula suite's
`IMEXP`/`IMSIN`/`IMCOS` cases differ in the last ULP on macOS arm64.
Unmodified `main` gives 3462 passed, 1 failed on the same host — same failure,
same three cases.

Not run here: the Linux-only `public-api` snapshot job. No public item is
added, removed or re-typed — `builtins::lookup::lookup_utils` does not appear
in `public-api/formualizer-eval.txt`, `LookupHashKey::from_literal` is
`pub(crate)`, and the `LookupHashKey` variants that *are* in the snapshot are
untouched.

## Deliberately not in this PR

- **Exact `MATCH` coerces blanks to zero** (#319): `=MATCH(0,A1:A10,0)`
  over a range with a blank tail returns 6 where Excel returns `#N/A`. Same
  helper (`Empty -> 0.0`), different path, and `Empty -> 0.0` is load-bearing
  elsewhere (#279, #285), so it deserves its own decision.
- **`MATCH` with `match_type = -1` on 8+ descending entries** (#320)
  returns the first entry `>=` the needle instead of the last. Unrelated to
  temporal values; verified present on unmodified `main`.
- Whether `Duration` should also compare as a serial. `as_serial_number`
  supports it, but `Duration` has no Excel counterpart and no lookup was
  observed to need it, so it stays incomparable.

Drafted by Claude (agent), verified by execution against a real Excel
oracle, reviewed by a human before submission.