### PR TITLE
fix(py): release the GIL while the engine evaluates to avoid deadlock

### DIFF
--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -36,6 +36,15 @@ fn validate_cell_coords(row: u32, col: u32) -> PyResult<()> {
     Ok(())
 }
 
+/// Map a poisoned-lock error to a workbook `IoError` so it can cross the thread
+/// boundary of a `py.detach` region without touching Python objects.
+fn lock_error_to_io<E: std::fmt::Display>(e: &E) -> formualizer::workbook::IoError {
+    formualizer::workbook::IoError::Backend {
+        backend: "lock".to_string(),
+        message: e.to_string(),
+    }
+}
+
 struct PyCustomFnHandler {
     callback: PyObject,
 }
@@ -776,29 +785,29 @@ impl PyWorkbook {
     ) -> PyResult<PyObject> {
         validate_cell_coords(row, col)?;
 
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
-        let v = wb
-            .evaluate_cell(sheet, row, col)
-            .map_err(workbook_error_to_pyerr)?;
+        let res = py.detach(|| {
+            self.inner
+                .write()
+                .map_err(|e| lock_error_to_io(&e))?
+                .evaluate_cell(sheet, row, col)
+        });
+        let v = res.map_err(workbook_error_to_pyerr)?;
         literal_to_py(py, &v)
     }
 
-    pub fn evaluate_all(&self) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
-
+    pub fn evaluate_all(&self, py: Python<'_>) -> PyResult<()> {
         // Ensure flag is reset before starting
         self.cancel_flag
             .store(false, std::sync::atomic::Ordering::SeqCst);
 
-        wb.evaluate_all_cancellable(formualizer::eval::engine::CancelToken::from_flag(
-            self.cancel_flag.clone(),
-        ))
+        py.detach(|| {
+            self.inner
+                .write()
+                .map_err(|e| lock_error_to_io(&e))?
+                .evaluate_all_cancellable(formualizer::eval::engine::CancelToken::from_flag(
+                    self.cancel_flag.clone(),
+                ))
+        })
         .map_err(workbook_error_to_pyerr)?;
         Ok(())
     }
@@ -850,11 +859,6 @@ impl PyWorkbook {
             target_vec.push((sheet, row, col));
         }
 
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
-
         // Ensure flag is reset
         self.cancel_flag
             .store(false, std::sync::atomic::Ordering::SeqCst);
