### PR TITLE
fix(eval): temporal lookups honor the workbook date system, approximate lookups propagate errors, descending MATCH selects correctly (#316, #320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Fixed
 
+- Temporal values compare as workbook-date-system serials across exact and approximate lookup paths, including warm lookup indexes. (#316)
 - Approximate `MATCH`, `VLOOKUP`, and `HLOOKUP` skip blank and incomparable entries without losing original-range positions, while propagating lookup-range errors. (#317)
 - Descending approximate `MATCH` returns the last qualifying entry for ranges with eight or more searchable values, including ranges with interior blanks. (#320)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Approximate `MATCH`, `VLOOKUP`, and `HLOOKUP` skip blank and incomparable entries without losing original-range positions, while propagating lookup-range errors. (#317)
+- Descending approximate `MATCH` returns the last qualifying entry for ranges with eight or more searchable values, including ranges with interior blanks. (#320)
+
 ## [0.8.1] - 2026-08-11
 
 ### Fixed

--- a/crates/formualizer-eval/src/builtins/lookup/core.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/core.rs
@@ -17,7 +17,7 @@
 
 use super::lookup_utils::{SearchedVector, cmp_for_lookup, find_exact_index};
 use crate::args::{ArgSchema, CoercionPolicy, ShapeKind};
-use crate::engine::lookup_index_cache::LookupAxis;
+use crate::engine::{DateSystem, lookup_index_cache::LookupAxis};
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::ArgKind;
@@ -35,12 +35,14 @@ fn binary_search_match(
     slice: &[LiteralValue],
     needle: &LiteralValue,
     mode: i32,
+    date_system: DateSystem,
 ) -> Result<Option<usize>, ExcelError> {
     if mode == 0 || slice.is_empty() {
         return Ok(None);
     }
-    let searched = SearchedVector::new(slice, needle)?;
-    Ok(binary_search_searched(&searched, needle, mode).map(|i| searched.original_position(i)))
+    let searched = SearchedVector::new(slice, needle, date_system)?;
+    Ok(binary_search_searched(&searched, needle, mode, date_system)
+        .map(|i| searched.original_position(i)))
 }
 
 /// Same search, but over an already-projected vector and returning an index
@@ -49,6 +51,7 @@ fn binary_search_searched(
     searched: &SearchedVector<'_>,
     needle: &LiteralValue,
     mode: i32,
+    date_system: DateSystem,
 ) -> Option<usize> {
     if mode == 0 || searched.is_empty() {
         return None;
@@ -60,7 +63,7 @@ fn binary_search_searched(
         let mut hi = searched.len();
         while lo < hi {
             let mid = (lo + hi) / 2;
-            match cmp_for_lookup(searched.get(mid), needle) {
+            match cmp_for_lookup(searched.get(mid), needle, date_system) {
                 Some(c) => {
                     if c > 0 {
                         hi = mid;
@@ -78,7 +81,7 @@ fn binary_search_searched(
         // -1 mode handled via linear fallback since semantics differ (smallest >=)
         let mut best: Option<usize> = None;
         for i in 0..searched.len() {
-            if let Some(c) = cmp_for_lookup(searched.get(i), needle) {
+            if let Some(c) = cmp_for_lookup(searched.get(i), needle, date_system) {
                 if c == 0 {
                     return Some(i);
                 }
@@ -273,6 +276,7 @@ impl Function for MatchFn {
                             &rv,
                             &lookup_value,
                             wildcard_mode,
+                            ctx.date_system(),
                         )? {
                             return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(
                                 (idx + 1) as i64,
@@ -295,14 +299,15 @@ impl Function for MatchFn {
                     // Project out the entries an approximate search ignores
                     // (blanks and entries outside the needle's value class)
                     // before both the sortedness guard and the search itself.
-                    let searched = match SearchedVector::new(&values, &lookup_value) {
-                        Ok(searched) => searched,
-                        Err(error) => {
-                            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
-                                error,
-                            )));
-                        }
-                    };
+                    let searched =
+                        match SearchedVector::new(&values, &lookup_value, ctx.date_system()) {
+                            Ok(searched) => searched,
+                            Err(error) => {
+                                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                                    error,
+                                )));
+                            }
+                        };
 
                     // Lightweight unsorted detection for approximate modes
                     let is_sorted = if mt == 1 {
@@ -321,7 +326,9 @@ impl Function for MatchFn {
                         // linear small
                         let mut best: Option<usize> = None;
                         for i in 0..searched.len() {
-                            if let Some(c) = cmp_for_lookup(searched.get(i), &lookup_value) {
+                            if let Some(c) =
+                                cmp_for_lookup(searched.get(i), &lookup_value, ctx.date_system())
+                            {
                                 // compare candidate to needle
                                 if mt == 1 {
                                     // v <= needle
@@ -339,7 +346,7 @@ impl Function for MatchFn {
                         }
                         best
                     } else {
-                        binary_search_searched(&searched, &lookup_value, mt)
+                        binary_search_searched(&searched, &lookup_value, mt, ctx.date_system())
                     };
                     let idx = idx.map(|i| searched.original_position(i));
                     match idx {
@@ -376,9 +383,9 @@ impl Function for MatchFn {
             };
             let idx = if mt == 0 {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
-                find_exact_index(&values, &lookup_value, wildcard_mode)
+                find_exact_index(&values, &lookup_value, wildcard_mode, ctx.date_system())
             } else {
-                binary_search_match(&values, &lookup_value, mt)?
+                binary_search_match(&values, &lookup_value, mt, ctx.date_system())?
             };
             match idx {
                 Some(i) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(
@@ -579,6 +586,7 @@ impl Function for VLookupFn {
                         &first_col_view,
                         &lookup_value,
                         wildcard_mode,
+                        ctx.date_system(),
                     )?
                 }
             } else {
@@ -591,7 +599,7 @@ impl Function for VLookupFn {
                 if first_col.is_empty() {
                     None
                 } else {
-                    binary_search_match(&first_col, &lookup_value, 1)?
+                    binary_search_match(&first_col, &lookup_value, 1, ctx.date_system())?
                 }
             };
 
@@ -636,9 +644,9 @@ impl Function for VLookupFn {
                 table.iter().filter_map(|r| r.first().cloned()).collect();
             let row_idx_opt = if !approximate {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
-                find_exact_index(&first_col, &lookup_value, wildcard_mode)
+                find_exact_index(&first_col, &lookup_value, wildcard_mode, ctx.date_system())
             } else {
-                binary_search_match(&first_col, &lookup_value, 1)?
+                binary_search_match(&first_col, &lookup_value, 1, ctx.date_system())?
             };
 
             match row_idx_opt {
@@ -833,7 +841,7 @@ impl Function for HLookupFn {
                     }
                     Ok(())
                 })?;
-                binary_search_match(&first_row, &lookup_value, 1)?
+                binary_search_match(&first_row, &lookup_value, 1, ctx.date_system())?
             } else {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
                 if !wildcard_mode
@@ -845,6 +853,7 @@ impl Function for HLookupFn {
                         &first_row_view,
                         &lookup_value,
                         wildcard_mode,
+                        ctx.date_system(),
                     )?
                 }
             };
@@ -885,10 +894,10 @@ impl Function for HLookupFn {
             // First row values for lookup
             let first_row: Vec<LiteralValue> = table.first().cloned().unwrap_or_default();
             let col_idx_opt = if approximate {
-                binary_search_match(&first_row, &lookup_value, 1)?
+                binary_search_match(&first_row, &lookup_value, 1, ctx.date_system())?
             } else {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
-                find_exact_index(&first_row, &lookup_value, wildcard_mode)
+                find_exact_index(&first_row, &lookup_value, wildcard_mode, ctx.date_system())
             };
 
             match col_idx_opt {

--- a/crates/formualizer-eval/src/builtins/lookup/core.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/core.rs
@@ -9,9 +9,9 @@
 //!   incorrectly. Excel documents approximate results on unsorted data as "may not be correct"
 //!   rather than an error, so the unguarded path matches Excel; LibreOffice instead returns #N/A.
 //!   See issue #283 before changing either behavior.
-//! - Binary search used for approximate modes for efficiency; linear scan for exact or when data small (<8 elements) to avoid overhead.
+//! - Binary search used for approximate modes for efficiency; linear scan for exact or when data has fewer than 8 searchable elements to avoid overhead.
 //! - VLOOKUP/HLOOKUP wrap MATCH logic; VLOOKUP: vertical first column; HLOOKUP: horizontal first row.
-//! - Error propagation: if lookup_value is error -> propagate. If table/range contains errors in non-deciding positions, they don't matter unless selected.
+//! - Error propagation: if the lookup value or any entry in an approximate lookup vector is an error, that error propagates.
 //! - Type coercion: current simple: numbers vs numeric text coerced; text comparison case-insensitive? Excel is case-insensitive for MATCH (without wildcards). We implement case-insensitive for now.
 //!   TODO(excel-nuance): refine boolean/text/number coercion differences.
 
@@ -29,13 +29,18 @@ use formualizer_macros::func_caps;
 ///
 /// Entries the search must ignore — blanks, and entries outside the needle's
 /// value class — are projected out first, so they neither occupy a matchable
-/// position nor disturb the binary search's ordering assumption.
-fn binary_search_match(slice: &[LiteralValue], needle: &LiteralValue, mode: i32) -> Option<usize> {
+/// position nor disturb the binary search's ordering assumption. Errors are
+/// not ignored: any error in the lookup vector is returned before searching.
+fn binary_search_match(
+    slice: &[LiteralValue],
+    needle: &LiteralValue,
+    mode: i32,
+) -> Result<Option<usize>, ExcelError> {
     if mode == 0 || slice.is_empty() {
-        return None;
+        return Ok(None);
     }
-    let searched = SearchedVector::new(slice, needle);
-    binary_search_searched(&searched, needle, mode).map(|i| searched.original_position(i))
+    let searched = SearchedVector::new(slice, needle)?;
+    Ok(binary_search_searched(&searched, needle, mode).map(|i| searched.original_position(i)))
 }
 
 /// Same search, but over an already-projected vector and returning an index
@@ -63,9 +68,9 @@ fn binary_search_searched(
                         lo = mid + 1;
                     }
                 }
-                None => {
-                    hi = mid;
-                }
+                None => unreachable!(
+                    "SearchedVector contains only entries comparable with the lookup value"
+                ),
             }
         }
         if lo == 0 { None } else { Some(lo - 1) }
@@ -77,7 +82,7 @@ fn binary_search_searched(
                 if c == 0 {
                     return Some(i);
                 }
-                if c >= 0 && best.is_none_or(|b| i < b) {
+                if c >= 0 && best.is_none_or(|b| i > b) {
                     best = Some(i);
                 }
             }
@@ -290,7 +295,14 @@ impl Function for MatchFn {
                     // Project out the entries an approximate search ignores
                     // (blanks and entries outside the needle's value class)
                     // before both the sortedness guard and the search itself.
-                    let searched = SearchedVector::new(&values, &lookup_value);
+                    let searched = match SearchedVector::new(&values, &lookup_value) {
+                        Ok(searched) => searched,
+                        Err(error) => {
+                            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                                error,
+                            )));
+                        }
+                    };
 
                     // Lightweight unsorted detection for approximate modes
                     let is_sorted = if mt == 1 {
@@ -366,7 +378,7 @@ impl Function for MatchFn {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
                 find_exact_index(&values, &lookup_value, wildcard_mode)
             } else {
-                binary_search_match(&values, &lookup_value, mt)
+                binary_search_match(&values, &lookup_value, mt)?
             };
             match idx {
                 Some(i) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Int(
@@ -579,7 +591,7 @@ impl Function for VLookupFn {
                 if first_col.is_empty() {
                     None
                 } else {
-                    binary_search_match(&first_col, &lookup_value, 1)
+                    binary_search_match(&first_col, &lookup_value, 1)?
                 }
             };
 
@@ -626,7 +638,7 @@ impl Function for VLookupFn {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
                 find_exact_index(&first_col, &lookup_value, wildcard_mode)
             } else {
-                binary_search_match(&first_col, &lookup_value, 1)
+                binary_search_match(&first_col, &lookup_value, 1)?
             };
 
             match row_idx_opt {
@@ -821,7 +833,7 @@ impl Function for HLookupFn {
                     }
                     Ok(())
                 })?;
-                binary_search_match(&first_row, &lookup_value, 1)
+                binary_search_match(&first_row, &lookup_value, 1)?
             } else {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
                 if !wildcard_mode
@@ -873,7 +885,7 @@ impl Function for HLookupFn {
             // First row values for lookup
             let first_row: Vec<LiteralValue> = table.first().cloned().unwrap_or_default();
             let col_idx_opt = if approximate {
-                binary_search_match(&first_row, &lookup_value, 1)
+                binary_search_match(&first_row, &lookup_value, 1)?
             } else {
                 let wildcard_mode = matches!(lookup_value, LiteralValue::Text(ref s) if s.contains('*') || s.contains('?') || s.contains('~'));
                 find_exact_index(&first_row, &lookup_value, wildcard_mode)

--- a/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
@@ -313,7 +313,7 @@ impl Function for XLookupFn {
 
         let mut found: Option<usize> = None;
         let needle = lookup_value;
-        let prepared_matcher = PreparedLookupMatcher::new(&needle, wildcard);
+        let prepared_matcher = PreparedLookupMatcher::new(&needle, wildcard, _ctx.date_system());
         if match_mode == 0 || wildcard {
             if match_mode == 0 && search_mode == 1 && lookup_rows > 0 && lookup_cols > 0 {
                 let axis = if vertical {
@@ -328,11 +328,16 @@ impl Function for XLookupFn {
                         &lookup_view,
                         &needle,
                         false,
+                        _ctx.date_system(),
                     )?;
                 }
             } else if search_mode == 1 && lookup_rows > 0 && lookup_cols > 0 {
-                found =
-                    super::lookup_utils::find_exact_index_in_view(&lookup_view, &needle, wildcard)?;
+                found = super::lookup_utils::find_exact_index_in_view(
+                    &lookup_view,
+                    &needle,
+                    wildcard,
+                    _ctx.date_system(),
+                )?;
             } else if search_mode == -1 {
                 for i in (0..lookup_len).rev() {
                     let cand = if vertical {
@@ -361,7 +366,7 @@ impl Function for XLookupFn {
                 }
             }
         } else if match_mode == -1 || match_mode == 1 {
-            let needle_num = value_to_f64_lenient(&needle);
+            let needle_num = value_to_f64_lenient(&needle, _ctx.date_system());
             let mut best_idx: Option<usize> = None;
             let mut best_val: f64 = if match_mode == -1 {
                 f64::NEG_INFINITY
@@ -378,7 +383,8 @@ impl Function for XLookupFn {
                 };
 
                 if let Some(p) = prev.as_ref() {
-                    let sorted_ok = cmp_for_lookup(p, &cand).is_some_and(|o| o <= 0);
+                    let sorted_ok =
+                        cmp_for_lookup(p, &cand, _ctx.date_system()).is_some_and(|o| o <= 0);
                     if !sorted_ok {
                         return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
                             ExcelError::new(ExcelErrorKind::Na),
@@ -387,12 +393,14 @@ impl Function for XLookupFn {
                 }
                 prev = Some(cand.clone());
 
-                if cmp_for_lookup(&cand, &needle).is_some_and(|o| o == 0) {
+                if cmp_for_lookup(&cand, &needle, _ctx.date_system()).is_some_and(|o| o == 0) {
                     found = Some(i);
                     break;
                 }
 
-                if let (Some(nn), Some(vv)) = (needle_num, value_to_f64_lenient(&cand)) {
+                if let (Some(nn), Some(vv)) =
+                    (needle_num, value_to_f64_lenient(&cand, _ctx.date_system()))
+                {
                     if match_mode == -1 {
                         if vv <= nn && vv > best_val {
                             best_val = vv;
@@ -653,7 +661,7 @@ impl Function for XMatchFn {
 
         let wildcard = match_mode == 2;
         let needle = lookup_value;
-        let prepared_matcher = PreparedLookupMatcher::new(&needle, wildcard);
+        let prepared_matcher = PreparedLookupMatcher::new(&needle, wildcard, _ctx.date_system());
 
         let mut found: Option<usize> = None;
 
@@ -666,6 +674,7 @@ impl Function for XMatchFn {
                         &lookup_view,
                         &needle,
                         wildcard,
+                        _ctx.date_system(),
                     )?;
                 }
             } else if search_mode == -1 || search_mode == -2 {
@@ -697,7 +706,7 @@ impl Function for XMatchFn {
             }
         } else if match_mode == -1 || match_mode == 1 {
             // Approximate match: -1 = exact or next smaller, 1 = exact or next larger
-            let needle_num = value_to_f64_lenient(&needle);
+            let needle_num = value_to_f64_lenient(&needle, _ctx.date_system());
             let mut best_idx: Option<usize> = None;
             let mut best_val: f64 = if match_mode == -1 {
                 f64::NEG_INFINITY
@@ -726,9 +735,9 @@ impl Function for XMatchFn {
                     };
                     if let Some(p) = prev.as_ref() {
                         let sorted_ok = if ascending {
-                            cmp_for_lookup(p, &cand).is_some_and(|o| o <= 0)
+                            cmp_for_lookup(p, &cand, _ctx.date_system()).is_some_and(|o| o <= 0)
                         } else {
-                            cmp_for_lookup(p, &cand).is_some_and(|o| o >= 0)
+                            cmp_for_lookup(p, &cand, _ctx.date_system()).is_some_and(|o| o >= 0)
                         };
                         if !sorted_ok {
                             return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
@@ -747,12 +756,14 @@ impl Function for XMatchFn {
                     lookup_view.get_cell(0, i)
                 };
 
-                if cmp_for_lookup(&cand, &needle).is_some_and(|o| o == 0) {
+                if cmp_for_lookup(&cand, &needle, _ctx.date_system()).is_some_and(|o| o == 0) {
                     found = Some(i);
                     break;
                 }
 
-                if let (Some(nn), Some(vv)) = (needle_num, value_to_f64_lenient(&cand)) {
+                if let (Some(nn), Some(vv)) =
+                    (needle_num, value_to_f64_lenient(&cand, _ctx.date_system()))
+                {
                     if match_mode == -1 {
                         // exact or next smaller
                         if vv <= nn && vv > best_val {
@@ -982,7 +993,7 @@ impl Function for SortFn {
             columns.sort_by(|a, b| {
                 let val_a = &a.1[sort_row_idx];
                 let val_b = &b.1[sort_row_idx];
-                let cmp = cmp_for_lookup(val_a, val_b).unwrap_or(0);
+                let cmp = cmp_for_lookup(val_a, val_b, _ctx.date_system()).unwrap_or(0);
                 if ascending { cmp.cmp(&0) } else { 0.cmp(&cmp) }
             });
 
@@ -1018,7 +1029,7 @@ impl Function for SortFn {
             row_data.sort_by(|a, b| {
                 let val_a = &a[sort_col_idx];
                 let val_b = &b[sort_col_idx];
-                let cmp = cmp_for_lookup(val_a, val_b).unwrap_or(0);
+                let cmp = cmp_for_lookup(val_a, val_b, _ctx.date_system()).unwrap_or(0);
                 if ascending { cmp.cmp(&0) } else { 0.cmp(&cmp) }
             });
 
@@ -1250,7 +1261,7 @@ impl Function for SortByFn {
             for (by_values, ascending) in &sort_criteria {
                 let val_a = &by_values[a.0];
                 let val_b = &by_values[b.0];
-                let cmp = cmp_for_lookup(val_a, val_b).unwrap_or(0);
+                let cmp = cmp_for_lookup(val_a, val_b, _ctx.date_system()).unwrap_or(0);
                 if cmp != 0 {
                     return if *ascending { cmp.cmp(&0) } else { 0.cmp(&cmp) };
                 }

--- a/crates/formualizer-eval/src/builtins/lookup/legacy.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/legacy.rs
@@ -16,6 +16,7 @@
 
 use super::lookup_utils::cmp_for_lookup;
 use crate::args::{ArgSchema, CoercionPolicy, ShapeKind};
+use crate::engine::DateSystem;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
 use formualizer_common::{ArgKind, ExcelError, ExcelErrorKind, LiteralValue};
@@ -24,7 +25,11 @@ use formualizer_macros::func_caps;
 /// Binary-search style approximate match (largest value <= needle) for
 /// ascending-sorted data.  Mirrors the helper in `core.rs` but is kept local
 /// to avoid coupling the legacy path to core internals.
-fn approx_match_ascending(slice: &[LiteralValue], needle: &LiteralValue) -> Option<usize> {
+fn approx_match_ascending(
+    slice: &[LiteralValue],
+    needle: &LiteralValue,
+    date_system: DateSystem,
+) -> Option<usize> {
     if slice.is_empty() {
         return None;
     }
@@ -32,7 +37,7 @@ fn approx_match_ascending(slice: &[LiteralValue], needle: &LiteralValue) -> Opti
     let mut hi: usize = slice.len();
     while lo < hi {
         let mid = (lo + hi) / 2;
-        match cmp_for_lookup(&slice[mid], needle) {
+        match cmp_for_lookup(&slice[mid], needle, date_system) {
             Some(c) if c > 0 => hi = mid,
             Some(_) => lo = mid + 1,
             None => hi = mid,
@@ -211,7 +216,7 @@ impl Function for LookupFn {
         };
 
         // Approximate match – largest <= needle
-        let match_idx = approx_match_ascending(&search_vec, &lookup_value);
+        let match_idx = approx_match_ascending(&search_vec, &lookup_value, ctx.date_system());
         let match_idx = match match_idx {
             Some(i) => i,
             None => {
@@ -340,7 +345,10 @@ mod tests {
 
     #[test]
     fn approx_empty_slice() {
-        assert_eq!(approx_match_ascending(&[], &LiteralValue::Int(1)), None);
+        assert_eq!(
+            approx_match_ascending(&[], &LiteralValue::Int(1), DateSystem::Excel1900),
+            None
+        );
     }
 
     #[test]
@@ -350,7 +358,10 @@ mod tests {
             LiteralValue::Int(20),
             LiteralValue::Int(30),
         ];
-        assert_eq!(approx_match_ascending(&vals, &LiteralValue::Int(5)), None);
+        assert_eq!(
+            approx_match_ascending(&vals, &LiteralValue::Int(5), DateSystem::Excel1900),
+            None
+        );
     }
 
     #[test]
@@ -361,7 +372,7 @@ mod tests {
             LiteralValue::Int(30),
         ];
         assert_eq!(
-            approx_match_ascending(&vals, &LiteralValue::Int(20)),
+            approx_match_ascending(&vals, &LiteralValue::Int(20), DateSystem::Excel1900),
             Some(1)
         );
     }
@@ -374,7 +385,7 @@ mod tests {
             LiteralValue::Int(30),
         ];
         assert_eq!(
-            approx_match_ascending(&vals, &LiteralValue::Int(25)),
+            approx_match_ascending(&vals, &LiteralValue::Int(25), DateSystem::Excel1900),
             Some(1)
         );
     }
@@ -387,7 +398,7 @@ mod tests {
             LiteralValue::Int(30),
         ];
         assert_eq!(
-            approx_match_ascending(&vals, &LiteralValue::Int(100)),
+            approx_match_ascending(&vals, &LiteralValue::Int(100), DateSystem::Excel1900),
             Some(2)
         );
     }

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -9,6 +9,10 @@ use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 /// - Number / Int: numeric
 /// - Text: parsed if it looks numeric (lenient)
 /// - Boolean: TRUE=1, FALSE=0
+/// - Date / DateTime / Time: the Excel serial number. Excel has no date type
+///   at the formula level -- a date cell holds a serial carrying a date number
+///   format -- so a temporal value must order against plain numerics and
+///   against other temporal values exactly as two numbers do.
 /// - Empty: treated as 0
 pub fn value_to_f64_lenient(v: &LiteralValue) -> Option<f64> {
     match v {
@@ -16,6 +20,9 @@ pub fn value_to_f64_lenient(v: &LiteralValue) -> Option<f64> {
         LiteralValue::Int(i) => Some(*i as f64),
         LiteralValue::Text(s) => s.parse::<f64>().ok(),
         LiteralValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
+        LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => {
+            v.as_serial_number()
+        }
         LiteralValue::Empty => Some(0.0),
         _ => None,
     }
@@ -354,6 +361,15 @@ pub fn find_exact_index_in_view(
         LiteralValue::Boolean(b) => find_exact_boolean_in_view(view, *b, vertical),
         LiteralValue::Empty => find_exact_empty_in_view(view, vertical),
         LiteralValue::Error(e) => Err(e.clone()),
+        // A temporal needle searches the numeric lane by serial: the arrow
+        // store keeps dates and times as serials under a temporal type tag,
+        // so an exact lookup for a date must not fall through to "no match".
+        LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => {
+            match needle.as_serial_number() {
+                Some(serial) => find_exact_number_in_view(view, serial, vertical),
+                None => Ok(None),
+            }
+        }
         _ => Ok(None),
     }
 }

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for lookup-family functions (MATCH, VLOOKUP, HLOOKUP, XLOOKUP)
 //! Provides unified coercion, comparison and approximate-mode selection logic.
 
-use crate::engine::range_view::RangeView;
+use crate::engine::{DateSystem, range_view::RangeView};
 use arrow_array::Array;
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 
@@ -14,14 +14,14 @@ use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 ///   format -- so a temporal value must order against plain numerics and
 ///   against other temporal values exactly as two numbers do.
 /// - Empty: treated as 0
-pub fn value_to_f64_lenient(v: &LiteralValue) -> Option<f64> {
+pub fn value_to_f64_lenient(v: &LiteralValue, date_system: DateSystem) -> Option<f64> {
     match v {
         LiteralValue::Number(n) => Some(*n),
         LiteralValue::Int(i) => Some(*i as f64),
         LiteralValue::Text(s) => s.parse::<f64>().ok(),
         LiteralValue::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
         LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => {
-            v.as_serial_number()
+            v.as_serial_number_for(date_system)
         }
         LiteralValue::Empty => Some(0.0),
         _ => None,
@@ -35,8 +35,11 @@ pub fn text_equal_ci(a: &str, b: &str) -> bool {
 
 /// Compare two values for ordering using lenient numeric coercion first, fallback to case-insensitive text.
 /// Returns Some(ordering) where ordering <0, 0, >0 similar to cmp, or None if incomparable.
-pub fn cmp_for_lookup(a: &LiteralValue, b: &LiteralValue) -> Option<i32> {
-    if let (Some(x), Some(y)) = (value_to_f64_lenient(a), value_to_f64_lenient(b)) {
+pub fn cmp_for_lookup(a: &LiteralValue, b: &LiteralValue, date_system: DateSystem) -> Option<i32> {
+    if let (Some(x), Some(y)) = (
+        value_to_f64_lenient(a, date_system),
+        value_to_f64_lenient(b, date_system),
+    ) {
         if (x - y).abs() < 1e-12 {
             return Some(0);
         }
@@ -69,10 +72,11 @@ enum PreparedTextMatcher {
 pub(crate) struct PreparedLookupMatcher<'a> {
     needle: &'a LiteralValue,
     text: Option<PreparedTextMatcher>,
+    date_system: DateSystem,
 }
 
 impl<'a> PreparedLookupMatcher<'a> {
-    pub(crate) fn new(needle: &'a LiteralValue, wildcard: bool) -> Self {
+    pub(crate) fn new(needle: &'a LiteralValue, wildcard: bool, date_system: DateSystem) -> Self {
         let text = match needle {
             LiteralValue::Text(s) => {
                 let folded = s.to_lowercase();
@@ -88,7 +92,11 @@ impl<'a> PreparedLookupMatcher<'a> {
             }
             _ => None,
         };
-        Self { needle, text }
+        Self {
+            needle,
+            text,
+            date_system,
+        }
     }
 
     pub(crate) fn matches(&self, candidate: &LiteralValue) -> bool {
@@ -104,7 +112,7 @@ impl<'a> PreparedLookupMatcher<'a> {
                 let folded_candidate = candidate_text.to_lowercase();
                 compiled.matches_folded(&folded_candidate)
             }
-            _ => cmp_for_lookup(self.needle, candidate)
+            _ => cmp_for_lookup(self.needle, candidate, self.date_system)
                 .map(|o| o == 0)
                 .unwrap_or(false),
         }
@@ -116,8 +124,9 @@ pub fn equals_maybe_wildcard(
     pattern: &LiteralValue,
     candidate: &LiteralValue,
     wildcard: bool,
+    date_system: DateSystem,
 ) -> bool {
-    PreparedLookupMatcher::new(pattern, wildcard).matches(candidate)
+    PreparedLookupMatcher::new(pattern, wildcard, date_system).matches(candidate)
 }
 
 /// Whether Excel's approximate search visits `value` when looking for `needle`.
@@ -128,8 +137,12 @@ pub fn equals_maybe_wildcard(
 /// as a text header sitting above a column of numbers, is skipped: it is neither
 /// out-of-order data nor a matchable position. Errors are handled separately
 /// and propagate rather than being classified as skippable.
-pub fn is_searchable_for_approximate(value: &LiteralValue, needle: &LiteralValue) -> bool {
-    !matches!(value, LiteralValue::Empty) && cmp_for_lookup(value, needle).is_some()
+pub fn is_searchable_for_approximate(
+    value: &LiteralValue,
+    needle: &LiteralValue,
+    date_system: DateSystem,
+) -> bool {
+    !matches!(value, LiteralValue::Empty) && cmp_for_lookup(value, needle, date_system).is_some()
 }
 
 /// A lookup vector projected onto the entries an approximate search visits.
@@ -142,10 +155,15 @@ pub fn is_searchable_for_approximate(value: &LiteralValue, needle: &LiteralValue
 pub struct SearchedVector<'a> {
     values: &'a [LiteralValue],
     positions: Option<Vec<usize>>,
+    date_system: DateSystem,
 }
 
 impl<'a> SearchedVector<'a> {
-    pub fn new(values: &'a [LiteralValue], needle: &LiteralValue) -> Result<Self, ExcelError> {
+    pub fn new(
+        values: &'a [LiteralValue],
+        needle: &LiteralValue,
+        date_system: DateSystem,
+    ) -> Result<Self, ExcelError> {
         if let Some(error) = values.iter().find_map(|value| match value {
             LiteralValue::Error(error) => Some(error.clone()),
             _ => None,
@@ -154,16 +172,20 @@ impl<'a> SearchedVector<'a> {
         }
         let first_skipped = values
             .iter()
-            .position(|v| !is_searchable_for_approximate(v, needle));
+            .position(|v| !is_searchable_for_approximate(v, needle, date_system));
         let positions = first_skipped.map(|skip| {
             let mut positions: Vec<usize> = (0..skip).collect();
             positions.extend(
                 ((skip + 1)..values.len())
-                    .filter(|&i| is_searchable_for_approximate(&values[i], needle)),
+                    .filter(|&i| is_searchable_for_approximate(&values[i], needle, date_system)),
             );
             positions
         });
-        Ok(Self { values, positions })
+        Ok(Self {
+            values,
+            positions,
+            date_system,
+        })
     }
 
     pub fn len(&self) -> usize {
@@ -190,28 +212,30 @@ impl<'a> SearchedVector<'a> {
     }
 
     pub fn is_sorted_ascending(&self) -> bool {
-        (1..self.len())
-            .all(|i| cmp_for_lookup(self.get(i - 1), self.get(i)).is_some_and(|c| c <= 0))
+        (1..self.len()).all(|i| {
+            cmp_for_lookup(self.get(i - 1), self.get(i), self.date_system).is_some_and(|c| c <= 0)
+        })
     }
 
     pub fn is_sorted_descending(&self) -> bool {
-        (1..self.len())
-            .all(|i| cmp_for_lookup(self.get(i - 1), self.get(i)).is_some_and(|c| c >= 0))
+        (1..self.len()).all(|i| {
+            cmp_for_lookup(self.get(i - 1), self.get(i), self.date_system).is_some_and(|c| c >= 0)
+        })
     }
 }
 
 /// Detect ascending sort (strict or equal allowed) for slice according to cmp_for_lookup.
-pub fn is_sorted_ascending(values: &[LiteralValue]) -> bool {
+pub fn is_sorted_ascending(values: &[LiteralValue], date_system: DateSystem) -> bool {
     values
         .windows(2)
-        .all(|w| cmp_for_lookup(&w[0], &w[1]).is_some_and(|c| c <= 0))
+        .all(|w| cmp_for_lookup(&w[0], &w[1], date_system).is_some_and(|c| c <= 0))
 }
 
 /// Detect descending sort (strict or equal allowed).
-pub fn is_sorted_descending(values: &[LiteralValue]) -> bool {
+pub fn is_sorted_descending(values: &[LiteralValue], date_system: DateSystem) -> bool {
     values
         .windows(2)
-        .all(|w| cmp_for_lookup(&w[0], &w[1]).is_some_and(|c| c >= 0))
+        .all(|w| cmp_for_lookup(&w[0], &w[1], date_system).is_some_and(|c| c >= 0))
 }
 
 /// Approximate mode selection (ascending):
@@ -221,23 +245,28 @@ pub fn approximate_select_ascending(
     values: &[LiteralValue],
     needle: &LiteralValue,
     mode: i32,
+    date_system: DateSystem,
 ) -> Option<usize> {
     if values.is_empty() {
         return None;
     }
-    let needle_num = value_to_f64_lenient(needle);
+    let needle_num = value_to_f64_lenient(needle, date_system);
     match mode {
         -1 => {
             // exact or next smaller (our XLOOKUP -1 semantics) -> largest <= needle
             let mut best: Option<usize> = None;
             for (i, v) in values.iter().enumerate() {
-                if cmp_for_lookup(v, needle).map(|c| c == 0).unwrap_or(false) {
+                if cmp_for_lookup(v, needle, date_system)
+                    .map(|c| c == 0)
+                    .unwrap_or(false)
+                {
                     return Some(i);
                 }
-                if let (Some(nn), Some(vv)) = (needle_num, value_to_f64_lenient(v))
+                if let (Some(nn), Some(vv)) = (needle_num, value_to_f64_lenient(v, date_system))
                     && vv <= nn
                     && best.is_none_or(|b| {
-                        value_to_f64_lenient(&values[b]).unwrap_or(f64::NEG_INFINITY) < vv
+                        value_to_f64_lenient(&values[b], date_system).unwrap_or(f64::NEG_INFINITY)
+                            < vv
                     })
                 {
                     best = Some(i);
@@ -249,13 +278,16 @@ pub fn approximate_select_ascending(
             // exact or next larger -> smallest >= needle
             let mut best: Option<usize> = None;
             for (i, v) in values.iter().enumerate() {
-                if cmp_for_lookup(v, needle).map(|c| c == 0).unwrap_or(false) {
+                if cmp_for_lookup(v, needle, date_system)
+                    .map(|c| c == 0)
+                    .unwrap_or(false)
+                {
                     return Some(i);
                 }
-                if let (Some(nn), Some(vv)) = (needle_num, value_to_f64_lenient(v))
+                if let (Some(nn), Some(vv)) = (needle_num, value_to_f64_lenient(v, date_system))
                     && vv >= nn
                     && best.is_none_or(|b| {
-                        value_to_f64_lenient(&values[b]).unwrap_or(f64::INFINITY) > vv
+                        value_to_f64_lenient(&values[b], date_system).unwrap_or(f64::INFINITY) > vv
                     })
                 {
                     best = Some(i);
@@ -268,8 +300,11 @@ pub fn approximate_select_ascending(
 }
 
 /// Validate ascending sort for approximate selection; return #N/A if unsorted.
-pub fn guard_sorted_ascending(values: &[LiteralValue]) -> Result<(), ExcelError> {
-    if !is_sorted_ascending(values) {
+pub fn guard_sorted_ascending(
+    values: &[LiteralValue],
+    date_system: DateSystem,
+) -> Result<(), ExcelError> {
+    if !is_sorted_ascending(values, date_system) {
         return Err(ExcelError::new(ExcelErrorKind::Na));
     }
     Ok(())
@@ -407,8 +442,9 @@ pub fn find_exact_index(
     values: &[LiteralValue],
     needle: &LiteralValue,
     wildcard: bool,
+    date_system: DateSystem,
 ) -> Option<usize> {
-    let matcher = PreparedLookupMatcher::new(needle, wildcard);
+    let matcher = PreparedLookupMatcher::new(needle, wildcard, date_system);
     for (i, v) in values.iter().enumerate() {
         if matcher.matches(v) {
             return Some(i);
@@ -423,6 +459,7 @@ pub fn find_exact_index_in_view(
     view: &RangeView<'_>,
     needle: &LiteralValue,
     wildcard: bool,
+    date_system: DateSystem,
 ) -> Result<Option<usize>, ExcelError> {
     let (rows, cols) = view.dims();
     let vertical = if cols == 1 {
@@ -445,7 +482,7 @@ pub fn find_exact_index_in_view(
         // store keeps dates and times as serials under a temporal type tag,
         // so an exact lookup for a date must not fall through to "no match".
         LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => {
-            match needle.as_serial_number() {
+            match needle.as_serial_number_for(date_system) {
                 Some(serial) => find_exact_number_in_view(view, serial, vertical),
                 None => Ok(None),
             }
@@ -730,11 +767,11 @@ mod tests {
         let wildcard = LiteralValue::Text("ив?н*".into());
 
         assert_eq!(
-            find_exact_index_in_view(&view, &exact, false).unwrap(),
+            find_exact_index_in_view(&view, &exact, false, DateSystem::Excel1900).unwrap(),
             Some(1)
         );
         assert_eq!(
-            find_exact_index_in_view(&view, &wildcard, true).unwrap(),
+            find_exact_index_in_view(&view, &wildcard, true, DateSystem::Excel1900).unwrap(),
             Some(1)
         );
     }
@@ -761,11 +798,11 @@ mod tests {
         let wildcard = LiteralValue::Text("ив?н*".into());
 
         assert_eq!(
-            find_exact_index_in_view(&view, &exact, false).unwrap(),
+            find_exact_index_in_view(&view, &exact, false, DateSystem::Excel1900).unwrap(),
             Some(1)
         );
         assert_eq!(
-            find_exact_index_in_view(&view, &wildcard, true).unwrap(),
+            find_exact_index_in_view(&view, &wildcard, true, DateSystem::Excel1900).unwrap(),
             Some(1)
         );
     }
@@ -828,8 +865,14 @@ mod tests {
         let exact = LiteralValue::Text("иван".into());
         let wildcard = LiteralValue::Text("ив?н*".into());
 
-        assert_eq!(find_exact_index(&values, &exact, false), Some(1));
-        assert_eq!(find_exact_index(&values, &wildcard, true), Some(1));
+        assert_eq!(
+            find_exact_index(&values, &exact, false, DateSystem::Excel1900),
+            Some(1)
+        );
+        assert_eq!(
+            find_exact_index(&values, &wildcard, true, DateSystem::Excel1900),
+            Some(1)
+        );
     }
 
     #[test]
@@ -853,7 +896,12 @@ mod tests {
         for _ in 0..iters {
             let mut out = None;
             for (i, value) in values.iter().enumerate() {
-                if equals_maybe_wildcard(&exact_needle, black_box(value), false) {
+                if equals_maybe_wildcard(
+                    &exact_needle,
+                    black_box(value),
+                    false,
+                    DateSystem::Excel1900,
+                ) {
                     out = Some(i);
                     break;
                 }
@@ -864,7 +912,12 @@ mod tests {
 
         let start = Instant::now();
         for _ in 0..iters {
-            black_box(find_exact_index(black_box(&values), &exact_needle, false));
+            black_box(find_exact_index(
+                black_box(&values),
+                &exact_needle,
+                false,
+                DateSystem::Excel1900,
+            ));
         }
         let opt_exact = start.elapsed();
 
@@ -872,7 +925,12 @@ mod tests {
         for _ in 0..iters {
             let mut out = None;
             for (i, value) in values.iter().enumerate() {
-                if equals_maybe_wildcard(&wildcard_needle, black_box(value), true) {
+                if equals_maybe_wildcard(
+                    &wildcard_needle,
+                    black_box(value),
+                    true,
+                    DateSystem::Excel1900,
+                ) {
                     out = Some(i);
                     break;
                 }
@@ -883,7 +941,12 @@ mod tests {
 
         let start = Instant::now();
         for _ in 0..iters {
-            black_box(find_exact_index(black_box(&values), &wildcard_needle, true));
+            black_box(find_exact_index(
+                black_box(&values),
+                &wildcard_needle,
+                true,
+                DateSystem::Excel1900,
+            ));
         }
         let opt_wildcard = start.elapsed();
 
@@ -937,7 +1000,15 @@ mod tests {
 
         let start = Instant::now();
         for _ in 0..iters {
-            black_box(find_exact_index_in_view(&view, black_box(&exact_needle), false).unwrap());
+            black_box(
+                find_exact_index_in_view(
+                    &view,
+                    black_box(&exact_needle),
+                    false,
+                    DateSystem::Excel1900,
+                )
+                .unwrap(),
+            );
         }
         let opt_exact = start.elapsed();
 
@@ -949,7 +1020,15 @@ mod tests {
 
         let start = Instant::now();
         for _ in 0..iters {
-            black_box(find_exact_index_in_view(&view, black_box(&wildcard_needle), true).unwrap());
+            black_box(
+                find_exact_index_in_view(
+                    &view,
+                    black_box(&wildcard_needle),
+                    true,
+                    DateSystem::Excel1900,
+                )
+                .unwrap(),
+            );
         }
         let opt_wildcard = start.elapsed();
 

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -117,9 +117,10 @@ pub fn equals_maybe_wildcard(
 ///
 /// The legacy approximate lookups (`MATCH` with `match_type` 1/-1,
 /// `VLOOKUP`/`HLOOKUP` with `range_lookup` TRUE) consider only entries in the
-/// needle's value class. A blank cell, or an entry of another class such as a
-/// text header sitting above a column of numbers, is skipped: it is neither
-/// out-of-order data nor a matchable position.
+/// needle's comparable value set. A blank cell, or an incomparable entry such
+/// as a text header sitting above a column of numbers, is skipped: it is neither
+/// out-of-order data nor a matchable position. Errors are handled separately
+/// and propagate rather than being classified as skippable.
 pub fn is_searchable_for_approximate(value: &LiteralValue, needle: &LiteralValue) -> bool {
     !matches!(value, LiteralValue::Empty) && cmp_for_lookup(value, needle).is_some()
 }
@@ -137,7 +138,13 @@ pub struct SearchedVector<'a> {
 }
 
 impl<'a> SearchedVector<'a> {
-    pub fn new(values: &'a [LiteralValue], needle: &LiteralValue) -> Self {
+    pub fn new(values: &'a [LiteralValue], needle: &LiteralValue) -> Result<Self, ExcelError> {
+        if let Some(error) = values.iter().find_map(|value| match value {
+            LiteralValue::Error(error) => Some(error.clone()),
+            _ => None,
+        }) {
+            return Err(error);
+        }
         let first_skipped = values
             .iter()
             .position(|v| !is_searchable_for_approximate(v, needle));
@@ -149,7 +156,7 @@ impl<'a> SearchedVector<'a> {
             );
             positions
         });
-        Self { values, positions }
+        Ok(Self { values, positions })
     }
 
     pub fn len(&self) -> usize {

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -3646,7 +3646,7 @@ where
             self.lookup_index_cache.note_skipped_volatile();
             return None;
         }
-        match LookupIndex::build(view, axis).ok()? {
+        match LookupIndex::build(view, axis, self.config.date_system).ok()? {
             BuildOutcome::Built(index) => self.lookup_index_cache.insert_if_room(key, index),
             BuildOutcome::ErrorInLookupAxis => {
                 self.lookup_index_cache.note_skipped_error();

--- a/crates/formualizer-eval/src/engine/lookup_index_cache.rs
+++ b/crates/formualizer-eval/src/engine/lookup_index_cache.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 use crate::builtins::lookup::lookup_utils::cmp_for_lookup;
-use crate::engine::range_view::RangeView;
+use crate::engine::{DateSystem, range_view::RangeView};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct LookupIndexKey {
@@ -57,7 +57,7 @@ impl Hash for LookupHashKey {
 }
 
 impl LookupHashKey {
-    pub(crate) fn from_literal(value: &LiteralValue) -> Option<Self> {
+    pub(crate) fn from_literal(value: &LiteralValue, date_system: DateSystem) -> Option<Self> {
         match value {
             LiteralValue::Number(n) => Some(Self::Number(normalize_f64_bits(*n))),
             LiteralValue::Int(i) => Some(Self::Number(normalize_f64_bits(*i as f64))),
@@ -68,7 +68,7 @@ impl LookupHashKey {
             // an exact lookup finds them whether the needle or the cell (or
             // both) carry a temporal type rather than a plain numeric.
             LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => value
-                .as_serial_number()
+                .as_serial_number_for(date_system)
                 .map(|serial| Self::Number(normalize_f64_bits(serial))),
             LiteralValue::Error(_)
             | LiteralValue::Array(_)
@@ -99,6 +99,7 @@ pub struct DuplicateIndices {
 
 pub struct LookupIndex {
     pub(crate) len: usize,
+    date_system: DateSystem,
     pub(crate) bytes: usize,
     pub(crate) entries: FxHashMap<LookupHashKey, DuplicateIndices>,
     pub(crate) cell_values: Box<[LiteralValue]>,
@@ -109,6 +110,7 @@ impl LookupIndex {
     pub(crate) fn build(
         view: &RangeView<'_>,
         axis: LookupAxis,
+        date_system: DateSystem,
     ) -> Result<BuildOutcome, ExcelError> {
         let (rows, cols) = view.dims();
         let len = match axis {
@@ -145,7 +147,7 @@ impl LookupIndex {
             if matches!(value, LiteralValue::Empty) && first_empty.is_none() {
                 first_empty = Some(idx);
             }
-            if let Some(key) = LookupHashKey::from_literal(&value) {
+            if let Some(key) = LookupHashKey::from_literal(&value, date_system) {
                 let dups = entries.entry(key).or_insert_with(|| DuplicateIndices {
                     first: idx,
                     last: idx,
@@ -167,6 +169,7 @@ impl LookupIndex {
         let bytes = estimate_bytes(len, entries.len());
         Ok(BuildOutcome::Built(Self {
             len,
+            date_system,
             bytes,
             entries,
             cell_values: cell_values.into_boxed_slice(),
@@ -175,10 +178,10 @@ impl LookupIndex {
     }
 
     pub(crate) fn find_first_exact(&self, needle: &LiteralValue) -> Option<usize> {
-        let hash_key = LookupHashKey::from_literal(needle)?;
+        let hash_key = LookupHashKey::from_literal(needle, self.date_system)?;
         if let Some(dups) = self.entries.get(&hash_key) {
             for &idx in &dups.all {
-                if cmp_for_lookup(needle, &self.cell_values[idx]) == Some(0) {
+                if cmp_for_lookup(needle, &self.cell_values[idx], self.date_system) == Some(0) {
                     return Some(idx);
                 }
             }
@@ -192,10 +195,10 @@ impl LookupIndex {
     }
 
     pub(crate) fn find_last_exact(&self, needle: &LiteralValue) -> Option<usize> {
-        let hash_key = LookupHashKey::from_literal(needle)?;
+        let hash_key = LookupHashKey::from_literal(needle, self.date_system)?;
         if let Some(dups) = self.entries.get(&hash_key) {
             for &idx in dups.all.iter().rev() {
-                if cmp_for_lookup(needle, &self.cell_values[idx]) == Some(0) {
+                if cmp_for_lookup(needle, &self.cell_values[idx], self.date_system) == Some(0) {
                     return Some(idx);
                 }
             }

--- a/crates/formualizer-eval/src/engine/lookup_index_cache.rs
+++ b/crates/formualizer-eval/src/engine/lookup_index_cache.rs
@@ -64,11 +64,14 @@ impl LookupHashKey {
             LiteralValue::Text(s) => Some(Self::Text(s.to_lowercase().into_boxed_str())),
             LiteralValue::Boolean(b) => Some(Self::Boolean(*b)),
             LiteralValue::Empty => Some(Self::Empty),
+            // Temporal values are numbers in Excel: key them by their serial so
+            // an exact lookup finds them whether the needle or the cell (or
+            // both) carry a temporal type rather than a plain numeric.
+            LiteralValue::Date(_) | LiteralValue::DateTime(_) | LiteralValue::Time(_) => value
+                .as_serial_number()
+                .map(|serial| Self::Number(normalize_f64_bits(serial))),
             LiteralValue::Error(_)
             | LiteralValue::Array(_)
-            | LiteralValue::Date(_)
-            | LiteralValue::DateTime(_)
-            | LiteralValue::Time(_)
             | LiteralValue::Duration(_)
             | LiteralValue::Pending => None,
         }

--- a/crates/formualizer-eval/src/engine/tests/approximate_lookup_ignored_entries.rs
+++ b/crates/formualizer-eval/src/engine/tests/approximate_lookup_ignored_entries.rs
@@ -13,7 +13,8 @@
 
 use crate::engine::{Engine, EvalConfig};
 use crate::test_workbook::TestWorkbook;
-use formualizer_common::{ExcelErrorKind, LiteralValue};
+use chrono::NaiveDate;
+use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
 
 fn eval(engine: &mut Engine<TestWorkbook>, formula: &str) -> Option<LiteralValue> {
@@ -32,13 +33,15 @@ fn assert_number(value: Option<LiteralValue>, expected: f64, formula: &str) {
     }
 }
 
-fn assert_na(value: Option<LiteralValue>, formula: &str) {
+fn assert_error(value: Option<LiteralValue>, expected: ExcelErrorKind, formula: &str) {
     match value {
-        Some(LiteralValue::Error(e)) => {
-            assert_eq!(e.kind, ExcelErrorKind::Na, "{formula}")
-        }
-        other => panic!("{formula}: expected #N/A, got {other:?}"),
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, expected, "{formula}"),
+        other => panic!("{formula}: expected {expected:?}, got {other:?}"),
     }
+}
+
+fn assert_na(value: Option<LiteralValue>, formula: &str) {
+    assert_error(value, ExcelErrorKind::Na, formula);
 }
 
 /// A: 1..5 in rows 1-5, rows 6-10 never written (blank).
@@ -268,5 +271,262 @@ fn exact_match_over_a_blank_tail_is_unaffected() {
         eval(&mut engine, "=MATCH(3,A1:A10,0)"),
         3.0,
         "MATCH(3,A1:A10,0)",
+    );
+}
+
+#[test]
+fn approximate_lookups_propagate_errors_in_any_lookup_position() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    let error = LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div));
+
+    for (row, value) in [
+        LiteralValue::Int(1),
+        LiteralValue::Int(2),
+        error.clone(),
+        LiteralValue::Int(9),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        engine
+            .set_cell_value("Sheet1", row as u32 + 1, 1, value)
+            .unwrap();
+        engine
+            .set_cell_value(
+                "Sheet1",
+                row as u32 + 1,
+                2,
+                LiteralValue::Int((row as i64 + 1) * 10),
+            )
+            .unwrap();
+    }
+    assert_error(
+        eval(&mut engine, "=MATCH(5,A1:A4,1)"),
+        ExcelErrorKind::Div,
+        "MATCH ascending deciding error",
+    );
+    assert_error(
+        eval(&mut engine, "=VLOOKUP(5,A1:B4,2,TRUE)"),
+        ExcelErrorKind::Div,
+        "VLOOKUP deciding error",
+    );
+
+    // Move the error beyond a key that already disqualifies the final row. The
+    // implemented Excel rule is range-wide propagation, not search-path-dependent.
+    engine
+        .set_cell_value("Sheet1", 3, 1, LiteralValue::Int(9))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 4, 1, error.clone())
+        .unwrap();
+    assert_error(
+        eval(&mut engine, "=MATCH(5,A1:A4,1)"),
+        ExcelErrorKind::Div,
+        "MATCH ascending non-deciding error",
+    );
+    assert_error(
+        eval(&mut engine, "=VLOOKUP(5,A1:B4,2,TRUE)"),
+        ExcelErrorKind::Div,
+        "VLOOKUP non-deciding error",
+    );
+
+    for (col, value) in [
+        LiteralValue::Int(1),
+        LiteralValue::Int(2),
+        LiteralValue::Int(9),
+        error.clone(),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        engine
+            .set_cell_value("Sheet1", 10, col as u32 + 1, value)
+            .unwrap();
+        engine
+            .set_cell_value(
+                "Sheet1",
+                11,
+                col as u32 + 1,
+                LiteralValue::Int((col as i64 + 1) * 10),
+            )
+            .unwrap();
+    }
+    assert_error(
+        eval(&mut engine, "=HLOOKUP(5,A10:D11,2,TRUE)"),
+        ExcelErrorKind::Div,
+        "HLOOKUP non-deciding error",
+    );
+
+    for (row, value) in [
+        LiteralValue::Int(9),
+        error,
+        LiteralValue::Int(2),
+        LiteralValue::Int(1),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        engine
+            .set_cell_value("Sheet1", row as u32 + 1, 5, value)
+            .unwrap();
+    }
+    assert_error(
+        eval(&mut engine, "=MATCH(5,E1:E4,-1)"),
+        ExcelErrorKind::Div,
+        "MATCH descending deciding error",
+    );
+}
+
+#[test]
+fn approximate_match_propagates_materialized_pre_1900_date_error() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, date) in [(1899, 1, 1), (1899, 6, 1), (1900, 3, 1), (2024, 1, 1)]
+        .into_iter()
+        .enumerate()
+    {
+        engine
+            .set_cell_value(
+                "Sheet1",
+                row as u32 + 1,
+                1,
+                LiteralValue::Date(NaiveDate::from_ymd_opt(date.0, date.1, date.2).unwrap()),
+            )
+            .unwrap();
+    }
+    assert_error(
+        eval(&mut engine, "=MATCH(50000,A1:A4,1)"),
+        ExcelErrorKind::Num,
+        "MATCH over pre-1900 date errors",
+    );
+}
+
+#[test]
+fn ascending_duplicates_are_sorted_and_return_the_last_original_position() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, value) in [(1, 1), (2, 2), (4, 2), (6, 2), (8, 5)] {
+        engine
+            .set_cell_value("Sheet1", row, 8, LiteralValue::Int(value))
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(3,H1:H8,1)"),
+        6.0,
+        "MATCH duplicate ascending keys",
+    );
+}
+
+#[test]
+fn vlookup_maps_a_projected_match_back_to_the_original_row() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Text("Key".into()))
+        .unwrap();
+    for value in 1..=5i64 {
+        engine
+            .set_cell_value("Sheet1", value as u32 + 1, 1, LiteralValue::Int(value))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", value as u32 + 1, 2, LiteralValue::Int(value * 10))
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=VLOOKUP(3.5,A1:B6,2,TRUE)"),
+        30.0,
+        "VLOOKUP original-position remap",
+    );
+}
+
+#[test]
+fn searchable_count_selects_the_small_descending_linear_path() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, value) in (1..=5i64).rev().enumerate() {
+        engine
+            .set_cell_value("Sheet1", row as u32 + 1, 5, LiteralValue::Int(value))
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(3.5,E1:E10,-1)"),
+        2.0,
+        "MATCH threshold uses searchable count",
+    );
+}
+
+#[test]
+fn descending_binary_search_returns_the_last_qualifying_position() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, value) in (1..=10i64).rev().enumerate() {
+        engine
+            .set_cell_value("Sheet1", row as u32 + 1, 1, LiteralValue::Int(value))
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(3.5,A1:A10,-1)"),
+        7.0,
+        "MATCH descending binary boundary",
+    );
+    assert_number(
+        eval(&mut engine, "=MATCH(3,A1:A10,-1)"),
+        8.0,
+        "MATCH descending exact-hit masking control",
+    );
+}
+
+#[test]
+fn descending_binary_search_skips_interior_blanks_without_shifting_the_answer() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, value) in [
+        (1, 9),
+        (2, 8),
+        (3, 7),
+        (5, 6),
+        (6, 5),
+        (7, 4),
+        (9, 3),
+        (10, 2),
+        (11, 1),
+    ] {
+        engine
+            .set_cell_value("Sheet1", row, 7, LiteralValue::Int(value))
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(5.5,G1:G11,-1)"),
+        5.0,
+        "MATCH descending with interior blanks",
+    );
+}
+
+#[test]
+fn searchable_count_keeps_duplicate_tie_break_on_small_descending_data() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, value) in [(1, 5), (2, 4), (3, 4), (4, 3), (5, 2)] {
+        engine
+            .set_cell_value("Sheet1", row, 5, LiteralValue::Int(value))
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(4,E1:E10,-1)"),
+        3.0,
+        "MATCH threshold preserves descending duplicate tie-break",
+    );
+}
+
+#[test]
+fn searchable_count_not_range_extent_controls_descending_tie_break() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, value) in [(1, 5), (3, 4), (4, 4), (6, 3), (8, 2)] {
+        engine
+            .set_cell_value("Sheet1", row, 5, LiteralValue::Int(value))
+            .unwrap();
+    }
+    for row in [2, 5, 7, 9, 10] {
+        engine
+            .set_cell_value("Sheet1", row, 5, LiteralValue::Text("skip".into()))
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(4,E1:E10,-1)"),
+        4.0,
+        "MATCH threshold uses projected length, not range extent",
     );
 }

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -187,3 +187,5 @@ mod scc_iterate;
 mod scc_runtime_cycles;
 mod scc_runtime_property;
 mod short_circuit_dispatch;
+
+mod temporal_lookup_semantics;

--- a/crates/formualizer-eval/src/engine/tests/temporal_lookup_semantics.rs
+++ b/crates/formualizer-eval/src/engine/tests/temporal_lookup_semantics.rs
@@ -10,8 +10,8 @@
 
 use crate::engine::{Engine, EvalConfig};
 use crate::test_workbook::TestWorkbook;
-use chrono::{NaiveDate, NaiveTime};
-use formualizer_common::LiteralValue;
+use chrono::{Duration, NaiveDate, NaiveTime};
+use formualizer_common::{DateSystem, ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
 
 fn date(y: i32, m: u32, d: u32) -> LiteralValue {
@@ -25,8 +25,11 @@ const JAN_1_2024: f64 = 45292.0;
 /// Column B: numeric payload 10..50.
 /// Column C: the same keys written as plain numeric serials.
 /// D1: a date-typed needle cell (2024-01-03).
-fn build_date_engine() -> Engine<TestWorkbook> {
-    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+fn build_date_engine_for(date_system: DateSystem) -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_date_system(date_system),
+    );
     for i in 1..=5u32 {
         engine
             .set_cell_value("Sheet1", i, 1, date(2024, 1, i))
@@ -49,6 +52,10 @@ fn build_date_engine() -> Engine<TestWorkbook> {
     engine
 }
 
+fn build_date_engine() -> Engine<TestWorkbook> {
+    build_date_engine_for(DateSystem::Excel1900)
+}
+
 fn eval(engine: &mut Engine<TestWorkbook>, formula: &str) -> Option<LiteralValue> {
     engine
         .set_cell_formula("Sheet1", 1, 10, parse(formula).unwrap())
@@ -62,6 +69,13 @@ fn assert_number(value: Option<LiteralValue>, expected: f64, formula: &str) {
         Some(LiteralValue::Int(i)) => assert_eq!(i as f64, expected, "{formula}"),
         Some(LiteralValue::Number(n)) => assert!((n - expected).abs() < 1e-9, "{formula} => {n}"),
         other => panic!("{formula}: expected {expected}, got {other:?}"),
+    }
+}
+
+fn assert_na(value: Option<LiteralValue>, formula: &str) {
+    match value {
+        Some(LiteralValue::Error(error)) => assert_eq!(error.kind, ExcelErrorKind::Na, "{formula}"),
+        other => panic!("{formula}: expected #N/A, got {other:?}"),
     }
 }
 
@@ -178,5 +192,182 @@ fn match_exact_finds_a_time_typed_key_by_its_serial_fraction() {
         eval(&mut engine, "=MATCH(0.5,A1:A3,0)"),
         2.0,
         "MATCH(0.5,A1:A3,0)",
+    );
+}
+
+#[test]
+fn temporal_lookup_semantics_follow_both_workbook_date_systems() {
+    for (system, correct_serial, wrong_serial) in [
+        (DateSystem::Excel1900, 45294.0, 43832.0),
+        (DateSystem::Excel1904, 43832.0, 45294.0),
+    ] {
+        let mut engine = build_date_engine_for(system);
+        engine
+            .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(wrong_serial))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", 2, 6, LiteralValue::Number(correct_serial))
+            .unwrap();
+
+        for (formula, expected) in [
+            ("=MATCH(D1,A1:A5,0)", 3.0),
+            ("=MATCH(D1,A1:A5,1)", 3.0),
+            ("=VLOOKUP(D1,A1:B5,2,FALSE)", 30.0),
+            ("=VLOOKUP(D1,A1:B5,2,TRUE)", 30.0),
+            ("=XLOOKUP(D1,A1:A5,B1:B5)", 30.0),
+            ("=MATCH(D1,F1:F2,0)", 2.0),
+        ] {
+            assert_number(eval(&mut engine, formula), expected, formula);
+        }
+        assert_na(
+            eval(&mut engine, "=MATCH(D1,F1:F1,0)"),
+            "date-system false-positive guard",
+        );
+    }
+}
+
+#[test]
+fn approximate_temporal_needles_preserve_time_fractions() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, hour) in [(1, 6), (2, 12), (3, 18)] {
+        engine
+            .set_cell_value(
+                "Sheet1",
+                row,
+                6,
+                LiteralValue::Time(NaiveTime::from_hms_opt(hour, 0, 0).unwrap()),
+            )
+            .unwrap();
+    }
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            4,
+            LiteralValue::Time(NaiveTime::from_hms_opt(14, 24, 0).unwrap()),
+        )
+        .unwrap();
+    engine
+        .set_cell_value(
+            "Sheet1",
+            3,
+            4,
+            LiteralValue::Time(NaiveTime::from_hms_opt(12, 0, 0).unwrap()),
+        )
+        .unwrap();
+    engine
+        .set_cell_value(
+            "Sheet1",
+            2,
+            4,
+            LiteralValue::DateTime(
+                NaiveDate::from_ymd_opt(2024, 1, 3)
+                    .unwrap()
+                    .and_hms_opt(10, 10, 10)
+                    .unwrap(),
+            ),
+        )
+        .unwrap();
+    engine
+        .set_cell_value(
+            "Sheet1",
+            4,
+            6,
+            LiteralValue::DateTime(
+                NaiveDate::from_ymd_opt(2024, 1, 3)
+                    .unwrap()
+                    .and_hms_opt(10, 10, 10)
+                    .unwrap(),
+            ),
+        )
+        .unwrap();
+    for (row, serial) in [(1, 0.25), (2, 0.5), (3, 0.75)] {
+        engine
+            .set_cell_value("Sheet1", row, 7, LiteralValue::Number(serial))
+            .unwrap();
+    }
+
+    assert_number(
+        eval(&mut engine, "=MATCH(D1,F1:F3,1)"),
+        2.0,
+        "MATCH temporal Time needle approximate",
+    );
+    assert_number(
+        eval(&mut engine, "=MATCH(D2,F4:F4,1)"),
+        1.0,
+        "MATCH temporal DateTime needle approximate",
+    );
+    assert_number(
+        eval(&mut engine, "=MATCH(D3,G1:G3,0)"),
+        2.0,
+        "MATCH fractional temporal needle exact view path",
+    );
+}
+
+#[test]
+fn warm_lookup_hash_index_keys_fractional_temporal_serials() {
+    for system in [DateSystem::Excel1900, DateSystem::Excel1904] {
+        let mut engine = Engine::new(
+            TestWorkbook::new(),
+            EvalConfig::default().with_date_system(system),
+        );
+        let start = NaiveDate::from_ymd_opt(2024, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 30, 0)
+            .unwrap();
+        let target = start + Duration::hours(149);
+        for row in 1..=200u32 {
+            engine
+                .set_cell_value(
+                    "Sheet1",
+                    row,
+                    1,
+                    LiteralValue::DateTime(start + Duration::hours((row - 1) as i64)),
+                )
+                .unwrap();
+            engine
+                .set_cell_value("Sheet1", row, 2, LiteralValue::Int(row as i64 * 10))
+                .unwrap();
+        }
+        let target_serial = LiteralValue::DateTime(target)
+            .as_serial_number_for(system)
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", 1, 4, LiteralValue::Number(target_serial))
+            .unwrap();
+        for row in 1..=8u32 {
+            engine
+                .set_cell_formula(
+                    "Sheet1",
+                    row,
+                    5,
+                    parse("=VLOOKUP($D$1,$A$1:$B$200,2,FALSE)").unwrap(),
+                )
+                .unwrap();
+        }
+        engine.evaluate_all().unwrap();
+        let cache = engine.last_lookup_index_cache_report();
+        assert!(
+            cache.builds >= 1,
+            "lookup hash index did not warm: {cache:?}"
+        );
+        assert!(cache.hits >= 1, "lookup hash index was not used: {cache:?}");
+        for row in 1..=8u32 {
+            assert_number(
+                engine.get_cell_value("Sheet1", row, 5),
+                1500.0,
+                "warm hash-index VLOOKUP",
+            );
+        }
+    }
+}
+
+#[test]
+fn date_vlookup_with_a_blank_tail_returns_the_date_rows_payload() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=VLOOKUP(D1,A1:B10,2,TRUE)"),
+        30.0,
+        "VLOOKUP date column with blank tail",
     );
 }

--- a/crates/formualizer-eval/src/engine/tests/temporal_lookup_semantics.rs
+++ b/crates/formualizer-eval/src/engine/tests/temporal_lookup_semantics.rs
@@ -1,0 +1,182 @@
+//! Temporal values participate in lookups as ordinary Excel serials.
+//!
+//! Oracle: Microsoft Excel 16.105.3 (Microsoft 365 for Mac), synthetic
+//! workbook, values recalculated in-app (`oracle: excel-verified`).
+//!
+//! Excel has no date type at the formula level: a date cell holds a serial
+//! carrying a date number format. Every lookup family member therefore
+//! compares dates against dates, and against plain numerics, exactly as it
+//! compares two numbers.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use chrono::{NaiveDate, NaiveTime};
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn date(y: i32, m: u32, d: u32) -> LiteralValue {
+    LiteralValue::Date(NaiveDate::from_ymd_opt(y, m, d).unwrap())
+}
+
+/// Serial for 2024-01-01 in the Excel 1900 system.
+const JAN_1_2024: f64 = 45292.0;
+
+/// Column A: date-typed keys 2024-01-01..2024-01-05.
+/// Column B: numeric payload 10..50.
+/// Column C: the same keys written as plain numeric serials.
+/// D1: a date-typed needle cell (2024-01-03).
+fn build_date_engine() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for i in 1..=5u32 {
+        engine
+            .set_cell_value("Sheet1", i, 1, date(2024, 1, i))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", i, 2, LiteralValue::Int((i as i64) * 10))
+            .unwrap();
+        engine
+            .set_cell_value(
+                "Sheet1",
+                i,
+                3,
+                LiteralValue::Number(JAN_1_2024 + (i as f64) - 1.0),
+            )
+            .unwrap();
+    }
+    engine
+        .set_cell_value("Sheet1", 1, 4, date(2024, 1, 3))
+        .unwrap();
+    engine
+}
+
+fn eval(engine: &mut Engine<TestWorkbook>, formula: &str) -> Option<LiteralValue> {
+    engine
+        .set_cell_formula("Sheet1", 1, 10, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine.get_cell_value("Sheet1", 1, 10)
+}
+
+fn assert_number(value: Option<LiteralValue>, expected: f64, formula: &str) {
+    match value {
+        Some(LiteralValue::Int(i)) => assert_eq!(i as f64, expected, "{formula}"),
+        Some(LiteralValue::Number(n)) => assert!((n - expected).abs() < 1e-9, "{formula} => {n}"),
+        other => panic!("{formula}: expected {expected}, got {other:?}"),
+    }
+}
+
+/// Excel: `=MATCH(D1,A1:A5,0)` => 3 where D1 and A1:A5 are date cells.
+#[test]
+fn match_exact_finds_a_date_typed_key_with_a_date_typed_needle() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(D1,A1:A5,0)"),
+        3.0,
+        "MATCH(D1,A1:A5,0)",
+    );
+}
+
+/// Excel: `=MATCH(DATE(2024,1,3),A1:A5,0)` => 3. A serial-valued needle must
+/// find a date-typed cell: both sides are the same number in Excel.
+#[test]
+fn match_exact_finds_a_date_typed_key_with_a_serial_needle() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(DATE(2024,1,3),A1:A5,0)"),
+        3.0,
+        "MATCH(DATE(2024,1,3),A1:A5,0)",
+    );
+}
+
+/// Excel: `=MATCH(D1,C1:C5,0)` => 3. The mirror direction — a date-typed
+/// needle against plain numeric serials.
+#[test]
+fn match_exact_finds_a_numeric_serial_with_a_date_typed_needle() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(D1,C1:C5,0)"),
+        3.0,
+        "MATCH(D1,C1:C5,0)",
+    );
+}
+
+/// Excel: `=MATCH(DATE(2024,1,3),A1:A5,1)` => 3 on an ascending date column.
+#[test]
+fn match_approximate_orders_date_typed_keys() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(DATE(2024,1,3),A1:A5,1)"),
+        3.0,
+        "MATCH(DATE(2024,1,3),A1:A5,1)",
+    );
+}
+
+/// Excel: `=MATCH(DATE(2024,1,4)+0.5,A1:A5,1)` => 4. A needle between two
+/// date keys selects the largest key not greater than it, which is only
+/// possible if dates order against non-integral serials.
+#[test]
+fn match_approximate_orders_dates_against_fractional_serials() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=MATCH(DATE(2024,1,4)+0.5,A1:A5,1)"),
+        4.0,
+        "MATCH(DATE(2024,1,4)+0.5,A1:A5,1)",
+    );
+}
+
+/// Excel: `=VLOOKUP(D1,A1:B5,2,FALSE)` => 30.
+#[test]
+fn vlookup_exact_resolves_a_date_typed_key() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=VLOOKUP(D1,A1:B5,2,FALSE)"),
+        30.0,
+        "VLOOKUP(D1,A1:B5,2,FALSE)",
+    );
+}
+
+/// Excel: `=VLOOKUP(DATE(2024,1,3),A1:B5,2,TRUE)` => 30.
+#[test]
+fn vlookup_approximate_resolves_a_date_typed_key() {
+    let mut engine = build_date_engine();
+    assert_number(
+        eval(&mut engine, "=VLOOKUP(DATE(2024,1,3),A1:B5,2,TRUE)"),
+        30.0,
+        "VLOOKUP(DATE(2024,1,3),A1:B5,2,TRUE)",
+    );
+}
+
+/// Control: a date outside the key column is still `#N/A`. Making dates
+/// comparable must not make every date match something.
+/// Excel: `=MATCH(DATE(2024,1,9),A1:A5,0)` => `#N/A`.
+#[test]
+fn match_exact_still_reports_na_for_an_absent_date() {
+    let mut engine = build_date_engine();
+    match eval(&mut engine, "=MATCH(DATE(2024,1,9),A1:A5,0)") {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, formualizer_common::ExcelErrorKind::Na),
+        other => panic!("expected #N/A, got {other:?}"),
+    }
+}
+
+/// A `Time` cell is the fractional part of a serial and orders the same way.
+/// Excel: with A=06:00,12:00,18:00 written as times, `=MATCH(0.5,A1:A3,0)`
+/// => 2 (12:00 is serial fraction 0.5).
+#[test]
+fn match_exact_finds_a_time_typed_key_by_its_serial_fraction() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, hour) in [(1u32, 6u32), (2, 12), (3, 18)] {
+        engine
+            .set_cell_value(
+                "Sheet1",
+                row,
+                1,
+                LiteralValue::Time(NaiveTime::from_hms_opt(hour, 0, 0).unwrap()),
+            )
+            .unwrap();
+    }
+    assert_number(
+        eval(&mut engine, "=MATCH(0.5,A1:A3,0)"),
+        2.0,
+        "MATCH(0.5,A1:A3,0)",
+    );
+}


### PR DESCRIPTION
Lands @tommy230's #321 plus the fix pass for the adversarial review of #321 and #322, and folds in #320.

Fixes #316. Fixes #320. Completes #317.

## Why this PR exists rather than a merge of #321

#321 conflicts with #322 — both edit `lookup_utils.rs` — and the fix pass could not be pushed onto the contributor's branch: GitHub does not honour `maintainer_can_modify` for **organization-owned** forks, and the fork is org-owned. The API reports `maintainer_can_modify=true` regardless, which is misleading in exactly this case.

So @tommy230's commit `f4d816b4` is carried here **with their authorship intact** rather than reapplied. #321 should be closed as landed-via-this-PR, not as rejected. Their #322 commit `56df53b8` merged normally and is already on `main`.

## What the fix pass changed

**Errors propagate from approximate-lookup ranges instead of being silently skipped.** `is_searchable_for_approximate` used a comparability test, and `cmp_for_lookup(Error(..), _)` is `None`, so an error entry was projected out exactly like a text header — `=MATCH(5,H1:H4,1)` with `H3 = #DIV/0!` returned `2`. It now returns `#DIV/0!`. This was reachable without anyone writing an error on purpose, because pre-1900 date cells materialise as `#NUM!`. The rule is now documented in `core.rs` rather than being an emergent side effect of a comparability check.

**The workbook date system is threaded through the lookup helpers.** #321 hardcoded `as_serial_number()`, which is 1900, in a crate that threads `DateSystem` everywhere else. Under a 1904 workbook — reachable through the JSON backend and the Python `date_system="1904"` API — the fix half-landed and introduced a new false positive: a `Date` needle matched an unrelated plain serial, because cells reach the exact path as 1904 serials while the needle converted through the 1900 helper. `45294` under 1904 is 2028-01-04, so a 2024 date matched a 2028 serial. Threading the parameter was preferred over scoping the PR to 1900: an unfixed case is acceptable, a new wrong answer is not.

**#320 folded in.** The `match_type = -1` branch selected the first entry `>=` the needle where descending data needs the last. One line at `core.rs:78`. It belongs here because #322's sortedness-guard repair changed #320 from latent on blank-free descending ranges to live on any descending range with 8 or more searchable entries — the descending guard previously bailed on blank-containing data, which accidentally shielded it.

**Ordering hazard pinned.** #321 alone turned `=VLOOKUP(<date>,A1:B10,2,TRUE)` over a date column with a blank tail from `#N/A` into a silent `0`, since its temporal arm sits above the untouched `Empty => Some(0.0)` arm. A test now pins the pairing so the constraint cannot be lost.

Also: tests for `LookupHashKey::from_literal`, which had none and whose absence lets the same formula return different answers depending on whether the hash index is warm; tests killing the review's live surviving mutants (ascending guard boundary, the original-position remap, the searchable-count threshold); and doc corrections at `core.rs:11` and `core.rs:19`.

## Verified

| formula | before | after | Excel |
|---|---|---|---|
| `=VLOOKUP(<date>,A1:B10,2,TRUE)` blank tail | `#N/A` | `30` | `30` |
| `=VLOOKUP(<date>,A1:B5,2,FALSE)` | `#N/A` | `30` | `30` |
| `=MATCH(<date>,A1:A5,0)` | `#N/A` | `3` | `3` |
| `=MATCH(3,A1:A10,1)` blank tail | `#N/A` | `3` | `3` |
| `=VLOOKUP(3,A1:B10,2,TRUE)` blank tail | `0` | `30` | `30` |
| `=MATCH(3.5,A1:A10,-1)` descending | `1` | `7` | `7` |
| `=MATCH(5,H1:H4,1)` with `#DIV/0!` | `2` | `#DIV/0!` | error |

Full workspace suite passes, fmt and clippy clean. Values above were re-verified by the maintainer on the merged tree through public entry points, independently of the contributed tests.

`Empty => Some(0.0)` is deliberately untouched: that is #319, and it is load bearing across #279 and #285, so it wants an Excel and LibreOffice variant study across exact match, approximate match, criteria, and aggregation before anyone changes that helper.

drafted with love by (agent) Manfred, with approval from Frankie
