### PR TITLE
fix(eval): approximate lookup ignores blanks and other-class entries (#317)

### DIFF
--- a/crates/formualizer-eval/src/builtins/lookup/core.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/core.rs
@@ -15,7 +15,7 @@
 //! - Type coercion: current simple: numbers vs numeric text coerced; text comparison case-insensitive? Excel is case-insensitive for MATCH (without wildcards). We implement case-insensitive for now.
 //!   TODO(excel-nuance): refine boolean/text/number coercion differences.
 
-use super::lookup_utils::{cmp_for_lookup, find_exact_index, is_sorted_ascending};
+use super::lookup_utils::{SearchedVector, cmp_for_lookup, find_exact_index};
 use crate::args::{ArgSchema, CoercionPolicy, ShapeKind};
 use crate::engine::lookup_index_cache::LookupAxis;
 use crate::function::Function;
@@ -24,18 +24,38 @@ use formualizer_common::ArgKind;
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_macros::func_caps;
 
+/// Approximate search over a lookup vector, returning a position in the
+/// *original* vector.
+///
+/// Entries the search must ignore — blanks, and entries outside the needle's
+/// value class — are projected out first, so they neither occupy a matchable
+/// position nor disturb the binary search's ordering assumption.
 fn binary_search_match(slice: &[LiteralValue], needle: &LiteralValue, mode: i32) -> Option<usize> {
     if mode == 0 || slice.is_empty() {
+        return None;
+    }
+    let searched = SearchedVector::new(slice, needle);
+    binary_search_searched(&searched, needle, mode).map(|i| searched.original_position(i))
+}
+
+/// Same search, but over an already-projected vector and returning an index
+/// into that projection.
+fn binary_search_searched(
+    searched: &SearchedVector<'_>,
+    needle: &LiteralValue,
+    mode: i32,
+) -> Option<usize> {
+    if mode == 0 || searched.is_empty() {
         return None;
     }
     // Only ascending binary search currently (mode 1); descending path kept linear for now.
     if mode == 1 {
         // largest <= needle
         let mut lo = 0usize;
-        let mut hi = slice.len();
+        let mut hi = searched.len();
         while lo < hi {
             let mid = (lo + hi) / 2;
-            match cmp_for_lookup(&slice[mid], needle) {
+            match cmp_for_lookup(searched.get(mid), needle) {
                 Some(c) => {
                     if c > 0 {
                         hi = mid;
@@ -52,8 +72,8 @@ fn binary_search_match(slice: &[LiteralValue], needle: &LiteralValue, mode: i32)
     } else {
         // -1 mode handled via linear fallback since semantics differ (smallest >=)
         let mut best: Option<usize> = None;
-        for (i, v) in slice.iter().enumerate() {
-            if let Some(c) = cmp_for_lookup(v, needle) {
+        for i in 0..searched.len() {
+            if let Some(c) = cmp_for_lookup(searched.get(i), needle) {
                 if c == 0 {
                     return Some(i);
                 }
@@ -267,13 +287,16 @@ impl Function for MatchFn {
                         return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e)));
                     }
 
+                    // Project out the entries an approximate search ignores
+                    // (blanks and entries outside the needle's value class)
+                    // before both the sortedness guard and the search itself.
+                    let searched = SearchedVector::new(&values, &lookup_value);
+
                     // Lightweight unsorted detection for approximate modes
                     let is_sorted = if mt == 1 {
-                        is_sorted_ascending(&values)
+                        searched.is_sorted_ascending()
                     } else if mt == -1 {
-                        values
-                            .windows(2)
-                            .all(|w| cmp_for_lookup(&w[0], &w[1]).is_some_and(|c| c >= 0))
+                        searched.is_sorted_descending()
                     } else {
                         true
                     };
@@ -282,32 +305,31 @@ impl Function for MatchFn {
                             ExcelError::new(ExcelErrorKind::Na),
                         )));
                     }
-                    let idx = if values.len() < 8 {
+                    let idx = if searched.len() < 8 {
                         // linear small
-                        let mut best: Option<(usize, &LiteralValue)> = None;
-                        for (i, v) in values.iter().enumerate() {
-                            if let Some(c) = cmp_for_lookup(v, &lookup_value) {
+                        let mut best: Option<usize> = None;
+                        for i in 0..searched.len() {
+                            if let Some(c) = cmp_for_lookup(searched.get(i), &lookup_value) {
                                 // compare candidate to needle
                                 if mt == 1 {
                                     // v <= needle
-                                    if (c == 0 || c == -1)
-                                        && (best.is_none() || i > best.unwrap().0)
+                                    if (c == 0 || c == -1) && (best.is_none() || i > best.unwrap())
                                     {
-                                        best = Some((i, v));
+                                        best = Some(i);
                                     }
                                 } else {
                                     // -1, v >= needle
-                                    if (c == 0 || c == 1) && (best.is_none() || i > best.unwrap().0)
-                                    {
-                                        best = Some((i, v));
+                                    if (c == 0 || c == 1) && (best.is_none() || i > best.unwrap()) {
+                                        best = Some(i);
                                     }
                                 }
                             }
                         }
-                        best.map(|(i, _)| i)
+                        best
                     } else {
-                        binary_search_match(&values, &lookup_value, mt)
+                        binary_search_searched(&searched, &lookup_value, mt)
                     };
+                    let idx = idx.map(|i| searched.original_position(i));
                     match idx {
                         Some(i) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(
                             (i + 1) as i64,

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -113,6 +113,79 @@ pub fn equals_maybe_wildcard(
     PreparedLookupMatcher::new(pattern, wildcard).matches(candidate)
 }
 
+/// Whether Excel's approximate search visits `value` when looking for `needle`.
+///
+/// The legacy approximate lookups (`MATCH` with `match_type` 1/-1,
+/// `VLOOKUP`/`HLOOKUP` with `range_lookup` TRUE) consider only entries in the
+/// needle's value class. A blank cell, or an entry of another class such as a
+/// text header sitting above a column of numbers, is skipped: it is neither
+/// out-of-order data nor a matchable position.
+pub fn is_searchable_for_approximate(value: &LiteralValue, needle: &LiteralValue) -> bool {
+    !matches!(value, LiteralValue::Empty) && cmp_for_lookup(value, needle).is_some()
+}
+
+/// A lookup vector projected onto the entries an approximate search visits.
+///
+/// Positions are only materialized when something is actually skipped, so the
+/// common case — a vector that is entirely in the needle's class — borrows the
+/// original slice and allocates nothing. Indices returned by a search over this
+/// projection are mapped back with [`SearchedVector::original_position`],
+/// because Excel counts the answer from the top of the *original* range.
+pub struct SearchedVector<'a> {
+    values: &'a [LiteralValue],
+    positions: Option<Vec<usize>>,
+}
+
+impl<'a> SearchedVector<'a> {
+    pub fn new(values: &'a [LiteralValue], needle: &LiteralValue) -> Self {
+        let first_skipped = values
+            .iter()
+            .position(|v| !is_searchable_for_approximate(v, needle));
+        let positions = first_skipped.map(|skip| {
+            let mut positions: Vec<usize> = (0..skip).collect();
+            positions.extend(
+                ((skip + 1)..values.len())
+                    .filter(|&i| is_searchable_for_approximate(&values[i], needle)),
+            );
+            positions
+        });
+        Self { values, positions }
+    }
+
+    pub fn len(&self) -> usize {
+        match &self.positions {
+            Some(positions) => positions.len(),
+            None => self.values.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn get(&self, index: usize) -> &'a LiteralValue {
+        &self.values[self.original_position(index)]
+    }
+
+    /// Map an index in this projection back to its row in the original range.
+    pub fn original_position(&self, index: usize) -> usize {
+        match &self.positions {
+            Some(positions) => positions[index],
+            None => index,
+        }
+    }
+
+    pub fn is_sorted_ascending(&self) -> bool {
+        (1..self.len())
+            .all(|i| cmp_for_lookup(self.get(i - 1), self.get(i)).is_some_and(|c| c <= 0))
+    }
+
+    pub fn is_sorted_descending(&self) -> bool {
+        (1..self.len())
+            .all(|i| cmp_for_lookup(self.get(i - 1), self.get(i)).is_some_and(|c| c >= 0))
+    }
+}
+
 /// Detect ascending sort (strict or equal allowed) for slice according to cmp_for_lookup.
 pub fn is_sorted_ascending(values: &[LiteralValue]) -> bool {
     values

--- a/crates/formualizer-eval/src/engine/tests/approximate_lookup_ignored_entries.rs
+++ b/crates/formualizer-eval/src/engine/tests/approximate_lookup_ignored_entries.rs
@@ -1,0 +1,272 @@
+//! Approximate lookup ignores entries it cannot compare against the needle.
+//!
+//! Oracle: Microsoft Excel 16.105.3 (Microsoft 365 for Mac), synthetic
+//! workbook, values recalculated in-app (`oracle: excel-verified`).
+//!
+//! Excel's legacy approximate match (`MATCH` with `match_type` 1/-1,
+//! `VLOOKUP`/`HLOOKUP` with `range_lookup` TRUE) searches only the entries
+//! belonging to the needle's value class. Blank cells and entries of another
+//! class -- a text header above a numeric column, a stray number inside a
+//! text column -- are skipped. They neither make the vector look unsorted nor
+//! occupy a matchable position, and the returned index is still the position
+//! in the *original* range, not in the compacted one.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+fn eval(engine: &mut Engine<TestWorkbook>, formula: &str) -> Option<LiteralValue> {
+    engine
+        .set_cell_formula("Sheet1", 1, 20, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.get_cell_value("Sheet1", 1, 20)
+}
+
+fn assert_number(value: Option<LiteralValue>, expected: f64, formula: &str) {
+    match value {
+        Some(LiteralValue::Int(i)) => assert_eq!(i as f64, expected, "{formula}"),
+        Some(LiteralValue::Number(n)) => assert!((n - expected).abs() < 1e-9, "{formula} => {n}"),
+        other => panic!("{formula}: expected {expected}, got {other:?}"),
+    }
+}
+
+fn assert_na(value: Option<LiteralValue>, formula: &str) {
+    match value {
+        Some(LiteralValue::Error(e)) => {
+            assert_eq!(e.kind, ExcelErrorKind::Na, "{formula}")
+        }
+        other => panic!("{formula}: expected #N/A, got {other:?}"),
+    }
+}
+
+/// A: 1..5 in rows 1-5, rows 6-10 never written (blank).
+/// C: "Header" in row 1, then 1..5 in rows 2-6.
+/// E: 5..1 descending in rows 1-5, rows 6-10 blank.
+/// G: 1, 2, blank, 4, 5 -- an interior blank.
+/// I: "apple", 1, 2, "zebra" -- both classes interleaved.
+/// K: "alpha", "beta", "gamma" in rows 1-3, rows 4-10 blank.
+/// M: 3, 1, 5, 2, 4 -- genuinely unsorted control.
+fn build_engine() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    fn num(engine: &mut Engine<TestWorkbook>, row: u32, col: u32, v: i64) {
+        engine
+            .set_cell_value("Sheet1", row, col, LiteralValue::Int(v))
+            .unwrap();
+    }
+    for i in 1..=5i64 {
+        num(&mut engine, i as u32, 1, i);
+        num(&mut engine, i as u32, 5, 6 - i);
+    }
+    // Column C: text header then ascending numbers.
+    engine
+        .set_cell_value("Sheet1", 1, 3, LiteralValue::Text("Header".into()))
+        .unwrap();
+    for i in 1..=5i64 {
+        num(&mut engine, (i as u32) + 1, 3, i);
+    }
+    // Column G: interior blank at row 3.
+    num(&mut engine, 1, 7, 1);
+    num(&mut engine, 2, 7, 2);
+    num(&mut engine, 4, 7, 4);
+    num(&mut engine, 5, 7, 5);
+    // Column I: mixed classes.
+    engine
+        .set_cell_value("Sheet1", 1, 9, LiteralValue::Text("apple".into()))
+        .unwrap();
+    num(&mut engine, 2, 9, 1);
+    num(&mut engine, 3, 9, 2);
+    engine
+        .set_cell_value("Sheet1", 4, 9, LiteralValue::Text("zebra".into()))
+        .unwrap();
+    // Column K: ascending text with a blank tail.
+    for (row, word) in [(1u32, "alpha"), (2, "beta"), (3, "gamma")] {
+        engine
+            .set_cell_value("Sheet1", row, 11, LiteralValue::Text(word.into()))
+            .unwrap();
+    }
+    // Column M: unsorted control.
+    for (row, v) in [(1u32, 3i64), (2, 1), (3, 5), (4, 2), (5, 4)] {
+        num(&mut engine, row, 13, v);
+    }
+    // Column B: payload for VLOOKUP against column A.
+    for i in 1..=5i64 {
+        num(&mut engine, i as u32, 2, i * 10);
+    }
+    engine
+}
+
+/// Excel: `=MATCH(3,A1:A10,1)` => 3. An over-wide range whose tail is blank
+/// is still sorted; the blanks are not out-of-order data.
+#[test]
+fn blank_tail_does_not_make_an_ascending_range_unsorted() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(3,A1:A10,1)"),
+        3.0,
+        "MATCH(3,A1:A10,1)",
+    );
+}
+
+/// Excel: `=MATCH(3.5,A1:A10,1)` => 3. A needle between keys still selects
+/// the largest key not greater than it, not a trailing blank.
+#[test]
+fn blank_tail_is_never_the_selected_approximate_position() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(3.5,A1:A10,1)"),
+        3.0,
+        "MATCH(3.5,A1:A10,1)",
+    );
+}
+
+/// Excel: `=MATCH(6,A1:A10,1)` => 5. A needle past the last key selects the
+/// last populated row, not the last row of the range.
+#[test]
+fn needle_past_the_last_key_selects_the_last_populated_row() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(6,A1:A10,1)"),
+        5.0,
+        "MATCH(6,A1:A10,1)",
+    );
+}
+
+/// Excel: `=VLOOKUP(3,A1:B10,2,TRUE)` => 30.
+#[test]
+fn vlookup_approximate_tolerates_a_blank_tail() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=VLOOKUP(3,A1:B10,2,TRUE)"),
+        30.0,
+        "VLOOKUP(3,A1:B10,2,TRUE)",
+    );
+}
+
+/// Excel: `=MATCH(4,G1:G5,1)` => 4 and `=MATCH(3,G1:G5,1)` => 2, where G3 is
+/// blank. Interior blanks are skipped, and the result is the position in the
+/// original range.
+#[test]
+fn interior_blank_is_skipped_and_positions_stay_original() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(4,G1:G5,1)"),
+        4.0,
+        "MATCH(4,G1:G5,1)",
+    );
+    assert_number(
+        eval(&mut engine, "=MATCH(3,G1:G5,1)"),
+        2.0,
+        "MATCH(3,G1:G5,1)",
+    );
+}
+
+/// Excel: `=MATCH(3,C1:C6,1)` => 4, where C1 is the text "Header". The header
+/// is skipped rather than treated as out-of-order data, and the answer is
+/// still counted from the top of the range.
+#[test]
+fn text_header_above_a_numeric_column_is_skipped() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(3,C1:C6,1)"),
+        4.0,
+        "MATCH(3,C1:C6,1)",
+    );
+}
+
+/// Excel: `=MATCH(3.5,C1:C6,1)` => 4.
+#[test]
+fn text_header_is_skipped_for_a_between_keys_needle() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(3.5,C1:C6,1)"),
+        4.0,
+        "MATCH(3.5,C1:C6,1)",
+    );
+}
+
+/// Excel: `=MATCH(2,I1:I4,1)` => 3, where I1 and I4 are text. Numbers are the
+/// needle's class; the surrounding text is skipped in both directions.
+#[test]
+fn numeric_needle_skips_text_entries_on_both_sides() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(2,I1:I4,1)"),
+        3.0,
+        "MATCH(2,I1:I4,1)",
+    );
+}
+
+/// Excel: `=MATCH("m",I1:I4,1)` => 1. The mirror direction: a text needle
+/// searches only the text entries.
+#[test]
+fn text_needle_skips_numeric_entries() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(\"m\",I1:I4,1)"),
+        1.0,
+        "MATCH(\"m\",I1:I4,1)",
+    );
+}
+
+/// Excel: `=MATCH("beta",K1:K10,1)` => 2. Text vectors get the same blank
+/// tolerance as numeric ones.
+#[test]
+fn text_vector_with_a_blank_tail_matches() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(\"beta\",K1:K10,1)"),
+        2.0,
+        "MATCH(\"beta\",K1:K10,1)",
+    );
+}
+
+/// Excel: `=MATCH(3,E1:E10,-1)` => 3 on a descending column with a blank
+/// tail. Descending mode gets the same treatment as ascending.
+#[test]
+fn blank_tail_does_not_make_a_descending_range_unsorted() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(3,E1:E10,-1)"),
+        3.0,
+        "MATCH(3,E1:E10,-1)",
+    );
+}
+
+/// Control: genuinely unsorted data is still `#N/A`. Ignoring blanks must not
+/// weaken the sortedness guard.
+/// Excel: `=MATCH(2,M1:M5,1)` => `#N/A`.
+#[test]
+fn genuinely_unsorted_data_is_still_na() {
+    let mut engine = build_engine();
+    assert_na(eval(&mut engine, "=MATCH(2,M1:M5,1)"), "MATCH(2,M1:M5,1)");
+}
+
+/// Control: a needle below every key is still `#N/A`.
+/// Excel: `=MATCH(0.5,A1:A10,1)` => `#N/A`.
+#[test]
+fn needle_below_every_key_is_still_na() {
+    let mut engine = build_engine();
+    assert_na(
+        eval(&mut engine, "=MATCH(0.5,A1:A10,1)"),
+        "MATCH(0.5,A1:A10,1)",
+    );
+}
+
+/// Control: exact match over the same blank-tailed range is unaffected.
+/// Excel: `=MATCH(3,A1:A10,0)` => 3.
+///
+/// Note: `=MATCH(0,A1:A10,0)` is `#N/A` in Excel but returns 6 here, because
+/// the exact path coerces a blank cell to numeric zero. That is a separate
+/// defect on a separate code path and is filed on its own; this PR neither
+/// fixes nor worsens it.
+#[test]
+fn exact_match_over_a_blank_tail_is_unaffected() {
+    let mut engine = build_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(3,A1:A10,0)"),
+        3.0,
+        "MATCH(3,A1:A10,0)",
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -187,3 +187,5 @@ mod scc_iterate;
 mod scc_runtime_cycles;
 mod scc_runtime_property;
 mod short_circuit_dispatch;
+
+mod approximate_lookup_ignored_entries;


### PR DESCRIPTION
Fixes #317.

## What was wrong

Point an approximate lookup at a range wider than its populated rows — a
whole column, or a range sized for rows that do not exist yet — and it
breaks:

- `MATCH(3, A1:A10, 1)` over `A1:A5 = 1..5` with `A6:A10` blank returns
  `#N/A`. `value_to_f64_lenient` maps `Empty` to `0.0`, so `is_sorted_ascending`
  sees `1,2,3,4,5,0,0,0,0,0`, calls it unsorted, and bails.
- `VLOOKUP(3, A1:B10, 2, TRUE)` over the same data returns `0`. There is no
  sortedness guard on that path (deliberately — see #283), so the binary
  search runs over the misordered vector, lands on a blank row, and egress
  publishes the blank as numeric `0`. A wrong number, silently.

The same coercion breaks the type-mismatch case. A text header above a
numeric column, or a stray number inside a text column, is compared rather
than skipped, and `MATCH` calls the range unsorted.

## Excel behaviour

Excel's legacy approximate lookups (`MATCH` with `match_type` 1 or -1,
`VLOOKUP`/`HLOOKUP` with `range_lookup` TRUE) search only the entries in the
needle's value class. Blanks are skipped. Entries of another class are
skipped. Neither counts as out-of-order data, and neither is a matchable
position. Crucially, the returned index is still a position in the
**original** range, not in the compacted one.

Measured on Microsoft Excel 16.105.3 (Microsoft 365 for Mac), synthetic
workbook. `A1:A5` = 1..5 with `A6:A10` blank; `B1:B5` = 10..50; `C1` =
`"Header"` with `C2:C6` = 1..5; `E1:E5` = 5..1 descending with `E6:E10`
blank; `G` = `1, 2, blank, 4, 5`; `I` = `"apple", 1, 2, "zebra"`; `K1:K3` =
`"alpha","beta","gamma"` with a blank tail; `M` = `3,1,5,2,4`:

| Formula | Excel | main @ `fe7b9111` |
| --- | --- | --- |
| `=MATCH(3,A1:A10,1)` | 3 | `#N/A` |
| `=MATCH(3.5,A1:A10,1)` | 3 | `#N/A` |
| `=MATCH(6,A1:A10,1)` | 5 | `#N/A` |
| `=VLOOKUP(3,A1:B10,2,TRUE)` | 30 | `0` |
| `=MATCH(4,G1:G5,1)` | 4 | `#N/A` |
| `=MATCH(3,G1:G5,1)` | 2 | `#N/A` |
| `=MATCH(3,C1:C6,1)` | 4 | `#N/A` |
| `=MATCH(3.5,C1:C6,1)` | 4 | `#N/A` |
| `=MATCH(2,I1:I4,1)` | 3 | `#N/A` |
| `=MATCH("m",I1:I4,1)` | 1 | `#N/A` |
| `=MATCH("beta",K1:K10,1)` | 2 | `#N/A` |
| `=MATCH(2,M1:M5,1)` (control) | `#N/A` | `#N/A` |
| `=MATCH(0.5,A1:A10,1)` (control) | `#N/A` | `#N/A` |

Two rows are worth dwelling on. `=MATCH(3,C1:C6,1)` is **4**, not 3: the
skipped header does not shift the answer, which is the direct evidence that
Excel maps back to the original position. And `=MATCH("m",I1:I4,1)` is 1,
the mirror direction — a text needle skips the numbers.

The unsorted control matters too. Excel does not silently guess on genuinely
unsorted data here; it returns `#N/A`, which is what `MATCH` already does and
what this PR keeps doing.

## The fix

`SearchedVector` (in `lookup_utils.rs`) projects a lookup vector onto the
entries an approximate search visits, and maps an index in that projection
back to its row in the original range.

The projection is lazy about allocating: it scans for the first entry that
would be skipped and, if there is none, borrows the slice and stores no
positions at all. The common case — a vector entirely in the needle's class —
costs one pass and zero allocation, which matters because these paths already
materialize the vector and are on the hot lookup route.

`binary_search_match` builds a `SearchedVector` internally and returns an
original-range index, so all six approximate call sites are covered at once:
`MATCH`, and both the reference and the array-literal paths of `VLOOKUP` and
`HLOOKUP`. `MatchFn` additionally runs its sortedness guard over the same
projection, so the guard and the search can no longer disagree about what is
being searched, and its small-vector linear scan iterates the projection too.

What does **not** change:

- No sortedness guard is added to `VLOOKUP`/`HLOOKUP`. #283 is a separate
  question and stays open; the module doc's account of the deliberate
  difference between `MATCH` and `VLOOKUP` is still accurate.
- Exact match is untouched. `find_exact_index` and friends see the same
  values they always did.
- The tie-breaking and direction logic inside the search is unchanged. Only
  *which entries* it visits changed.

## Scope

Not a regression; the coercion is long-standing. The blast radius is wide
because the trigger is an ordinary spreadsheet habit: sizing a lookup range
past the current data, or keeping a header row inside the range. Every such
formula either errors or, on the `VLOOKUP` path, quietly returns zero.

## Verification

Fourteen regression tests in
`crates/formualizer-eval/src/engine/tests/approximate_lookup_ignored_entries.rs`,
each pinned to a measured Excel result. Revert the production change and
**ten of the fourteen fail**. The four survivors are controls:

- genuinely unsorted data is still `#N/A` (the fix must not weaken the guard),
- a needle below every key is still `#N/A`,
- exact match over the same blank-tailed range is unchanged,
- the descending blank-tail case, which `main` already answers correctly —
  but only because the needle hits a key exactly and the linear scan returns
  early, so it is a control rather than evidence.

Gates, run locally on the CI-pinned toolchain (macOS 15, aarch64):

```
cargo +1.93.0 fmt --all -- --check                                  exit 0
cargo +1.93.0 clippy --workspace --exclude formualizer-bench-core \
  --exclude formualizer-python --exclude formualizer-wasm \
  --all-targets --all-features -- -D warnings                       exit 0
cargo +1.93.0 test --workspace --exclude formualizer-bench-core \
  --exclude formualizer-python --exclude formualizer-wasm \
  --all-features --no-fail-fast            3476 passed, 1 failed
```

The single failure is pre-existing and unrelated: the JSON formula suite's
`IMEXP`/`IMSIN`/`IMCOS` cases differ in the last ULP on macOS arm64.
Unmodified `main` gives 3462 passed, 1 failed on the same host.

Not run here: the Linux-only `public-api` snapshot job. `SearchedVector` and
`is_searchable_for_approximate` are added to
`builtins::lookup::lookup_utils`, which does not appear in
`public-api/formualizer-eval.txt`; no exported item changes.

## Deliberately not in this PR

- **`MATCH` with `match_type = -1` on 8+ descending entries** (#320):
  `binary_search_match`'s `-1` branch selects the *first* entry `>=` the
  needle where descending data wants the *last*, so
  `=MATCH(3.5,A1:A10,-1)` over `10..1` returns 1 where Excel returns 7. The
  `< 8` linear path gets it right, and an exact hit masks it. Verified
  present on unmodified `main`; this PR changes which entries that branch
  visits, not how it chooses among them, so the defect is orthogonal and
  gets its own fix.
- **Exact `MATCH` coercing blanks to zero** (#319): `=MATCH(0,A1:A10,0)`
  returns 6 where Excel returns `#N/A`. Different code path; and
  `Empty -> 0.0` is load-bearing elsewhere (#279, #285), so narrowing it
  deserves its own decision.
- **A sortedness guard for `VLOOKUP`/`HLOOKUP`** (#283). Unchanged here.
- **`XLOOKUP`/`XMATCH`.** `approximate_select_ascending` and
  `guard_sorted_ascending` still see blanks as zero. Those functions have
  their own match-mode semantics and deserve their own oracle pass rather
  than being swept in.

Drafted by Claude (agent), verified by execution against a real Excel
oracle, reviewed by a human before submission.