### PR TITLE
feat(python): deterministic clock setter on Workbook (#330)

### DIFF
--- a/bindings/python/formualizer/formualizer_py.pyi
+++ b/bindings/python/formualizer/formualizer_py.pyi
@@ -1780,6 +1780,18 @@ class Workbook:
             print(wb.evaluate_cell("Data", 3, 1))
         ```
         """
+    def set_deterministic_clock(self, deterministic_timestamp_utc: datetime.datetime, deterministic_timezone: typing.Optional[typing.Any] = None) -> None:
+        r"""
+        Pin the evaluation clock to a caller-supplied instant, so the
+        volatile date/time builtins (TODAY, NOW) evaluate deterministically
+        on the next recalculation. Takes effect on a live workbook; no
+        reload is required.
+        
+        `deterministic_timezone` accepts `"utc"`, `"local"`, or a fixed
+        offset in seconds — the same spelling as
+        `SheetPortSession.evaluate_once(deterministic_timezone=...)`.
+        Omitted means UTC.
+        """
     def evaluate_all(self) -> None: ...
     def last_cycle_telemetry(self) -> CycleTelemetry:
         r"""

--- a/bindings/python/src/sheetport.rs
+++ b/bindings/python/src/sheetport.rs
@@ -288,7 +288,7 @@ impl PySheetPortSession {
     }
 }
 
-fn parse_timezone_spec(obj: &Bound<'_, PyAny>) -> PyResult<TimeZoneSpec> {
+pub(crate) fn parse_timezone_spec(obj: &Bound<'_, PyAny>) -> PyResult<TimeZoneSpec> {
     if let Ok(s) = obj.extract::<String>() {
         match s.to_ascii_lowercase().as_str() {
             "utc" => Ok(TimeZoneSpec::Utc),

--- a/bindings/python/src/workbook.rs
+++ b/bindings/python/src/workbook.rs
@@ -851,6 +851,34 @@ impl PyWorkbook {
         literal_to_py(py, &v)
     }
 
+    /// Pin the evaluation clock to a caller-supplied instant, so the
+    /// volatile date/time builtins (TODAY, NOW) evaluate deterministically
+    /// on the next recalculation. Takes effect on a live workbook; no
+    /// reload is required.
+    ///
+    /// `deterministic_timezone` accepts `"utc"`, `"local"`, or a fixed
+    /// offset in seconds — the same spelling as
+    /// `SheetPortSession.evaluate_once(deterministic_timezone=...)`.
+    /// Omitted means UTC.
+    #[pyo3(signature = (deterministic_timestamp_utc, deterministic_timezone=None))]
+    pub fn set_deterministic_clock(
+        &self,
+        deterministic_timestamp_utc: chrono::DateTime<chrono::Utc>,
+        deterministic_timezone: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<()> {
+        let timezone = match deterministic_timezone {
+            Some(obj) => crate::sheetport::parse_timezone_spec(obj)?,
+            None => formualizer::eval::timezone::TimeZoneSpec::Utc,
+        };
+        let mut wb = self.write_inner()?;
+        wb.set_deterministic_mode(formualizer::eval::engine::DeterministicMode::Enabled {
+            timestamp_utc: deterministic_timestamp_utc,
+            timezone,
+        })
+        .map_err(workbook_error_to_pyerr)?;
+        Ok(())
+    }
+
     pub fn evaluate_all(&self, py: Python<'_>) -> PyResult<()> {
         // Ensure flag is reset before starting
         self.cancel_flag

--- a/bindings/python/tests/test_workbook_deterministic_clock.py
+++ b/bindings/python/tests/test_workbook_deterministic_clock.py
@@ -1,0 +1,64 @@
+"""Workbook.set_deterministic_clock pins TODAY()/NOW() on a live workbook.
+
+An embedder holding a plain `Workbook` previously had no way to pin the
+evaluation clock at all; determinism was reachable only through
+`SheetPortSession.evaluate_once`. The setter must take effect on the next
+recalculation of a live workbook, with no reload.
+"""
+
+import datetime
+
+import pytest
+
+import formualizer as fz
+
+_PINNED = datetime.datetime(2026, 3, 14, 15, 9, 26, tzinfo=datetime.timezone.utc)
+
+
+def _workbook_with(formula: str) -> fz.Workbook:
+    workbook = fz.Workbook(mode=fz.WorkbookMode.Ephemeral)
+    workbook.add_sheet("Sheet1")
+    workbook.set_formula("Sheet1", 1, 1, formula)
+    return workbook
+
+
+def test_pinned_clock_fixes_today() -> None:
+    workbook = _workbook_with("=TODAY()")
+    workbook.set_deterministic_clock(_PINNED)
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _PINNED.date()
+
+
+def test_pinned_clock_fixes_now_including_the_time_fraction() -> None:
+    workbook = _workbook_with("=NOW()")
+    workbook.set_deterministic_clock(_PINNED)
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _PINNED.replace(tzinfo=None)
+
+
+def test_pin_takes_effect_on_the_next_recalc_without_reload() -> None:
+    workbook = _workbook_with("=TODAY()")
+    live = workbook.evaluate_cell("Sheet1", 1, 1)
+    # The live wall clock cannot be reading 2026-03-14 when this suite runs;
+    # the assertion below is therefore a real transition, not a coincidence.
+    assert live != _PINNED.date()
+    workbook.set_deterministic_clock(_PINNED)
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _PINNED.date()
+
+
+def test_fixed_offset_timezone_shifts_the_local_date() -> None:
+    # 01:30 UTC with a -2h offset is still the previous local day.
+    pinned = datetime.datetime(2026, 3, 15, 1, 30, tzinfo=datetime.timezone.utc)
+    workbook = _workbook_with("=TODAY()")
+    workbook.set_deterministic_clock(pinned, -7200)
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == datetime.date(2026, 3, 14)
+
+
+def test_utc_string_timezone_spec_is_accepted() -> None:
+    workbook = _workbook_with("=TODAY()")
+    workbook.set_deterministic_clock(_PINNED, "utc")
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _PINNED.date()
+
+
+def test_malformed_timezone_spec_raises() -> None:
+    workbook = _workbook_with("=TODAY()")
+    with pytest.raises(TypeError):
+        workbook.set_deterministic_clock(_PINNED, "mars")

--- a/bindings/python/tests/test_workbook_deterministic_clock.py
+++ b/bindings/python/tests/test_workbook_deterministic_clock.py
@@ -1,0 +1,74 @@
+"""Workbook.set_deterministic_clock pins TODAY()/NOW() on a live workbook.
+
+An embedder holding a plain `Workbook` previously had no way to pin the
+evaluation clock at all; determinism was reachable only through
+`SheetPortSession.evaluate_once`. The setter must take effect on the next
+recalculation of a live workbook, with no reload.
+"""
+
+import datetime
+
+import pytest
+
+import formualizer as fz
+
+# Excel's 1900 date system counts from this day, with the 1900 leap-year
+# artifact already absorbed for every date after 1900-03-01.
+_EXCEL_EPOCH = datetime.date(1899, 12, 30)
+
+_PINNED = datetime.datetime(2026, 3, 14, 15, 9, 26, tzinfo=datetime.timezone.utc)
+
+
+def _serial(day: datetime.date) -> float:
+    return float((day - _EXCEL_EPOCH).days)
+
+
+def _workbook_with(formula: str) -> fz.Workbook:
+    workbook = fz.Workbook(mode=fz.WorkbookMode.Ephemeral)
+    workbook.add_sheet("Sheet1")
+    workbook.set_formula("Sheet1", 1, 1, formula)
+    return workbook
+
+
+def test_pinned_clock_fixes_today() -> None:
+    workbook = _workbook_with("=TODAY()")
+    workbook.set_deterministic_clock(_PINNED)
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _serial(_PINNED.date())
+
+
+def test_pinned_clock_fixes_now_including_the_time_fraction() -> None:
+    workbook = _workbook_with("=NOW()")
+    workbook.set_deterministic_clock(_PINNED)
+    seconds = _PINNED.hour * 3600 + _PINNED.minute * 60 + _PINNED.second
+    expected = _serial(_PINNED.date()) + seconds / 86400.0
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == pytest.approx(expected)
+
+
+def test_pin_takes_effect_on_the_next_recalc_without_reload() -> None:
+    workbook = _workbook_with("=TODAY()")
+    live = workbook.evaluate_cell("Sheet1", 1, 1)
+    # The live wall clock cannot be reading 2026-03-14 when this suite runs;
+    # the assertion below is therefore a real transition, not a coincidence.
+    assert live != _serial(_PINNED.date())
+    workbook.set_deterministic_clock(_PINNED)
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _serial(_PINNED.date())
+
+
+def test_fixed_offset_timezone_shifts_the_local_date() -> None:
+    # 01:30 UTC with a -2h offset is still the previous local day.
+    pinned = datetime.datetime(2026, 3, 15, 1, 30, tzinfo=datetime.timezone.utc)
+    workbook = _workbook_with("=TODAY()")
+    workbook.set_deterministic_clock(pinned, -7200)
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _serial(datetime.date(2026, 3, 14))
+
+
+def test_utc_string_timezone_spec_is_accepted() -> None:
+    workbook = _workbook_with("=TODAY()")
+    workbook.set_deterministic_clock(_PINNED, "utc")
+    assert workbook.evaluate_cell("Sheet1", 1, 1) == _serial(_PINNED.date())
+
+
+def test_malformed_timezone_spec_raises() -> None:
+    workbook = _workbook_with("=TODAY()")
+    with pytest.raises(TypeError):
+        workbook.set_deterministic_clock(_PINNED, "mars")


### PR DESCRIPTION
## Problem

Python callers holding a live `Workbook` cannot pin its evaluation clock. Deterministic time is available through `SheetPortSession.evaluate_once`, but not through the workbook object used by long-running embedders and Pyodide.

## Solution

`Workbook.set_deterministic_clock` wraps the engine's existing deterministic mode and reuses SheetPort's timezone parser. The new clock applies on the next recalculation without reloading the workbook.

After #357 changed the default temporal egress contract, this branch was rebased onto current `main` and the clock tests now assert native `datetime.date` and `datetime.datetime` values directly.

## Verification

Built the Python extension from the rebased branch with CPython 3.14.6 and `maturin develop --release`.

```text
python -m pytest tests/test_workbook_deterministic_clock.py -q   6 passed
ruff check tests/test_workbook_deterministic_clock.py            passed
ruff format --check tests/test_workbook_deterministic_clock.py   passed
cargo fmt --all -- --check                                      passed
```
