### PR TITLE
fix(financial): coerce date cells to serials in XNPV/XIRR dates

### DIFF
--- a/crates/formualizer-eval/src/builtins/financial/tvm.rs
+++ b/crates/formualizer-eval/src/builtins/financial/tvm.rs
@@ -3,7 +3,10 @@
 use crate::args::ArgSchema;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
-use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
+use formualizer_common::{
+    DateSystem, ExcelError, ExcelErrorKind, LiteralValue, date_to_serial_for,
+    datetime_to_serial_for,
+};
 use formualizer_macros::func_caps;
 
 fn coerce_num(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
@@ -19,6 +22,14 @@ fn coerce_literal_num(v: &LiteralValue) -> Result<f64, ExcelError> {
         LiteralValue::Empty => Ok(0.0),
         LiteralValue::Error(e) => Err(e.clone()),
         _ => Err(ExcelError::new_value()),
+    }
+}
+
+fn coerce_literal_date_serial(v: &LiteralValue, system: DateSystem) -> Result<f64, ExcelError> {
+    match v {
+        LiteralValue::Date(d) => Ok(date_to_serial_for(system, d)),
+        LiteralValue::DateTime(dt) => Ok(datetime_to_serial_for(system, dt)),
+        other => coerce_literal_num(other),
     }
 }
 
@@ -1878,7 +1889,7 @@ impl Function for XnpvFn {
     fn eval<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
-        _ctx: &dyn FunctionContext<'b>,
+        ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
         let rate = coerce_num(&args[0])?;
 
@@ -1927,20 +1938,20 @@ impl Function for XnpvFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_num(&cell) {
+                            if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
                                 dates.push(n);
                             }
                         }
                     }
                 }
-                other => dates.push(coerce_literal_num(&other)?),
+                other => dates.push(coerce_literal_date_serial(&other, ctx.date_system())?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_num(&cell) {
+                        if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
                             dates.push(n);
                         }
                     }
@@ -2072,7 +2083,7 @@ impl Function for XirrFn {
     fn eval<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
-        _ctx: &dyn FunctionContext<'b>,
+        ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
         // Collect values
         let mut values = Vec::new();
@@ -2119,20 +2130,20 @@ impl Function for XirrFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_num(&cell) {
+                            if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
                                 dates.push(n);
                             }
                         }
                     }
                 }
-                other => dates.push(coerce_literal_num(&other)?),
+                other => dates.push(coerce_literal_date_serial(&other, ctx.date_system())?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_num(&cell) {
+                        if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
                             dates.push(n);
                         }
                     }

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -148,6 +148,7 @@ mod info_reference_context;
 mod inspect;
 mod let_lambda;
 mod npv_variadic;
+mod xnpv_xirr_dates;
 mod offset_dynamic;
 mod omitted_arguments;
 mod open_ended_bounds_caps;

