### PR TITLE
fix(workbook): gate calc_pr tests on calamine/umya features

### DIFF
--- a/crates/formualizer-workbook/src/calc_pr.rs
+++ b/crates/formualizer-workbook/src/calc_pr.rs
@@ -295,6 +295,7 @@ pub fn rewrite_calc_pr_in_zip(
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "calamine", feature = "umya"))]
 mod tests {
     use super::*;
     use formualizer_eval::engine::{CycleDetection, CyclePolicy};


### PR DESCRIPTION
The calc_pr test module uses types from the file-loading backends which are only available when calamine or umya features are enabled. Without this gate, builds with no backend features fail to compile tests.