### PR TITLE
fix(eval): unscoped name queries mean workbook scope, and Current locators resolve from context (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- A name scoped to a single sheet no longer answers a query that asked for no scope. `has_name(name, None)` and `resolved_name_value(name, None)` mapped the absent scope to the *default* sheet, and sheet-scoped names are resolved before workbook-scoped ones, so a name scoped only to `Sheet1` was indistinguishable from a workbook-scoped name — while the same query against any other sheet correctly reported it absent. An unscoped query now means workbook scope, and nothing else. (#110)
+- Target preparation no longer pulls in the default sheet for range dependencies that carry an unresolved sheet locator. A `Current` locator means "the sheet this reference lives on", and two sites substituted the workbook default instead — one of them via a `_` wildcard that also swallowed named-sheet locators, so a sheet name that failed to resolve silently became the default sheet. A named formula scoped to `Alpha` with a whole-column dependency selected cells on both `Alpha` and `Sheet1`; it now selects `Alpha` alone. Sheet resolution for these paths is now a single derivation that requires an explicit context sheet, and every locator variant is matched exhaustively so a new variant is a compile error rather than a silent default. (#110)
+
 ### Changed
 
 - **Loading a file no longer leaves a phantom default sheet, so sheet indices shift.** A freshly constructed `Workbook`/`Engine` is seeded with one default sheet (`Sheet1`), and every backend loader appended the file's sheets alongside it. Loading a workbook whose sheets were `Data` and `Extra` produced `sheet_names() == ["Sheet1", "Data", "Extra"]` — a sheet that does not exist in the file — and `SHEET()` on the file's first sheet returned `2` instead of `1`. The default sheet is now folded into the file's first sheet, so the same load produces `["Data", "Extra"]` with `SHEET()` returning `1` and `2`. This affects the calamine, umya, json and csv backends alike; previously only csv was accidentally immune, because its sheet name is `Sheet1` by default and so always collided with the seeded one. (#332)

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4045,22 +4045,73 @@ where
         self.graph.resolve_name_entry(name, current_sheet)
     }
 
-    pub fn has_name(&self, name: &str, scope_sheet: Option<&str>) -> bool {
-        let current_sheet = scope_sheet
-            .and_then(|sheet| self.graph.sheet_id(sheet))
-            .unwrap_or_else(|| self.graph.default_sheet_id());
-        self.graph.resolve_name_entry(name, current_sheet).is_some()
+    /// The [`NameScope`] an optional scope-sheet argument denotes.
+    ///
+    /// `None` means **workbook scope**, not "the default sheet": a caller that
+    /// supplies no sheet context is asking about workbook-scoped names only.
+    /// An unknown sheet name is a malformed query and errors rather than
+    /// silently degrading to another sheet's scope (issue #110).
+    ///
+    /// This is the one owned derivation from `Option<&str>` to a name scope;
+    /// every scope-taking entry point routes through it.
+    pub(crate) fn name_query_scope(
+        &self,
+        scope_sheet: Option<&str>,
+    ) -> Result<NameScope, ExcelError> {
+        match scope_sheet {
+            None => Ok(NameScope::Workbook),
+            Some(sheet) => self
+                .graph
+                .sheet_id(sheet)
+                .map(NameScope::Sheet)
+                .ok_or_else(|| {
+                    ExcelError::new(ExcelErrorKind::Ref)
+                        .with_message(format!("name scope sheet not found: {sheet}"))
+                }),
+        }
     }
 
+    /// Whether `name` resolves in the scope denoted by `scope_sheet`.
+    ///
+    /// `scope_sheet == None` asks about workbook scope only; a name scoped to a
+    /// single sheet (including the default sheet) does not answer it. An unknown
+    /// sheet name resolves nothing.
+    /// Resolve a [`SharedSheetLocator`](crate::reference::SharedSheetLocator)
+    /// against an explicit context sheet.
+    ///
+    /// Thin forwarder to
+    /// [`SheetRegistry::resolve_locator`](crate::engine::sheet_registry::SheetRegistry::resolve_locator),
+    /// the single owned derivation. `Current` resolves to `context_sheet`, never
+    /// to the workbook's default sheet.
+    fn resolve_sheet_locator(
+        &self,
+        locator: &crate::reference::SharedSheetLocator<'_>,
+        context_sheet: SheetId,
+    ) -> Result<SheetId, ExcelError> {
+        self.graph
+            .sheet_reg()
+            .resolve_locator(locator, context_sheet)
+    }
+
+    pub fn has_name(&self, name: &str, scope_sheet: Option<&str>) -> bool {
+        let Ok(scope) = self.name_query_scope(scope_sheet) else {
+            return false;
+        };
+        self.graph
+            .resolve_name_entry_in_scope(name, scope)
+            .is_some()
+    }
+
+    /// The current value of `name` in the scope denoted by `scope_sheet`.
+    ///
+    /// Scoping follows [`Self::has_name`]: `None` is workbook scope only.
     pub fn resolved_name_value(
         &self,
         name: &str,
         scope_sheet: Option<&str>,
     ) -> Option<LiteralValue> {
-        let current_sheet = scope_sheet
-            .and_then(|sheet| self.graph.sheet_id(sheet))
-            .unwrap_or_else(|| self.graph.default_sheet_id());
-        let entry = self.graph.resolve_name_entry(name, current_sheet)?;
+        let scope = self.name_query_scope(scope_sheet).ok()?;
+        let entry = self.graph.resolve_name_entry_in_scope(name, scope)?;
         self.graph.get_value(entry.vertex)
     }
 
@@ -9843,11 +9894,8 @@ where
                     )?;
                 }
                 crate::engine::EvaluationTarget::Name { name, scope_sheet } => {
-                    let sheet_id = scope_sheet
-                        .as_deref()
-                        .and_then(|sheet| self.graph.sheet_id(sheet))
-                        .unwrap_or_else(|| self.graph.default_sheet_id());
-                    if let Some(entry) = self.graph.resolve_name_entry(name, sheet_id) {
+                    let scope = self.name_query_scope(scope_sheet.as_deref())?;
+                    if let Some(entry) = self.graph.resolve_name_entry_in_scope(name, scope) {
                         roots
                             .push(TargetProducer::Symbol(entry.vertex))
                             .map_err(|_| {
@@ -10048,14 +10096,8 @@ where
                     normalized.push(target.clone());
                 }
                 crate::engine::EvaluationTarget::Name { name, scope_sheet } => {
-                    let current_sheet = match scope_sheet {
-                        Some(sheet) => self.graph.sheet_id(sheet).ok_or_else(|| {
-                            ExcelError::new(ExcelErrorKind::Ref)
-                                .with_message(format!("name scope sheet not found: {sheet}"))
-                        })?,
-                        None => self.graph.default_sheet_id(),
-                    };
-                    if let Some(entry) = self.graph.resolve_name_entry(name, current_sheet) {
+                    let name_scope = self.name_query_scope(scope_sheet.as_deref())?;
+                    if let Some(entry) = self.graph.resolve_name_entry_in_scope(name, name_scope) {
                         symbol_vertices.push_back(entry.vertex);
                     } else {
                         Self::widen_target_preparation(
@@ -10280,25 +10322,20 @@ where
                     {
                         for range in range_dependencies {
                             self.target_preparation_checkpoint(options.deadline, 1)?;
-                            let sheet_id = match range.sheet {
-                                crate::reference::SharedSheetLocator::Id(id) => id,
-                                crate::reference::SharedSheetLocator::Current => {
-                                    self.graph.get_vertex_sheet_id(vertex)
+                            // `Current` is the sheet the formula lives on.
+                            let context_sheet = self.graph.get_vertex_sheet_id(vertex);
+                            let Ok(sheet_id) =
+                                self.resolve_sheet_locator(&range.sheet, context_sheet)
+                            else {
+                                if Self::widen_target_preparation(
+                                    options.opaque_policy,
+                                    &mut scope,
+                                    &mut reasons,
+                                    OpaqueReason::UnresolvedCrossSheetBinding,
+                                )? {
+                                    break;
                                 }
-                                crate::reference::SharedSheetLocator::Name(ref name) => {
-                                    let Some(id) = self.graph.sheet_id(name) else {
-                                        if Self::widen_target_preparation(
-                                            options.opaque_policy,
-                                            &mut scope,
-                                            &mut reasons,
-                                            OpaqueReason::UnresolvedCrossSheetBinding,
-                                        )? {
-                                            break;
-                                        }
-                                        continue;
-                                    };
-                                    id
-                                }
+                                continue;
                             };
                             let sheet = self.graph.sheet_name(sheet_id).to_string();
                             regions.push_back(PreparationRegion {
@@ -10367,9 +10404,26 @@ where
                                 }
                                 for range in range_deps {
                                     self.target_preparation_checkpoint(options.deadline, 1)?;
-                                    let sheet_id = match range.sheet {
-                                        crate::reference::SharedSheetLocator::Id(id) => id,
-                                        _ => self.graph.default_sheet_id(),
+                                    // `Current` is the sheet this name's formula
+                                    // was interpreted on, which is the sheet its
+                                    // vertex is placed on -- the same derivation
+                                    // the formula-vertex arm above uses. It is
+                                    // never the workbook default sheet, and an
+                                    // unresolvable `Name` widens instead of
+                                    // silently landing on some other sheet.
+                                    let context_sheet = self.graph.get_vertex_sheet_id(vertex);
+                                    let Ok(sheet_id) =
+                                        self.resolve_sheet_locator(&range.sheet, context_sheet)
+                                    else {
+                                        if Self::widen_target_preparation(
+                                            options.opaque_policy,
+                                            &mut scope,
+                                            &mut reasons,
+                                            OpaqueReason::UnresolvedCrossSheetBinding,
+                                        )? {
+                                            break;
+                                        }
+                                        continue;
                                     };
                                     regions.push_back(PreparationRegion {
                                         sheet: self.graph.sheet_name(sheet_id).to_string(),
@@ -10577,21 +10631,18 @@ where
                     }
                     for range in &ingested.dep_plan.range_deps {
                         self.target_preparation_checkpoint(options.deadline, 1)?;
-                        let dependency_sheet = match &range.sheet {
-                            crate::reference::SharedSheetLocator::Id(id) => *id,
-                            crate::reference::SharedSheetLocator::Current => package.sheet_id,
-                            crate::reference::SharedSheetLocator::Name(name) => {
-                                let Some(id) = self.graph.sheet_id(name) else {
-                                    Self::widen_target_preparation(
-                                        options.opaque_policy,
-                                        &mut scope,
-                                        &mut reasons,
-                                        OpaqueReason::UnresolvedCrossSheetBinding,
-                                    )?;
-                                    continue;
-                                };
-                                id
-                            }
+                        // `Current` is the sheet the staged package's formula
+                        // lives on.
+                        let Ok(dependency_sheet) =
+                            self.resolve_sheet_locator(&range.sheet, package.sheet_id)
+                        else {
+                            Self::widen_target_preparation(
+                                options.opaque_policy,
+                                &mut scope,
+                                &mut reasons,
+                                OpaqueReason::UnresolvedCrossSheetBinding,
+                            )?;
+                            continue;
                         };
                         regions.push_back(PreparationRegion {
                             sheet: self.graph.sheet_name(dependency_sheet).to_string(),
@@ -10816,25 +10867,20 @@ where
                 }
                 for range in &ingested.dep_plan.range_deps {
                     self.target_preparation_checkpoint(options.deadline, 1)?;
-                    let sheet_id = match range.sheet {
-                        crate::reference::SharedSheetLocator::Id(id) => id,
-                        crate::reference::SharedSheetLocator::Current => sheet_id,
-                        crate::reference::SharedSheetLocator::Name(ref name) => {
-                            let Some(id) = self.graph.sheet_id(name) else {
-                                Self::widen_target_preparation(
-                                    options.opaque_policy,
-                                    &mut scope,
-                                    &mut reasons,
-                                    OpaqueReason::UnresolvedCrossSheetBinding,
-                                )?;
-                                continue;
-                            };
-                            id
-                        }
+                    // `Current` is the sheet the staged formula lives on.
+                    let Ok(dependency_sheet) = self.resolve_sheet_locator(&range.sheet, sheet_id)
+                    else {
+                        Self::widen_target_preparation(
+                            options.opaque_policy,
+                            &mut scope,
+                            &mut reasons,
+                            OpaqueReason::UnresolvedCrossSheetBinding,
+                        )?;
+                        continue;
                     };
                     regions.push_back(PreparationRegion {
-                        sheet: self.graph.sheet_name(sheet_id).to_string(),
-                        sheet_id,
+                        sheet: self.graph.sheet_name(dependency_sheet).to_string(),
+                        sheet_id: dependency_sheet,
                         start_row: range.start_row.map_or(1, |bound| bound.index + 1),
                         start_col: range.start_col.map_or(1, |bound| bound.index + 1),
                         end_row: range
@@ -19017,9 +19063,12 @@ where
                     units = units.saturating_add(index_units(point));
                 }
             }
+            let vertex_sheet = self.graph.get_vertex_sheet_id(vertex);
             if let Some(ranges) = self.graph.get_range_dependencies(vertex) {
                 for range in ranges {
-                    if let Ok(Some(region)) = self.shared_range_to_region_pattern(range) {
+                    if let Ok(Some(region)) =
+                        self.shared_range_to_region_pattern(range, vertex_sheet)
+                    {
                         entry_count = entry_count.saturating_add(1);
                         units = units.saturating_add(index_units(region));
                     }
@@ -19077,7 +19126,9 @@ where
             }
             if let Some(ranges) = self.graph.get_range_dependencies(*vertex) {
                 for range in ranges {
-                    let region = self.shared_range_to_region_pattern(range).ok()??;
+                    let region = self
+                        .shared_range_to_region_pattern(range, cell.sheet_id)
+                        .ok()??;
                     if span_boundary_sheets.contains(&region.sheet_id()) {
                         return None;
                     }
@@ -19468,7 +19519,9 @@ where
                 }
                 if let Some(ranges) = self.graph.get_range_dependencies(*vertex) {
                     for range in ranges {
-                        let Some(read_region) = self.shared_range_to_region_pattern(range)? else {
+                        let Some(read_region) =
+                            self.shared_range_to_region_pattern(range, cell.sheet_id)?
+                        else {
                             legacy_reads_complete = false;
                             continue;
                         };
@@ -20672,15 +20725,27 @@ impl<R> Engine<R>
 where
     R: EvaluationContext,
 {
+    /// The [`Region`] a compressed range dependency covers.
+    ///
+    /// `context_sheet` is the sheet the dependency's formula lives on, which is
+    /// what a `Current` locator means. It must be supplied by the caller: this
+    /// method has no way to recover it, and substituting the workbook default
+    /// sheet pointed the region at an unrelated sheet (issue #110). `None` means
+    /// "no region pattern"; callers treat that as an incomplete summary and fall
+    /// back to the conservative global path.
     fn shared_range_to_region_pattern(
         &self,
         range: &crate::reference::SharedRangeRef<'static>,
+        context_sheet: SheetId,
     ) -> Result<Option<Region>, ExcelError> {
-        use crate::reference::SharedSheetLocator;
-        let sheet_id = match range.sheet {
-            SharedSheetLocator::Id(id) => id,
-            SharedSheetLocator::Current => self.graph.default_sheet_id(),
-            SharedSheetLocator::Name(_) => return Ok(None),
+        assert!(
+            matches!(range.sheet, crate::reference::SharedSheetLocator::Id(_)),
+            "PROBE: non-Id locator reached shared_range_to_region_pattern: {:?}",
+            range.sheet
+        );
+        let Ok(sheet_id) = self.resolve_sheet_locator(&range.sheet, context_sheet) else {
+            // Unresolvable sheet name: no trustworthy region.
+            return Ok(None);
         };
         match (
             range.start_row,
@@ -23636,9 +23701,14 @@ where
                 let formualizer_common::SheetRef::Range(range) = shared else {
                     return Err(ExcelError::new(ExcelErrorKind::Ref));
                 };
+                // No context sheet is available here, so an unresolved locator
+                // is #REF! rather than a guess (issue #110).
                 let sheet_id = match range.sheet {
                     formualizer_common::SheetLocator::Id(id) => id,
-                    _ => return Err(ExcelError::new(ExcelErrorKind::Ref)),
+                    formualizer_common::SheetLocator::Current
+                    | formualizer_common::SheetLocator::Name(_) => {
+                        return Err(ExcelError::new(ExcelErrorKind::Ref));
+                    }
                 };
                 let sheet_name = self.graph.sheet_name(sheet_id);
 

--- a/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
@@ -104,13 +104,11 @@ fn collect_graph_reference(
         SemanticReference::OpenRange(range) => {
             if let Some(SharedRef::Range(range)) = range.original.to_sheet_ref_lossy() {
                 let owned = range.into_owned();
-                let sheet_id = match owned.sheet {
-                    SharedSheetLocator::Id(id) => id,
-                    SharedSheetLocator::Current => context.current_sheet_id,
-                    SharedSheetLocator::Name(name) => {
-                        context.graph.resolve_existing_sheet_id(name.as_ref())?
-                    }
-                };
+                // `Current` is the sheet the formula lives on.
+                let sheet_id = context
+                    .graph
+                    .sheet_reg()
+                    .resolve_locator(&owned.sheet, context.current_sheet_id)?;
                 context.range_dependencies.push(SharedRangeRef {
                     sheet: SharedSheetLocator::Id(sheet_id),
                     start_row: owned.start_row,
@@ -149,13 +147,11 @@ fn collect_graph_reference(
                 }
             } else if let Some(SharedRef::Range(range)) = range.original.to_sheet_ref_lossy() {
                 let owned = range.into_owned();
-                let sheet_id = match owned.sheet {
-                    SharedSheetLocator::Id(id) => id,
-                    SharedSheetLocator::Current => context.current_sheet_id,
-                    SharedSheetLocator::Name(name) => {
-                        context.graph.resolve_existing_sheet_id(name.as_ref())?
-                    }
-                };
+                // `Current` is the sheet the formula lives on.
+                let sheet_id = context
+                    .graph
+                    .sheet_reg()
+                    .resolve_locator(&owned.sheet, context.current_sheet_id)?;
                 context.range_dependencies.push(SharedRangeRef {
                     sheet: SharedSheetLocator::Id(sheet_id),
                     start_row: owned.start_row,

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -1749,10 +1749,11 @@ impl DependencyGraph {
             let target_row = target.row0();
             let target_col = target.col0();
             if plan.range_deps.iter().any(|range| {
-                let range_sheet = match range.sheet {
-                    SharedSheetLocator::Id(id) => id,
-                    _ => *sheet_id,
-                };
+                // `Current` is the formula's own sheet.
+                let range_sheet = self
+                    .sheet_reg
+                    .resolve_locator(&range.sheet, *sheet_id)
+                    .unwrap_or(*sheet_id);
                 range_sheet == *sheet_id
                     && range
                         .start_row
@@ -3199,10 +3200,11 @@ impl DependencyGraph {
             let old_sheet_id = self.store.sheet_id(vertex);
 
             for range in &old_ranges {
-                let sheet_id = match range.sheet {
-                    SharedSheetLocator::Id(id) => id,
-                    _ => old_sheet_id,
-                };
+                // `Current` is the sheet the moved formula used to live on.
+                let sheet_id = self
+                    .sheet_reg
+                    .resolve_locator(&range.sheet, old_sheet_id)
+                    .unwrap_or(old_sheet_id);
                 let s_row = range.start_row.map(|b| b.index);
                 let e_row = range.end_row.map(|b| b.index);
                 let s_col = range.start_col.map(|b| b.index);
@@ -3847,10 +3849,12 @@ impl DependencyGraph {
             };
             let mut hit = false;
             for range in ranges {
-                let range_sheet_id = match range.sheet {
-                    SharedSheetLocator::Id(id) => id,
-                    _ => sheet_id,
-                };
+                // `Current` is the dependent formula's own sheet; an
+                // unresolvable name keeps the dependent in the candidate set.
+                let range_sheet_id = self
+                    .sheet_reg
+                    .resolve_locator(&range.sheet, self.get_vertex_sheet_id(dep_id))
+                    .unwrap_or(sheet_id);
                 if range_sheet_id != sheet_id {
                     continue;
                 }

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -282,22 +282,53 @@ impl DependencyGraph {
         self.sheet_named_ranges.iter()
     }
 
-    pub fn resolve_name_entry(&self, name: &str, current_sheet: SheetId) -> Option<&NamedRange> {
-        if self.config.case_sensitive_names {
-            self.sheet_named_ranges
-                .get(&(current_sheet, name.to_string()))
-                .or_else(|| self.named_ranges.get(name))
-        } else {
-            let key = self.name_lookup_key(name);
-            self.sheet_named_ranges_lookup
-                .get(&(current_sheet, key.clone()))
-                .and_then(|canon| self.sheet_named_ranges.get(&(current_sheet, canon.clone())))
-                .or_else(|| {
-                    self.named_ranges_lookup
-                        .get(&key)
-                        .and_then(|canon| self.named_ranges.get(canon))
-                })
+    /// Resolve a name in an explicit [`NameScope`].
+    ///
+    /// [`NameScope::Sheet`] looks in that sheet's names first and falls back to
+    /// workbook scope, matching Excel's shadowing rules. [`NameScope::Workbook`]
+    /// looks in workbook-scoped names **only**: a sheet-scoped name is invisible
+    /// to a workbook-scope query even when it is scoped to the default sheet.
+    ///
+    /// This is the single owned derivation for name scoping. A caller with no
+    /// sheet context asks for [`NameScope::Workbook`], never for the default
+    /// sheet's scope - substituting the default sheet for missing context is
+    /// what leaked references onto unrelated sheets in issue #110.
+    pub fn resolve_name_entry_in_scope(&self, name: &str, scope: NameScope) -> Option<&NamedRange> {
+        let workbook_entry = || {
+            if self.config.case_sensitive_names {
+                self.named_ranges.get(name)
+            } else {
+                self.named_ranges_lookup
+                    .get(&self.name_lookup_key(name))
+                    .and_then(|canon| self.named_ranges.get(canon))
+            }
+        };
+
+        match scope {
+            NameScope::Workbook => workbook_entry(),
+            NameScope::Sheet(current_sheet) => {
+                if self.config.case_sensitive_names {
+                    self.sheet_named_ranges
+                        .get(&(current_sheet, name.to_string()))
+                        .or_else(workbook_entry)
+                } else {
+                    let key = self.name_lookup_key(name);
+                    self.sheet_named_ranges_lookup
+                        .get(&(current_sheet, key))
+                        .and_then(|canon| {
+                            self.sheet_named_ranges.get(&(current_sheet, canon.clone()))
+                        })
+                        .or_else(workbook_entry)
+                }
+            }
         }
+    }
+
+    /// Resolve a name as seen from `current_sheet`: sheet scope shadows
+    /// workbook scope. Equivalent to [`Self::resolve_name_entry_in_scope`] with
+    /// [`NameScope::Sheet`].
+    pub fn resolve_name_entry(&self, name: &str, current_sheet: SheetId) -> Option<&NamedRange> {
+        self.resolve_name_entry_in_scope(name, NameScope::Sheet(current_sheet))
     }
 
     /// Resolve a named range to its definition

--- a/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
+++ b/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
@@ -199,9 +199,14 @@ impl PreparedLegacyGraphPlan {
             let target_row = target.row0();
             let target_col = target.col0();
             let range_contains_target = formula.plan.range_deps.iter().any(|range| {
+                // `Current` is the formula's own sheet. This plan carries no
+                // sheet registry, so an unresolved `Name` is interpreted the
+                // same way rather than dropping the range from the count.
                 let sheet_id = match range.sheet {
                     SharedSheetLocator::Id(id) => id,
-                    _ => formula.current_sheet_id,
+                    SharedSheetLocator::Current | SharedSheetLocator::Name(_) => {
+                        formula.current_sheet_id
+                    }
                 };
                 sheet_id == target.sheet_id()
                     && range
@@ -370,10 +375,12 @@ impl DependencyGraph {
                         .entry(id)
                         .or_insert(self.checked_sheet_name(id)?);
                 }
-                let range_sheet = match range.sheet {
-                    SharedSheetLocator::Id(id) => id,
-                    _ => *sheet_id,
-                };
+                // `Current` is the formula's own sheet; an unresolvable name
+                // is bounds-checked against it rather than skipped.
+                let range_sheet = self
+                    .sheet_reg
+                    .resolve_locator(&range.sheet, *sheet_id)
+                    .unwrap_or(*sheet_id);
                 for bound in [range.start_row, range.end_row].into_iter().flatten() {
                     if bound.index > PackedSheetCell::MAX_ROW0 {
                         return Err(PreparedLegacyGraphError::InvalidCoordinate {

--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -33,12 +33,14 @@ impl DependencyGraph {
                 ranges
                     .iter()
                     .any(|range| {
-                        let range_sheet_id = match range.sheet {
-                            SharedSheetLocator::Id(id) => id,
-                            // Formula analysis normalizes ingested locators to Id, so this
-                            // fallback is unreachable today; match the sibling query semantics.
-                            _ => sheet_id,
-                        };
+                        // `Current` is the dependent formula's own sheet. An
+                        // unresolvable sheet name keeps the dependent in the
+                        // candidate set (over-approximating is safe here;
+                        // dropping it would silently lose a dependent).
+                        let range_sheet_id = self
+                            .sheet_reg
+                            .resolve_locator(&range.sheet, self.get_vertex_sheet_id(dependent))
+                            .unwrap_or(sheet_id);
                         let range_start = range.start_row.map(|bound| bound.index).unwrap_or(0);
                         let range_end = range.end_row.map(|bound| bound.index).unwrap_or(u32::MAX);
                         range_sheet_id == sheet_id
@@ -62,12 +64,11 @@ impl DependencyGraph {
                 ranges
                     .iter()
                     .any(|range| {
-                        let range_sheet_id = match range.sheet {
-                            SharedSheetLocator::Id(id) => id,
-                            // Formula analysis normalizes ingested locators to Id, so this
-                            // fallback is unreachable today; match the sibling query semantics.
-                            _ => sheet_id,
-                        };
+                        // See the row query above.
+                        let range_sheet_id = self
+                            .sheet_reg
+                            .resolve_locator(&range.sheet, self.get_vertex_sheet_id(dependent))
+                            .unwrap_or(sheet_id);
                         let range_start = range.start_col.map(|bound| bound.index).unwrap_or(0);
                         let range_end = range.end_col.map(|bound| bound.index).unwrap_or(u32::MAX);
                         range_sheet_id == sheet_id
@@ -142,12 +143,13 @@ impl DependencyGraph {
                         return false;
                     }
                     *remaining_work -= 1;
-                    // Match collect_range_dependents_for_rect: unresolved
-                    // non-Id locators are interpreted on the query sheet.
-                    let range_sheet = match range.sheet {
-                        SharedSheetLocator::Id(id) => id,
-                        _ => sheet_id,
-                    };
+                    // `Current` is the dependent formula's own sheet; an
+                    // unresolvable sheet name is interpreted on the query sheet
+                    // so the dependent is not silently dropped.
+                    let range_sheet = self
+                        .sheet_reg
+                        .resolve_locator(&range.sheet, self.get_vertex_sheet_id(dependent))
+                        .unwrap_or(sheet_id);
                     if range_sheet != sheet_id {
                         continue;
                     }
@@ -462,10 +464,13 @@ impl DependencyGraph {
             .insert(dependent, ranges.to_vec());
 
         for range in ranges {
-            let sheet_id = match range.sheet {
-                SharedSheetLocator::Id(id) => id,
-                _ => current_sheet_id,
-            };
+            // `current_sheet_id` is the dependent formula's sheet, which is what
+            // `Current` means. An unresolvable sheet name falls back to it so a
+            // stripe is still registered rather than the edge being dropped.
+            let sheet_id = self
+                .sheet_reg
+                .resolve_locator(&range.sheet, current_sheet_id)
+                .unwrap_or(current_sheet_id);
 
             let s_row = range.start_row.map(|b| b.index);
             let e_row = range.end_row.map(|b| b.index);
@@ -685,10 +690,11 @@ impl DependencyGraph {
             .insert(dependent, shared_ranges.clone());
 
         for range in &shared_ranges {
-            let sheet_id = match range.sheet {
-                SharedSheetLocator::Id(id) => id,
-                _ => current_sheet_id,
-            };
+            // See add_range_dependent_edges.
+            let sheet_id = self
+                .sheet_reg
+                .resolve_locator(&range.sheet, current_sheet_id)
+                .unwrap_or(current_sheet_id);
 
             let s_row = range.start_row.map(|b| b.index);
             let e_row = range.end_row.map(|b| b.index);

--- a/crates/formualizer-eval/src/engine/ingest_builder.rs
+++ b/crates/formualizer-eval/src/engine/ingest_builder.rs
@@ -77,12 +77,14 @@ impl SheetStage {
 
 fn range_key_from_shared(
     range: &crate::reference::SharedRangeRef<'static>,
+    sheet_reg: &crate::engine::sheet_registry::SheetRegistry,
     current_sheet: SheetId,
 ) -> RangeKey {
-    let sheet = match range.sheet {
-        crate::reference::SharedSheetLocator::Id(id) => id,
-        _ => current_sheet,
-    };
+    // `Current` is the sheet the formula lives on. An unresolvable sheet name
+    // falls back to it so the range still produces a key.
+    let sheet = sheet_reg
+        .resolve_locator(&range.sheet, current_sheet)
+        .unwrap_or(current_sheet);
     match (
         range.start_row,
         range.start_col,
@@ -117,6 +119,7 @@ fn range_key_from_shared(
 }
 
 fn dependency_plan_from_rows(
+    sheet_reg: &crate::engine::sheet_registry::SheetRegistry,
     sheet_id: SheetId,
     rows: &[(u32, u32, DependencyPlanRow)],
 ) -> DependencyPlan {
@@ -192,7 +195,7 @@ fn dependency_plan_from_rows(
             row_plan
                 .range_deps
                 .iter()
-                .map(|range| range_key_from_shared(range, sheet_id))
+                .map(|range| range_key_from_shared(range, sheet_reg, sheet_id))
                 .collect(),
         );
         let mut names = row_plan.resolved_named_refs.clone();
@@ -462,7 +465,7 @@ impl<'g> BulkIngestBuilder<'g> {
                         .zip(prepared.into_iter())
                         .map(|(formula, (_, plan))| (formula.row, formula.col, plan))
                         .collect();
-                    let plan = dependency_plan_from_rows(stage.id, &row_plans);
+                    let plan = dependency_plan_from_rows(self.g.sheet_reg(), stage.id, &row_plans);
                     edges_adj.reserve(plan.formula_targets.len());
                     t_plan_ms += tp0.elapsed().as_millis();
                     n_targets += plan.formula_targets.len();

--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -519,16 +519,8 @@ impl<'a> IngestPipeline<'a> {
         sheet: SharedSheetLocator<'static>,
         current_sheet_id: SheetId,
     ) -> Result<SheetId, ExcelError> {
-        match sheet {
-            SharedSheetLocator::Id(id) => Ok(id),
-            SharedSheetLocator::Current => Ok(current_sheet_id),
-            SharedSheetLocator::Name(name) => {
-                self.sheet_registry.get_id(name.as_ref()).ok_or_else(|| {
-                    ExcelError::new(ExcelErrorKind::Ref)
-                        .with_message(format!("Sheet not found: {name}"))
-                })
-            }
-        }
+        self.sheet_registry
+            .resolve_locator(&sheet, current_sheet_id)
     }
 
     fn rewrite_structured_references_for_cell(

--- a/crates/formualizer-eval/src/engine/sheet_registry.rs
+++ b/crates/formualizer-eval/src/engine/sheet_registry.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
+use formualizer_common::{ExcelError, ExcelErrorKind};
+
 use crate::SheetId;
+use crate::reference::SharedSheetLocator;
 
 #[derive(Default, Debug)]
 pub struct SheetRegistry {
@@ -38,6 +41,35 @@ impl SheetRegistry {
     pub fn get_id(&self, name: &str) -> Option<SheetId> {
         // Case-insensitive (Excel): e.g. INDIRECT("Config!B8") must find the sheet named "CONFIG".
         self.id_by_name.get(&name.to_lowercase()).copied()
+    }
+
+    /// Resolve a [`SharedSheetLocator`] against an explicit context sheet.
+    ///
+    /// This is the single owned derivation from a locator to a [`SheetId`].
+    /// Every variant is matched explicitly so that adding a variant is a
+    /// compile error rather than a silent default:
+    ///
+    /// * `Id` is already resolved.
+    /// * `Current` means "the sheet this reference lives on" and is taken from
+    ///   `context_sheet`. It is never the workbook's default sheet: a caller
+    ///   without a context sheet has lost the information the reference needs,
+    ///   and substituting the default sheet leaks the reference onto an
+    ///   unrelated sheet (issue #110). Such callers must supply the context or
+    ///   surface an error.
+    /// * `Name` must name a registered sheet; an unknown name is `#REF!`.
+    pub fn resolve_locator(
+        &self,
+        locator: &SharedSheetLocator<'_>,
+        context_sheet: SheetId,
+    ) -> Result<SheetId, ExcelError> {
+        match locator {
+            SharedSheetLocator::Id(id) => Ok(*id),
+            SharedSheetLocator::Current => Ok(context_sheet),
+            SharedSheetLocator::Name(name) => self.get_id(name.as_ref()).ok_or_else(|| {
+                ExcelError::new(ExcelErrorKind::Ref)
+                    .with_message(format!("Sheet not found: {name}"))
+            }),
+        }
     }
 
     /// Count active sheets without cloning sheet names.

--- a/crates/formualizer-eval/src/engine/tests/default_sheet_resolution.rs
+++ b/crates/formualizer-eval/src/engine/tests/default_sheet_resolution.rs
@@ -1,0 +1,335 @@
+//! Regression tests for default-sheet resolution leaks.
+//!
+//! `default_sheet_name`/`default_sheet_id` are legitimate stored configuration.
+//! They are not a legitimate *resolution fallback*: substituting them for a
+//! missing sheet context silently answers a question with data from an
+//! unrelated sheet (issue #110).
+
+use crate::engine::named_range::{NameScope, NamedDefinition};
+use crate::engine::{Engine, EvalConfig, EvaluationTarget, TargetEvalOptions};
+use crate::reference::{SharedRangeRef, SharedSheetLocator};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{AxisBound, LiteralValue};
+use formualizer_parse::parser::parse;
+
+fn engine_with_two_sheets() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.add_sheet("Sheet2").unwrap();
+    engine
+}
+
+/// A name scoped to the default sheet must not answer a query that asked for
+/// no scope at all. `None` means "workbook scope", not "the default sheet".
+#[test]
+fn sheet_scoped_name_does_not_leak_into_unscoped_has_name() {
+    let mut engine = engine_with_two_sheets();
+    let sheet1 = engine.sheet_id("Sheet1").unwrap();
+    assert_eq!(
+        sheet1,
+        engine.default_sheet_id(),
+        "precondition: Sheet1 is the default sheet"
+    );
+
+    engine
+        .define_name(
+            "SecretLocal",
+            NamedDefinition::Literal(LiteralValue::Number(42.0)),
+            NameScope::Sheet(sheet1),
+        )
+        .unwrap();
+
+    assert!(
+        engine.has_name("SecretLocal", Some("Sheet1")),
+        "the name is in scope on the sheet it is scoped to"
+    );
+    assert!(
+        !engine.has_name("SecretLocal", Some("Sheet2")),
+        "the name is not in scope on another sheet"
+    );
+    assert!(
+        !engine.has_name("SecretLocal", None),
+        "an unscoped query asks about workbook scope only; a name scoped to the \
+         default sheet must not answer it"
+    );
+}
+
+#[test]
+fn sheet_scoped_name_does_not_leak_into_unscoped_resolved_name_value() {
+    let mut engine = engine_with_two_sheets();
+    let sheet1 = engine.sheet_id("Sheet1").unwrap();
+
+    engine
+        .define_name(
+            "SecretLocal",
+            NamedDefinition::Literal(LiteralValue::Number(42.0)),
+            NameScope::Sheet(sheet1),
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.resolved_name_value("SecretLocal", Some("Sheet1")),
+        Some(LiteralValue::Number(42.0))
+    );
+    assert_eq!(
+        engine.resolved_name_value("SecretLocal", Some("Sheet2")),
+        None
+    );
+    assert_eq!(
+        engine.resolved_name_value("SecretLocal", None),
+        None,
+        "an unscoped read must not see a name scoped to the default sheet"
+    );
+}
+
+/// Workbook-scoped names still answer both unscoped and sheet-scoped queries.
+#[test]
+fn workbook_scoped_name_answers_unscoped_and_sheet_scoped_queries() {
+    let mut engine = engine_with_two_sheets();
+    engine
+        .define_name(
+            "Global",
+            NamedDefinition::Literal(LiteralValue::Number(7.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine.evaluate_all().unwrap();
+
+    assert!(engine.has_name("Global", None));
+    assert!(engine.has_name("Global", Some("Sheet1")));
+    assert!(engine.has_name("Global", Some("Sheet2")));
+    assert_eq!(
+        engine.resolved_name_value("Global", None),
+        Some(LiteralValue::Number(7.0))
+    );
+}
+
+/// `EvaluationTarget::Name { scope_sheet: None }` must not select a name that
+/// only exists in the default sheet's scope.
+#[test]
+fn unscoped_name_target_does_not_select_default_sheet_scoped_name() {
+    let mut engine = engine_with_two_sheets();
+    let sheet1 = engine.sheet_id("Sheet1").unwrap();
+    engine
+        .define_name(
+            "SecretLocal",
+            NamedDefinition::Literal(LiteralValue::Number(42.0)),
+            NameScope::Sheet(sheet1),
+        )
+        .unwrap();
+
+    let target = EvaluationTarget::Name {
+        name: "SecretLocal".to_string(),
+        scope_sheet: None,
+    };
+    let report = engine
+        .prepare_graph_for_targets(std::slice::from_ref(&target), TargetEvalOptions::default())
+        .unwrap();
+    assert!(
+        !report.widening_reasons.is_empty(),
+        "an unscoped target naming a sheet-scoped name is unresolved and must \
+         widen, not silently resolve through the default sheet: {report:?}"
+    );
+
+    let scoped = EvaluationTarget::Name {
+        name: "SecretLocal".to_string(),
+        scope_sheet: Some("Sheet1".to_string()),
+    };
+    let scoped_report = engine
+        .prepare_graph_for_targets(std::slice::from_ref(&scoped), TargetEvalOptions::default())
+        .unwrap();
+    assert!(
+        scoped_report.widening_reasons.is_empty(),
+        "the correctly scoped target resolves: {scoped_report:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T2 - SharedSheetLocator resolution
+// ---------------------------------------------------------------------------
+
+/// A 1..=10 x 1..=10 compressed range dependency on `sheet`.
+fn compressed_range(sheet: SharedSheetLocator<'static>) -> SharedRangeRef<'static> {
+    SharedRangeRef {
+        sheet,
+        start_row: Some(AxisBound::new(0, true)),
+        start_col: Some(AxisBound::new(0, true)),
+        end_row: Some(AxisBound::new(9, true)),
+        end_col: Some(AxisBound::new(9, true)),
+    }
+}
+
+fn staging_engine() -> Engine<TestWorkbook> {
+    let config = EvalConfig {
+        defer_graph_building: true,
+        ..EvalConfig::default()
+    };
+    let mut engine = Engine::new(TestWorkbook::new(), config);
+    for sheet in ["Alpha", "Beta"] {
+        engine.add_sheet(sheet).unwrap();
+    }
+    engine
+}
+
+/// Install a name whose stored definition carries `range_deps` verbatim.
+///
+/// `define_name` re-derives dependencies from the AST; `update_name`
+/// deliberately does not, so this is the production path by which a caller's
+/// own locators reach the graph.
+fn define_name_with_range_deps(
+    engine: &mut Engine<TestWorkbook>,
+    name: &str,
+    scope: NameScope,
+    range_deps: Vec<SharedRangeRef<'static>>,
+) {
+    engine
+        .define_name(
+            name,
+            NamedDefinition::Formula {
+                ast: parse("=1").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            scope,
+        )
+        .unwrap();
+    engine
+        .update_name(
+            name,
+            NamedDefinition::Formula {
+                ast: parse("=1").unwrap(),
+                dependencies: Vec::new(),
+                range_deps,
+            },
+            scope,
+        )
+        .unwrap();
+}
+
+fn selected_sheets(report: &crate::engine::PreparedTargetGraphReport) -> Vec<String> {
+    let mut sheets = report
+        .selected_cells
+        .iter()
+        .map(|cell| cell.sheet.to_string())
+        .collect::<Vec<_>>();
+    sheets.sort();
+    sheets.dedup();
+    sheets
+}
+
+/// `Current` in a named formula's range dependencies means the sheet the name
+/// lives on, exactly as it does for a cell formula's range dependencies ~90
+/// lines earlier in the same function. It must not become the default sheet.
+#[test]
+fn current_locator_in_named_formula_deps_uses_the_names_sheet_not_the_default() {
+    let mut engine = staging_engine();
+    let alpha = engine.sheet_id("Alpha").unwrap();
+    assert_ne!(alpha, engine.default_sheet_id());
+
+    // One staged formula inside the 1..10 x 1..10 box on each sheet.
+    engine.stage_formula_text("Alpha", 3, 3, "=1".into());
+    engine.stage_formula_text(
+        engine.default_sheet_name().to_string().as_str(),
+        3,
+        3,
+        "=2".into(),
+    );
+
+    define_name_with_range_deps(
+        &mut engine,
+        "AlphaBox",
+        NameScope::Sheet(alpha),
+        vec![compressed_range(SharedSheetLocator::Current)],
+    );
+
+    let target = EvaluationTarget::Name {
+        name: "AlphaBox".to_string(),
+        scope_sheet: Some("Alpha".to_string()),
+    };
+    let report = engine
+        .prepare_graph_for_targets(&[target], TargetEvalOptions::default())
+        .unwrap();
+
+    assert_eq!(
+        selected_sheets(&report),
+        vec!["Alpha".to_string()],
+        "the name is scoped to Alpha, so its `Current` range dependency covers          Alpha - not the workbook default sheet: {report:?}"
+    );
+}
+
+/// The same site used a `_` wildcard, so it also swallowed `Name`: a
+/// cross-sheet named-sheet dependency silently became the default sheet.
+#[test]
+fn named_sheet_locator_in_named_formula_deps_resolves_to_that_sheet() {
+    let mut engine = staging_engine();
+    let alpha = engine.sheet_id("Alpha").unwrap();
+
+    engine.stage_formula_text("Beta", 3, 3, "=1".into());
+    engine.stage_formula_text(
+        engine.default_sheet_name().to_string().as_str(),
+        3,
+        3,
+        "=2".into(),
+    );
+
+    define_name_with_range_deps(
+        &mut engine,
+        "BetaBox",
+        NameScope::Sheet(alpha),
+        vec![compressed_range(SharedSheetLocator::Name("Beta".into()))],
+    );
+
+    let target = EvaluationTarget::Name {
+        name: "BetaBox".to_string(),
+        scope_sheet: Some("Alpha".to_string()),
+    };
+    let report = engine
+        .prepare_graph_for_targets(&[target], TargetEvalOptions::default())
+        .unwrap();
+
+    assert_eq!(
+        selected_sheets(&report),
+        vec!["Beta".to_string()],
+        "a Beta! range dependency covers Beta, not the default sheet: {report:?}"
+    );
+}
+
+/// And an unresolvable sheet name must widen rather than land on the default
+/// sheet, matching how the cell-formula arm of the same function behaves.
+#[test]
+fn unresolvable_sheet_locator_in_named_formula_deps_widens() {
+    let mut engine = staging_engine();
+    let alpha = engine.sheet_id("Alpha").unwrap();
+
+    engine.stage_formula_text(
+        engine.default_sheet_name().to_string().as_str(),
+        3,
+        3,
+        "=2".into(),
+    );
+
+    define_name_with_range_deps(
+        &mut engine,
+        "GhostBox",
+        NameScope::Sheet(alpha),
+        vec![compressed_range(SharedSheetLocator::Name(
+            "NoSuchSheet".into(),
+        ))],
+    );
+
+    let target = EvaluationTarget::Name {
+        name: "GhostBox".to_string(),
+        scope_sheet: Some("Alpha".to_string()),
+    };
+    let report = engine
+        .prepare_graph_for_targets(&[target], TargetEvalOptions::default())
+        .unwrap();
+
+    assert!(
+        report
+            .widening_reasons
+            .contains(&crate::engine::OpaqueReason::UnresolvedCrossSheetBinding),
+        "an unresolved cross-sheet binding must be surfaced, not replaced by \
+         the default sheet: {report:?}"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -11,6 +11,7 @@ mod cross_sheet_named_range_first_cell;
 mod cycle_detection;
 mod database_blank_semantics;
 mod date_arithmetic_negative_serial;
+mod default_sheet_resolution;
 mod deferred_dirty;
 mod demand_driven;
 mod dependency;

--- a/crates/formualizer-eval/src/reference.rs
+++ b/crates/formualizer-eval/src/reference.rs
@@ -247,11 +247,16 @@ impl CellRef {
         )
     }
 
+    /// A `CellRef` is sheet-resolved by construction, so an unresolved locator
+    /// is `#REF!` rather than something to guess at: there is no context sheet
+    /// here to interpret `Current` against (issue #110).
     pub fn try_from_shared(cell: SharedCellRef<'_>) -> Result<Self, ExcelError> {
         let owned = cell.into_owned();
         let sheet_id = match owned.sheet {
             SharedSheetLocator::Id(id) => id,
-            _ => return Err(ExcelError::new(ExcelErrorKind::Ref)),
+            SharedSheetLocator::Current | SharedSheetLocator::Name(_) => {
+                return Err(ExcelError::new(ExcelErrorKind::Ref));
+            }
         };
         Ok(Self::new(sheet_id, Coord(owned.coord)))
     }
@@ -296,11 +301,14 @@ impl RangeRef {
             .map_err(|_| ExcelError::new(ExcelErrorKind::Ref))
     }
 
+    /// See [`CellRef::try_from_shared`]: an unresolved locator is `#REF!`.
     pub fn try_from_shared(range: SharedRangeRef<'_>) -> Result<Self, ExcelError> {
         let owned = range.into_owned();
         let sheet_id = match owned.sheet {
             SharedSheetLocator::Id(id) => id,
-            _ => return Err(ExcelError::new(ExcelErrorKind::Ref)),
+            SharedSheetLocator::Current | SharedSheetLocator::Name(_) => {
+                return Err(ExcelError::new(ExcelErrorKind::Ref));
+            }
         };
         let (sr, sc, er, ec) = match (
             owned.start_row,

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -2610,6 +2610,7 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::named_range_by_vertex(&
 pub fn formualizer_eval::engine::graph::DependencyGraph::named_ranges_iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&alloc::string::String, &formualizer_eval::engine::named_range::NamedRange)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::resolve_name(&self, &str, formualizer_eval::reference::SheetId) -> core::option::Option<&formualizer_eval::engine::named_range::NamedDefinition>
 pub fn formualizer_eval::engine::graph::DependencyGraph::resolve_name_entry(&self, &str, formualizer_eval::reference::SheetId) -> core::option::Option<&formualizer_eval::engine::named_range::NamedRange>
+pub fn formualizer_eval::engine::graph::DependencyGraph::resolve_name_entry_in_scope(&self, &str, formualizer_eval::engine::named_range::NameScope) -> core::option::Option<&formualizer_eval::engine::named_range::NamedRange>
 pub fn formualizer_eval::engine::graph::DependencyGraph::sheet_named_ranges_iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&(formualizer_eval::reference::SheetId, alloc::string::String), &formualizer_eval::engine::named_range::NamedRange)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::update_name(&mut self, &str, formualizer_eval::engine::named_range::NamedDefinition, formualizer_eval::engine::named_range::NameScope) -> core::result::Result<(), formualizer_common::error::ExcelError>
 impl formualizer_eval::engine::graph::DependencyGraph
@@ -4416,6 +4417,7 @@ pub fn formualizer_eval::engine::sheet_registry::SheetRegistry::name(&self, form
 pub fn formualizer_eval::engine::sheet_registry::SheetRegistry::new() -> Self
 pub fn formualizer_eval::engine::sheet_registry::SheetRegistry::remove(&mut self, formualizer_eval::reference::SheetId) -> core::result::Result<(), formualizer_common::error::ExcelError>
 pub fn formualizer_eval::engine::sheet_registry::SheetRegistry::rename(&mut self, formualizer_eval::reference::SheetId, &str) -> core::result::Result<(), formualizer_common::error::ExcelError>
+pub fn formualizer_eval::engine::sheet_registry::SheetRegistry::resolve_locator(&self, &formualizer_eval::reference::SharedSheetLocator<'_>, formualizer_eval::reference::SheetId) -> core::result::Result<formualizer_eval::reference::SheetId, formualizer_common::error::ExcelError>
 impl core::default::Default for formualizer_eval::engine::sheet_registry::SheetRegistry
 pub fn formualizer_eval::engine::sheet_registry::SheetRegistry::default() -> formualizer_eval::engine::sheet_registry::SheetRegistry
 impl core::fmt::Debug for formualizer_eval::engine::sheet_registry::SheetRegistry
@@ -5878,6 +5880,7 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::named_range_by_vertex(&
 pub fn formualizer_eval::engine::graph::DependencyGraph::named_ranges_iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&alloc::string::String, &formualizer_eval::engine::named_range::NamedRange)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::resolve_name(&self, &str, formualizer_eval::reference::SheetId) -> core::option::Option<&formualizer_eval::engine::named_range::NamedDefinition>
 pub fn formualizer_eval::engine::graph::DependencyGraph::resolve_name_entry(&self, &str, formualizer_eval::reference::SheetId) -> core::option::Option<&formualizer_eval::engine::named_range::NamedRange>
+pub fn formualizer_eval::engine::graph::DependencyGraph::resolve_name_entry_in_scope(&self, &str, formualizer_eval::engine::named_range::NameScope) -> core::option::Option<&formualizer_eval::engine::named_range::NamedRange>
 pub fn formualizer_eval::engine::graph::DependencyGraph::sheet_named_ranges_iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&(formualizer_eval::reference::SheetId, alloc::string::String), &formualizer_eval::engine::named_range::NamedRange)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::update_name(&mut self, &str, formualizer_eval::engine::named_range::NamedDefinition, formualizer_eval::engine::named_range::NameScope) -> core::result::Result<(), formualizer_common::error::ExcelError>
 impl formualizer_eval::engine::graph::DependencyGraph


### PR DESCRIPTION
Tranches T1 and T2 of the default-sheet elimination program. Both are correctness fixes with one root cause: the workbook default sheet was being substituted wherever sheet context was missing.

The principle is not new here. `eval.rs:23087` settled it for issue #110:

> Previously this fell back to `default_sheet_name()`, which leaked the reference onto an unrelated sheet (issue #110). ... Returning `#REF!` for an unqualified reference here surfaces the missing context instead of silently returning data from the wrong sheet.

That was applied at one site and never propagated. This finishes it for the two places where it is reachable.

## T1 — a sheet-scoped name answered a query that asked for no scope

`resolve_name_entry` took a `SheetId`, and callers holding `scope_sheet: Option<&str>` mapped `None` to `default_sheet_id()`. Sheet-scoped names resolve before workbook-scoped ones, so a name scoped only to `Sheet1` was indistinguishable from a workbook-scoped name.

| query, name scoped to `Sheet1` only | before | after |
|---|---|---|
| `has_name(n, Some("Sheet1"))` | `true` | `true` |
| `has_name(n, Some("Sheet2"))` | `false` | `false` |
| `has_name(n, None)` | **`true`** | `false` |
| `resolved_name_value(n, None)` | **`Some(..)`** | `None` |

The inconsistency is the tell: the same query against any *other* sheet correctly reported the name absent. Only the default sheet leaked.

Replaced with `resolve_name_entry_in_scope(name, scope: NameScope)`. `Sheet(id)` checks that sheet then falls back to workbook scope, matching Excel's shadowing. `Workbook` consults workbook-scoped names only. One owned derivation, and callers with no sheet context now ask for workbook scope explicitly rather than borrowing the default sheet's.

## T2 — `Current` locators resolved inconsistently, including twice in one function

`SharedSheetLocator::Current` means "the sheet this reference lives on". Six sites resolved it from real context; two substituted the workbook default. Two of those are in `prepare_graph_for_targets_transaction`, which does it correctly at `eval.rs:10285` with `get_vertex_sheet_id(vertex)` and then, ninety lines later, does `_ => self.graph.default_sheet_id()`. That wildcard also swallowed `Name`, so a sheet name that failed to resolve silently became the default sheet.

This is reachable and observable. A named formula scoped to `Alpha` carrying a whole-column dependency selected cells on **both** `Alpha` and `Sheet1` during target preparation:

```
left:  ["Alpha", "Sheet1"]
right: ["Alpha"]
```

`shared_range_to_region_pattern` now takes an explicit context sheet, threaded from its callers (`get_vertex_sheet_id(vertex)`, `cell.sheet_id`) — the same explicit-parameter shape `bindings/python/src/reference.rs:74` already uses. Every locator variant is now matched exhaustively; no `_` arms remain on either locator enum, so a future variant is a compile error rather than a silent default.

## Evidence

Seven tests in `engine/tests/default_sheet_resolution.rs`, driven through public entry points (`define_name`, `has_name`, `resolved_name_value`, and `PreparedTargetGraphReport` for the preparation paths).

**Five of the seven fail on plain `main`.** The two that pass are deliberate controls: a genuinely workbook-scoped name must still answer both unscoped and sheet-scoped queries, and an unresolvable sheet locator must widen rather than resolve to anything. Controls that pass before and after are what make the other five attributable.

Full workspace green, fmt and clippy clean.

## Deliberately out of scope

Three `graph/mod.rs` methods — `set_cell_value_ref`, `set_cell_formula_ref`, `get_cell_value_ref` — substitute the default sheet for `formualizer_common::SheetLocator::Current`, a *different* enum from the one fixed here and the one the parser actually emits for unqualified references. They have no callers anywhere in the workspace, so this is latent rather than live, and it is tracked as its own tranche. Note `formualizer-eval` sets `dead_code = "allow"` crate-wide, which is why unused public API of this kind goes unflagged.

`names.rs:739` binds unqualified references in workbook-scoped named formulas to the default sheet, and carries a comment saying so. That one is a genuine semantic question rather than drift — a workbook-scoped name has no ambient context, and Excel binds to the sheet active at definition time — so the real fix is to record the definition-time sheet on the name. Left alone here.

Whether the two locator enums should unify is a separate decision: `formualizer-common` and `formualizer-parse` are separately versioned at 3.0.0, so changing a public enum there has its own release consequences.

drafted with love by (agent) Manfred, with approval from Frankie