--- a/crates/formualizer-eval/src/engine/tests/xnpv_xirr_dates.rs
+++ b/crates/formualizer-eval/src/engine/tests/xnpv_xirr_dates.rs
@@ -1,0 +1,135 @@
+//! XNPV/XIRR accept date cells in the dates argument.
+//!
+//! Regression: before the fix, dates were coerced with `coerce_literal_num`,
+//! which dropped `Date`/`DateTime` cells from the array/range collection
+//! paths, so the date vector ended up shorter than the values vector and the
+//! function returned #NUM!.
+//!
+//! Oracle: LibreOffice 24.2 headless recalculation (values
+//! [-1000, 200, 300, 400, 500] on 2024-01-01 .. 2025-01-01 at rate 10%).
+use chrono::NaiveDate;
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+fn xnpv_fixture() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, value) in [(1, -1000), (2, 200), (3, 300), (4, 400), (5, 500)] {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Int(value))
+            .unwrap();
+    }
+    for (row, date) in [
+        (1, (2024, 1, 1)),
+        (2, (2024, 4, 1)),
+        (3, (2024, 7, 1)),
+        (4, (2024, 10, 1)),
+        (5, (2025, 1, 1)),
+    ] {
+        engine
+            .set_cell_value(
+                "Sheet1",
+                row,
+                2,
+                LiteralValue::Date(NaiveDate::from_ymd_opt(date.0, date.1, date.2).unwrap()),
+            )
+            .unwrap();
+    }
+    engine
+}
+
+fn eval_formula(mut engine: Engine<TestWorkbook>, formula: &str) -> LiteralValue {
+    engine
+        .set_cell_formula("Sheet1", 1, 5, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+        .get_cell_value("Sheet1", 1, 5)
+        .unwrap_or(LiteralValue::Empty)
+}
+
+fn assert_number(formula: &str, expected: f64, tol: f64) {
+    match eval_formula(xnpv_fixture(), formula) {
+        LiteralValue::Number(actual) => assert!(
+            (actual - expected).abs() < tol,
+            "{formula}: expected {expected}, got {actual}"
+        ),
+        other => panic!("{formula}: expected {expected}, got {other:?}"),
+    }
+}
+
+fn assert_num_error(formula: &str) {
+    match eval_formula(xnpv_fixture(), formula) {
+        LiteralValue::Error(error) => {
+            assert_eq!(error.kind, ExcelErrorKind::Num, "{formula}: {error}")
+        }
+        other => panic!("{formula}: expected #NUM!, got {other:?}"),
+    }
+}
+
+#[test]
+fn xnpv_accepts_date_cells() {
+    assert_number(
+        "=XNPV(0.1,A1:A5,B1:B5)",
+        308.1871372025822211,
+        1e-9,
+    );
+}
+
+#[test]
+fn xnpv_accepts_numeric_serials() {
+    // Numeric serial dates must keep working.
+    assert_number(
+        "=XNPV(0.1,A1:A5,{45292,45383,45474,45566,45658})",
+        308.1871372025822211,
+        1e-9,
+    );
+}
+
+#[test]
+fn xnpv_accepts_datetime_cells() {
+    // First date carries a time fraction: 2024-01-01 12:00 -> serial 45292.5.
+    let mut engine = xnpv_fixture();
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            2,
+            LiteralValue::DateTime(
+                NaiveDate::from_ymd_opt(2024, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+        )
+        .unwrap();
+    match eval_formula(engine, "=XNPV(0.1,A1:A5,B1:B5)") {
+        LiteralValue::Number(actual) => assert!(
+            (actual - 308.3579477383065068).abs() < 1e-9,
+            "expected 308.3579477383065068, got {actual}"
+        ),
+        other => panic!("expected number, got {other:?}"),
+    }
+}
+
+#[test]
+fn xnpv_missing_dates_returns_num_error() {
+    // 5 values but only 3 dates must stay #NUM!.
+    assert_num_error("=XNPV(0.1,A1:A5,B1:B3)");
+}
+
+#[test]
+fn xirr_accepts_date_cells() {
+    assert_number("=XIRR(A1:A5,B1:B5)", 0.6197585938091048, 1e-6);
+}
+
+#[test]
+fn xirr_accepts_numeric_serials() {
+    assert_number(
+        "=XIRR(A1:A5,{45292,45383,45474,45566,45658})",
+        0.6197585938091048,
+        1e-6,
+    );
+}


### PR DESCRIPTION
XNPV and XIRR collected their dates argument with coerce_literal_num, which does not know Date/DateTime values. Cells holding dates were silently dropped from the array/range collection paths, so the dates vector ended up shorter than the values vector and the functions returned #NUM! on any date-typed input.

Add coerce_literal_date_serial, which maps Date/DateTime to their Excel serial in the workbook's date system (via date_to_serial_for / datetime_to_serial_for) and defers everything else to coerce_literal_num. Numeric serials, booleans, empties, errors and length-mismatch behavior are unchanged.

Regression tests (LibreOffice 24.2 oracle): XNPV(10%, [-1000,200,300, 400,500], [2024-01-01..2025-01-01]) = 308.1871372025822 and XIRR of the same cashflows = 0.6197585938091048, via date cells, datetime cells and numeric serials alike.