### PR TITLE
fix(eval): XLOOKUP Excel-parity no-match and exact-match class rules

### DIFF
--- a/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/dynamic.rs
@@ -458,7 +458,9 @@ impl Function for XLookupFn {
             ));
         }
 
-        if args.len() >= 4 {
+        // An omitted-in-place slot (`XLOOKUP(v,l,r,,mode)`) is not a supplied
+        // if_not_found; Excel returns #N/A, not the omitted slot's 0.
+        if args.len() >= 4 && !args[3].is_omitted() {
             return args[3].value();
         }
         Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -112,6 +112,9 @@ impl<'a> PreparedLookupMatcher<'a> {
                 let folded_candidate = candidate_text.to_lowercase();
                 compiled.matches_folded(&folded_candidate)
             }
+            // Excel exact lookups never match a text needle against a
+            // non-text candidate: "20" does not find the number 20.
+            (Some(_), _) => false,
             _ => cmp_for_lookup(self.needle, candidate, self.date_system)
                 .map(|o| o == 0)
                 .unwrap_or(false),
@@ -534,6 +537,10 @@ fn find_exact_text_in_view(
     let compiled_wildcard = (wildcard && (s.contains('*') || s.contains('?') || s.contains('~')))
         .then(|| CompiledWildcardPattern::from_folded(&needle_folded));
 
+    // The lowered-text lane can carry text renderings of non-text cells
+    // (some load paths materialize them), so a lane hit is only a match
+    // when the underlying cell value really is text: Excel exact lookups
+    // never match a text needle against a number/boolean/date cell.
     if vertical {
         for res in view.lowered_text_slices() {
             let (row_start, _row_len, cols) = res?;
@@ -542,11 +549,12 @@ fn find_exact_text_in_view(
                 for i in 0..arr.len() {
                     if !arr.is_null(i) {
                         let val = arr.value(i);
-                        if let Some(pattern) = &compiled_wildcard {
-                            if pattern.matches_folded(val) {
-                                return Ok(Some(row_start + i));
-                            }
-                        } else if val == needle_folded {
+                        let hit = if let Some(pattern) = &compiled_wildcard {
+                            pattern.matches_folded(val)
+                        } else {
+                            val == needle_folded
+                        };
+                        if hit && matches!(view.get_cell(row_start + i, 0), LiteralValue::Text(_)) {
                             return Ok(Some(row_start + i));
                         }
                     }
@@ -559,11 +567,12 @@ fn find_exact_text_in_view(
             for (c, arr) in cols.iter().enumerate() {
                 if !arr.is_null(0) {
                     let val = arr.value(0);
-                    if let Some(pattern) = &compiled_wildcard {
-                        if pattern.matches_folded(val) {
-                            return Ok(Some(c));
-                        }
-                    } else if val == needle_folded {
+                    let hit = if let Some(pattern) = &compiled_wildcard {
+                        pattern.matches_folded(val)
+                    } else {
+                        val == needle_folded
+                    };
+                    if hit && matches!(view.get_cell(0, c), LiteralValue::Text(_)) {
                         return Ok(Some(c));
                     }
                 }

--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -112,6 +112,13 @@ impl<'a> PreparedLookupMatcher<'a> {
                 let folded_candidate = candidate_text.to_lowercase();
                 compiled.matches_folded(&folded_candidate)
             }
+            // Excel: an empty-string needle also matches a blank cell.
+            (Some(PreparedTextMatcher::Exact { folded_needle }), LiteralValue::Empty) => {
+                folded_needle.is_empty()
+            }
+            // Excel exact lookups never match a text needle against a
+            // non-text candidate: "20" does not find the number 20.
+            (Some(_), _) => false,
             _ => cmp_for_lookup(self.needle, candidate, self.date_system)
                 .map(|o| o == 0)
                 .unwrap_or(false),
@@ -468,6 +475,11 @@ pub fn find_exact_index_in_view(
     match needle {
         LiteralValue::Number(n) => find_exact_number_in_view(view, *n, vertical),
         LiteralValue::Int(i) => find_exact_number_in_view(view, *i as f64, vertical),
+        // Excel: an empty-string needle matches the first blank cell (blank
+        // and "" are the same value class at the formula level).
+        LiteralValue::Text(s) if s.is_empty() && !wildcard => {
+            find_exact_empty_in_view(view, vertical)
+        }
         LiteralValue::Text(s) => find_exact_text_in_view(view, s, wildcard, vertical),
         LiteralValue::Boolean(b) => find_exact_boolean_in_view(view, *b, vertical),
         LiteralValue::Empty => find_exact_empty_in_view(view, vertical),
@@ -534,6 +546,10 @@ fn find_exact_text_in_view(
     let compiled_wildcard = (wildcard && (s.contains('*') || s.contains('?') || s.contains('~')))
         .then(|| CompiledWildcardPattern::from_folded(&needle_folded));
 
+    // The lowered-text lane can carry text renderings of non-text cells
+    // (some load paths materialize them), so a lane hit is only a match
+    // when the underlying cell value really is text: Excel exact lookups
+    // never match a text needle against a number/boolean/date cell.
     if vertical {
         for res in view.lowered_text_slices() {
             let (row_start, _row_len, cols) = res?;
@@ -542,11 +558,12 @@ fn find_exact_text_in_view(
                 for i in 0..arr.len() {
                     if !arr.is_null(i) {
                         let val = arr.value(i);
-                        if let Some(pattern) = &compiled_wildcard {
-                            if pattern.matches_folded(val) {
-                                return Ok(Some(row_start + i));
-                            }
-                        } else if val == needle_folded {
+                        let hit = if let Some(pattern) = &compiled_wildcard {
+                            pattern.matches_folded(val)
+                        } else {
+                            val == needle_folded
+                        };
+                        if hit && matches!(view.get_cell(row_start + i, 0), LiteralValue::Text(_)) {
                             return Ok(Some(row_start + i));
                         }
                     }
@@ -559,11 +576,12 @@ fn find_exact_text_in_view(
             for (c, arr) in cols.iter().enumerate() {
                 if !arr.is_null(0) {
                     let val = arr.value(0);
-                    if let Some(pattern) = &compiled_wildcard {
-                        if pattern.matches_folded(val) {
-                            return Ok(Some(c));
-                        }
-                    } else if val == needle_folded {
+                    let hit = if let Some(pattern) = &compiled_wildcard {
+                        pattern.matches_folded(val)
+                    } else {
+                        val == needle_folded
+                    };
+                    if hit && matches!(view.get_cell(0, c), LiteralValue::Text(_)) {
                         return Ok(Some(c));
                     }
                 }

--- a/crates/formualizer-eval/src/engine/lookup_index_cache.rs
+++ b/crates/formualizer-eval/src/engine/lookup_index_cache.rs
@@ -191,6 +191,10 @@ impl LookupIndex {
         {
             return self.first_empty;
         }
+        // Excel: an empty-string needle matches a blank cell.
+        if matches!(needle, LiteralValue::Text(s) if s.is_empty()) {
+            return self.first_empty;
+        }
         None
     }
 

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -200,3 +200,4 @@ mod approximate_lookup_ignored_entries;
 mod temporal_lookup_semantics;
 
 mod format_channel_t1;
+mod xlookup_excel_parity;

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -195,3 +195,4 @@ mod short_circuit_dispatch;
 
 mod approximate_lookup_ignored_entries;
 mod temporal_lookup_semantics;
+mod xlookup_excel_parity;

--- a/crates/formualizer-eval/src/engine/tests/xlookup_excel_parity.rs
+++ b/crates/formualizer-eval/src/engine/tests/xlookup_excel_parity.rs
@@ -1,0 +1,103 @@
+//! Excel-parity semantics for XLOOKUP no-match and exact-match class rules.
+//!
+//! - An omitted-in-place `if_not_found` slot (`XLOOKUP(v,l,r,,mode)`) is not a
+//!   supplied argument: a no-match returns #N/A, never the slot's implicit 0.
+//! - Exact match never crosses value classes: a text needle does not find a
+//!   number, whichever search direction or storage path is used.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+fn numeric_grid_engine() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, v) in [(1u32, 10.0), (2, 20.0), (3, 30.0)] {
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(v))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 3, LiteralValue::Number(v * 10.0))
+            .unwrap();
+    }
+    engine
+}
+
+fn assert_na(engine: &Engine<TestWorkbook>, row: u32, col: u32) {
+    match engine.get_cell_value("Sheet1", row, col) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Na),
+        other => panic!("expected #N/A, got {other:?}"),
+    }
+}
+
+#[test]
+fn xlookup_omitted_if_not_found_returns_na_on_approximate_no_match() {
+    let mut engine = numeric_grid_engine();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            10,
+            1,
+            parse("=XLOOKUP(5,B1:B3,C1:C3,,-1)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            11,
+            1,
+            parse("=XLOOKUP(35,B1:B3,C1:C3,,1)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            12,
+            1,
+            parse("=XLOOKUP(35,B1:B3,C1:C3,\"none\",1)").unwrap(),
+        )
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_na(&engine, 10, 1);
+    assert_na(&engine, 11, 1);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 12, 1),
+        Some(LiteralValue::Text("none".into()))
+    );
+}
+
+#[test]
+fn xlookup_text_needle_does_not_coerce_to_number() {
+    let mut engine = numeric_grid_engine();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            10,
+            1,
+            parse("=XLOOKUP(\"20\",B1:B3,C1:C3)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            11,
+            1,
+            parse("=XLOOKUP(\"20\",B1:B3,C1:C3,,0,-1)").unwrap(),
+        )
+        .unwrap();
+    // Control: a real numeric needle still matches.
+    engine
+        .set_cell_formula("Sheet1", 12, 1, parse("=XLOOKUP(20,B1:B3,C1:C3)").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_na(&engine, 10, 1);
+    assert_na(&engine, 11, 1);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 12, 1),
+        Some(LiteralValue::Number(200.0))
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/xlookup_excel_parity.rs
+++ b/crates/formualizer-eval/src/engine/tests/xlookup_excel_parity.rs
@@ -1,0 +1,149 @@
+//! Excel-parity semantics for XLOOKUP no-match and exact-match class rules.
+//!
+//! - An omitted-in-place `if_not_found` slot (`XLOOKUP(v,l,r,,mode)`) is not a
+//!   supplied argument: a no-match returns #N/A, never the slot's implicit 0.
+//! - Exact match never crosses value classes: a text needle does not find a
+//!   number, whichever search direction or storage path is used.
+//! - An empty-string needle matches the first blank cell.
+
+use crate::engine::{Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+fn numeric_grid_engine() -> Engine<TestWorkbook> {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    for (row, v) in [(1u32, 10.0), (2, 20.0), (3, 30.0)] {
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(v))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 3, LiteralValue::Number(v * 10.0))
+            .unwrap();
+    }
+    engine
+}
+
+fn assert_na(engine: &Engine<TestWorkbook>, row: u32, col: u32) {
+    match engine.get_cell_value("Sheet1", row, col) {
+        Some(LiteralValue::Error(e)) => assert_eq!(e.kind, ExcelErrorKind::Na),
+        other => panic!("expected #N/A, got {other:?}"),
+    }
+}
+
+#[test]
+fn xlookup_omitted_if_not_found_returns_na_on_approximate_no_match() {
+    let mut engine = numeric_grid_engine();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            10,
+            1,
+            parse("=XLOOKUP(5,B1:B3,C1:C3,,-1)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            11,
+            1,
+            parse("=XLOOKUP(35,B1:B3,C1:C3,,1)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            12,
+            1,
+            parse("=XLOOKUP(35,B1:B3,C1:C3,\"none\",1)").unwrap(),
+        )
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_na(&engine, 10, 1);
+    assert_na(&engine, 11, 1);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 12, 1),
+        Some(LiteralValue::Text("none".into()))
+    );
+}
+
+#[test]
+fn xlookup_text_needle_does_not_coerce_to_number() {
+    let mut engine = numeric_grid_engine();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            10,
+            1,
+            parse("=XLOOKUP(\"20\",B1:B3,C1:C3)").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            11,
+            1,
+            parse("=XLOOKUP(\"20\",B1:B3,C1:C3,,0,-1)").unwrap(),
+        )
+        .unwrap();
+    // Control: a real numeric needle still matches.
+    engine
+        .set_cell_formula("Sheet1", 12, 1, parse("=XLOOKUP(20,B1:B3,C1:C3)").unwrap())
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_na(&engine, 10, 1);
+    assert_na(&engine, 11, 1);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 12, 1),
+        Some(LiteralValue::Number(200.0))
+    );
+}
+
+#[test]
+fn xlookup_empty_string_needle_matches_blank_cell() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    // B1 blank, B2/B3 text; C1:C3 = 7,8,9.
+    engine
+        .set_cell_value("Sheet1", 2, 2, LiteralValue::Text("x".into()))
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 3, 2, LiteralValue::Text("y".into()))
+        .unwrap();
+    for (row, v) in [(1u32, 7.0), (2, 8.0), (3, 9.0)] {
+        engine
+            .set_cell_value("Sheet1", row, 3, LiteralValue::Number(v))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            10,
+            1,
+            parse("=XLOOKUP(\"\",B1:B3,C1:C3)").unwrap(),
+        )
+        .unwrap();
+    // Control: text needles still match text cells.
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            11,
+            1,
+            parse("=XLOOKUP(\"x\",B1:B3,C1:C3)").unwrap(),
+        )
+        .unwrap();
+
+    engine.evaluate_all().unwrap();
+
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 10, 1),
+        Some(LiteralValue::Number(7.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 11, 1),
+        Some(LiteralValue::Number(8.0))
+    );
+}


### PR DESCRIPTION
## Problem

XLOOKUP had two independent paths that could return a plausible but wrong result.

An omitted `if_not_found` slot, as in `=XLOOKUP(5,B1:B3,C1:C3,,-1)`, evaluated to implicit zero. Excel returns `#N/A`. Exact text needles also crossed value classes, so `"20"` could match numeric `20` through the linear or lowered-text path.

## Solution

Omitted `if_not_found` nodes no longer count as supplied fallbacks. Exact text needles now match only true text cells on both lookup paths and in both search directions.

Per review, the blank-versus-empty-string claim was removed from this PR. Its isolated patch is retained on `pr/xlookup-empty-string-blank-followup` and stays gated on the host-compatibility decision in #319.

## Verification

Rebased onto current upstream `main` at `06dad200fe87cb5bff9c17104c1487cdbf4b4eca`.

```text
cargo fmt --all -- --check                         passed
cargo test -p formualizer-eval xlookup_            16 passed, 0 failed
```

The focused run includes both new regression tests and the existing XLOOKUP tests selected by the filter.