@@ -865,11 +869,16 @@ impl PyWorkbook {
             .map(|(s, r, c)| (s.as_str(), *r, *c))
             .collect();
 
-        let results = wb
-            .evaluate_cells_cancellable(
-                &refs,
-                formualizer::eval::engine::CancelToken::from_flag(self.cancel_flag.clone()),
-            )
+        let results = py
+            .detach(|| {
+                self.inner
+                    .write()
+                    .map_err(|e| lock_error_to_io(&e))?
+                    .evaluate_cells_cancellable(
+                        &refs,
+                        formualizer::eval::engine::CancelToken::from_flag(self.cancel_flag.clone()),
+                    )
+            })
             .map_err(workbook_error_to_pyerr)?;
 
         let py_results = pyo3::types::PyList::empty(py);

--- a/bindings/python/tests/test_custom_fn_loaded_deadlock.py
+++ b/bindings/python/tests/test_custom_fn_loaded_deadlock.py
@@ -1,0 +1,122 @@
+"""Custom functions must work on workbooks loaded from XLSX without hanging.
+
+Regression test for the GIL deadlock where `evaluate_all`/`evaluate_cell`/
+`evaluate_cells` on a loaded workbook would block forever as soon as a rayon
+worker evaluated a Python-backed custom function: the main thread held the GIL
+while waiting on the parallel layer, and the worker blocked on
+``PyGILState_Ensure`` waiting for that same GIL.
+
+The workbook is sized so a single evaluation layer contains many formula
+vertices, which forces the engine's parallel layer to run on rayon worker
+threads and reproduces the deadlock on the broken binding.
+"""
+import datetime
+from pathlib import Path
+
+import pytest
+
+import formualizer as fz
+
+try:
+    import openpyxl  # type: ignore
+except Exception:  # pragma: no cover - allow skipping if not present in dev env
+    openpyxl = None
+
+pytestmark = pytest.mark.skipif(openpyxl is None, reason="openpyxl not installed")
+
+_SER0 = datetime.date(1899, 12, 30)
+
+# Matches the benchmark XNPV reference case (LibreOffice cross-check):
+# rate 0.1, cashflows -1000/200/300/400/500 on quarterly dates.
+_NPV_VALUE = 308.1871372025822
+
+_NUM_FORMULAS = 120
+
+
+def _xnpv(rate, values, dates):
+    def column(m):
+        return [row[0] if isinstance(row, (list, tuple)) else row for row in m]
+
+    def to_serial(x):
+        if isinstance(x, datetime.date):
+            return (x - _SER0).days
+        return float(x)
+
+    v = [float(x) for x in column(values)]
+    d = [to_serial(x) for x in column(dates)]
+    d0 = d[0]
+    return sum(v[i] / (1.0 + rate) ** ((d[i] - d0) / 365.0) for i in range(len(v)))
+
+
+def make_loaded_workbook(tmp: Path) -> fz.Workbook:
+    path = tmp / "custom_fn.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = 0.1
+    values = [-1000, 200, 300, 400, 500]
+    dates = [
+        datetime.date(2024, 1, 1),
+        datetime.date(2024, 4, 1),
+        datetime.date(2024, 7, 1),
+        datetime.date(2024, 10, 1),
+        datetime.date(2025, 1, 1),
+    ]
+    for i, (value, date) in enumerate(zip(values, dates)):
+        ws.cell(row=2 + i, column=2, value=value)
+        cell = ws.cell(row=2 + i, column=3, value=date)
+        cell.number_format = "yyyy-mm-dd"
+    for i in range(_NUM_FORMULAS):
+        ws.cell(
+            row=2 + i,
+            column=4,
+            value="=XNPV($A$1,$B$2:$B$6,$C$2:$C$6)",
+        )
+    wb.save(path)
+    return fz.load_workbook(str(path), strategy="eager_all")
+
+
+def register_xnpv(wb: fz.Workbook) -> None:
+    wb.register_function(
+        "xnpv", _xnpv, min_args=3, max_args=3, allow_override_builtin=True
+    )
+
+
+def test_custom_function_on_loaded_workbook_evaluate_all(tmp_path: Path):
+    wb = make_loaded_workbook(tmp_path)
+    register_xnpv(wb)
+
+    wb.evaluate_all()
+    for row in (3, 42, 121):
+        assert wb.get_value("Sheet1", row, 4) == pytest.approx(
+            _NPV_VALUE, rel=1e-9
+        )
+
+
+def test_custom_function_on_loaded_workbook_evaluate_cell(tmp_path: Path):
+    wb = make_loaded_workbook(tmp_path)
+    register_xnpv(wb)
+
+    value = wb.evaluate_cell("Sheet1", 3, 4)
+    assert value == pytest.approx(_NPV_VALUE, rel=1e-9)
+
+
+def test_custom_function_on_loaded_workbook_evaluate_cells(tmp_path: Path):
+    wb = make_loaded_workbook(tmp_path)
+    register_xnpv(wb)
+
+    results = wb.evaluate_cells(
+        [("Sheet1", 3, 4), ("Sheet1", 121, 4)]
+    )
+    assert results[0] == pytest.approx(_NPV_VALUE, rel=1e-9)
+    assert results[1] == pytest.approx(_NPV_VALUE, rel=1e-9)
+
+
+def test_native_xnpv_still_errors_without_override(tmp_path: Path):
+    wb = make_loaded_workbook(tmp_path)
+
+    wb.evaluate_all()
+    value = wb.get_value("Sheet1", 3, 4)
+    assert isinstance(value, dict)
+    assert value.get("type") == "Error"
+    assert value.get("kind") == "Num"


### PR DESCRIPTION
evaluate_cell/evaluate_all/evaluate_cells called the engine while holding the GIL. The engine evaluates layers in parallel on rayon worker threads, so any worker that reached a Python-backed custom function blocked on PyGILState_Ensure waiting for the GIL the main thread held while waiting on the pool - a deadlock. On a workbook loaded from XLSX with a custom function registered, evaluate_all hung forever.

Wrap the engine calls in py.detach() so the GIL is released during evaluation and worker threads can acquire it when invoking Python callbacks. The workbook lock is now acquired inside the detached closure because the std RwLockWriteGuard is not Send.

Regression test: load an XLSX with many XNPV formulas, override XNPV with a Python callback, and evaluate via evaluate_all/evaluate_cell/ evaluate_cells. The suite hangs on 0.8.2 and passes with this fix.