### PR TITLE
fix(python): TODAY()/NOW() read the host clock instead of the 1970 epoch (#318)

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -37,7 +37,11 @@ chrono = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-formualizer = { path = "../../crates/formualizer", default-features = false, features = ["eval", "workbook", "sheetport", "parse", "calamine", "umya"] }
+# `system-clock` is required for TODAY()/NOW() to read the wall clock. Without
+# it the engine falls back to the FixedClock at the UTC epoch and every
+# volatile date/time builtin answers 1970-01-01. The emscripten target below is
+# left as-is: ambient wall-clock time is not part of the portable wasm profile.
+formualizer = { path = "../../crates/formualizer", default-features = false, features = ["eval", "workbook", "sheetport", "parse", "calamine", "umya", "system-clock"] }
 pyo3-stub-gen = "0.23.0"
 
 # Pyodide 0.29's wasm-EH sysroot is pinned to Rust 1.86, while Calamine 0.36

--- a/bindings/python/tests/test_volatile_clock.py
+++ b/bindings/python/tests/test_volatile_clock.py
@@ -1,0 +1,49 @@
+"""TODAY()/NOW() must read the host wall clock, not the epoch fallback.
+
+The engine falls back to a `FixedClock` at the UTC epoch when the
+`system-clock` cargo feature is off. A binding built that way answers
+1970-01-01 for every volatile date/time builtin, which is silently wrong
+rather than an error, so it needs a test rather than a build-time check.
+"""
+
+import datetime
+
+import formualizer as fz
+
+# Excel's 1900 date system counts from this day, with the 1900 leap-year
+# artifact already absorbed for every date after 1900-03-01.
+_EXCEL_EPOCH = datetime.date(1899, 12, 30)
+
+# The serial the epoch FixedClock produces: 1970-01-01.
+_UNIX_EPOCH_SERIAL = 25569.0
+
+
+def _serial(day: datetime.date) -> float:
+    return float((day - _EXCEL_EPOCH).days)
+
+
+def _evaluate(formula: str) -> float:
+    workbook = fz.Workbook(mode=fz.WorkbookMode.Ephemeral)
+    workbook.add_sheet("Sheet1")
+    workbook.set_formula("Sheet1", 1, 1, formula)
+    value = workbook.evaluate_cell("Sheet1", 1, 1)
+    assert isinstance(value, float), f"{formula} returned {value!r}"
+    return value
+
+
+def test_today_is_the_host_date_not_the_epoch() -> None:
+    today = _evaluate("=TODAY()")
+    assert today != _UNIX_EPOCH_SERIAL
+    # One day of slack absorbs a midnight rollover between the two reads and
+    # any offset between the engine's local zone and the interpreter's.
+    assert abs(today - _serial(datetime.date.today())) <= 1.0
+
+
+def test_now_is_the_host_instant_not_the_epoch() -> None:
+    now = _evaluate("=NOW()")
+    assert now != _UNIX_EPOCH_SERIAL
+    assert abs(now - _serial(datetime.date.today())) <= 1.0
+
+
+def test_year_of_today_is_the_host_year() -> None:
+    assert _evaluate("=YEAR(TODAY())") == float(datetime.date.today().year)


### PR DESCRIPTION
Fixes #318.

## What was wrong

`bindings/python/Cargo.toml` pulls in `formualizer` with
`default-features = false` and an explicit feature list:

```toml
features = ["eval", "workbook", "sheetport", "parse", "calamine", "umya"]
```

`system-clock` is not in it. `crates/formualizer/Cargo.toml` puts it in
`default`, and `FunctionContext::clock` documents the consequence of turning
it off: the default clock becomes a `FixedClock` pinned to the UTC epoch. So
the Python binding — and therefore every published wheel — evaluates
`TODAY()` and `NOW()` as 1970-01-01.

This is a one-word omission with a whole-product blast radius, and it fails
silently. There is no error, no warning, and no type difference; the formula
just returns a wrong number. Any `=IF(TODAY()>...)`, ageing bucket, days-late
calculation or accrual-to-date in a user's workbook evaluates against 1970
and produces a plausible-looking answer.

## Measured

Two wheels, same host (macOS 15 aarch64, abi3, CPython 3.12.13), same day
(2026-08-11), differing only in this feature:

```
                    without system-clock      with system-clock
TODAY()             25569.0                   46245.0
YEAR(TODAY())       1970.0                    2026.0
NOW()               25569.0                   46245.18751157408
host date                       2026-08-11
```

25569 is 1899-12-30 + 25569 days = 1970-01-01. 46245 is 2026-08-11. Note that
without the feature `NOW()` carries no time fraction at all — it is exactly
the epoch, not merely a stale date.

## The fix

Add `system-clock` to the non-emscripten dependency's feature list, with a
comment recording why it has to be there.

The emscripten target is left alone. Ambient wall-clock time is not part of
the portable wasm profile, and changing the Pyodide build's runtime
assumptions is a separate decision from fixing the native wheels.

Determinism is not lost. A caller who wants a fixed clock passes
`deterministic_timestamp_utc` to `SheetPortSession.evaluate_once`, which
`tests/test_sheetport_session.py::test_deterministic_now_today_via_sheetport_session`
already exercises and which this change does not touch. This only moves the
*default*, and only to match what the Rust crate's own default feature set
has always given.

## Verification

Three tests in `bindings/python/tests/test_volatile_clock.py`. They compare
against the interpreter's own clock with a day of slack — enough to absorb a
midnight rollover between the two reads and any offset between the engine's
local zone and the interpreter's — and additionally assert outright that the
value is not the epoch serial, so the test cannot pass by coincidence.

All three fail against a binding built without the feature (verified: the
tests were run first against a `main`-built extension and reported
`assert 25569.0 != 25569.0`).

Local gates, `bindings/python`, CPython 3.12.13:

```
maturin develop                                            ok
python -m pytest tests/ -q --no-cov         89 passed, 1 warning
ruff check .                                All checks passed!
ruff format --check .                       31 files already formatted
```

Not run here: `cargo run --bin stub_gen` plus the `git diff --exit-code`
stub check, `mypy`, and `mypy.stubtest`. This change adds no Python-visible
API — a cargo feature flag and a test file — so the generated stubs cannot
move.

## Deliberately not in this PR

- **The emscripten/Pyodide feature list.** Left as-is on purpose; whether
  Pyodide builds should carry `js-runtime` (which brings `web-time` and a
  JS-backed clock) is a separate decision with its own runtime implications.
- **A build-time guard** that would make an omitted clock feature loud rather
  than silent — for example failing the wheel build, or having the binding
  refuse to register `TODAY`/`NOW` under a fallback clock. Worth discussing;
  it is a design change, not a fix.
- **Exposing clock injection on `Workbook`.** Today the only Python-visible
  way to pin time is `SheetPortSession.evaluate_once(deterministic_timestamp_utc=...)`;
  `bindings/python/src/workbook.rs` has no clock surface at all, so an
  embedder on the plain `Workbook` / `load_workbook` path cannot inject one.
  Separate feature request.

Drafted by Claude (agent), verified by building both wheels and running
them, reviewed by a human before submission.