### PR TITLE
fix(eval): resolve LET/LAMBDA locals before the named-range reference path

### DIFF
--- a/crates/formualizer-eval/src/engine/tests/let_lambda.rs
+++ b/crates/formualizer-eval/src/engine/tests/let_lambda.rs
@@ -228,3 +228,73 @@ fn nested_let_lambda_dependency_recalc_engine() {
         Some(LiteralValue::Number(22.0))
     );
 }
+
+#[test]
+fn let_range_binding_feeds_aggregates_engine() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+
+    for (row, v) in [(1u32, 1.0), (2, 2.0), (3, 3.0)] {
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(v))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=LET(r,B1:B3,SUM(r))").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            2,
+            1,
+            parse("=LET(r,B1:B3,SUM(r)+COUNT(r))").unwrap(),
+        )
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(6.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 1),
+        Some(LiteralValue::Number(9.0))
+    );
+}
+
+#[test]
+fn let_range_binding_shadows_workbook_name_engine() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+
+    engine
+        .define_name(
+            "r",
+            NamedDefinition::Literal(LiteralValue::Number(100.0)),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    for (row, v) in [(1u32, 1.0), (2, 2.0), (3, 3.0)] {
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(v))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Sheet1", 1, 1, parse("=LET(r,B1:B3,SUM(r))").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 2, 1, parse("=SUM(r)").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    // The LET-local binding wins inside the LET body...
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 1),
+        Some(LiteralValue::Number(6.0))
+    );
+    // ...while the workbook name still resolves outside it.
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 1),
+        Some(LiteralValue::Number(100.0))
+    );
+}

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -503,6 +503,14 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         match &self.expr {
             ArgumentExpr::Ast(node) => match &node.node_type {
                 ASTNodeType::Reference { reference, .. } => {
+                    // A LET/LAMBDA local shadows any workbook name of the same
+                    // spelling; locals only resolve on the value path, so a
+                    // bound name must not be sent down the named-range route.
+                    if let ReferenceType::NamedRange(name) = reference
+                        && self.interp.resolve_local_name(name).is_some()
+                    {
+                        return None;
+                    }
                     Some(self.interp.reference_for_current_offset(reference))
                 }
                 ASTNodeType::BinaryOp { op, .. } if op == ":" => {
@@ -536,6 +544,15 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
                 };
                 match node {
                     crate::engine::arena::AstNodeData::Reference { ref_type, .. } => {
+                        // Same local-shadowing rule as the AST branch above.
+                        if let crate::engine::arena::CompactRefType::NamedRange(name_id) = ref_type
+                            && self
+                                .interp
+                                .resolve_local_name(data_store.resolve_ast_string(*name_id))
+                                .is_some()
+                        {
+                            return None;
+                        }
                         let reference = data_store
                             .reconstruct_reference_type_for_eval(ref_type, sheet_registry);
                         Some(self.interp.reference_for_current_offset(&reference))


### PR DESCRIPTION
## What was wrong

A name bound by LET or LAMBDA breaks as soon as a range-consuming
argument uses it:

```
=LET(r, A1:A3, SUM(r))      → #NAME?     (Excel: the sum)
=LET(r, A1:A3, COUNT(r))    → #NAME?     (Excel: the count)
```

Scalar uses of the same binding (`=LET(x, 1, x+1)`) work, which makes the
failure look input-dependent rather than structural: the same `LET` works
or dies depending on which function consumes the local.

## Why

The name parses as `ReferenceType::NamedRange`, and
`ArgumentHandle::reference_attempt` sends every `NamedRange` straight to
workbook named-range resolution. The local environment — where LET/LAMBDA
bindings actually live — is only consulted on the value path, which a
range-consuming argument never reaches. The workbook has no name of that
spelling, so the argument resolves to `#NAME?` even though the binding is
sitting in scope.

## The fix

In `reference_attempt`, return `None` for a name that
`resolve_local_name` knows, in both the AST and the arena branches, so
resolution falls through to the value path where locals already resolve.

One semantic consequence, made deliberately: a local now shadows a
workbook name of the same spelling on the reference path. That matches
what the value path has always done, so the two paths now agree instead
of disagreeing depending on the consuming function — and it matches
Excel, where `LET(r, ..., ...)` shadows a defined name `r` inside the
LET body.

## Verification

New tests in `engine/tests/let_lambda.rs` cover: `SUM` and
`SUM(r)+COUNT(r)` over a LET-bound range, and a LET local shadowing a
workbook defined name of the same spelling (the local wins inside the
LET body; the workbook name still resolves outside it). The
range-consuming cases fail on current `main` with `#NAME?` before this
change.

Local gates (macOS aarch64, rustc 1.97.1):

```
cargo fmt --all --check          clean
cargo test -p formualizer-eval   2670 passed, 1 failed
```

The one failure is pre-existing and reproduces byte-identically on
unmodified `main` (2668 passed, same failure): three last-digit
floating-point diffs in `extended_coverage.json` IMEXP/IMSIN/IMCOS,
which look platform-dependent. Local `cargo clippy -- -D warnings`
also fires a set of lints that fire identically on unmodified `main`,
none of them in the files this PR touches; the branch adds no lint.

No public API change: both hunks are inside existing method bodies.

## How this was found

Workbook-level probe batteries in an evaluation harness that compares
engine output against Excel-verified expected values; this was one of
two systematic deviations isolated to the local-binding path. Drafted by
Claude (agent), verified by execution, reviewed by a human before
submission.
