### PR TITLE
fix(py,eval): SheetPort GIL deadlock, re-entrancy guard, bounded test timeouts, date-cell coercion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   test-python:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -101,6 +102,7 @@ jobs:
     # covered by test-python and the WASM workflow, and pulling them in here
     # needlessly compiles PyO3/wasm-bindgen twice.
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v4
@@ -157,6 +159,7 @@ jobs:
 
   public-api:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     permissions:
       contents: read
 
@@ -199,6 +202,7 @@ jobs:
 
   build-wheels:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -230,6 +234,7 @@ jobs:
 
   build-pyodide-wheel:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v4
@@ -294,6 +299,7 @@ jobs:
     needs: [test-python, test-rust]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -17,6 +17,7 @@ jobs:
   test-wasm:
     name: test-wasm
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Date-typed cells are treated as the numbers they are throughout the financial and statistical builtins. Excel has no separate date type on the sheet — a date cell holds a serial and is only formatted as a date — but three copy-pasted private coercion helpers plus two range collectors had no date arm, so `Date`/`DateTime`/`Time`/`Duration` cells were dropped or rejected. The consequences ranged from loud to invisible: `PRICE`, `YIELD`, `ACCRINT`, `ACCRINTM`, `TBILLPRICE`, `TBILLEQ`, `TBILLYIELD` returned `#VALUE!` when handed the date cells a workbook loaded from XLSX actually contains in their `settlement`/`maturity`/`issue` arguments; `NPV` returned `#VALUE!`; `XNPV`/`XIRR` returned `#NUM!` on their `values` argument; and `IRR`, `MIRR`, `MEDIAN`, `STDEV`, `VAR`, `LARGE`, `SMALL`, `PRODUCT`, `DEVSQ`, `PERCENTILE`, `QUARTILE`, `CORREL`, `SLOPE`, `RSQ`, `COVARIANCE`, `MAXA`, `MINA`, `AVERAGEA`, `STDEVA`, `VARA` and their siblings returned a *different number* with no error at all — while `SUM`, `AVERAGE` and `COUNT` over the very same range counted the date. All of these now agree with the numerically identical serial. (#328)
+- `XNPV` and `XIRR` truncate date serials to whole days. A cell holding `2024-01-01 12:00` (serial 45292.5) now discounts as day 45292, matching Microsoft's documented remark that numbers in dates are truncated to integers, and reproduced against LibreOffice 24.2.7.2, which returns `308.187137202582` where formualizer previously returned `308.357947738306`. (#328)
+- The date-serial conversion used by the financial builtins is now the crate-central `coercion::to_serial_strict` rather than three local duplicates, so it honours the workbook's date system and covers `Time`/`Duration` as well as `Date`/`DateTime`. (#328)
+
+### Python bindings
+
+- `SheetPortSession.evaluate_once`, `write_inputs`, `read_inputs` and `read_outputs` release the GIL while the engine runs. `SheetPortSession` owns a `Workbook` and `from_manifest_yaml` accepts a user-supplied one, so Python-backed custom functions are reachable from a SheetPort evaluation and hit exactly the deadlock fixed on `Workbook.evaluate_*`: the calling thread held the GIL waiting for the parallel layer while rayon workers blocked in `PyGILState_Ensure`. (#327)
+- Using a `Workbook` from inside one of its own Python custom functions raises `RuntimeError` instead of hanging forever. The engine holds a non-reentrant lock for the duration of an evaluation, so `get_value` on an uncached cell, `set_value`, `sheet_names`, a nested `evaluate_*`, `Sheet.get_cell` and every other workbook operation could never be granted and blocked permanently — non-deterministically, since `get_value` served from the compatibility cache returned normally. `cancel()` and `reset_cancel()` remain safe from a callback, and a callback may still drive a *different* workbook. The contract is documented on `register_function`. (#327)
+- The Python test suite is bounded by `faulthandler_timeout` with `faulthandler_exit_on_timeout`, and every CI job has a `timeout-minutes`. A deadlock regression now fails in 90 seconds with every thread's stack dumped, instead of running until GitHub's six-hour default. Measured: neither pytest-timeout's `thread` nor its `signal` method fires during a GIL deadlock, because both need to execute Python. (#327)
+
 ## [0.8.3] - 2026-08-13
 
 ### Fixed

--- a/bindings/python/formualizer/formualizer_py.pyi
+++ b/bindings/python/formualizer/formualizer_py.pyi
@@ -1655,6 +1655,41 @@ class Workbook:
     def register_function(self, name: builtins.str, callback: typing.Any, *, min_args: builtins.int = 0, max_args: typing.Optional[builtins.int] = None, volatile: builtins.bool = False, thread_safe: builtins.bool = False, deterministic: builtins.bool = True, allow_override_builtin: builtins.bool = False) -> None:
         r"""
         Register a workbook-local custom function backed by a Python callable.
+        
+        Re-entrancy contract
+        --------------------
+        **The callback must not touch the workbook it is registered on.** While
+        a custom function runs, the evaluation that invoked it holds the
+        workbook's lock, and that lock is not reentrant — a call back into the
+        same workbook can never be granted. Only `cancel()` and
+        `reset_cancel()` are safe from inside a callback: they flip an atomic
+        flag and never take the lock.
+        
+        Every other method (`get_value`, `set_value`, `sheet_names`,
+        `evaluate_cell`, `to_xlsx_bytes`, `Sheet.get_cell`, ...) now raises
+        `RuntimeError` when called from a callback rather than hanging forever.
+        `get_value` may still return from the compatibility cache without
+        raising, but that is a cache hit, not a supported operation — do not
+        rely on it.
+        
+        A callback *may* use a different `Workbook` instance, and may of course
+        use any non-formualizer Python state.
+        
+        The callback receives the evaluated arguments as Python values and must
+        return a Python value; raising an exception yields `#VALUE!` carrying
+        the exception text.
+        
+        Example:
+        ```python
+            import formualizer as fz
+        
+            wb = fz.Workbook()
+            wb.register_function("double", lambda x: x * 2, min_args=1, max_args=1)
+            s = wb.sheet("S")
+            s.set_value(1, 1, 21)
+            s.set_formula(1, 2, "=DOUBLE(A1)")
+            print(wb.evaluate_cell("S", 1, 2))  # 42.0
+        ```
         """
     def unregister_function(self, name: builtins.str) -> None:
         r"""

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -39,6 +39,9 @@ Repository = "https://github.com/PSU3D0/formualizer"
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=4.0",
+    # A deadlock regression must fail the suite, not hang the runner: the GIL
+    # deadlock fixed in #327 produced a test that ran >180s with no output.
+    "pytest-timeout>=2.3",
     "ruff>=0.1.0",
     "mypy>=1.0",
     "openpyxl"
@@ -92,6 +95,24 @@ known-first-party = ["formualizer"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
+# Two independent bounds, because they fail in different situations.
+#
+# `faulthandler_timeout` is the one that matters for this extension. pytest
+# arms it with `faulthandler.dump_traceback_later(..., exit=True)`, whose
+# watchdog is a *native* thread that never takes the GIL, so it still fires
+# when the interpreter is fully deadlocked (the GIL holder blocked in native
+# code while native threads wait for the GIL - the #327 bug). It dumps every
+# thread's stack and kills the process. MEASURED: neither pytest-timeout's
+# "thread" nor its "signal" method fires in that state, because both need to
+# execute Python.
+faulthandler_timeout = 60
+# Dumping alone is not enough: without this pytest passes `exit=False` and the
+# deadlocked process keeps running until the CI job's own limit. MEASURED.
+faulthandler_exit_on_timeout = true
+# pytest-timeout gives per-test bounds and a proper failure report for hangs
+# that *are* interruptible (a pure-Python loop, a stuck socket). Tests bound
+# themselves more tightly with @pytest.mark.timeout(...).
+timeout = 300
 addopts = [
     "--strict-markers",
     "--strict-config",
@@ -146,4 +167,5 @@ dev = [
     "openpyxl>=3.1.5",
     "pytest>=9.0.3",
     "pytest-cov>=5.0.0",
+    "pytest-timeout>=2.3",
 ]

--- a/bindings/python/src/inspect.rs
+++ b/bindings/python/src/inspect.rs
@@ -20,10 +20,6 @@ use crate::workbook::PyWorkbook;
 
 type PyObject = Py<PyAny>;
 
-fn lock_error(error: impl std::fmt::Display) -> PyErr {
-    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {error}"))
-}
-
 fn address_text(address: &CellAddress) -> String {
     address.to_string()
 }
@@ -1715,7 +1711,7 @@ impl PyWorkbook {
     #[pyo3(signature = (address, *, include_values=true))]
     fn inspect_cell(&self, address: &str, include_values: bool) -> PyResult<PyCellSnapshotReport> {
         let address = parse_cell(address)?;
-        let wb = self.inner.read().map_err(lock_error)?;
+        let wb = self.read_inner()?;
         wb.engine()
             .inspect_cell(
                 &address,
@@ -1736,7 +1732,7 @@ impl PyWorkbook {
         let options = core::PrecedentOptions::default()
             .with_max_links(max_links)
             .with_max_work(max_work);
-        let wb = self.inner.read().map_err(lock_error)?;
+        let wb = self.read_inner()?;
         wb.engine()
             .precedents(&address, &options)
             .map(Into::into)
@@ -1754,7 +1750,7 @@ impl PyWorkbook {
         let options = core::DependentsOptions::default()
             .with_max_results(max_results)
             .with_max_work(max_work);
-        let wb = self.inner.read().map_err(lock_error)?;
+        let wb = self.read_inner()?;
         wb.engine()
             .dependents(&address, &options)
             .map(Into::into)
@@ -1786,7 +1782,7 @@ impl PyWorkbook {
             .with_max_work(max_work)
             .with_range_member_budget(range_member_budget)
             .with_include_values(include_values);
-        let wb = self.inner.read().map_err(lock_error)?;
+        let wb = self.read_inner()?;
         wb.engine()
             .trace(&roots, &options)
             .map(Into::into)
@@ -1810,7 +1806,7 @@ impl PyWorkbook {
         if let Some(stamp) = expected_stamp {
             options = options.with_expected_stamp(stamp.inner);
         }
-        let wb = self.inner.read().map_err(lock_error)?;
+        let wb = self.read_inner()?;
         wb.engine()
             .range_page(&area, &options)
             .map(Into::into)

--- a/bindings/python/src/sheet.rs
+++ b/bindings/python/src/sheet.rs
@@ -82,6 +82,11 @@ impl PySheet {
             ));
         }
 
+        // `handle` shares the workbook's `RwLock`, so a callback reaching a
+        // Sheet obtained before evaluation deadlocks the same way the workbook
+        // methods do. Fail fast instead.
+        self.workbook.check_reentrancy()?;
+
         let cached = {
             let sheets = self.workbook.sheets.read().unwrap();
             sheets
@@ -181,6 +186,7 @@ impl PySheet {
             range.end_col,
         )
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+        self.workbook.check_reentrancy()?;
         let vals = self.handle.read_range(&ra);
         vals.into_iter()
             .map(|row| {
@@ -204,6 +210,7 @@ impl PySheet {
             range.end_col,
         )
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+        self.workbook.check_reentrancy()?;
         let height = ra.height();
         let width = ra.width();
         let mut out = Vec::with_capacity(height as usize);

--- a/bindings/python/src/sheetport.rs
+++ b/bindings/python/src/sheetport.rs
@@ -312,25 +312,62 @@ impl PySheetPortSession {
         Ok(Self { workbook, bindings })
     }
 
+    /// Run `f` against a `SheetPort` bound to the session's workbook **with the
+    /// GIL released**.
+    ///
+    /// `evaluate_once` drives a full engine evaluation, which fans out onto
+    /// rayon workers; if one of those workers reaches a Python-backed custom
+    /// function it blocks in `PyGILState_Ensure` while this thread waits for
+    /// the parallel layer to finish — the exact deadlock #327 fixed on
+    /// `Workbook.evaluate_*`. `PySheetPortSession` owns a `PyWorkbook` and
+    /// `from_manifest_yaml` takes a user-supplied one, so Python custom
+    /// functions are fully reachable here and the same treatment is required.
+    ///
+    /// Everything inside the detached region is plain Rust: the workbook lock,
+    /// the SheetPort run, and a `SheetPortError` carried back out. Errors are
+    /// converted to Python exceptions only after the GIL is re-attached.
     fn with_sheetport<'py, F, T>(&mut self, py: Python<'py>, f: F) -> PyResult<T>
     where
-        F: FnOnce(&mut SheetPort<'_>) -> RuntimeResult<T>,
+        F: FnOnce(&mut SheetPort<'_>) -> RuntimeResult<T> + Send,
+        T: Send,
     {
         let bindings_clone = self.bindings.clone();
-        let mut updated: Option<ManifestBindings> = None;
-        let result = self.workbook.with_workbook_mut(|workbook| {
-            let mut sheetport = SheetPort::from_bindings(workbook, bindings_clone)
-                .map_err(|err| map_sheetport_err(py, err))?;
-            let output = f(&mut sheetport).map_err(|err| map_sheetport_err(py, err))?;
-            let (_, bindings) = sheetport.into_parts();
-            updated = Some(bindings);
-            Ok(output)
-        })?;
-        if let Some(new_bindings) = updated {
-            self.bindings = new_bindings;
+        let workbook = self.workbook.clone();
+        let outcome = py.detach(
+            move || -> Result<(T, ManifestBindings), SheetPortCallError> {
+                let mut guard = workbook
+                    .write_inner_detached()
+                    .map_err(|err| SheetPortCallError::Runtime(err.into()))?;
+                // Internal mutations bypass the legacy `sheets` compatibility
+                // cache, so it is invalidated alongside the write (mirrors
+                // `PyWorkbook::with_workbook_mut`).
+                let mut sheetport = SheetPort::from_bindings(&mut guard, bindings_clone)
+                    .map_err(SheetPortCallError::Runtime)?;
+                let output = f(&mut sheetport).map_err(SheetPortCallError::Runtime)?;
+                let (_, bindings) = sheetport.into_parts();
+                Ok((output, bindings))
+            },
+        );
+
+        // The cache is cleared regardless of outcome: a failed write may still
+        // have mutated cells before erroring.
+        self.workbook.clear_sheet_cache();
+
+        match outcome {
+            Ok((output, bindings)) => {
+                self.bindings = bindings;
+                Ok(output)
+            }
+            Err(SheetPortCallError::Runtime(err)) => Err(map_sheetport_err(py, err)),
         }
-        Ok(result)
     }
+}
+
+/// Error escaping the detached region in [`PySheetPortSession::with_sheetport`].
+/// It must not reference Python state, so lock failures ride along as the
+/// runtime error's `Workbook` variant.
+enum SheetPortCallError {
+    Runtime(RuntimeSheetPortError),
 }
 
 fn bind_manifest(

--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -45,13 +45,66 @@ fn lock_error_to_io<E: std::fmt::Display>(e: &E) -> formualizer::workbook::IoErr
     }
 }
 
+/// Tracks, per OS thread, which workbooks are currently inside one of their own
+/// Python custom-function callbacks.
+///
+/// `Workbook`'s state lives behind a plain `std::sync::RwLock`, which is not
+/// reentrant: a callback that calls back into the workbook it is registered on
+/// blocks forever on a lock its own evaluation already holds. The callback runs
+/// on whichever thread the engine dispatched it to (the main thread serially,
+/// or a rayon worker in parallel mode), and any re-entrant call necessarily
+/// happens on that same thread, so a thread-local marker sees every case.
+mod reentrancy {
+    use std::cell::RefCell;
+
+    thread_local! {
+        static ACTIVE: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+    }
+
+    /// Marks `id` as evaluating on this thread for the guard's lifetime.
+    pub(super) struct ActiveCallback(usize);
+
+    impl ActiveCallback {
+        pub(super) fn enter(id: usize) -> Self {
+            ACTIVE.with(|active| active.borrow_mut().push(id));
+            Self(id)
+        }
+    }
+
+    impl Drop for ActiveCallback {
+        fn drop(&mut self) {
+            ACTIVE.with(|active| {
+                let mut active = active.borrow_mut();
+                if let Some(pos) = active.iter().rposition(|id| *id == self.0) {
+                    active.remove(pos);
+                }
+            });
+        }
+    }
+
+    pub(super) fn is_active(id: usize) -> bool {
+        ACTIVE.with(|active| active.borrow().contains(&id))
+    }
+}
+
+pub(crate) const REENTRANCY_MESSAGE: &str = "cannot use this Workbook from inside one of its own \
+     custom functions: the evaluation that invoked the callback already holds the workbook lock, so \
+     the call would deadlock. Only cancel() and reset_cancel() are safe from a callback.";
+
 struct PyCustomFnHandler {
     callback: PyObject,
+    /// Identity of the workbook this handler is registered on, used to detect
+    /// re-entrant access. The handler is owned by that workbook, so the `Arc`
+    /// is always alive while the handler runs and the address is stable.
+    workbook_id: usize,
 }
 
 impl PyCustomFnHandler {
-    fn new(callback: PyObject) -> Self {
-        Self { callback }
+    fn new(callback: PyObject, workbook_id: usize) -> Self {
+        Self {
+            callback,
+            workbook_id,
+        }
     }
 
     fn pyerr_to_excel_value(err: pyo3::PyErr, py: Python<'_>) -> ExcelError {
@@ -86,6 +139,9 @@ impl PyCustomFnHandler {
 
 impl formualizer::workbook::CustomFnHandler for PyCustomFnHandler {
     fn call(&self, args: &[LiteralValue]) -> Result<LiteralValue, ExcelError> {
+        // Held for the whole callback so any workbook method this callback
+        // reaches raises instead of deadlocking on the non-reentrant lock.
+        let _active = reentrancy::ActiveCallback::enter(self.workbook_id);
         Python::attach(|py| {
             let callback = self.callback.bind(py);
             let py_args = args
@@ -264,9 +320,7 @@ impl PyWorkbook {
     pub fn sheet(&self, name: &str) -> PyResult<crate::sheet::PySheet> {
         // Ensure sheet exists
         {
-            let mut wb = self.inner.write().map_err(|e| {
-                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
-            })?;
+            let mut wb = self.write_inner()?;
             // add_sheet is idempotent on duplicate names
             wb.add_sheet(name)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
@@ -389,9 +443,7 @@ impl PyWorkbook {
     ) -> PyResult<Bound<'py, PyBytes>> {
         match backend.unwrap_or("umya") {
             "umya" => {
-                let wb = self.inner.read().map_err(|e| {
-                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
-                })?;
+                let wb = self.read_inner()?;
                 let bytes = wb.to_xlsx_bytes().map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("save failed: {e}"))
                 })?;
@@ -419,10 +471,7 @@ impl PyWorkbook {
     ///     wb.add_sheet("Outputs")
     /// ```
     pub fn add_sheet(&self, name: &str) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.add_sheet(name)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         let mut sheets = self.sheets.write().unwrap();
@@ -460,9 +509,7 @@ impl PyWorkbook {
         header_row: bool,
         totals_row: bool,
     ) -> PyResult<()> {
-        self.inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?
+        self.write_inner()?
             .define_table(name, sheet, cell_range, headers, header_row, totals_row)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
     }
@@ -473,10 +520,7 @@ impl PyWorkbook {
     /// `(first_row, first_col, last_row, last_col)` tuple), `headers`,
     /// `header_row` and `totals_row`.
     pub fn tables(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
-        let wb = self
-            .inner
-            .read()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let wb = self.read_inner()?;
         let mut out = Vec::new();
         for table in wb.tables() {
             let dict = pyo3::types::PyDict::new(py);
@@ -501,14 +545,46 @@ impl PyWorkbook {
 
     #[getter]
     pub fn sheet_names(&self) -> PyResult<Vec<String>> {
-        let wb = self
-            .inner
-            .read()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let wb = self.read_inner()?;
         Ok(wb.sheet_names())
     }
 
     /// Register a workbook-local custom function backed by a Python callable.
+    ///
+    /// Re-entrancy contract
+    /// --------------------
+    /// **The callback must not touch the workbook it is registered on.** While
+    /// a custom function runs, the evaluation that invoked it holds the
+    /// workbook's lock, and that lock is not reentrant — a call back into the
+    /// same workbook can never be granted. Only `cancel()` and
+    /// `reset_cancel()` are safe from inside a callback: they flip an atomic
+    /// flag and never take the lock.
+    ///
+    /// Every other method (`get_value`, `set_value`, `sheet_names`,
+    /// `evaluate_cell`, `to_xlsx_bytes`, `Sheet.get_cell`, ...) now raises
+    /// `RuntimeError` when called from a callback rather than hanging forever.
+    /// `get_value` may still return from the compatibility cache without
+    /// raising, but that is a cache hit, not a supported operation — do not
+    /// rely on it.
+    ///
+    /// A callback *may* use a different `Workbook` instance, and may of course
+    /// use any non-formualizer Python state.
+    ///
+    /// The callback receives the evaluated arguments as Python values and must
+    /// return a Python value; raising an exception yields `#VALUE!` carrying
+    /// the exception text.
+    ///
+    /// Example:
+    /// ```python
+    ///     import formualizer as fz
+    ///
+    ///     wb = fz.Workbook()
+    ///     wb.register_function("double", lambda x: x * 2, min_args=1, max_args=1)
+    ///     s = wb.sheet("S")
+    ///     s.set_value(1, 1, 21)
+    ///     s.set_formula(1, 2, "=DOUBLE(A1)")
+    ///     print(wb.evaluate_cell("S", 1, 2))  # 42.0
+    /// ```
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (name, callback, *, min_args = 0, max_args = None, volatile = false, thread_safe = false, deterministic = true, allow_override_builtin = false))]
     pub fn register_function(
@@ -528,7 +604,10 @@ impl PyWorkbook {
             ));
         }
 
-        let handler = std::sync::Arc::new(PyCustomFnHandler::new(callback.clone().unbind()));
+        let handler = std::sync::Arc::new(PyCustomFnHandler::new(
+            callback.clone().unbind(),
+            self.workbook_id(),
+        ));
         let options = formualizer::workbook::CustomFnOptions {
             min_args,
             max_args,
@@ -538,30 +617,21 @@ impl PyWorkbook {
             allow_override_builtin,
         };
 
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.register_custom_function(name, options, handler)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
     }
 
     /// Unregister a previously registered workbook-local custom function.
     pub fn unregister_function(&self, name: &str) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.unregister_custom_function(name)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
     }
 
     /// List registered workbook-local custom functions and their options.
     pub fn list_functions(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let wb = self
-            .inner
-            .read()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let wb = self.read_inner()?;
         let out = PyList::empty(py);
 
         for info in wb.list_custom_functions() {
@@ -597,10 +667,7 @@ impl PyWorkbook {
     ///     - address fields for `cell`/`range` kinds
     #[pyo3(signature = (sheet=None))]
     pub fn get_named_ranges(&self, py: Python<'_>, sheet: Option<&str>) -> PyResult<PyObject> {
-        let wb = self
-            .inner
-            .read()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let wb = self.read_inner()?;
 
         let engine = wb.engine();
         let entries = if let Some(sheet_name) = sheet {
@@ -699,10 +766,7 @@ impl PyWorkbook {
         validate_cell_coords(row, col)?;
 
         let literal = py_to_literal(value)?;
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.set_value(sheet, row, col, literal.clone())
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         // Update compatibility cache
@@ -737,10 +801,7 @@ impl PyWorkbook {
     pub fn set_formula(&self, sheet: &str, row: u32, col: u32, formula: &str) -> PyResult<()> {
         validate_cell_coords(row, col)?;
 
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.set_formula(sheet, row, col, formula)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         // Update compatibility cache
@@ -785,12 +846,7 @@ impl PyWorkbook {
     ) -> PyResult<PyObject> {
         validate_cell_coords(row, col)?;
 
-        let res = py.detach(|| {
-            self.inner
-                .write()
-                .map_err(|e| lock_error_to_io(&e))?
-                .evaluate_cell(sheet, row, col)
-        });
+        let res = py.detach(|| self.write_inner_detached()?.evaluate_cell(sheet, row, col));
         let v = res.map_err(workbook_error_to_pyerr)?;
         literal_to_py(py, &v)
     }
@@ -801,12 +857,9 @@ impl PyWorkbook {
             .store(false, std::sync::atomic::Ordering::SeqCst);
 
         py.detach(|| {
-            self.inner
-                .write()
-                .map_err(|e| lock_error_to_io(&e))?
-                .evaluate_all_cancellable(formualizer::eval::engine::CancelToken::from_flag(
-                    self.cancel_flag.clone(),
-                ))
+            self.write_inner_detached()?.evaluate_all_cancellable(
+                formualizer::eval::engine::CancelToken::from_flag(self.cancel_flag.clone()),
+            )
         })
         .map_err(workbook_error_to_pyerr)?;
         Ok(())
@@ -835,10 +888,7 @@ impl PyWorkbook {
     ///     print(t.iterated_sccs, t.converged_sccs, t.capped_sccs)
     /// ```
     pub fn last_cycle_telemetry(&self) -> PyResult<PyCycleTelemetry> {
-        let wb = self
-            .inner
-            .read()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let wb = self.read_inner()?;
         Ok(PyCycleTelemetry::from_engine(
             wb.engine().last_cycle_telemetry(),
         ))
@@ -871,13 +921,10 @@ impl PyWorkbook {
 
         let results = py
             .detach(|| {
-                self.inner
-                    .write()
-                    .map_err(|e| lock_error_to_io(&e))?
-                    .evaluate_cells_cancellable(
-                        &refs,
-                        formualizer::eval::engine::CancelToken::from_flag(self.cancel_flag.clone()),
-                    )
+                self.write_inner_detached()?.evaluate_cells_cancellable(
+                    &refs,
+                    formualizer::eval::engine::CancelToken::from_flag(self.cancel_flag.clone()),
+                )
             })
             .map_err(workbook_error_to_pyerr)?;
 
@@ -909,10 +956,7 @@ impl PyWorkbook {
             .map(|(s, r, c)| (s.as_str(), *r, *c))
             .collect();
 
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         let plan = wb
             .get_eval_plan_with_options(&refs, build_graph_if_needed)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
@@ -946,10 +990,7 @@ impl PyWorkbook {
                 return Ok(Some(literal_to_py(py, &value)?));
             }
         }
-        let wb = self
-            .inner
-            .read()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let wb = self.read_inner()?;
         Ok(match wb.get_value(sheet, row, col) {
             Some(v) => Some(literal_to_py(py, &v)?),
             None => None,
@@ -959,19 +1000,13 @@ impl PyWorkbook {
     pub fn get_formula(&self, sheet: &str, row: u32, col: u32) -> PyResult<Option<String>> {
         validate_cell_coords(row, col)?;
 
-        let wb = self
-            .inner
-            .read()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let wb = self.read_inner()?;
         Ok(wb.get_formula(sheet, row, col))
     }
 
     // Changelog controls
     pub fn set_changelog_enabled(&self, enabled: bool) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.set_changelog_enabled(enabled);
         Ok(())
     }
@@ -979,30 +1014,21 @@ impl PyWorkbook {
     // Changelog metadata
     #[pyo3(signature = (actor_id=None))]
     pub fn set_actor_id(&self, actor_id: Option<String>) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.set_actor_id(actor_id);
         Ok(())
     }
 
     #[pyo3(signature = (correlation_id=None))]
     pub fn set_correlation_id(&self, correlation_id: Option<String>) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.set_correlation_id(correlation_id);
         Ok(())
     }
 
     #[pyo3(signature = (reason=None))]
     pub fn set_reason(&self, reason: Option<String>) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.set_reason(reason);
         Ok(())
     }
@@ -1027,30 +1053,21 @@ impl PyWorkbook {
     ///     wb.undo()  # reverts both values at once
     /// ```
     pub fn begin_action(&self, description: &str) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.begin_action(description.to_string());
         Ok(())
     }
 
     /// End the current grouped undo/redo action.
     pub fn end_action(&self) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.end_action();
         Ok(())
     }
 
     /// Undo the most recent workbook edit.
     pub fn undo(&self) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         {
             let mut sheets = self.sheets.write().map_err(|e| {
                 PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
@@ -1064,10 +1081,7 @@ impl PyWorkbook {
 
     /// Redo the most recently undone edit.
     pub fn redo(&self) -> PyResult<()> {
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         {
             let mut sheets = self.sheets.write().map_err(|e| {
                 PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
@@ -1099,10 +1113,7 @@ impl PyWorkbook {
             }
             rows_vec.push(row_vals);
         }
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         // Auto-group batch changes into a single undoable action when changelog is enabled
         wb.begin_action("batch: set values".to_string());
         let res = wb
@@ -1150,10 +1161,7 @@ impl PyWorkbook {
             }
             rows_vec.push(row_vals);
         }
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         wb.begin_action("batch: set formulas".to_string());
         let res = wb
             .set_formulas(sheet, start_row, start_col, &rows_vec)
@@ -1184,9 +1192,7 @@ impl PyWorkbook {
     /// Indexing to get a Sheet view (compatibility)
     fn __getitem__(&self, name: &str) -> PyResult<crate::sheet::PySheet> {
         {
-            let mut wb = self.inner.write().map_err(|e| {
-                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}"))
-            })?;
+            let mut wb = self.write_inner()?;
             wb.add_sheet(name)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         }
@@ -1459,6 +1465,72 @@ impl PyWorkbook {
         }
     }
 
+    /// Drop the legacy `sheets` compatibility cache. Mutations made through
+    /// internal helpers (e.g. SheetPort) bypass it, so it must be invalidated
+    /// for `get_value()` to stay correct.
+    pub(crate) fn clear_sheet_cache(&self) {
+        if let Ok(mut sheets) = self.sheets.write() {
+            sheets.clear();
+        }
+    }
+
+    /// Stable identity for this workbook, shared by every clone of the handle
+    /// (`PyWorkbook` is `Clone` and `PySheet` holds one).
+    pub(crate) fn workbook_id(&self) -> usize {
+        std::sync::Arc::as_ptr(&self.inner) as usize
+    }
+
+    /// Fail fast when a Python custom-function callback re-enters the workbook
+    /// it is registered on. Without this the call would block forever on the
+    /// non-reentrant `RwLock` the running evaluation already holds.
+    pub(crate) fn check_reentrancy(&self) -> PyResult<()> {
+        if reentrancy::is_active(self.workbook_id()) {
+            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                REENTRANCY_MESSAGE,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Shared access to the engine state, re-entrancy checked.
+    pub(crate) fn read_inner(
+        &self,
+    ) -> PyResult<std::sync::RwLockReadGuard<'_, formualizer::workbook::Workbook>> {
+        self.check_reentrancy()?;
+        self.inner
+            .read()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))
+    }
+
+    /// Exclusive access to the engine state, re-entrancy checked.
+    pub(crate) fn write_inner(
+        &self,
+    ) -> PyResult<std::sync::RwLockWriteGuard<'_, formualizer::workbook::Workbook>> {
+        self.check_reentrancy()?;
+        self.inner
+            .write()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))
+    }
+
+    /// Exclusive access from inside a `py.detach` region: the error type must
+    /// not touch Python, so lock failures and re-entrancy both surface as
+    /// `IoError::Backend`, which `workbook_error_to_pyerr` maps to
+    /// `RuntimeError` exactly as the direct paths above do.
+    pub(crate) fn write_inner_detached(
+        &self,
+    ) -> Result<
+        std::sync::RwLockWriteGuard<'_, formualizer::workbook::Workbook>,
+        formualizer::workbook::IoError,
+    > {
+        if reentrancy::is_active(self.workbook_id()) {
+            return Err(formualizer::workbook::IoError::Backend {
+                backend: "workbook".to_string(),
+                message: REENTRANCY_MESSAGE.to_string(),
+            });
+        }
+        self.inner.write().map_err(|e| lock_error_to_io(&e))
+    }
+
     pub(crate) fn with_workbook_mut<T, F>(&self, f: F) -> PyResult<T>
     where
         F: FnOnce(&mut formualizer::workbook::Workbook) -> PyResult<T>,
@@ -1467,10 +1539,7 @@ impl PyWorkbook {
         // legacy `sheets` cache; invalidate it so `get_value()` stays correct.
         self.sheets.write().unwrap().clear();
 
-        let mut wb = self
-            .inner
-            .write()
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("lock: {e}")))?;
+        let mut wb = self.write_inner()?;
         f(&mut wb)
     }
 }

--- a/bindings/python/tests/test_custom_fn_loaded_deadlock.py
+++ b/bindings/python/tests/test_custom_fn_loaded_deadlock.py
@@ -9,7 +9,15 @@ while waiting on the parallel layer, and the worker blocked on
 The workbook is sized so a single evaluation layer contains many formula
 vertices, which forces the engine's parallel layer to run on rayon worker
 threads and reproduces the deadlock on the broken binding.
+
+These tests are timeout-bounded. A deadlock cannot be interrupted from Python
+(the GIL holder is blocked in native code, so neither a signal handler nor a
+pure-Python watchdog ever runs), which is why the suite configures
+pytest-timeout with `timeout_method = "thread"`: on expiry it dumps every
+thread's stack and kills the process, turning a would-be six-hour CI hang into
+a bounded failure with the deadlock cycle printed.
 """
+
 import datetime
 from pathlib import Path
 
@@ -62,7 +70,7 @@ def make_loaded_workbook(tmp: Path) -> fz.Workbook:
         datetime.date(2024, 10, 1),
         datetime.date(2025, 1, 1),
     ]
-    for i, (value, date) in enumerate(zip(values, dates)):
+    for i, (value, date) in enumerate(zip(values, dates, strict=True)):
         ws.cell(row=2 + i, column=2, value=value)
         cell = ws.cell(row=2 + i, column=3, value=date)
         cell.number_format = "yyyy-mm-dd"
@@ -82,17 +90,17 @@ def register_xnpv(wb: fz.Workbook) -> None:
     )
 
 
+@pytest.mark.timeout(60)
 def test_custom_function_on_loaded_workbook_evaluate_all(tmp_path: Path):
     wb = make_loaded_workbook(tmp_path)
     register_xnpv(wb)
 
     wb.evaluate_all()
     for row in (3, 42, 121):
-        assert wb.get_value("Sheet1", row, 4) == pytest.approx(
-            _NPV_VALUE, rel=1e-9
-        )
+        assert wb.get_value("Sheet1", row, 4) == pytest.approx(_NPV_VALUE, rel=1e-9)
 
 
+@pytest.mark.timeout(60)
 def test_custom_function_on_loaded_workbook_evaluate_cell(tmp_path: Path):
     wb = make_loaded_workbook(tmp_path)
     register_xnpv(wb)
@@ -101,22 +109,36 @@ def test_custom_function_on_loaded_workbook_evaluate_cell(tmp_path: Path):
     assert value == pytest.approx(_NPV_VALUE, rel=1e-9)
 
 
+@pytest.mark.timeout(60)
 def test_custom_function_on_loaded_workbook_evaluate_cells(tmp_path: Path):
     wb = make_loaded_workbook(tmp_path)
     register_xnpv(wb)
 
-    results = wb.evaluate_cells(
-        [("Sheet1", 3, 4), ("Sheet1", 121, 4)]
-    )
+    results = wb.evaluate_cells([("Sheet1", 3, 4), ("Sheet1", 121, 4)])
     assert results[0] == pytest.approx(_NPV_VALUE, rel=1e-9)
     assert results[1] == pytest.approx(_NPV_VALUE, rel=1e-9)
 
 
-def test_native_xnpv_still_errors_without_override(tmp_path: Path):
+@pytest.mark.timeout(60)
+def test_native_xnpv_handles_date_cells_without_the_override(tmp_path: Path):
+    """The native XNPV must agree with the Python override on this fixture.
+
+    This started life as ``test_native_xnpv_still_errors_without_override``,
+    asserting ``#NUM!`` - true when #327 was written, because the native XNPV
+    dropped the ``Date`` cells in ``C2:C6`` and hit its length guard. #328
+    landed the date-serial coercion right afterwards, so on plain ``main``
+    (baf5b363) that assertion is already failing::
+
+        assert isinstance(value, dict)
+        E   assert False
+        E    +  where False = isinstance(308.1871372025822, dict)
+
+    The guard the original test wanted - "the override is not masking a change
+    in the native function" - is preserved by pinning the native result to the
+    same oracle constant the override produces.
+    """
     wb = make_loaded_workbook(tmp_path)
 
     wb.evaluate_all()
     value = wb.get_value("Sheet1", 3, 4)
-    assert isinstance(value, dict)
-    assert value.get("type") == "Error"
-    assert value.get("kind") == "Num"
+    assert value == pytest.approx(_NPV_VALUE, rel=1e-9)

--- a/bindings/python/tests/test_custom_fn_reentrancy.py
+++ b/bindings/python/tests/test_custom_fn_reentrancy.py
@@ -1,0 +1,172 @@
+"""A custom-function callback must not be able to hang the interpreter.
+
+`Workbook` keeps its engine state behind a non-reentrant `RwLock`, held for the
+whole evaluation. Before this change, *any* workbook call made from inside a
+Python custom function blocked forever on that lock — `get_value` on an
+uncached cell, `set_value`, `sheet_names`, a nested `evaluate_*`, and so on.
+The failure was also non-deterministic: `get_value` served from the legacy
+compatibility cache returned normally, so the same code "worked" on an
+in-memory workbook and hung on a loaded one.
+
+Those calls now raise `RuntimeError` immediately. `cancel()` / `reset_cancel()`
+stay usable because they only flip an atomic flag.
+
+Every test here is timeout-bounded: without the guard these hang rather than
+fail, and an unbounded deadlock test burns a CI runner instead of reporting.
+"""
+
+import pytest
+
+import formualizer as fz
+
+# Wide enough to push the callback onto rayon workers as well as the
+# serial path, so the guard is exercised off-thread too.
+_NUM_FORMULAS = 64
+
+
+def build_workbook():
+    wb = fz.Workbook()
+    wb.add_sheet("S")
+    wb.set_value("S", 1, 1, 1.0)
+    wb.set_formula("S", 1, 2, "=B2+1")  # a formula cell, never in the cache
+    for row in range(1, _NUM_FORMULAS + 1):
+        wb.set_formula("S", row, 3, "=PYPROBE(A1)")
+    return wb
+
+
+def run_probe(operation):
+    """Register `operation` as a custom function body and evaluate."""
+    wb = build_workbook()
+    captured = {}
+
+    def probe(_value):
+        if "result" not in captured:
+            try:
+                operation(wb)
+                captured["result"] = None
+            except BaseException as exc:
+                captured["result"] = exc
+        return 1.0
+
+    wb.register_function("pyprobe", probe, min_args=1, max_args=1)
+    wb.evaluate_all()
+    return captured.get("result", KeyError("callback never ran"))
+
+
+REENTRANT_OPERATIONS = {
+    "get_value_formula_cell": lambda wb: wb.get_value("S", 1, 2),
+    "set_value": lambda wb: wb.set_value("S", 50, 50, 1.0),
+    "set_formula": lambda wb: wb.set_formula("S", 51, 51, "=1+1"),
+    "sheet_names": lambda wb: wb.sheet_names,
+    "evaluate_cell": lambda wb: wb.evaluate_cell("S", 1, 2),
+    "evaluate_all": lambda wb: wb.evaluate_all(),
+    "evaluate_cells": lambda wb: wb.evaluate_cells([("S", 1, 2)]),
+    "list_functions": lambda wb: wb.list_functions(),
+    "register_function": lambda wb: wb.register_function("other", lambda: 1.0),
+    "tables": lambda wb: wb.tables(),
+    "add_sheet": lambda wb: wb.add_sheet("Another"),
+    "sheet_handle": lambda wb: wb.sheet("S"),
+    "last_cycle_telemetry": lambda wb: wb.last_cycle_telemetry(),
+    "get_eval_plan": lambda wb: wb.get_eval_plan([("S", 1, 2)]),
+    "to_xlsx_bytes": lambda wb: wb.to_xlsx_bytes(),
+}
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("name", sorted(REENTRANT_OPERATIONS))
+def test_reentrant_workbook_access_raises_instead_of_hanging(name):
+    result = run_probe(REENTRANT_OPERATIONS[name])
+    assert isinstance(result, RuntimeError), (
+        f"{name} from inside a custom function returned {result!r}; "
+        "expected RuntimeError"
+    )
+    assert "custom function" in str(result)
+
+
+@pytest.mark.timeout(60)
+def test_reentrant_sheet_handle_access_raises():
+    """A `Sheet` acquired *before* evaluation shares the same lock."""
+    wb = build_workbook()
+    sheet = wb.sheet("S")
+    captured = {}
+
+    def probe(_value):
+        if "result" not in captured:
+            try:
+                captured["result"] = sheet.get_cell(1, 2)
+            except BaseException as exc:
+                captured["result"] = exc
+        return 1.0
+
+    wb.register_function("pyprobe", probe, min_args=1, max_args=1)
+    wb.evaluate_all()
+    assert isinstance(captured["result"], RuntimeError)
+
+
+@pytest.mark.timeout(60)
+def test_cancel_is_still_safe_from_a_callback():
+    """`cancel`/`reset_cancel` touch only an atomic flag and must keep working."""
+    wb = build_workbook()
+    seen = []
+
+    def probe(_value):
+        wb.reset_cancel()
+        wb.cancel()
+        seen.append(True)
+        return 1.0
+
+    wb.register_function("pyprobe", probe, min_args=1, max_args=1)
+    with pytest.raises(Exception) as excinfo:
+        wb.evaluate_all()
+    assert "CANCELLED" in str(excinfo.value).upper()
+    assert seen
+
+
+@pytest.mark.timeout(60)
+def test_a_second_workbook_is_unaffected():
+    """The guard is per workbook: a callback may drive a *different* workbook."""
+    wb = build_workbook()
+    other = fz.Workbook()
+    other.add_sheet("T")
+    other.set_value("T", 1, 1, 20.0)
+    other.set_formula("T", 1, 2, "=A1*2")
+    captured = {}
+
+    def probe(_value):
+        if "result" not in captured:
+            captured["result"] = other.evaluate_cell("T", 1, 2)
+        return 1.0
+
+    wb.register_function("pyprobe", probe, min_args=1, max_args=1)
+    wb.evaluate_all()
+    assert captured["result"] == pytest.approx(40.0)
+
+
+@pytest.mark.timeout(60)
+def test_workbook_is_usable_again_after_the_callback_returns():
+    """The marker must be cleared on the way out, including on exceptions."""
+    wb = build_workbook()
+
+    def probe(_value):
+        try:
+            _ = wb.sheet_names
+        except RuntimeError:
+            pass
+        return 1.0
+
+    wb.register_function("pyprobe", probe, min_args=1, max_args=1)
+    wb.evaluate_all()
+    assert "S" in wb.sheet_names
+    assert wb.get_value("S", 1, 3) == pytest.approx(1.0)
+
+
+@pytest.mark.timeout(60)
+def test_raising_callback_still_clears_the_marker():
+    wb = build_workbook()
+
+    def probe(_value):
+        raise ValueError("boom")
+
+    wb.register_function("pyprobe", probe, min_args=1, max_args=1)
+    wb.evaluate_all()
+    assert "S" in wb.sheet_names

--- a/bindings/python/tests/test_sheetport_custom_fn_deadlock.py
+++ b/bindings/python/tests/test_sheetport_custom_fn_deadlock.py
@@ -1,0 +1,101 @@
+"""SheetPort must release the GIL while the engine evaluates.
+
+Regression for the same GIL deadlock #327 fixed on ``Workbook.evaluate_*``,
+which ``SheetPortSession.evaluate_once`` still had: the calling thread held the
+GIL while waiting on the engine's parallel layer, and the rayon workers
+evaluating Python-backed custom functions blocked in ``PyGILState_Ensure``
+waiting for that same GIL.
+
+SheetPort only evaluates the cone reachable from the output ports, so the
+custom-function cells must be *upstream of an output port* and numerous enough
+to form a wide parallel layer — a workbook whose custom-function cells are not
+reachable from a port evaluates fine even on the broken binding.
+"""
+
+import textwrap
+
+import pytest
+
+from formualizer import SheetPortSession, Workbook
+
+_NUM_FORMULAS = 200
+
+MANIFEST_YAML = textwrap.dedent(
+    """
+    spec: fio
+    spec_version: "0.3.0"
+    manifest:
+      id: python-sheetport-custom-fn
+      name: SheetPort custom function deadlock
+      workbook:
+        uri: memory://sheetport-custom-fn.xlsx
+        locale: en-US
+        date_system: 1900
+    ports:
+      - id: scale
+        dir: in
+        shape: scalar
+        location:
+          a1: Inputs!A1
+        schema:
+          type: number
+      - id: total
+        dir: out
+        shape: scalar
+        location:
+          a1: Outputs!A1
+        schema:
+          type: number
+    """
+).strip()
+
+
+def _triple(x):
+    return float(x) * 3.0
+
+
+def build_session() -> SheetPortSession:
+    wb = Workbook()
+    wb.add_sheet("Inputs")
+    wb.add_sheet("Work")
+    wb.add_sheet("Outputs")
+    wb.set_value("Inputs", 1, 1, 2.0)
+
+    # One wide layer of custom-function cells, all reachable from the output
+    # port through the SUM below.
+    for row in range(1, _NUM_FORMULAS + 1):
+        wb.set_formula("Work", row, 1, "=PYTRIPLE(Inputs!$A$1)")
+    wb.set_formula("Outputs", 1, 1, f"=SUM(Work!A1:A{_NUM_FORMULAS})")
+
+    wb.register_function("pytriple", _triple, min_args=1, max_args=1)
+    return SheetPortSession.from_manifest_yaml(MANIFEST_YAML, wb)
+
+
+@pytest.mark.timeout(60)
+def test_sheetport_evaluate_once_with_python_custom_function():
+    session = build_session()
+    out = session.evaluate_once()
+    assert out["total"] == pytest.approx(2.0 * 3.0 * _NUM_FORMULAS)
+
+
+@pytest.mark.timeout(60)
+def test_sheetport_write_inputs_then_evaluate_once():
+    session = build_session()
+    session.write_inputs({"scale": 5.0})
+    out = session.evaluate_once()
+    assert out["total"] == pytest.approx(5.0 * 3.0 * _NUM_FORMULAS)
+
+    # A second round-trip must keep working: `with_sheetport` now re-acquires
+    # the workbook lock inside the detached region each call.
+    session.write_inputs({"scale": 1.0})
+    out = session.evaluate_once()
+    assert out["total"] == pytest.approx(1.0 * 3.0 * _NUM_FORMULAS)
+
+
+@pytest.mark.timeout(60)
+def test_sheetport_reads_still_see_writes_through_the_detached_path():
+    session = build_session()
+    session.write_inputs({"scale": 7.0})
+    assert session.read_inputs()["scale"] == pytest.approx(7.0)
+    assert session.evaluate_once()["total"] == pytest.approx(7.0 * 3.0 * _NUM_FORMULAS)
+    assert session.read_outputs()["total"] == pytest.approx(7.0 * 3.0 * _NUM_FORMULAS)

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -112,6 +112,7 @@ dev = [
     { name = "openpyxl" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -120,6 +121,7 @@ dev = [
     { name = "openpyxl" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -128,6 +130,7 @@ requires-dist = [
     { name = "openpyxl", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev"]
@@ -137,6 +140,7 @@ dev = [
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
 ]
 
 [[package]]
@@ -263,6 +267,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841, upload-time = "2025-04-05T14:07:49.641Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]

--- a/crates/formualizer-eval/src/builtins/financial/bonds.rs
+++ b/crates/formualizer-eval/src/builtins/financial/bonds.rs
@@ -1,26 +1,23 @@
 //! Bond pricing functions: ACCRINT, ACCRINTM, PRICE, YIELD
 
 use crate::args::ArgSchema;
+use crate::coercion::to_serial_strict;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
 use chrono::{Datelike, NaiveDate};
 use formualizer_common::{ExcelError, LiteralValue, try_serial_to_date_for};
 use formualizer_macros::func_caps;
 
+/// Numeric coercion for bond arguments.
+///
+/// `settlement`, `maturity` and `issue` are date arguments, and a workbook
+/// loaded from XLSX holds genuine `Date` cells there. The previous local
+/// copy of the value -> number policy had no date arm, so `PRICE(A1,B1,...)`
+/// over date cells returned `#VALUE!` (see #328). Delegates to the central
+/// [`crate::coercion::to_serial_strict`].
 fn coerce_num(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
     let v = arg.value()?.into_literal();
-    coerce_literal_num(&v)
-}
-
-fn coerce_literal_num(v: &LiteralValue) -> Result<f64, ExcelError> {
-    match v {
-        LiteralValue::Number(f) => Ok(*f),
-        LiteralValue::Int(i) => Ok(*i as f64),
-        LiteralValue::Boolean(b) => Ok(if *b { 1.0 } else { 0.0 }),
-        LiteralValue::Empty => Ok(0.0),
-        LiteralValue::Error(e) => Err(e.clone()),
-        _ => Err(ExcelError::new_value()),
-    }
+    to_serial_strict(&v, arg.date_system())
 }
 
 /// Day count basis calculation

--- a/crates/formualizer-eval/src/builtins/financial/depreciation.rs
+++ b/crates/formualizer-eval/src/builtins/financial/depreciation.rs
@@ -1,21 +1,18 @@
 //! Depreciation functions: SLN, SYD, DB, DDB
 
 use crate::args::ArgSchema;
+use crate::coercion::to_serial_strict;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
 use formualizer_common::{ExcelError, LiteralValue};
 use formualizer_macros::func_caps;
 
+/// Numeric coercion for depreciation arguments. Shares the crate-central
+/// value -> number policy with the rest of the financial builtins so a date
+/// cell resolves to its serial instead of `#VALUE!`.
 fn coerce_num(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
     let v = arg.value()?.into_literal();
-    match v {
-        LiteralValue::Number(f) => Ok(f),
-        LiteralValue::Int(i) => Ok(i as f64),
-        LiteralValue::Boolean(b) => Ok(if b { 1.0 } else { 0.0 }),
-        LiteralValue::Empty => Ok(0.0),
-        LiteralValue::Error(e) => Err(e),
-        _ => Err(ExcelError::new_value()),
-    }
+    to_serial_strict(&v, arg.date_system())
 }
 
 /// Returns straight-line depreciation for a single period.

--- a/crates/formualizer-eval/src/builtins/financial/tvm.rs
+++ b/crates/formualizer-eval/src/builtins/financial/tvm.rs
@@ -1,35 +1,33 @@
 //! Time Value of Money functions: PMT, PV, FV, NPV, NPER, RATE, IPMT, PPMT, XNPV, XIRR, DOLLARDE, DOLLARFR
 
 use crate::args::ArgSchema;
+use crate::coercion::to_serial_strict;
 use crate::function::Function;
 use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
-use formualizer_common::{
-    DateSystem, ExcelError, ExcelErrorKind, LiteralValue, date_to_serial_for,
-    datetime_to_serial_for,
-};
+use formualizer_common::{DateSystem, ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_macros::func_caps;
 
+/// Numeric coercion for financial arguments.
+///
+/// Excel has no separate date type on the sheet: a date cell holds a number
+/// and is only *formatted* as a date, so every date/time literal reaching a
+/// financial builtin must coerce to its serial in the workbook's date system.
+/// This delegates to the crate-central [`crate::coercion::to_serial_strict`]
+/// rather than re-implementing the value -> number policy locally; the old
+/// private `coerce_literal_num`/`coerce_literal_date_serial` pair silently
+/// dropped `Date`/`DateTime`/`Time`/`Duration` cells (see #328).
 fn coerce_num(arg: &ArgumentHandle) -> Result<f64, ExcelError> {
     let v = arg.value()?.into_literal();
-    coerce_literal_num(&v)
+    to_serial_strict(&v, arg.date_system())
 }
 
-fn coerce_literal_num(v: &LiteralValue) -> Result<f64, ExcelError> {
-    match v {
-        LiteralValue::Number(f) => Ok(*f),
-        LiteralValue::Int(i) => Ok(*i as f64),
-        LiteralValue::Boolean(b) => Ok(if *b { 1.0 } else { 0.0 }),
-        LiteralValue::Empty => Ok(0.0),
-        LiteralValue::Error(e) => Err(e.clone()),
-        _ => Err(ExcelError::new_value()),
-    }
-}
-
-fn coerce_literal_date_serial(v: &LiteralValue, system: DateSystem) -> Result<f64, ExcelError> {
-    match v {
-        LiteralValue::Date(d) => Ok(date_to_serial_for(system, d)),
-        LiteralValue::DateTime(dt) => Ok(datetime_to_serial_for(system, dt)),
-        other => coerce_literal_num(other),
+/// Excel truncates date serials to whole days inside XNPV/XIRR: a cell holding
+/// `2024-01-01 12:00` (serial 45292.5) discounts as day 45292. Documented in
+/// Microsoft's XNPV/XIRR remarks ("numbers in dates are truncated to
+/// integers") and reproduced by LibreOffice 24.2.7.
+fn truncate_date_serials(dates: &mut [f64]) {
+    for d in dates.iter_mut() {
+        *d = d.trunc();
     }
 }
 
@@ -400,13 +398,14 @@ impl Function for NpvFn {
     fn eval<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
-        _ctx: &dyn FunctionContext<'b>,
+        ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
         if args.len() > 255 {
             return Err(ExcelError::new_value()
                 .with_message("NPV accepts at most 255 total arguments (rate plus 254 values)"));
         }
 
+        let date_system = ctx.date_system();
         let rate = coerce_num(&args[0])?;
         let mut npv = 0.0;
         let mut period = 1;
@@ -433,6 +432,7 @@ impl Function for NpvFn {
                                 rate,
                                 &mut npv,
                                 &mut period,
+                                date_system,
                             )?;
                         }
                     }
@@ -446,6 +446,7 @@ impl Function for NpvFn {
                                 rate,
                                 &mut npv,
                                 &mut period,
+                                date_system,
                             )?;
                         }
                     }
@@ -456,6 +457,7 @@ impl Function for NpvFn {
                     rate,
                     &mut npv,
                     &mut period,
+                    date_system,
                 )?,
                 CalcValue::Callable(_) => {
                     return Ok(CalcValue::Scalar(LiteralValue::Error(
@@ -482,6 +484,7 @@ fn accumulate_npv_cash_flow(
     rate: f64,
     npv: &mut f64,
     period: &mut i32,
+    date_system: DateSystem,
 ) -> Result<(), ExcelError> {
     let numeric = match value {
         LiteralValue::Number(n) => Some(n),
@@ -492,6 +495,18 @@ fn accumulate_npv_cash_flow(
         LiteralValue::Boolean(b) => Some(if b { 1.0 } else { 0.0 }),
         LiteralValue::Text(_) | LiteralValue::Empty if reference_argument => None,
         LiteralValue::Error(error) => return Err(error),
+        // A date cell is a number on the sheet; take its serial rather than #VALUE!.
+        ref other
+            if matches!(
+                other,
+                LiteralValue::Date(_)
+                    | LiteralValue::DateTime(_)
+                    | LiteralValue::Time(_)
+                    | LiteralValue::Duration(_)
+            ) =>
+        {
+            Some(to_serial_strict(other, date_system)?)
+        }
         _ => return Err(ExcelError::new_value()),
     };
 
@@ -1389,8 +1404,9 @@ impl Function for IrrFn {
     fn eval<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
-        _ctx: &dyn FunctionContext<'b>,
+        ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
+        let date_system = ctx.date_system();
         // Collect cash flows
         let mut cashflows = Vec::new();
         let val = args[0].value()?;
@@ -1400,20 +1416,20 @@ impl Function for IrrFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_num(&cell) {
+                            if let Ok(n) = to_serial_strict(&cell, date_system) {
                                 cashflows.push(n);
                             }
                         }
                     }
                 }
-                other => cashflows.push(coerce_literal_num(&other)?),
+                other => cashflows.push(to_serial_strict(&other, date_system)?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_num(&cell) {
+                        if let Ok(n) = to_serial_strict(&cell, date_system) {
                             cashflows.push(n);
                         }
                     }
@@ -1513,8 +1529,9 @@ impl Function for MirrFn {
     fn eval<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
-        _ctx: &dyn FunctionContext<'b>,
+        ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
+        let date_system = ctx.date_system();
         // Collect cash flows
         let mut cashflows = Vec::new();
         let val = args[0].value()?;
@@ -1524,20 +1541,20 @@ impl Function for MirrFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_num(&cell) {
+                            if let Ok(n) = to_serial_strict(&cell, date_system) {
                                 cashflows.push(n);
                             }
                         }
                     }
                 }
-                other => cashflows.push(coerce_literal_num(&other)?),
+                other => cashflows.push(to_serial_strict(&other, date_system)?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_num(&cell) {
+                        if let Ok(n) = to_serial_strict(&cell, date_system) {
                             cashflows.push(n);
                         }
                     }
@@ -1891,6 +1908,7 @@ impl Function for XnpvFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
+        let date_system = ctx.date_system();
         let rate = coerce_num(&args[0])?;
 
         // Collect values
@@ -1902,20 +1920,20 @@ impl Function for XnpvFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_num(&cell) {
+                            if let Ok(n) = to_serial_strict(&cell, date_system) {
                                 values.push(n);
                             }
                         }
                     }
                 }
-                other => values.push(coerce_literal_num(&other)?),
+                other => values.push(to_serial_strict(&other, date_system)?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_num(&cell) {
+                        if let Ok(n) = to_serial_strict(&cell, date_system) {
                             values.push(n);
                         }
                     }
@@ -1938,20 +1956,20 @@ impl Function for XnpvFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
+                            if let Ok(n) = to_serial_strict(&cell, date_system) {
                                 dates.push(n);
                             }
                         }
                     }
                 }
-                other => dates.push(coerce_literal_date_serial(&other, ctx.date_system())?),
+                other => dates.push(to_serial_strict(&other, date_system)?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
+                        if let Ok(n) = to_serial_strict(&cell, date_system) {
                             dates.push(n);
                         }
                     }
@@ -1964,6 +1982,8 @@ impl Function for XnpvFn {
                 )));
             }
         }
+
+        truncate_date_serials(&mut dates);
 
         // Validate that values and dates have the same length
         if values.len() != dates.len() || values.is_empty() {
@@ -2085,6 +2105,7 @@ impl Function for XirrFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         ctx: &dyn FunctionContext<'b>,
     ) -> Result<CalcValue<'b>, ExcelError> {
+        let date_system = ctx.date_system();
         // Collect values
         let mut values = Vec::new();
         let val = args[0].value()?;
@@ -2094,20 +2115,20 @@ impl Function for XirrFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_num(&cell) {
+                            if let Ok(n) = to_serial_strict(&cell, date_system) {
                                 values.push(n);
                             }
                         }
                     }
                 }
-                other => values.push(coerce_literal_num(&other)?),
+                other => values.push(to_serial_strict(&other, date_system)?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_num(&cell) {
+                        if let Ok(n) = to_serial_strict(&cell, date_system) {
                             values.push(n);
                         }
                     }
@@ -2130,20 +2151,20 @@ impl Function for XirrFn {
                 LiteralValue::Array(arr) => {
                     for row in arr {
                         for cell in row {
-                            if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
+                            if let Ok(n) = to_serial_strict(&cell, date_system) {
                                 dates.push(n);
                             }
                         }
                     }
                 }
-                other => dates.push(coerce_literal_date_serial(&other, ctx.date_system())?),
+                other => dates.push(to_serial_strict(&other, date_system)?),
             },
             CalcValue::Range(range) => {
                 let (rows, cols) = range.dims();
                 for r in 0..rows {
                     for c in 0..cols {
                         let cell = range.get_cell(r, c);
-                        if let Ok(n) = coerce_literal_date_serial(&cell, ctx.date_system()) {
+                        if let Ok(n) = to_serial_strict(&cell, date_system) {
                             dates.push(n);
                         }
                     }
@@ -2156,6 +2177,8 @@ impl Function for XirrFn {
                 )));
             }
         }
+
+        truncate_date_serials(&mut dates);
 
         // Validate
         if values.len() != dates.len() || values.len() < 2 {

--- a/crates/formualizer-eval/src/builtins/stats/mod.rs
+++ b/crates/formualizer-eval/src/builtins/stats/mod.rs
@@ -67,11 +67,24 @@ fn collect_numeric_stats(args: &[ArgumentHandle]) -> Result<Vec<f64>, ExcelError
         }
 
         if let Ok(view) = a.range_view() {
+            let date_system = a.date_system();
             view.for_each_cell(&mut |v| {
                 match v {
                     LiteralValue::Error(e) => return Err(e.clone()),
                     LiteralValue::Number(n) => out.push(*n),
                     LiteralValue::Int(i) => out.push(*i as f64),
+                    // A date cell is a number on the sheet: SUM/AVERAGE/COUNT
+                    // already include it, so dropping it here made MEDIAN,
+                    // STDEV, LARGE, CORREL, ... silently disagree with SUM
+                    // over the very same range.
+                    LiteralValue::Date(_)
+                    | LiteralValue::DateTime(_)
+                    | LiteralValue::Time(_)
+                    | LiteralValue::Duration(_) => {
+                        if let Ok(n) = crate::coercion::to_serial_strict(v, date_system) {
+                            out.push(n);
+                        }
+                    }
                     _ => {}
                 }
                 Ok(())
@@ -8342,6 +8355,7 @@ fn collect_numeric_a(args: &[ArgumentHandle]) -> Result<Vec<f64>, ExcelError> {
         }
 
         if let Ok(view) = a.range_view() {
+            let date_system = a.date_system();
             view.for_each_cell(&mut |v| {
                 match v {
                     LiteralValue::Error(e) => return Err(e.clone()),
@@ -8350,6 +8364,16 @@ fn collect_numeric_a(args: &[ArgumentHandle]) -> Result<Vec<f64>, ExcelError> {
                     LiteralValue::Boolean(b) => out.push(if *b { 1.0 } else { 0.0 }),
                     LiteralValue::Text(_) => out.push(0.0),
                     LiteralValue::Empty => {} // skip blanks
+                    // Date-bearing cells are numbers; MAXA/MINA returned 0.0
+                    // over an all-date range before this arm existed.
+                    LiteralValue::Date(_)
+                    | LiteralValue::DateTime(_)
+                    | LiteralValue::Time(_)
+                    | LiteralValue::Duration(_) => {
+                        if let Ok(n) = crate::coercion::to_serial_strict(v, date_system) {
+                            out.push(n);
+                        }
+                    }
                     _ => {}
                 }
                 Ok(())

--- a/crates/formualizer-eval/src/coercion.rs
+++ b/crates/formualizer-eval/src/coercion.rs
@@ -53,6 +53,33 @@ pub fn to_serial_lenient(value: &LiteralValue, system: DateSystem) -> Result<f64
     }
 }
 
+/// Strict numeric coercion that resolves temporal values in a date system.
+///
+/// Identical to [`to_number_strict`] except that date-bearing literals are
+/// converted to serials using the workbook's date system instead of the
+/// implicit Excel-1900 default. Unlike [`to_serial_lenient`] it does **not**
+/// parse numeric text, so callers that reject text today keep rejecting it.
+///
+/// This is the coercion financial builtins want for arguments Excel treats as
+/// plain numbers on the sheet: a date cell *is* a number there, so a
+/// `Date`/`DateTime`/`Time`/`Duration` literal must become its serial rather
+/// than being dropped or rejected.
+pub(crate) fn to_serial_strict(
+    value: &LiteralValue,
+    system: DateSystem,
+) -> Result<f64, ExcelError> {
+    match value {
+        LiteralValue::Date(_)
+        | LiteralValue::DateTime(_)
+        | LiteralValue::Time(_)
+        | LiteralValue::Duration(_) => value.as_serial_number_for(system).ok_or_else(|| {
+            ExcelError::new(ExcelErrorKind::Value)
+                .with_message("Cannot convert to date/time serial")
+        }),
+        _ => to_number_strict(value),
+    }
+}
+
 /// Context-aware lenient numeric coercion using locale.
 pub fn to_number_lenient_with_locale(
     value: &LiteralValue,

--- a/crates/formualizer-eval/src/engine/tests/date_cells_are_numbers.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_cells_are_numbers.rs
@@ -1,0 +1,225 @@
+//! A date cell is a number: date-bearing cells must behave exactly like the
+//! numerically identical serial in every builtin that collects numbers.
+//!
+//! Class regression for the date-blind `coerce_literal_num`/`collect_*`
+//! helpers found while reviewing #328. Each case is *differential*: the same
+//! formula is evaluated over a range holding `Date`/`DateTime` cells and over
+//! a range holding the identical `Int` serials, and the two must agree. Before
+//! the fix the date cells were dropped by the collector, which produced either
+//! a short vector (`#NUM!`/`#N/A`), a hard `#VALUE!`, or — worst — a different
+//! number with no error at all.
+//!
+//! `SUM`/`AVERAGE`/`COUNT` already agreed (they route through the arrow fold
+//! path) and are kept here as controls: the engine must not be internally
+//! inconsistent about whether a date cell counts as a number.
+use chrono::NaiveDate;
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+fn date(y: i32, m: u32, d: u32) -> LiteralValue {
+    LiteralValue::Date(NaiveDate::from_ymd_opt(y, m, d).unwrap())
+}
+
+/// Column layout, 5 rows each:
+///   A: pure dates                 B: the identical serials
+///   C: 10,20,<date>,40,50         D: 10,20,<serial>,40,50
+///   E: -1000,200,300,<date>,500   F: -1000,200,300,<serial>,500
+fn fixture() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    let dates = [
+        (2024, 1, 1),
+        (2024, 4, 1),
+        (2024, 7, 1),
+        (2024, 10, 1),
+        (2025, 1, 1),
+    ];
+    let serials = [45292, 45383, 45474, 45566, 45658];
+    for (i, (d, s)) in dates.iter().zip(serials.iter()).enumerate() {
+        let row = i as u32 + 1;
+        engine
+            .set_cell_value("Sheet1", row, 1, date(d.0, d.1, d.2))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Int(*s))
+            .unwrap();
+    }
+
+    for (i, v) in [10, 20, 30, 40, 50].iter().enumerate() {
+        let row = i as u32 + 1;
+        engine
+            .set_cell_value("Sheet1", row, 3, LiteralValue::Int(*v))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 4, LiteralValue::Int(*v))
+            .unwrap();
+    }
+    engine
+        .set_cell_value("Sheet1", 3, 3, date(2024, 7, 1))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 3, 4, LiteralValue::Int(45474))
+        .unwrap();
+
+    for (i, v) in [-1000, 200, 300, 400, 500].iter().enumerate() {
+        let row = i as u32 + 1;
+        engine
+            .set_cell_value("Sheet1", row, 5, LiteralValue::Int(*v))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 6, LiteralValue::Int(*v))
+            .unwrap();
+    }
+    engine
+        .set_cell_value("Sheet1", 4, 5, date(2024, 10, 1))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 4, 6, LiteralValue::Int(45566))
+        .unwrap();
+
+    engine
+}
+
+fn eval(engine: &mut Engine<TestWorkbook>, row: u32, formula: &str) -> LiteralValue {
+    engine
+        .set_cell_formula("Sheet1", row, 10, parse(formula).unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+        .get_cell_value("Sheet1", row, 10)
+        .unwrap_or(LiteralValue::Empty)
+}
+
+/// Assert that `date_formula` returns the same finite number as the
+/// numerically identical `serial_formula`.
+fn assert_agrees_with_serial_control(date_formula: &str, serial_formula: &str) {
+    let mut engine = fixture();
+    let got = eval(&mut engine, 1, date_formula);
+    let want = eval(&mut engine, 2, serial_formula);
+    match (&got, &want) {
+        (LiteralValue::Number(a), LiteralValue::Number(b)) => {
+            let tol = 1e-9 * b.abs().max(1.0);
+            assert!(
+                (a - b).abs() <= tol,
+                "{date_formula} = {a} but serial control {serial_formula} = {b}"
+            );
+        }
+        _ => panic!(
+            "{date_formula} => {got:?}, serial control {serial_formula} => {want:?} \
+             (both must be numbers)"
+        ),
+    }
+}
+
+#[test]
+fn controls_already_agreed() {
+    // These routed through the arrow fold path and were never affected; they
+    // are what made the divergence of the collectors below observable.
+    assert_agrees_with_serial_control("=SUM(C1:C5)", "=SUM(D1:D5)");
+    assert_agrees_with_serial_control("=AVERAGE(C1:C5)", "=AVERAGE(D1:D5)");
+    assert_agrees_with_serial_control("=COUNT(C1:C5)", "=COUNT(D1:D5)");
+    assert_agrees_with_serial_control("=MAX(C1:C5)", "=MAX(D1:D5)");
+}
+
+#[test]
+fn statistical_collectors_include_date_cells() {
+    // `collect_numeric_stats` range path: silently dropped the date cell, so
+    // MEDIAN/STDEV/... saw 4 values where SUM/COUNT saw 5.
+    for (d, s) in [
+        ("=MEDIAN(C1:C5)", "=MEDIAN(D1:D5)"),
+        ("=STDEV(C1:C5)", "=STDEV(D1:D5)"),
+        ("=STDEV.P(C1:C5)", "=STDEV.P(D1:D5)"),
+        ("=VAR(C1:C5)", "=VAR(D1:D5)"),
+        ("=LARGE(C1:C5,1)", "=LARGE(D1:D5,1)"),
+        ("=SMALL(C1:C5,5)", "=SMALL(D1:D5,5)"),
+        ("=PRODUCT(C1:C5)", "=PRODUCT(D1:D5)"),
+        ("=DEVSQ(C1:C5)", "=DEVSQ(D1:D5)"),
+        ("=AVEDEV(C1:C5)", "=AVEDEV(D1:D5)"),
+        ("=PERCENTILE(C1:C5,0.5)", "=PERCENTILE(D1:D5,0.5)"),
+        ("=QUARTILE(C1:C5,1)", "=QUARTILE(D1:D5,1)"),
+    ] {
+        assert_agrees_with_serial_control(d, s);
+    }
+}
+
+#[test]
+fn paired_collectors_include_date_cells() {
+    // `collect_paired_arrays` built two vectors of unequal length -> #N/A.
+    for (d, s) in [
+        ("=CORREL(C1:C5,E1:E5)", "=CORREL(D1:D5,F1:F5)"),
+        ("=SLOPE(C1:C5,E1:E5)", "=SLOPE(D1:D5,F1:F5)"),
+        ("=RSQ(C1:C5,E1:E5)", "=RSQ(D1:D5,F1:F5)"),
+        ("=COVARIANCE.P(C1:C5,E1:E5)", "=COVARIANCE.P(D1:D5,F1:F5)"),
+    ] {
+        assert_agrees_with_serial_control(d, s);
+    }
+}
+
+#[test]
+fn a_variant_collectors_include_date_cells() {
+    // `collect_numeric_a`: MAXA/MINA returned 0.0 over an all-date range.
+    for (d, s) in [
+        ("=MAXA(A1:A5)", "=MAXA(B1:B5)"),
+        ("=MINA(A1:A5)", "=MINA(B1:B5)"),
+        ("=AVERAGEA(A1:A5)", "=AVERAGEA(B1:B5)"),
+        ("=STDEVA(C1:C5)", "=STDEVA(D1:D5)"),
+        ("=VARA(C1:C5)", "=VARA(D1:D5)"),
+    ] {
+        assert_agrees_with_serial_control(d, s);
+    }
+}
+
+#[test]
+fn cashflow_functions_include_date_cells() {
+    // IRR/MIRR had no length guard, so a dropped cell silently changed the
+    // answer; NPV hard-errored with #VALUE!; XNPV/XIRR `values` went #NUM!.
+    for (d, s) in [
+        ("=IRR(E1:E5)", "=IRR(F1:F5)"),
+        ("=MIRR(E1:E5,0.1,0.12)", "=MIRR(F1:F5,0.1,0.12)"),
+        ("=NPV(0.1,E1:E5)", "=NPV(0.1,F1:F5)"),
+        ("=XNPV(0.1,E1:E5,B1:B5)", "=XNPV(0.1,F1:F5,B1:B5)"),
+        ("=XIRR(E1:E5,B1:B5)", "=XIRR(F1:F5,B1:B5)"),
+    ] {
+        assert_agrees_with_serial_control(d, s);
+    }
+}
+
+#[test]
+fn bond_functions_accept_date_cells_as_date_arguments() {
+    // settlement/maturity/issue are date arguments and a workbook loaded from
+    // XLSX holds real Date cells there; every one of these was #VALUE!.
+    for (d, s) in [
+        (
+            "=PRICE(A1,A5,0.05,0.06,100,2,0)",
+            "=PRICE(B1,B5,0.05,0.06,100,2,0)",
+        ),
+        (
+            "=YIELD(A1,A5,0.05,95,100,2,0)",
+            "=YIELD(B1,B5,0.05,95,100,2,0)",
+        ),
+        (
+            "=ACCRINTM(A1,A5,0.05,10000,0)",
+            "=ACCRINTM(B1,B5,0.05,10000,0)",
+        ),
+        (
+            "=ACCRINT(A1,A2,A5,0.05,10000,2,0)",
+            "=ACCRINT(B1,B2,B5,0.05,10000,2,0)",
+        ),
+        // T-bill maturities must be within a year of settlement, so these use
+        // A1/A4 (274 days) rather than A1/A5 (366 days).
+        ("=TBILLPRICE(A1,A4,0.05)", "=TBILLPRICE(B1,B4,0.05)"),
+        ("=TBILLYIELD(A1,A4,98)", "=TBILLYIELD(B1,B4,98)"),
+        ("=TBILLEQ(A1,A4,0.05)", "=TBILLEQ(B1,B4,0.05)"),
+    ] {
+        assert_agrees_with_serial_control(d, s);
+    }
+}
+
+#[test]
+fn financial_scalars_accept_date_cells() {
+    // Scalar financial arguments share the same coercion; a date there is
+    // meaningless but Excel still treats it as its serial rather than #VALUE!.
+    assert_agrees_with_serial_control("=SLN(A5,A1,10)", "=SLN(B5,B1,10)");
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -149,7 +149,6 @@ mod info_reference_context;
 mod inspect;
 mod let_lambda;
 mod npv_variadic;
-mod xnpv_xirr_dates;
 mod offset_dynamic;
 mod omitted_arguments;
 mod open_ended_bounds_caps;
@@ -165,6 +164,7 @@ mod used_bounds_cache;
 mod used_extent_resolver;
 mod whole_column_sumifs;
 mod wildcard_star_semantics;
+mod xnpv_xirr_dates;
 
 mod aggregate_visibility_options;
 mod row_visibility_mask;
@@ -174,6 +174,7 @@ mod subtotal_visibility;
 mod visibility_mask_cache;
 
 mod csr_rebuild_amortization;
+mod date_cells_are_numbers;
 mod demand_subgraph_named_range;
 mod dn_range_xlsx_subgraph;
 mod iferror_ifna_lazy;

--- a/crates/formualizer-eval/src/engine/tests/xnpv_xirr_dates.rs
+++ b/crates/formualizer-eval/src/engine/tests/xnpv_xirr_dates.rs
@@ -1,21 +1,42 @@
-//! XNPV/XIRR accept date cells in the dates argument.
+//! XNPV/XIRR accept date cells in the dates argument, and truncate serials.
 //!
-//! Regression: before the fix, dates were coerced with `coerce_literal_num`,
-//! which dropped `Date`/`DateTime` cells from the array/range collection
-//! paths, so the date vector ended up shorter than the values vector and the
-//! function returned #NUM!.
+//! Regression (#328): before the fix, dates were coerced with a local
+//! date-blind helper, which dropped `Date`/`DateTime` cells from the
+//! array/range collection paths, so the date vector ended up shorter than the
+//! values vector and the function returned #NUM!.
 //!
-//! Oracle: LibreOffice 24.2 headless recalculation (values
-//! [-1000, 200, 300, 400, 500] on 2024-01-01 .. 2025-01-01 at rate 10%).
+//! Follow-up (#328 review §2c): Excel documents that XNPV/XIRR truncate the
+//! date serials to whole days ("numbers in dates are truncated to integers"),
+//! so a cell holding `2024-01-01 12:00` discounts as day 45292, not 45292.5.
+//!
+//! Oracle: LibreOffice 24.2.7.2 headless recalculation of the same fixture
+//! (values [-1000, 200, 300, 400, 500] on 2024-01-01 .. 2025-01-01 at rate
+//! 10%), cross-checked against a 60-digit `decimal` recomputation:
+//!
+//! ```text
+//! XNPV(0.1, A1:A5, B1:B5 as date cells)             = 308.187137202582
+//! XIRR(A1:A5, B1:B5 as date cells)                  = 0.619758593809105
+//! XNPV(0.1, A1:A5, {45292.5;45383;45474;45566;45658}) = 308.187137202582
+//! ```
+//!
+//! The third line is the truncation control: LibreOffice keeps the .5 in the
+//! cell (`=(B1-45292)*24` returns 12) and still discounts from day 45292.
 use chrono::NaiveDate;
 
-use crate::engine::{Engine, EvalConfig};
+use crate::engine::{DateSystem, Engine, EvalConfig};
 use crate::test_workbook::TestWorkbook;
 use formualizer_common::{ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
 
-fn xnpv_fixture() -> Engine<TestWorkbook> {
-    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+/// XNPV of the fixture at rate 10%, day deltas [0, 91, 182, 274, 366].
+/// 60-digit truth is 308.18713720258222141746583200819242..., whose
+/// correctly-rounded double is this literal.
+const XNPV_EXPECTED: f64 = 308.187_137_202_582_2;
+/// XIRR of the same fixture (root of XNPV to ~6e-15).
+const XIRR_EXPECTED: f64 = 0.6197585938091048;
+
+fn fixture_with_config(config: EvalConfig) -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), config);
     for (row, value) in [(1, -1000), (2, 200), (3, 300), (4, 400), (5, 500)] {
         engine
             .set_cell_value("Sheet1", row, 1, LiteralValue::Int(value))
@@ -40,6 +61,10 @@ fn xnpv_fixture() -> Engine<TestWorkbook> {
     engine
 }
 
+fn xnpv_fixture() -> Engine<TestWorkbook> {
+    fixture_with_config(EvalConfig::default())
+}
+
 fn eval_formula(mut engine: Engine<TestWorkbook>, formula: &str) -> LiteralValue {
     engine
         .set_cell_formula("Sheet1", 1, 5, parse(formula).unwrap())
@@ -50,14 +75,18 @@ fn eval_formula(mut engine: Engine<TestWorkbook>, formula: &str) -> LiteralValue
         .unwrap_or(LiteralValue::Empty)
 }
 
-fn assert_number(formula: &str, expected: f64, tol: f64) {
-    match eval_formula(xnpv_fixture(), formula) {
+fn assert_number_from(engine: Engine<TestWorkbook>, formula: &str, expected: f64, tol: f64) {
+    match eval_formula(engine, formula) {
         LiteralValue::Number(actual) => assert!(
             (actual - expected).abs() < tol,
             "{formula}: expected {expected}, got {actual}"
         ),
         other => panic!("{formula}: expected {expected}, got {other:?}"),
     }
+}
+
+fn assert_number(formula: &str, expected: f64, tol: f64) {
+    assert_number_from(xnpv_fixture(), formula, expected, tol);
 }
 
 fn assert_num_error(formula: &str) {
@@ -71,11 +100,7 @@ fn assert_num_error(formula: &str) {
 
 #[test]
 fn xnpv_accepts_date_cells() {
-    assert_number(
-        "=XNPV(0.1,A1:A5,B1:B5)",
-        308.1871372025822211,
-        1e-9,
-    );
+    assert_number("=XNPV(0.1,A1:A5,B1:B5)", XNPV_EXPECTED, 1e-12);
 }
 
 #[test]
@@ -83,14 +108,17 @@ fn xnpv_accepts_numeric_serials() {
     // Numeric serial dates must keep working.
     assert_number(
         "=XNPV(0.1,A1:A5,{45292,45383,45474,45566,45658})",
-        308.1871372025822211,
-        1e-9,
+        XNPV_EXPECTED,
+        1e-12,
     );
 }
 
 #[test]
-fn xnpv_accepts_datetime_cells() {
+fn xnpv_truncates_datetime_cells_to_whole_days() {
     // First date carries a time fraction: 2024-01-01 12:00 -> serial 45292.5.
+    // Excel documents that XNPV truncates date serials to integers, and
+    // LibreOffice 24.2.7.2 returns the same 308.187137202582 for this exact
+    // input, so the time-of-day must not shift the discounting.
     let mut engine = xnpv_fixture();
     engine
         .set_cell_value(
@@ -105,13 +133,42 @@ fn xnpv_accepts_datetime_cells() {
             ),
         )
         .unwrap();
-    match eval_formula(engine, "=XNPV(0.1,A1:A5,B1:B5)") {
-        LiteralValue::Number(actual) => assert!(
-            (actual - 308.3579477383065068).abs() < 1e-9,
-            "expected 308.3579477383065068, got {actual}"
-        ),
-        other => panic!("expected number, got {other:?}"),
-    }
+    assert_number_from(engine, "=XNPV(0.1,A1:A5,B1:B5)", XNPV_EXPECTED, 1e-12);
+}
+
+#[test]
+fn xnpv_truncates_fractional_serials_to_whole_days() {
+    // Same truncation, reached through plain numbers rather than date cells,
+    // matching LibreOffice's `{45292.5;45383;45474;45566;45658}` control.
+    assert_number(
+        "=XNPV(0.1,A1:A5,{45292.5,45383,45474,45566,45658})",
+        XNPV_EXPECTED,
+        1e-12,
+    );
+    assert_number(
+        "=XNPV(0.1,A1:A5,{45292.9,45383,45474,45566,45658})",
+        XNPV_EXPECTED,
+        1e-12,
+    );
+}
+
+#[test]
+fn xirr_truncates_datetime_cells_to_whole_days() {
+    let mut engine = xnpv_fixture();
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            2,
+            LiteralValue::DateTime(
+                NaiveDate::from_ymd_opt(2024, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(12, 0, 0)
+                    .unwrap(),
+            ),
+        )
+        .unwrap();
+    assert_number_from(engine, "=XIRR(A1:A5,B1:B5)", XIRR_EXPECTED, 1e-9);
 }
 
 #[test]
@@ -122,14 +179,45 @@ fn xnpv_missing_dates_returns_num_error() {
 
 #[test]
 fn xirr_accepts_date_cells() {
-    assert_number("=XIRR(A1:A5,B1:B5)", 0.6197585938091048, 1e-6);
+    assert_number("=XIRR(A1:A5,B1:B5)", XIRR_EXPECTED, 1e-9);
 }
 
 #[test]
 fn xirr_accepts_numeric_serials() {
     assert_number(
         "=XIRR(A1:A5,{45292,45383,45474,45566,45658})",
-        0.6197585938091048,
-        1e-6,
+        XIRR_EXPECTED,
+        1e-9,
+    );
+}
+
+#[test]
+fn xnpv_date_cells_use_the_workbook_date_system() {
+    // All-date input: XNPV only looks at serial *differences*, so a 1904
+    // workbook must return exactly the 1900 answer.
+    let config = EvalConfig {
+        date_system: DateSystem::Excel1904,
+        ..EvalConfig::default()
+    };
+    assert_number_from(
+        fixture_with_config(config.clone()),
+        "=XNPV(0.1,A1:A5,B1:B5)",
+        XNPV_EXPECTED,
+        1e-12,
+    );
+
+    // Mixed input pins *which* serial the date cell produced: B1 is
+    // 2024-01-01, which is serial 45292 under the 1900 system and 43830 under
+    // the 1904 one, while the literal serials stay put. A conversion that
+    // hardcoded 1900 would return XNPV_EXPECTED here instead.
+    //
+    // Expected value recomputed from the definition at 60 significant digits
+    // with day deltas [0, 1553, 1644, 1736, 1828]:
+    //   -106.957094440625988464471915527341387070579521682317473951547
+    assert_number_from(
+        fixture_with_config(config),
+        "=XNPV(0.1,A1:A5,{43830,45383,45474,45566,45658})",
+        -106.957094440626,
+        1e-9,
     );
 }

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -305,6 +305,15 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         }
     }
 
+    /// Workbook date system in force for the evaluation this argument belongs to.
+    ///
+    /// Lets value-collecting helpers resolve date literals to serials without
+    /// threading a `DateSystem` (or the whole `FunctionContext`) through every
+    /// call site.
+    pub(crate) fn date_system(&self) -> crate::engine::DateSystem {
+        self.interp.context.date_system()
+    }
+
     /// Returns whether this handle represents an explicitly omitted argument slot.
     ///
     /// This is false for absent arguments, explicit empty text, and blank references.


### PR DESCRIPTION
Follow-up pass on the two adversarial reviews of #327 (Python GIL deadlock) and #328 (XNPV/XIRR date coercion). Every claim below has a command and observed output behind it; the full write-up with the raw outputs is in the fix report accompanying this branch.

Two "unpatched" control builds were produced from this same worktree by stashing only production paths and rebuilding, so tests and config are byte-identical between control and patched runs.

## SheetPort had the same deadlock (#327 review §6)

`SheetPortSession.evaluate_once` reached `Function::dispatch` while holding the GIL, so a rayon worker evaluating a Python-backed custom function blocked in `PyGILState_Ensure` waiting for the GIL its own caller was holding. `PySheetPortSession` owns a `PyWorkbook` and `from_manifest_yaml` takes a user-supplied one, so custom functions are fully reachable. `with_sheetport` now runs the lock + SheetPort + operation inside `py.detach`, returning a plain `Result` and mapping errors to Python only after re-attach. All four entry points (`evaluate_once`, `write_inputs`, `read_inputs`, `read_outputs`) go through it.

New regression test sizes the workbook so the output port's cone contains a wide custom-function layer — SheetPort only evaluates the port cone, so a naive fixture passes even on the broken build. On the unpatched control it hangs (killed at 90s with the full thread dump: 24 rayon workers with no Python frame). With the fix: 3 passed in 0.11s.

I audited the rest of `bindings/python/src/` empirically: 15 further lock-taking or potentially-evaluating methods, each run twice (before and after `evaluate_all`) against a workbook holding 200 custom-function formulas, in its own subprocess under a 25s kill timeout. 30/30 completed, no hangs. `Workbook.evaluate_{cell,all,cells}` and `SheetPortSession.evaluate_once` are the only deadlock-capable surfaces and all four are now detached. `recalculate_file`, `from_path`/`from_bytes`, `to_xlsx_bytes`, `get_eval_plan` and the batch mutators remain GIL hoggers with no deadlock possible (their workbooks contain no user callback, or they do not evaluate — measured: `to_xlsx_bytes` completes on an unevaluated workbook). Left alone deliberately: the only observable is wall-clock responsiveness, so any regression test would be a flaky timing assertion.

## Deadlock tests now fail in bounded time (#327 review §5)

The review's suggested remedy — `pytest-timeout` plus a marker — **does not work for this bug class**, which I measured rather than assumed:

```
# pytest-timeout, timeout_method = "thread", @pytest.mark.timeout(60), unpatched build
$ timeout -s KILL 300 python -m pytest tests/test_sheetport_custom_fn_deadlock.py --no-cov -q
(no output)   rc=137   real 5m00.002s
```

pytest-timeout's `thread` method arms a `threading.Timer` and its `signal` method needs a Python-level `SIGALRM` handler. Both require executing Python bytecode, which requires the GIL — and the defining property of this bug is that no Python code can run anywhere in the process.

What does work is `faulthandler.dump_traceback_later(..., exit=True)`, whose watchdog is a native thread that never takes the GIL. pytest exposes it as `faulthandler_timeout`, but passes `exit=False` unless `faulthandler_exit_on_timeout` is also set — also measured: dumping alone leaves the process running to the outer kill at 5m00, while dumping plus exit terminates at 1m30 with rc=1 and every thread's stack printed.

Committed: `faulthandler_timeout = 60` and `faulthandler_exit_on_timeout = true`, plus `pytest-timeout>=2.3` in the dev extra and dependency group (required by `--strict-config`/`--strict-markers` for the markers to be legal, and genuinely useful for *interruptible* hangs where it gives a proper per-test failure report). The pyproject comments state which tool covers which failure mode and that the pytest-timeout path was measured not to fire.

`timeout-minutes` added to every job in `ci.yml` and `wasm.yml`. `release.yml` and `npm-publish.yml` are left alone — they are publish pipelines, and timing out a partially-completed crates.io/PyPI publish has its own risk profile.

## Re-entrancy is enforced, not just documented (#327 review §3)

From inside a custom-function callback, almost every workbook operation used to hang forever on the non-reentrant `RwLock` — non-deterministically, since `get_value` served from the compatibility cache returned normally. That is now a `RuntimeError` naming the problem.

A thread-local stack of workbook identities is pushed for the duration of `PyCustomFnHandler::call` (RAII, so the exception path clears it too) and checked at every lock acquisition. The ~40 ad-hoc `self.inner.read()/.write()` sites in `workbook.rs` and the 5 in `inspect.rs` were rewritten onto new `read_inner`/`write_inner`/`write_inner_detached` helpers. `PySheet` checks before touching its `WorksheetHandle`, which shares the same lock.

A thread-local rather than a workbook-level flag, on purpose: the callback always runs on the thread that must not re-enter, whereas a workbook-level flag would also reject a legitimate second Python thread blocking on the lock — which the review measured working fine (34,914 reader iterations, no error) when no custom function is involved.

`cancel()`/`reset_cancel()` stay safe, and a callback may still drive a *different* `Workbook`; both are tested. `register_function` gained a "Re-entrancy contract" docstring section, which reaches Python users through `stub_gen`.

20 new tests. On the unpatched control they hang; the faulthandler bound kills the run at 90s with the stack naming the exact operation.

## XNPV/XIRR now truncate date serials, and the false-oracle constant is corrected (#328 review §2c)

`xnpv_accepts_datetime_cells` expected `308.3579477383065068` while citing LibreOffice 24.2 — which returns `308.187137202582` for that exact input, because it truncates date serials, as documented Excel does. I rebuilt the fixture and re-measured rather than taking the review's word:

```
-1000,45292.5,308.187137202582,0.619758593809105,12,308.187137202582,308.187137202582
```

`B1` really holds 45292.5; `=(B1-45292)*24` returns 12, proving the time fraction survives; XNPV over those date cells still returns the truncated value; and the inline-array control `{45292.5;...}` returns the same, confirming truncation rather than cell typing.

So formualizer now truncates, matching both oracles. The test is renamed to `xnpv_truncates_datetime_cells_to_whole_days` with the verified constant, and joined by fractional-serial and XIRR truncation cases, a 1904 date-system test (a mixed date-cell/literal-serial formula that a hardcoded-1900 conversion would fail), tightened tolerances (1e-12/1e-9), and a header that quotes the three LibreOffice outputs it actually relies on. No committed test now cites an oracle it does not agree with.

## Layering consolidated (#328 review §4)

Added `pub(crate) coercion::to_serial_strict(value, system)` — `to_number_strict` plus an explicit `DateSystem` — and deleted all three local date-blind duplicates: `tvm.rs::coerce_literal_num`, the `coerce_literal_date_serial` #328 added, `bonds.rs::coerce_literal_num`, and `depreciation.rs`'s inline match. Arm for arm this is behaviour-preserving apart from the intended date arm. Deliberately not `to_serial_lenient`, which additionally parses numeric text — a real behaviour change these sites never had.

`pub(crate)` keeps the `public-api/` snapshots and their CI gate untouched. The `DateSystem` reaches the helpers without threading `ctx` through ~90 call sites: `ArgumentHandle` gained a `pub(crate) date_system()`.

## The wider date-blind class, rows 1-17 (#328 review §3)

| Review row | Functions | Before | Now |
|---|---|---|---|
| 3-4 | XNPV/XIRR `values` | `#NUM!` | correct number |
| 5-6 | IRR, MIRR | **silently wrong number** | correct number |
| 7 | NPV | `#VALUE!` | correct number |
| 8-13 | ACCRINT, ACCRINTM, PRICE, YIELD, TBILLPRICE, TBILLEQ, TBILLYIELD | `#VALUE!` | correct number |
| 14 | SLN/SYD/DB/DDB | `#VALUE!` | serial, consistent with the rest |
| 15 | ~50 sites: MEDIAN, STDEV, VAR, LARGE, SMALL, PRODUCT, DEVSQ, PERCENTILE, QUARTILE, ... | **silently wrong number** | agrees with SUM/COUNT |
| 16 | CORREL, SLOPE, RSQ, COVARIANCE, ... | `#N/A` | correct number |
| 17 | MAXA, MINA, AVERAGEA, STDEVA, VARA, ... | **silently `0.0`** | correct number |

Rows 15-17 were fixed inside the two range-collector `for_each_cell` matches in `stats/mod.rs` — four lines each, using the same `ArgumentHandle::date_system()` route, so **none of the ~64 call sites changed**. That is what brought the review's "larger, worth its own task" item safely into this pass.

New test file with 40 formula pairs, every case differential: the same formula over `Date` cells and over the numerically identical `Int` serials must produce the same finite number, with both sides required to be `Number` so "both error identically" cannot pass. `SUM`/`AVERAGE`/`COUNT`/`MAX` are included as controls — they already agreed, which is what made the collectors' divergence a self-contradiction rather than merely a wrong answer.

Revert-proof: with production reverted to `main`, 9 fail and the 7 controls pass, e.g. `=IRR(E1:E5) = 6.25e-17 but serial control = 2.671709729817473`, `=MEDIAN(C1:C5) = 30 but serial control = 40`, `=MAXA(A1:A5) = 0 but serial control = 45658`.

## Two pre-existing failures on `main`, corrected

Both fail on plain `baf5b363` before anything in this branch, and were found while building the unpatched control.

`test_native_xnpv_still_errors_without_override` (from #327) asserts native XNPV returns `#NUM!` over date cells — true when #327 was written, but #328 merged immediately after and fixed exactly that. #328's branch was cut from `v0.8.3` and never saw #327's test, so nothing ran the combined suite. Renamed to `test_native_xnpv_handles_date_cells_without_the_override` and repointed at the same oracle constant the override produces; the guard the original wanted is preserved, only the expected value moved, and the docstring records the failure output.

#327's test file also fails `ruff check` (B905) and `ruff format --check` on `main`, both of which CI runs. Fixed with `strict=True` (both lists have length 5, so `strict` is correct rather than merely silencing) and `ruff format`.

## Verification

- `PYO3_PYTHON=/usr/bin/python3.12 cargo test --workspace` -> 3510 passed, 0 failed
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets` clean, zero warnings
- Python: 116 passed; `ruff check` and `ruff format --check` clean across 34 files; `mypy` and `mypy.stubtest` clean
- `cargo run --bin stub_gen` regenerated `formualizer_py.pyi` (the new docstring); the result is committed, so the stub-drift gate passes

## Left for follow-up tasks

- **#327 review §4(b), the `cancel_flag` clobber race.** `evaluate_all`/`evaluate_cells` still reset the flag before `py.detach`, so a second Python thread can wipe a cancel intended for the in-flight evaluation. The fix is four lines, but a deterministic regression test needs precise thread interleaving and the obvious version would be flaky in CI. Outside the scope of this pass; wants its own task with a synchronisation harness.
- **#327 review §4(a), the second-thread deadlock.** A non-callback Python thread blocking on the workbook lock during a custom-function evaluation still deadlocks. Covering it needs the broad workbook-level flag rejected above, or a lock strategy change (`try_write` with timeout, reentrancy-aware lock) — a design change, not a patch.
- **GIL hoggers**, listed above.
- **`Time`/`Duration` in the arrow fold path.** The financial and statistical collectors now handle all four temporal variants; I did not audit `SUM`/`AVERAGE`/`COUNT`'s arrow path beyond `Date`/`DateTime`. Likely fine, unverified.

drafted with love by (agent) Manfred, with approval from Frankie
