### PR TITLE
perf(workbook): pre-allocate Arrow capacity in set_values batch path

### DIFF
--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -2578,6 +2578,19 @@ impl Workbook {
         start_col: u32,
         rows: &[Vec<LiteralValue>],
     ) -> Result<(), IoError> {
+        // Pre-allocate the Arrow sheet to the full batch extent ONCE, so the
+        // per-cell `mirror_value_to_overlay` → `ensure_row_capacity` → `grow_len_to`
+        // (which rebuilds the whole column's type-tag/lanes on every call) is
+        // amortized to O(N) instead of O(N²). Mirrors set_formulas_inner.
+        let height = rows.len();
+        let width = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+        if height == 0 || width == 0 {
+            return Ok(());
+        }
+        let end_row = start_row.saturating_add((height - 1) as u32);
+        let end_col = start_col.saturating_add((width - 1) as u32);
+        self.ensure_arrow_sheet_capacity(sheet, end_row as usize, end_col as usize);
+
         if self.enable_changelog {
             let sheet_id = self
                 .engine


### PR DESCRIPTION
## Summary

`Workbook::set_values` — the batch path behind `Sheet.setValues` in the JS/WASM
binding — scales super-linearly (≈ O(N²)) on bulk numeric writes. This PR adds a
one-time Arrow pre-allocation, mirroring `set_formulas_inner`, which restores
linear scaling.

## Problem

Each cell written by `set_values_inner` (changelog-off branch) flows through:

```
set_values_inner                              workbook.rs:2574
  → Engine::set_cell_value                     eval.rs:16515
    → mirror_value_to_overlay                  eval.rs:15195
      → ArrowSheet::ensure_row_capacity        arrow_store/mod.rs:3584  (nrows +1 per cell)
        → ColumnChunk::grow_len_to             arrow_store/mod.rs:178   (⚠️ O(old_len))
```

`grow_len_to` does `type_tag.values().to_vec()` — a **full copy of the column's
type-tag array** — plus a full rebuild of every present lane
(numbers/booleans/errors/text) on *every* call. Because `ensure_row_capacity`
grows `nrows` by one per cell, a batch of N cells triggers rebuilds of
O(1), O(2), …, O(N) → **O(N²)** total. The same quadratic path also affects the
changelog-enabled branch (its per-cell `mirror_value_to_overlay`).

## Fix

Pre-allocate the Arrow sheet to the full batch extent once at the top of
`set_values_inner`, exactly as `set_formulas_inner` already does:

```rust
let height = rows.len();
let width = rows.iter().map(|r| r.len()).max().unwrap_or(0);
if height == 0 || width == 0 { return Ok(()); }
let end_row = start_row.saturating_add((height - 1) as u32);
let end_col = start_col.saturating_add((width - 1) as u32);
self.ensure_arrow_sheet_capacity(sheet, end_row as usize, end_col as usize);
```

The per-cell `ensure_row_capacity` then early-returns.

**No behavior change.** `ensure_arrow_sheet_capacity` only grows (never
overwrites) existing Arrow data; `set_value` (single-cell) and
`set_formulas_inner` already call the same helper at the same point. Empty and
ragged batches fall through to the existing early-return / per-cell handling.

## Benchmarks

JS/WASM binding, `setValues`, single numeric column, changelog off:

| rows | before | after | speedup |
|------|--------|-------|---------|
| 1,000 | 16.6 ms | 12.7 ms | 1.3× |
| 5,000 | 121.2 ms | 32.3 ms | 3.8× |
| 10,000 | 415.1 ms | 71.9 ms | 5.8× |
| 20,000 | 1502.5 ms | 164.9 ms | **9.1×** |

Per-cell cost returns to ~constant (~7 µs) instead of growing with N.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p formualizer-workbook --all-targets --all-features -- -D warnings`
- [x] `cargo test -p formualizer-workbook --all-features`

## Checklist

- [x] PR focused and reviewable (13 lines, one private function)
- [x] No public API change (no docs / `public-api` snapshot update needed)
- [x] Conventional commit style (`perf(workbook):`)
- [x] Benchmarks included