### PR TITLE
fix(eval): date arithmetic returns Number, not Date (#312)

### DIFF
--- a/crates/formualizer-eval/src/engine/tests/date_arithmetic_negative_serial.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_arithmetic_negative_serial.rs
@@ -3,10 +3,8 @@
 //!
 //! Excel has no date type at the formula level. A date cell holds a serial
 //! number carrying a date number format, so `=A1-B1` with `A1 < B1` is just a
-//! negative number. Formualizer keeps a first-class temporal tag so typed date
-//! values survive a round trip, and propagating that tag through `+`/`-` is a
-//! deliberate convenience -- but it must never turn arithmetic Excel performs
-//! happily into a numeric-domain error.
+//! negative number. All date arithmetic now returns plain `Number` values,
+//! matching Excel's value semantics (#312).
 //!
 //! Each test pins exactly the property it names.
 
@@ -53,14 +51,8 @@ fn date_minus_larger_number_returns_negative_number_not_num_error() {
 #[test]
 fn date_minus_number_at_serial_zero_boundary_stays_representable() {
     let mut engine = engine_with_date_anchor();
-    // Serial 0 is representable as a date, so the temporal tag is preserved.
-    // This pins the boundary the fix must not move.
-    match eval(&mut engine, "=A1-45627") {
-        LiteralValue::Date(d) => {
-            assert_eq!(d, NaiveDate::from_ymd_opt(1899, 12, 31).unwrap())
-        }
-        other => panic!("expected Date at serial 0, got {other:?}"),
-    }
+    // Serial 0 is plain arithmetic: 45627 - 45627 = 0. Excel returns a number.
+    assert_eq!(eval(&mut engine, "=A1-45627"), LiteralValue::Number(0.0));
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/date_arithmetic_ops.rs
+++ b/crates/formualizer-eval/src/engine/tests/date_arithmetic_ops.rs
@@ -5,16 +5,20 @@ use crate::test_workbook::TestWorkbook;
 use formualizer_common::LiteralValue;
 use formualizer_parse::parser::parse;
 
-fn assert_date_like(v: Option<LiteralValue>, expected: NaiveDate) {
+fn assert_number_near(v: Option<LiteralValue>, expected: f64) {
     match v {
-        Some(LiteralValue::Date(d)) => assert_eq!(d, expected),
-        Some(LiteralValue::DateTime(dt)) => assert_eq!(dt.date(), expected),
-        other => panic!("expected date-like {expected:?}, got {other:?}"),
+        Some(LiteralValue::Number(n)) => {
+            assert!(
+                (n - expected).abs() < 1e-9,
+                "expected {expected}, got {n}"
+            );
+        }
+        other => panic!("expected Number({expected}), got {other:?}"),
     }
 }
 
 #[test]
-fn date_plus_number_returns_date() {
+fn date_plus_number_returns_number() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
     engine
         .set_cell_value(
@@ -31,20 +35,15 @@ fn date_plus_number_returns_date() {
         .set_cell_formula("Sheet1", 1, 3, parse("=A1+B1").unwrap())
         .unwrap();
 
-    assert_date_like(
-        engine.get_cell_value("Sheet1", 1, 1),
-        NaiveDate::from_ymd_opt(2024, 10, 18).unwrap(),
-    );
-
     engine.evaluate_all().unwrap();
-    assert_date_like(
-        engine.get_cell_value("Sheet1", 1, 3),
-        NaiveDate::from_ymd_opt(2024, 11, 1).unwrap(),
-    );
+
+    // 2024-10-18 = serial 45583, +14 = 45597 (2024-11-01)
+    // Excel returns a plain number; display formatting shows it as a date.
+    assert_number_near(engine.get_cell_value("Sheet1", 1, 3), 45583.0 + 14.0);
 }
 
 #[test]
-fn date_minus_number_returns_date() {
+fn date_minus_number_returns_number() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
     engine
         .set_cell_value(
@@ -61,10 +60,9 @@ fn date_minus_number_returns_date() {
         .set_cell_formula("Sheet1", 1, 3, parse("=A1-B1").unwrap())
         .unwrap();
     engine.evaluate_all().unwrap();
-    assert_date_like(
-        engine.get_cell_value("Sheet1", 1, 3),
-        NaiveDate::from_ymd_opt(2024, 10, 18).unwrap(),
-    );
+
+    // 2024-11-01 = serial 45597, -14 = 45583
+    assert_number_near(engine.get_cell_value("Sheet1", 1, 3), 45597.0 - 14.0);
 }
 
 #[test]
@@ -97,7 +95,7 @@ fn date_minus_date_returns_number_delta() {
 }
 
 #[test]
-fn round_days_times_14_preserves_date_tag() {
+fn round_days_times_14_returns_number() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
 
     // Mimic the pattern: C107 + (ROUND(C108,0) * 14)
@@ -117,10 +115,9 @@ fn round_days_times_14_preserves_date_tag() {
         .unwrap();
 
     engine.evaluate_all().unwrap();
-    assert_date_like(
-        engine.get_cell_value("Sheet1", 109, 3),
-        NaiveDate::from_ymd_opt(2024, 11, 1).unwrap(),
-    );
+
+    // 2024-10-18 serial = 45583, + 14 = 45597
+    assert_number_near(engine.get_cell_value("Sheet1", 109, 3), 45583.0 + 14.0);
 }
 
 #[test]

--- a/crates/formualizer-eval/src/interpreter.rs
+++ b/crates/formualizer-eval/src/interpreter.rs
@@ -1190,63 +1190,47 @@ impl<'a> Interpreter<'a> {
                 )
             };
 
-            // Excel has no date type at the formula level: `date + number` is
-            // plain numeric addition, and the result only *displays* as a date
-            // because the cell inherits a date number format. We keep the
-            // temporal tag when the result is representable, because that is
-            // what lets typed date values survive a round trip, but a serial no
-            // date can represent is still an ordinary number. Erroring there
-            // invents a numeric-domain failure out of arithmetic Excel performs
-            // without complaint -- notably every negative serial, which the
-            // standard `end_date - start_date` accrual idiom produces whenever
-            // the period runs backwards.
-            let serial_to_literal = |serial: f64| -> LiteralValue {
+            // Excel has no date type at the formula level: a date cell holds
+            // a serial number carrying a date number format, arithmetic on it
+            // yields a plain number, and the result only *displays* as a date
+            // because the cell inherits the source's number format.
+            //
+            // Formualizer therefore returns Number from all date arithmetic,
+            // matching Excel's value semantics. The Date/DateTime tags are
+            // preserved only in the storage layer for round-trip fidelity; they
+            // do not leak into formula results. (#312)
+            let serial_or_error = |serial: f64| -> LiteralValue {
                 match crate::coercion::sanitize_numeric(serial) {
-                    Ok(serial) => {
-                        match formualizer_common::try_serial_to_datetime_for(date_system, serial) {
-                            Ok(dt) => {
-                                if dt.time() == chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap() {
-                                    Date(dt.date())
-                                } else {
-                                    DateTime(dt)
-                                }
-                            }
-                            // Not representable as a date: degrade to the
-                            // plain serial rather than manufacturing #NUM!.
-                            Err(_) => Number(serial),
-                        }
-                    }
-                    // NaN and infinity are genuine numeric-domain failures and
-                    // keep their error.
+                    Ok(n) => Number(n),
                     Err(e) => Error(e),
                 }
             };
 
-            // Date +/- number => date (propagate temporal tag)
+            // Date +/- number => Number (plain serial arithmetic)
             if let Some(ls) = date_like_serial(&l) {
                 match op {
                     '+' => {
                         let rn = to_num(&r)?;
-                        return Ok(serial_to_literal(ls + rn));
+                        return Ok(serial_or_error(ls + rn));
                     }
                     '-' => {
-                        // Date - Date => numeric day delta (Excel-compatible)
+                        // Date - Date => numeric day delta
                         if let Some(rs) = date_like_serial(&r) {
-                            return Ok(Number(ls - rs));
+                            return Ok(serial_or_error(ls - rs));
                         }
                         let rn = to_num(&r)?;
-                        return Ok(serial_to_literal(ls - rn));
+                        return Ok(serial_or_error(ls - rn));
                     }
                     _ => unreachable!(),
                 }
             }
 
-            // Number + Date => date (commutative)
+            // Number + Date => Number (commutative)
             if op == '+'
                 && let Some(rs) = date_like_serial(&r)
             {
                 let ln = to_num(&l)?;
-                return Ok(serial_to_literal(ln + rs));
+                return Ok(serial_or_error(ln + rs));
             }
 
             // Fallback: regular numeric operation

--- a/crates/formualizer-workbook/tests/calamine/date_arithmetic.rs
+++ b/crates/formualizer-workbook/tests/calamine/date_arithmetic.rs
@@ -1,15 +1,17 @@
 use crate::common::build_workbook;
-use chrono::NaiveDate;
 use formualizer_common::LiteralValue;
 use formualizer_eval::engine::ingest::EngineLoadStream;
 use formualizer_eval::engine::{Engine, EvalConfig};
 use formualizer_workbook::{CalamineAdapter, SpreadsheetReader};
 
 #[test]
-fn calamine_date_arithmetic_propagates_date_tag() {
+fn calamine_date_arithmetic_returns_number() {
     // C107 = 2024-10-18 (serial 45583)
     // C108 = 1
-    // C109 = C107 + (ROUND(C108,0) * 14) => 2024-11-01
+    // C109 = C107 + (ROUND(C108,0) * 14) => serial 45597
+    //
+    // Excel returns a plain number from date arithmetic; display formatting
+    // (not the value type) is what makes it look like a date. (#312)
     let path = build_workbook(|book| {
         let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
 
@@ -37,12 +39,13 @@ fn calamine_date_arithmetic_propagates_date_tag() {
     engine.evaluate_all().expect("evaluate");
 
     match engine.get_cell_value("Sheet1", 109, 3) {
-        Some(LiteralValue::Date(d)) => {
-            assert_eq!(d, NaiveDate::from_ymd_opt(2024, 11, 1).unwrap());
+        Some(LiteralValue::Number(n)) => {
+            // 45583 + 14 = 45597
+            assert!(
+                (n - 45597.0).abs() < 1e-9,
+                "expected serial 45597, got {n}"
+            );
         }
-        Some(LiteralValue::DateTime(dt)) => {
-            assert_eq!(dt.date(), NaiveDate::from_ymd_opt(2024, 11, 1).unwrap());
-        }
-        other => panic!("expected date-like at Sheet1!C109, got {other:?}"),
+        other => panic!("expected Number(45597) at Sheet1!C109, got {other:?}"),
     }
 }


### PR DESCRIPTION
Excel has no date type at the formula level. A date cell holds a serial number carrying a date number format; arithmetic on it yields a plain number and the result only displays as a date because the cell inherits the source's number format.

Previously, add_sub_date_aware() reconstructed a Date/DateTime variant when the arithmetic result was representable as a calendar date. This caused observable type divergence from Excel: callers received Date objects instead of numeric serials, and downstream formulas could behave differently depending on whether an intermediate result happened to land in the representable date range.

Now all date arithmetic uniformly returns LiteralValue::Number(serial). The Date/DateTime tags are preserved only in the storage layer for round-trip fidelity on ingested cells; they no longer leak into formula evaluation results.

Closes #312