### PR TITLE
fix(eval): approximate lookups skip error cells instead of propagating them (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Approximate `MATCH`, `VLOOKUP`, and `HLOOKUP` skip error cells in the lookup range instead of propagating them. 0.8.2 introduced range-wide propagation, which diverged from desktop Excel on 8 of 10 measured oracle rows: a single `#DIV/0!` anywhere in a lookup column poisoned every approximate lookup over that column, where Excel answers normally. Error cells are projected out of the search exactly like blanks and other-class entries — they cannot be returned, do not break sortedness, and are not propagated even when a bisection probe lands on one. A range with nothing searchable left yields `#N/A`, and exact mode still never matches an error cell. Oracle contributed by an external reporter running desktop Excel 16.105.3 under AppleScript automation. (#326)
+- Descending approximate `MATCH` returns the *first* entry of an exact-match run rather than the last, matching Excel; the last qualifying entry is still returned when the needle falls between two values. This affected ranges with fewer than eight searchable entries, whose linear path lacked the exact-match rule the bisection path already had. (#326)
+
 ## [0.8.2] - 2026-08-11
 
 ### Fixed

--- a/crates/formualizer-eval/src/builtins/lookup/core.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/core.rs
@@ -337,8 +337,16 @@ impl Function for MatchFn {
                                         best = Some(i);
                                     }
                                 } else {
-                                    // -1, v >= needle
-                                    if (c == 0 || c == 1) && (best.is_none() || i > best.unwrap()) {
+                                    // -1, v >= needle. Excel returns the *first*
+                                    // entry of an exact-match run on a descending
+                                    // range, but the *last* entry that still
+                                    // qualifies when the needle falls between two
+                                    // values. This mirrors the >= 8 path.
+                                    if c == 0 {
+                                        best = Some(i);
+                                        break;
+                                    }
+                                    if c == 1 && (best.is_none() || i > best.unwrap()) {
                                         best = Some(i);
                                     }
                                 }

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -164,12 +164,6 @@ impl<'a> SearchedVector<'a> {
         needle: &LiteralValue,
         date_system: DateSystem,
     ) -> Result<Self, ExcelError> {
-        if let Some(error) = values.iter().find_map(|value| match value {
-            LiteralValue::Error(error) => Some(error.clone()),
-            _ => None,
-        }) {
-            return Err(error);
-        }
         let first_skipped = values
             .iter()
             .position(|v| !is_searchable_for_approximate(v, needle, date_system));

--- a/crates/formualizer-eval/src/engine/tests/approximate_lookup_ignored_entries.rs
+++ b/crates/formualizer-eval/src/engine/tests/approximate_lookup_ignored_entries.rs
@@ -10,6 +10,12 @@
 //! text column -- are skipped. They neither make the vector look unsorted nor
 //! occupy a matchable position, and the returned index is still the position
 //! in the *original* range, not in the compacted one.
+//!
+//! Error cells are skipped on exactly the same terms (issue #326, oracle rows
+//! reproduced in `issue_326_error_skip_oracle.rs`): they are projected out of
+//! the search, cannot be returned, never break sortedness, and are not
+//! propagated even when a bisection probe lands on one. A range with nothing
+//! searchable left yields #N/A.
 
 use crate::engine::{Engine, EvalConfig};
 use crate::test_workbook::TestWorkbook;
@@ -275,10 +281,11 @@ fn exact_match_over_a_blank_tail_is_unaffected() {
 }
 
 #[test]
-fn approximate_lookups_propagate_errors_in_any_lookup_position() {
+fn approximate_lookups_skip_error_entries_in_any_lookup_position() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
     let error = LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div));
 
+    // A = 1, 2, #DIV/0!, 9 with B = 10, 20, 30, 40.
     for (row, value) in [
         LiteralValue::Int(1),
         LiteralValue::Int(2),
@@ -300,34 +307,37 @@ fn approximate_lookups_propagate_errors_in_any_lookup_position() {
             )
             .unwrap();
     }
-    assert_error(
+    // The error sits where the search decides. Excel projects it out and
+    // answers from the surviving entries: the largest value <= 5 is the 2 in
+    // row 2, counted in the original range.
+    assert_number(
         eval(&mut engine, "=MATCH(5,A1:A4,1)"),
-        ExcelErrorKind::Div,
-        "MATCH ascending deciding error",
+        2.0,
+        "MATCH ascending skips a deciding error",
     );
-    assert_error(
+    assert_number(
         eval(&mut engine, "=VLOOKUP(5,A1:B4,2,TRUE)"),
-        ExcelErrorKind::Div,
-        "VLOOKUP deciding error",
+        20.0,
+        "VLOOKUP skips a deciding error",
     );
 
-    // Move the error beyond a key that already disqualifies the final row. The
-    // implemented Excel rule is range-wide propagation, not search-path-dependent.
+    // Move the error past a key that already disqualifies the final row: the
+    // answer is unchanged, so skipping is not search-path dependent.
     engine
         .set_cell_value("Sheet1", 3, 1, LiteralValue::Int(9))
         .unwrap();
     engine
         .set_cell_value("Sheet1", 4, 1, error.clone())
         .unwrap();
-    assert_error(
+    assert_number(
         eval(&mut engine, "=MATCH(5,A1:A4,1)"),
-        ExcelErrorKind::Div,
-        "MATCH ascending non-deciding error",
+        2.0,
+        "MATCH ascending skips a non-deciding error",
     );
-    assert_error(
+    assert_number(
         eval(&mut engine, "=VLOOKUP(5,A1:B4,2,TRUE)"),
-        ExcelErrorKind::Div,
-        "VLOOKUP non-deciding error",
+        20.0,
+        "VLOOKUP skips a non-deciding error",
     );
 
     for (col, value) in [
@@ -351,12 +361,13 @@ fn approximate_lookups_propagate_errors_in_any_lookup_position() {
             )
             .unwrap();
     }
-    assert_error(
+    assert_number(
         eval(&mut engine, "=HLOOKUP(5,A10:D11,2,TRUE)"),
-        ExcelErrorKind::Div,
-        "HLOOKUP non-deciding error",
+        20.0,
+        "HLOOKUP skips a non-deciding error",
     );
 
+    // Descending: 9, #DIV/0!, 2, 1. The smallest entry >= 5 is the 9 in row 1.
     for (row, value) in [
         LiteralValue::Int(9),
         error,
@@ -370,15 +381,34 @@ fn approximate_lookups_propagate_errors_in_any_lookup_position() {
             .set_cell_value("Sheet1", row as u32 + 1, 5, value)
             .unwrap();
     }
-    assert_error(
+    assert_number(
         eval(&mut engine, "=MATCH(5,E1:E4,-1)"),
-        ExcelErrorKind::Div,
-        "MATCH descending deciding error",
+        1.0,
+        "MATCH descending skips a deciding error",
+    );
+
+    // An all-error range has nothing searchable: #N/A, not the error.
+    for row in 1..=3u32 {
+        engine
+            .set_cell_value(
+                "Sheet1",
+                row,
+                6,
+                LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div)),
+            )
+            .unwrap();
+    }
+    assert_na(eval(&mut engine, "=MATCH(5,F1:F3,1)"), "all-error range");
+
+    // Exact mode never matches an error cell.
+    assert_na(
+        eval(&mut engine, "=MATCH(5,F1:F3,0)"),
+        "exact mode over errors",
     );
 }
 
 #[test]
-fn approximate_match_propagates_materialized_pre_1900_date_error() {
+fn approximate_match_skips_materialized_pre_1900_date_error() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
     for (row, date) in [(1899, 1, 1), (1899, 6, 1), (1900, 3, 1), (2024, 1, 1)]
         .into_iter()
@@ -393,10 +423,13 @@ fn approximate_match_propagates_materialized_pre_1900_date_error() {
             )
             .unwrap();
     }
-    assert_error(
+    // The three pre-1900 dates materialize as #NUM!. Excel projects error cells
+    // out of an approximate search, so the only searchable entry is the 2024
+    // date in row 4, and the needle lands on it.
+    assert_number(
         eval(&mut engine, "=MATCH(50000,A1:A4,1)"),
-        ExcelErrorKind::Num,
-        "MATCH over pre-1900 date errors",
+        4.0,
+        "MATCH skips pre-1900 date errors",
     );
 }
 
@@ -506,7 +539,7 @@ fn searchable_count_keeps_duplicate_tie_break_on_small_descending_data() {
     }
     assert_number(
         eval(&mut engine, "=MATCH(4,E1:E10,-1)"),
-        3.0,
+        2.0,
         "MATCH threshold preserves descending duplicate tie-break",
     );
 }
@@ -526,7 +559,7 @@ fn searchable_count_not_range_extent_controls_descending_tie_break() {
     }
     assert_number(
         eval(&mut engine, "=MATCH(4,E1:E10,-1)"),
-        4.0,
+        3.0,
         "MATCH threshold uses projected length, not range extent",
     );
 }

--- a/crates/formualizer-eval/src/engine/tests/issue_326_error_skip_oracle.rs
+++ b/crates/formualizer-eval/src/engine/tests/issue_326_error_skip_oracle.rs
@@ -1,0 +1,121 @@
+//! Excel oracle for error cells and duplicate tie-breaks in approximate lookups.
+//!
+//! Issue #326. Oracle: desktop Microsoft Excel 16.105.3, driven by AppleScript
+//! against fresh workbooks so there is no manual-entry ambiguity; error cells
+//! produced by real formulas (`=1/0`, `=SQRT(-1)`); results read back twice.
+//! Contributed by @tommy230.
+//!
+//! The 100-element rows are load bearing: the range is large enough for true
+//! bisection and the error sits exactly where the midpoint probe lands, yet
+//! nothing propagates. The descending 100-element row is the projection proof --
+//! were the error cell live-valued the answer would be 50, and Excel returns 49.
+//!
+//! 0.8.2 shipped range-wide error propagation here, which diverged from Excel on
+//! 8 of these rows.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parse;
+
+fn mk() -> Engine<TestWorkbook> {
+    Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_parallel(false),
+    )
+}
+fn num(e: &mut Engine<TestWorkbook>, c: u32, r: u32, v: f64) {
+    e.set_cell_value("S", r, c, LiteralValue::Number(v))
+        .unwrap();
+}
+fn err(e: &mut Engine<TestWorkbook>, c: u32, r: u32, f: &str) {
+    e.set_cell_formula("S", r, c, parse(f).unwrap()).unwrap();
+}
+fn ev(e: &mut Engine<TestWorkbook>, f: &str) -> String {
+    e.set_cell_formula("S", 200, 20, parse(f).unwrap()).unwrap();
+    e.evaluate_all().unwrap();
+    match e.get_cell_value("S", 200, 20) {
+        Some(LiteralValue::Number(n)) => format!("{n}"),
+        Some(LiteralValue::Error(x)) => format!("{:?}", x.kind),
+        o => format!("{o:?}"),
+    }
+}
+fn row(label: &str, excel: &str, got: String, fails: &mut u32) {
+    if got != excel {
+        *fails += 1;
+    }
+    println!(
+        "  {:<6} excel={:<6} fz={:<8} {}",
+        label,
+        excel,
+        got,
+        if got == excel { "ok" } else { "** DIVERGES **" }
+    );
+}
+
+#[test]
+fn excel_oracle_table_for_error_cells_and_duplicate_tie_breaks() {
+    let mut f = 0u32;
+    println!("=== #326 oracle vs fix ===");
+    let mut e = mk();
+    num(&mut e, 8, 1, 1.0);
+    num(&mut e, 8, 2, 2.0);
+    err(&mut e, 8, 3, "=1/0");
+    num(&mut e, 8, 4, 9.0);
+    for r in 1..=4 {
+        num(&mut e, 9, r, f64::from(r * 10));
+    }
+    row("r1", "2", ev(&mut e, "=MATCH(5,H1:H4,1)"), &mut f);
+    row("r2", "20", ev(&mut e, "=VLOOKUP(5,H1:I4,2,TRUE)"), &mut f);
+    let mut a = mk();
+    for r in 1..=3 {
+        err(&mut a, 12, r, "=1/0");
+    }
+    row("r3", "Na", ev(&mut a, "=MATCH(5,L1:L3,1)"), &mut f);
+    let mut m = mk();
+    num(&mut m, 13, 1, 9.0);
+    num(&mut m, 13, 2, 8.0);
+    err(&mut m, 13, 3, "=1/0");
+    num(&mut m, 13, 4, 4.0);
+    num(&mut m, 13, 5, 1.0);
+    row("r4", "2", ev(&mut m, "=MATCH(5.5,M1:M5,-1)"), &mut f);
+    let mut s = mk();
+    for r in 1..=100u32 {
+        num(&mut s, 19, r, f64::from(r));
+    }
+    err(&mut s, 19, 50, "=SQRT(-1)");
+    err(&mut s, 19, 25, "=1/0");
+    row("r5", "75", ev(&mut s, "=MATCH(75.5,S1:S100,1)"), &mut f);
+    row("r6", "49", ev(&mut s, "=MATCH(50,S1:S100,1)"), &mut f);
+    row("r8", "Na", ev(&mut s, "=MATCH(50,S1:S100,0)"), &mut f);
+    let mut t = mk();
+    for r in 1..=100u32 {
+        num(&mut t, 20, r, f64::from(101 - r));
+    }
+    err(&mut t, 20, 50, "=SQRT(-1)");
+    row("r7", "49", ev(&mut t, "=MATCH(50.5,T1:T100,-1)"), &mut f);
+    // duplicates: descending small (<8) and large (>=8)
+    let mut d = mk();
+    for (i, v) in [9.0, 7.0, 7.0, 7.0, 5.0].iter().enumerate() {
+        num(&mut d, 21, (i + 1) as u32, *v);
+    }
+    row("dupA", "2", ev(&mut d, "=MATCH(7,U1:U5,-1)"), &mut f);
+    row("dupB", "4", ev(&mut d, "=MATCH(6,U1:U5,-1)"), &mut f);
+    let mut d2 = mk();
+    for (i, v) in [20.0, 9.0, 7.0, 7.0, 7.0, 5.0, 3.0, 2.0, 1.0, 0.0]
+        .iter()
+        .enumerate()
+    {
+        num(&mut d2, 22, (i + 1) as u32, *v);
+    }
+    row("dupA10", "3", ev(&mut d2, "=MATCH(7,V1:V10,-1)"), &mut f);
+    row("dupB10", "5", ev(&mut d2, "=MATCH(6,V1:V10,-1)"), &mut f);
+    // ascending duplicates: Excel returns LAST on equality
+    let mut asc = mk();
+    for (i, v) in [1.0, 5.0, 7.0, 7.0, 7.0, 9.0].iter().enumerate() {
+        num(&mut asc, 23, (i + 1) as u32, *v);
+    }
+    row("ascDup", "5", ev(&mut asc, "=MATCH(7,W1:W6,1)"), &mut f);
+    println!("=== divergences: {f} ===");
+    assert_eq!(f, 0, "{f} rows diverge from the Excel oracle");
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -21,6 +21,7 @@ mod evaluation_resource_ledger;
 mod evaluation_resource_observability;
 mod graph_basic;
 mod graph_internal_helpers;
+mod issue_326_error_skip_oracle;
 mod layer_evaluation;
 mod load_fast_mappings;
 //mod mark_dirty_benchmarks;


### PR DESCRIPTION
Fixes #326. Reverts the error-propagation semantics 0.8.2 shipped, because the Excel oracle contradicts them.

## What happened

The #322 adversarial review flagged that approximate lookups silently skipped error cells, since `is_searchable_for_approximate` used a comparability test and `cmp_for_lookup(Error(..), _)` is `None`. I argued that swallowing errors is wrong for a verifiability product and implemented range-wide propagation in the 0.8.2 fix pass. That was a defensible engineering position and wrong against Excel.

@tommy230 then ran the oracle the review had asked for — desktop Excel 16.105.3, AppleScript automation against fresh workbooks, error cells produced by real formulas, values read back twice — and measured the opposite. Excel projects error cells out of an approximate search. I reproduced their table against 0.8.2 and we diverged on 8 of 10 rows.

| | fixture | Excel | 0.8.2 | this PR |
|---|---|---|---|---|
| r1 | `MATCH(5,H1:H4,1)`, `#DIV/0!` at H3 | 2 | `#DIV/0!` | 2 |
| r2 | `VLOOKUP(5,H1:I4,2,TRUE)` | 20 | `#DIV/0!` | 20 |
| r3 | all-error range | `#N/A` | `#DIV/0!` | `#N/A` |
| r4 | descending, interior error | 2 | `#DIV/0!` | 2 |
| r5 | 100 elements, errors at S25 and S50 | 75 | `#DIV/0!` | 75 |
| r6 | needle equals the errored cell's would-be value | 49 | `#DIV/0!` | 49 |
| r7 | descending 100 elements | 49 | `#NUM!` | 49 |
| r8 | exact mode against the errored entry | `#N/A` | `#N/A` | `#N/A` |
| dupA | `MATCH(7,{9;7;7;7;5},-1)` | 2 | 4 | 2 |
| dupB | `MATCH(6,{9;7;7;7;5},-1)` | 4 | 4 | 4 |

The 100-element rows carry the argument: the range is large enough for true bisection and the error sits exactly where the midpoint probe lands, yet nothing propagates. r7 is the projection proof — were the error cell live-valued the answer would be 50, and Excel returns 49.

This was reachable in ordinary use. One `#DIV/0!` anywhere in a lookup column poisoned every approximate lookup over that column.

## Changes

The propagation block in `SearchedVector::new` is removed. Nothing replaces it: `cmp_for_lookup` already returns `None` for errors, so they project out through the existing skip path along with blanks and other-class entries. An exhausted projection yields `#N/A` via the existing empty-vector path.

`dupA` is a second, independent defect their run surfaced, and it is ours rather than a revert. There are two descending implementations, and the linear path for fewer than eight searchable entries lacked the exact-match-first rule that the bisection path at `core.rs:80` already had, so it returned the last duplicate on equality. Excel returns the first entry of an exact-match run on descending data, and the last qualifying entry only when the needle falls between two values.

## Tests

`issue_326_error_skip_oracle.rs` commits their table plus three rows I added to cover the boundary their fixtures did not reach: descending duplicates on a range at or above the eight-entry threshold, so both implementations are pinned, and ascending duplicates on equality. 13 rows, all matching Excel.

Four existing tests asserted the 0.8.2 semantics and were rewritten rather than deleted, keeping their original purpose. The two `searchable_count_*` tie-break tests were mutant-killing arbiters from the 0.8.2 fix pass; they still pin that the searchable count rather than the range extent selects the implementation, with the expected values corrected to Excel's. Note the two fixtures have different original positions, so they correct to 2 and 3 respectively rather than to the same value.

Mutation checked. Restoring the 0.8.2 propagation block fails 3 tests; reverting the descending tie-break fails 3 tests. Both include the new oracle table.

Full workspace: 2638 passed, 0 failed.

## Not changed

Exact-mode behaviour, which already matched (r8). The `Empty => Some(0.0)` coercion, which is #319. Error propagation from the lookup *value* argument, which is unrelated to range contents.

drafted with love by (agent) Manfred, with approval from Frankie
