### PR TITLE
Give symbol vertices their own address space (#302, #304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- **A structural edit no longer reaches a defined name, table or external source.** Those three, plus sheet-scoped names, are identified by name and have no position on any sheet, but the graph gave them fabricated grid coordinates on a real user-visible sheet: the first workbook name landed on `Sheet1!$A$1`, the second on `$B$1`, and a table on its range's anchor cell. The only thing separating such a vertex from the actual cell at that address was its deliberate absence from the cell index — a convention, not a structural property. Two code paths broke it, and both are fixed by giving symbols their own address space. (#302, #304)
+
+  A **default-sheet row or column insert** shifted a name's vertex onto an addressable cell *and* published it in the cell index at the new address. Every dependency resolved afterwards against that address then bound to the name instead of the cell. Three consequences followed, each measured against a matched control that varied only the insert row: a formula written later as `=A2+1` acquired `deps == ["NamedScalar@Sheet1!$A$2"]` rather than a direct cell edge, so editing the *name's* target dirtied an unrelated default-sheet formula; an ordinary data write at the hijacked address rewrote the name's own vertex from `NamedScalar` to `Cell`, silently destroying the name while `resolve_name_entry` kept returning it; and deleting the row the vertex then occupied stranded the name, after which `=Tracked+1` served `71` where `701` was correct. The same happened for sheet-scoped names, for tables, for expanded ranges that merely *covered* the address, and for the vertex's later positions after repeated inserts. (#304)
+
+  A **structural edit on a completely unrelated sheet** dropped formula→name edges. Deleting row 1 or column 1 of the default sheet swept up any name vertex parked at `$A$1` as an ordinary resident of that row or column and deleted it, taking its edges with it — even when both the formula and the name's target lived on another sheet entirely. Subsequent changes to the name's target no longer dirtied the formula, which then served silently stale values. (#302)
+
+  Symbol vertices now hold a `SymbolAddr` in an address space disjoint from the grid's, and the structures keyed by position — the cell index, the per-sheet range index, and the iteration that drives every structural edit — accept a `GridAddr`, which a symbol cannot produce. `NameScope` is now purely lookup metadata and no longer decides where a vertex lives. Evaluation results are unchanged; a name's scope, resolution and dirty propagation all behave exactly as before.
+
 ## [0.8.4] - 2026-08-14
 
 ### Changed

--- a/crates/formualizer-eval/src/engine/addr.rs
+++ b/crates/formualizer-eval/src/engine/addr.rs
@@ -1,0 +1,304 @@
+//! Vertex address space.
+//!
+//! The graph holds two disjoint kinds of vertex.
+//!
+//! * **Grid vertices** — cells, formulas, empty placeholders. Their address *is* their
+//!   identity: a `(SheetId, row, col)` position that users can see, reference, and shift
+//!   with structural edits.
+//! * **Symbol vertices** — defined names, tables, and external sources. They are identified
+//!   by name and have no position at all.
+//!
+//! Before this module existed, both kinds shared one address space: symbols were handed
+//! fabricated `(row, col)` coordinates on a real user-visible sheet, and the only thing that
+//! kept them from behaving like cells was their deliberate absence from `cell_to_vertex` —
+//! a convention any code path could break. Issues #302 and #304 are two paths that broke it.
+//!
+//! [`GridAddr`] and [`SymbolAddr`] make the distinction a type. [`VertexAddr`] is the tagged
+//! union actually stored in the vertex store and the edge coordinate arrays. Structures that
+//! are keyed by grid position take a `GridAddr`, which a symbol cannot produce, so inserting
+//! a symbol into a grid structure is a compile error rather than a runtime guard.
+//!
+//! # Representation
+//!
+//! [`VertexAddr`] is exactly 8 bytes — the same width as the [`AbsCoord`] it replaces. The
+//! coordinate encoding saturates rows (20 bits) and columns (14 bits) at Excel's limits but
+//! leaves the top 20 bits (`0xFFFFF000_00000000`) reserved and always zero for a real
+//! position, with `u64::MAX` already reserved as the invalid sentinel. Symbols live in that
+//! niche: bit 63 set with the rest of the reserved field clear. The edge coordinate arrays
+//! are `Vec` parallel to adjacency, so widening them to `Option<AbsCoord>` (16 bytes) would
+//! double hot memory; using the existing niche keeps the address free.
+
+use formualizer_common::Coord as AbsCoord;
+use std::fmt;
+
+/// The reserved high field of a packed coordinate. Zero for every real `(row, col)`.
+const RESERVED_HIGH_MASK: u64 = 0xFFFFF000_00000000;
+
+/// Tag written into the reserved high field to mark a symbol address.
+const SYMBOL_TAG: u64 = 1 << 63;
+
+/// Payload area available to a symbol address (44 bits; `u32` indices fit trivially).
+const SYMBOL_PAYLOAD_MASK: u64 = !RESERVED_HIGH_MASK;
+
+/// A real grid position.
+///
+/// Only vertices that live on a sheet's grid have one. Grid-keyed structures take this
+/// type so a symbol cannot be inserted into them.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GridAddr(AbsCoord);
+
+impl Default for GridAddr {
+    #[inline]
+    fn default() -> Self {
+        Self::new(0, 0)
+    }
+}
+
+impl Ord for GridAddr {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.row(), self.col()).cmp(&(other.row(), other.col()))
+    }
+}
+
+impl PartialOrd for GridAddr {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl GridAddr {
+    /// Construct from zero-based row/column, panicking beyond Excel's limits.
+    #[inline]
+    pub fn new(row: u32, col: u32) -> Self {
+        Self(AbsCoord::new(row, col))
+    }
+
+    /// Wrap an already-packed coordinate.
+    #[inline]
+    pub const fn from_coord(coord: AbsCoord) -> Self {
+        Self(coord)
+    }
+
+    /// The packed coordinate.
+    #[inline]
+    pub const fn coord(self) -> AbsCoord {
+        self.0
+    }
+
+    #[inline]
+    pub fn row(self) -> u32 {
+        self.0.row()
+    }
+
+    #[inline]
+    pub fn col(self) -> u32 {
+        self.0.col()
+    }
+}
+
+impl From<AbsCoord> for GridAddr {
+    #[inline]
+    fn from(coord: AbsCoord) -> Self {
+        Self(coord)
+    }
+}
+
+impl From<GridAddr> for AbsCoord {
+    #[inline]
+    fn from(addr: GridAddr) -> Self {
+        addr.0
+    }
+}
+
+/// A dense symbol identity.
+///
+/// Symbols have no position. The index is an allocation counter and carries no meaning
+/// beyond distinguishing one symbol vertex from another; nothing may derive a row, a
+/// column, or a sheet from it.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SymbolAddr(u32);
+
+impl SymbolAddr {
+    #[inline]
+    pub const fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    #[inline]
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// The address of a vertex: a grid position or a symbol identity, in 8 bytes.
+#[repr(transparent)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct VertexAddr(u64);
+
+impl VertexAddr {
+    /// The invalid sentinel. Neither a grid position nor a symbol.
+    pub const INVALID: Self = Self(u64::MAX);
+
+    /// Address of a vertex that occupies a grid position.
+    #[inline]
+    pub fn grid(addr: GridAddr) -> Self {
+        Self(addr.0.as_u64())
+    }
+
+    /// Address of a vertex identified by name rather than position.
+    #[inline]
+    pub const fn symbol(addr: SymbolAddr) -> Self {
+        Self(SYMBOL_TAG | (addr.0 as u64))
+    }
+
+    /// The grid position, or `None` for a symbol (or the invalid sentinel).
+    ///
+    /// This is the only route from a stored vertex address to a `(row, col)`, which is what
+    /// keeps symbols out of grid-keyed structures.
+    #[inline]
+    pub fn as_grid(self) -> Option<GridAddr> {
+        (self.0 & RESERVED_HIGH_MASK == 0).then(|| GridAddr(unsafe_coord_from_raw(self.0)))
+    }
+
+    /// The symbol identity, or `None` for a grid position.
+    #[inline]
+    pub fn as_symbol(self) -> Option<SymbolAddr> {
+        (self.0 & RESERVED_HIGH_MASK == SYMBOL_TAG)
+            .then(|| SymbolAddr((self.0 & SYMBOL_PAYLOAD_MASK) as u32))
+    }
+
+    #[inline]
+    pub fn is_symbol(self) -> bool {
+        self.0 & RESERVED_HIGH_MASK == SYMBOL_TAG
+    }
+
+    #[inline]
+    pub fn is_grid(self) -> bool {
+        self.0 & RESERVED_HIGH_MASK == 0
+    }
+
+    #[inline]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Total order used to keep edge lists deterministic.
+    ///
+    /// Grid vertices order by `(row, col)` exactly as they did when the arrays held bare
+    /// coordinates. Symbols have no position, so they sort after every grid vertex, by
+    /// allocation index.
+    #[inline]
+    pub fn order_key(self) -> (u32, u32) {
+        match (self.as_grid(), self.as_symbol()) {
+            (Some(grid), _) => (grid.row(), grid.col()),
+            (_, Some(symbol)) => (u32::MAX, symbol.index()),
+            _ => (u32::MAX, u32::MAX),
+        }
+    }
+}
+
+/// Rebuild a `Coord` from raw bits already known to have a clear reserved field.
+#[inline]
+fn unsafe_coord_from_raw(raw: u64) -> AbsCoord {
+    debug_assert!(raw & RESERVED_HIGH_MASK == 0);
+    // `Coord::from_raw` rejects reserved low bits too; a stored grid address never has them,
+    // and falling back to the packed row/col keeps this total rather than panicking.
+    AbsCoord::from_raw(raw).unwrap_or_else(|_| AbsCoord::new(0, 0))
+}
+
+impl From<GridAddr> for VertexAddr {
+    #[inline]
+    fn from(addr: GridAddr) -> Self {
+        Self::grid(addr)
+    }
+}
+
+impl From<SymbolAddr> for VertexAddr {
+    #[inline]
+    fn from(addr: SymbolAddr) -> Self {
+        Self::symbol(addr)
+    }
+}
+
+impl From<AbsCoord> for VertexAddr {
+    #[inline]
+    fn from(coord: AbsCoord) -> Self {
+        Self::grid(GridAddr(coord))
+    }
+}
+
+impl Default for VertexAddr {
+    #[inline]
+    fn default() -> Self {
+        Self::grid(GridAddr::default())
+    }
+}
+
+impl fmt::Debug for VertexAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(grid) = self.as_grid() {
+            write!(f, "Grid(r{}, c{})", grid.row(), grid.col())
+        } else if let Some(symbol) = self.as_symbol() {
+            write!(f, "Symbol({})", symbol.index())
+        } else {
+            write!(f, "VertexAddr::INVALID")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vertex_addr_is_eight_bytes() {
+        assert_eq!(std::mem::size_of::<VertexAddr>(), 8);
+        assert_eq!(std::mem::size_of::<VertexAddr>(), size_of::<AbsCoord>());
+        assert_eq!(std::mem::align_of::<VertexAddr>(), align_of::<AbsCoord>());
+        assert_eq!(size_of::<GridAddr>(), 8);
+    }
+
+    #[test]
+    fn grid_addresses_round_trip_and_are_never_symbols() {
+        for (row, col) in [(0, 0), (1, 1), (1_048_575, 16_383), (7, 0), (0, 16_383)] {
+            let addr = VertexAddr::grid(GridAddr::new(row, col));
+            assert!(addr.is_grid());
+            assert!(!addr.is_symbol());
+            assert_eq!(addr.as_symbol(), None);
+            let grid = addr.as_grid().expect("grid address must decode");
+            assert_eq!((grid.row(), grid.col()), (row, col));
+            assert_eq!(addr.order_key(), (row, col));
+        }
+    }
+
+    #[test]
+    fn symbol_addresses_round_trip_and_are_never_grid() {
+        for index in [0u32, 1, 16_384, u32::MAX] {
+            let addr = VertexAddr::symbol(SymbolAddr::new(index));
+            assert!(addr.is_symbol());
+            assert!(!addr.is_grid());
+            assert_eq!(addr.as_grid(), None);
+            assert_eq!(addr.as_symbol(), Some(SymbolAddr::new(index)));
+            assert_eq!(addr.order_key(), (u32::MAX, index));
+        }
+    }
+
+    #[test]
+    fn invalid_sentinel_is_neither_grid_nor_symbol() {
+        assert!(!VertexAddr::INVALID.is_grid());
+        assert!(!VertexAddr::INVALID.is_symbol());
+        assert_eq!(VertexAddr::INVALID.as_grid(), None);
+        assert_eq!(VertexAddr::INVALID.as_symbol(), None);
+    }
+
+    #[test]
+    fn symbols_order_after_every_grid_position() {
+        let last_cell = VertexAddr::grid(GridAddr::new(1_048_575, 16_383));
+        let first_symbol = VertexAddr::symbol(SymbolAddr::new(0));
+        assert!(last_cell.order_key() < first_symbol.order_key());
+    }
+}

--- a/crates/formualizer-eval/src/engine/addr.rs
+++ b/crates/formualizer-eval/src/engine/addr.rs
@@ -168,7 +168,7 @@ impl VertexAddr {
     #[inline]
     pub fn as_symbol(self) -> Option<SymbolAddr> {
         (self.0 & RESERVED_HIGH_MASK == SYMBOL_TAG)
-            .then(|| SymbolAddr((self.0 & SYMBOL_PAYLOAD_MASK) as u32))
+            .then_some(SymbolAddr((self.0 & SYMBOL_PAYLOAD_MASK) as u32))
     }
 
     #[inline]

--- a/crates/formualizer-eval/src/engine/csr_edges.rs
+++ b/crates/formualizer-eval/src/engine/csr_edges.rs
@@ -1,9 +1,15 @@
+use super::addr::VertexAddr;
 use super::vertex::VertexId;
-use formualizer_common::Coord as AbsCoord;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use super::super::addr::GridAddr;
+
+    fn grid(row: u32, col: u32) -> VertexAddr {
+        VertexAddr::grid(GridAddr::new(row, col))
+    }
 
     #[test]
     fn test_csr_construction() {
@@ -14,12 +20,7 @@ mod tests {
             (3u32, vec![]),
         ];
 
-        let coords = vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(1, 0),
-            AbsCoord::new(1, 1),
-        ];
+        let coords = vec![grid(0, 0), grid(0, 1), grid(1, 0), grid(1, 1)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -37,7 +38,7 @@ mod tests {
         for i in 0..10_000u32 {
             let targets: Vec<_> = (0..4).map(|j| (i + j + 1) % 10_000).collect();
             edges.push((i, targets));
-            coords.push(AbsCoord::new(i, i));
+            coords.push(grid(i, i));
         }
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
@@ -54,10 +55,10 @@ mod tests {
         ];
 
         let coords = vec![
-            AbsCoord::new(0, 0), // vertex 0
-            AbsCoord::new(0, 5), // vertex 1
-            AbsCoord::new(0, 3), // vertex 2
-            AbsCoord::new(1, 0), // vertex 3
+            grid(0, 0), // vertex 0
+            grid(0, 5), // vertex 1
+            grid(0, 3), // vertex 2
+            grid(1, 0), // vertex 3
         ];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
@@ -73,7 +74,7 @@ mod tests {
     #[test]
     fn test_csr_empty_graph() {
         let edges: Vec<(u32, Vec<u32>)> = vec![];
-        let coords: Vec<AbsCoord> = vec![];
+        let coords: Vec<VertexAddr> = vec![];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -86,7 +87,7 @@ mod tests {
     #[test]
     fn test_csr_single_vertex() {
         let edges = vec![(0u32, vec![])];
-        let coords = vec![AbsCoord::new(0, 0)];
+        let coords = vec![grid(0, 0)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -98,7 +99,7 @@ mod tests {
     #[test]
     fn test_csr_self_loop() {
         let edges = vec![(0u32, vec![0u32])]; // Self loop
-        let coords = vec![AbsCoord::new(0, 0)];
+        let coords = vec![grid(0, 0)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -110,11 +111,7 @@ mod tests {
     fn test_csr_duplicate_edges() {
         // CSR should preserve duplicates (formulas can reference same cell multiple times)
         let edges = vec![(0u32, vec![1u32, 1u32, 2u32, 1u32])];
-        let coords = vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(0, 2),
-        ];
+        let coords = vec![grid(0, 0), grid(0, 1), grid(0, 2)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -134,12 +131,7 @@ mod tests {
             (3u32, vec![0u32, 1u32]),
         ];
 
-        let coords = vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(1, 0),
-            AbsCoord::new(1, 1),
-        ];
+        let coords = vec![grid(0, 0), grid(0, 1), grid(1, 0), grid(1, 1)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -152,7 +144,7 @@ mod tests {
     #[test]
     fn test_out_of_bounds_access() {
         let edges = vec![(0u32, vec![])];
-        let coords = vec![AbsCoord::new(0, 0)];
+        let coords = vec![grid(0, 0)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -169,12 +161,7 @@ mod tests {
             (3u32, vec![]),
         ];
 
-        let coords = vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(1, 0),
-            AbsCoord::new(1, 1),
-        ];
+        let coords = vec![grid(0, 0), grid(0, 1), grid(1, 0), grid(1, 1)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -194,12 +181,7 @@ mod tests {
             (3u32, vec![0u32]), // Back edge
         ];
 
-        let coords = vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(1, 0),
-            AbsCoord::new(1, 1),
-        ];
+        let coords = vec![grid(0, 0), grid(0, 1), grid(1, 0), grid(1, 1)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -221,12 +203,7 @@ mod tests {
             (base_id + 3, vec![]),
         ];
 
-        let coords = vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(1, 0),
-            AbsCoord::new(1, 1),
-        ];
+        let coords = vec![grid(0, 0), grid(0, 1), grid(1, 0), grid(1, 1)];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
 
@@ -263,11 +240,11 @@ mod tests {
         ];
 
         let coords = vec![
-            AbsCoord::new(0, 0), // For vertex 100 (index 0)
-            AbsCoord::new(0, 0), // Padding (index 100-199)
-            AbsCoord::new(1, 0), // For vertex 300 (index 200)
-            AbsCoord::new(0, 0), // Padding (index 300-399)
-            AbsCoord::new(2, 0), // For vertex 500 (index 400)
+            grid(0, 0), // For vertex 100 (index 0)
+            grid(0, 0), // Padding (index 100-199)
+            grid(1, 0), // For vertex 300 (index 200)
+            grid(0, 0), // Padding (index 300-399)
+            grid(2, 0), // For vertex 500 (index 400)
         ];
 
         let csr = CsrEdges::from_adjacency(edges, &coords);
@@ -326,7 +303,7 @@ impl CsrEdges {
     /// # Edge Ordering
     /// Edges are sorted by (row, col, vertex_id) to ensure deterministic
     /// evaluation order for formulas (important for functions with side effects)
-    pub fn from_adjacency(adj: Vec<(u32, Vec<u32>)>, coords: &[AbsCoord]) -> Self {
+    pub fn from_adjacency(adj: Vec<(u32, Vec<u32>)>, coords: &[VertexAddr]) -> Self {
         if adj.is_empty() {
             return Self {
                 offsets: vec![0],
@@ -378,8 +355,8 @@ impl CsrEdges {
                 // Convert vertex ID to index in coords array
                 let coord_idx = (t - min_id) as usize;
                 if coord_idx < coords.len() {
-                    let coord = coords[coord_idx];
-                    (coord.row(), coord.col(), t)
+                    let (major, minor) = coords[coord_idx].order_key();
+                    (major, minor, t)
                 } else {
                     // Handle out-of-bounds gracefully for construction
                     (u32::MAX, u32::MAX, t)
@@ -412,8 +389,8 @@ impl CsrEdges {
             sources.sort_by_key(|&s| {
                 let coord_idx = (s - min_id) as usize;
                 if coord_idx < coords.len() {
-                    let coord = coords[coord_idx];
-                    (coord.row(), coord.col(), s)
+                    let (major, minor) = coords[coord_idx].order_key();
+                    (major, minor, s)
                 } else {
                     (u32::MAX, u32::MAX, s)
                 }
@@ -582,7 +559,7 @@ impl<'a> Iterator for CsrIterator<'a> {
 /// Builder for incremental CSR construction
 pub struct CsrBuilder {
     adjacency: Vec<Vec<usize>>,
-    coords: Vec<AbsCoord>,
+    coords: Vec<VertexAddr>,
 }
 
 impl Default for CsrBuilder {
@@ -600,10 +577,10 @@ impl CsrBuilder {
     }
 
     /// Add a vertex with its coordinate
-    pub fn add_vertex(&mut self, coord: AbsCoord) -> usize {
+    pub fn add_vertex(&mut self, addr: VertexAddr) -> usize {
         let idx = self.adjacency.len();
         self.adjacency.push(Vec::new());
-        self.coords.push(coord);
+        self.coords.push(addr);
         idx
     }
 

--- a/crates/formualizer-eval/src/engine/debug_views.rs
+++ b/crates/formualizer-eval/src/engine/debug_views.rs
@@ -23,12 +23,12 @@ impl<'s> VertexView<'s> {
 
     #[inline]
     pub fn row(&self) -> u32 {
-        self.store.coord(self.id).row()
+        self.store.grid_addr(self.id).map_or(0, |addr| addr.row())
     }
 
     #[inline]
     pub fn col(&self) -> u32 {
-        self.store.coord(self.id).col()
+        self.store.grid_addr(self.id).map_or(0, |addr| addr.col())
     }
 
     #[inline]
@@ -124,12 +124,12 @@ impl<'s> VertexViewMut<'s> {
     // Read accessors (same as immutable view)
     #[inline]
     pub fn row(&self) -> u32 {
-        self.store.coord(self.id).row()
+        self.store.grid_addr(self.id).map_or(0, |addr| addr.row())
     }
 
     #[inline]
     pub fn col(&self) -> u32 {
-        self.store.coord(self.id).col()
+        self.store.grid_addr(self.id).map_or(0, |addr| addr.col())
     }
 
     #[inline]
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn test_vertex_view_access() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(5, 10), 2, 0x03);
+        let id = store.allocate(AbsCoord::new(5, 10).into(), 2, 0x03);
 
         let view = store.view(id);
         assert_eq!(view.row(), 5);
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     fn test_debug_output() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(1, 1), 0, 0x01);
+        let id = store.allocate(AbsCoord::new(1, 1).into(), 0, 0x01);
         store.set_kind(id, VertexKind::Cell);
 
         let view = store.view(id);
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     fn test_mutable_view() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(0, 0), 0, 0);
+        let id = store.allocate(AbsCoord::new(0, 0).into(), 0, 0);
 
         {
             let mut view = store.view_mut(id);
@@ -275,8 +275,8 @@ mod tests {
     #[test]
     fn test_view_lifetime() {
         let mut store = VertexStore::new();
-        let id1 = store.allocate(AbsCoord::new(0, 0), 0, 0);
-        let id2 = store.allocate(AbsCoord::new(1, 1), 0, 0);
+        let id1 = store.allocate(AbsCoord::new(0, 0).into(), 0, 0);
+        let id2 = store.allocate(AbsCoord::new(1, 1).into(), 0, 0);
 
         // Multiple immutable views should work
         let view1 = store.view(id1);
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn test_view_display() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(0, 5), 1, 0x01);
+        let id = store.allocate(AbsCoord::new(0, 5).into(), 1, 0x01);
         store.set_kind(id, VertexKind::Cell);
 
         let view = store.view(id);
@@ -302,7 +302,7 @@ mod tests {
         // Verify that view methods are truly zero-cost
         // This test ensures inlining happens correctly
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(100, 200), 5, 0x07);
+        let id = store.allocate(AbsCoord::new(100, 200).into(), 5, 0x07);
 
         // These should compile to direct array access
         let view = store.view(id);

--- a/crates/formualizer-eval/src/engine/delta_edges.rs
+++ b/crates/formualizer-eval/src/engine/delta_edges.rs
@@ -1,22 +1,23 @@
+use super::addr::VertexAddr;
 use super::csr_edges::CsrEdges;
 use super::vertex::VertexId;
-use formualizer_common::Coord as AbsCoord;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 #[cfg(test)]
 mod tests {
+    use super::super::addr::GridAddr;
+
+    fn grid(row: u32, col: u32) -> VertexAddr {
+        VertexAddr::grid(GridAddr::new(row, col))
+    }
+
     use super::*;
-    use formualizer_common::Coord as AbsCoord;
 
     #[test]
     fn test_delta_slab_add_edge() {
         let csr = CsrEdges::from_adjacency(
             vec![(0u32, vec![1u32])],
-            &[
-                AbsCoord::new(0, 0),
-                AbsCoord::new(0, 1),
-                AbsCoord::new(0, 2),
-            ],
+            &[grid(0, 0), grid(0, 1), grid(0, 2)],
         );
         let mut delta = DeltaEdgeSlab::new();
 
@@ -30,12 +31,7 @@ mod tests {
     fn test_delta_slab_remove_edge() {
         let csr = CsrEdges::from_adjacency(
             vec![(0u32, vec![1u32, 2u32, 3u32])],
-            &[
-                AbsCoord::new(0, 0),
-                AbsCoord::new(0, 1),
-                AbsCoord::new(0, 2),
-                AbsCoord::new(0, 3),
-            ],
+            &[grid(0, 0), grid(0, 1), grid(0, 2), grid(0, 3)],
         );
         let mut delta = DeltaEdgeSlab::new();
 
@@ -62,12 +58,7 @@ mod tests {
     fn test_delta_slab_multiple_operations() {
         let csr = CsrEdges::from_adjacency(
             vec![(0u32, vec![1u32, 2u32]), (1u32, vec![3u32])],
-            &[
-                AbsCoord::new(0, 0),
-                AbsCoord::new(0, 1),
-                AbsCoord::new(0, 2),
-                AbsCoord::new(1, 0),
-            ],
+            &[grid(0, 0), grid(0, 1), grid(0, 2), grid(1, 0)],
         );
         let mut delta = DeltaEdgeSlab::new();
 
@@ -82,11 +73,7 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_exact_edge_count_includes_delta() {
-        let mut edges = CsrMutableEdges::with_coords(vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(0, 2),
-        ]);
+        let mut edges = CsrMutableEdges::with_coords(vec![grid(0, 0), grid(0, 1), grid(0, 2)]);
         edges.add_edge(VertexId(0), VertexId(1));
         edges.add_edge(VertexId(0), VertexId(2));
         assert_eq!(edges.num_edges_exact(), 2);
@@ -109,10 +96,7 @@ mod tests {
 
     #[test]
     fn test_delta_slab_remove_nonexistent() {
-        let csr = CsrEdges::from_adjacency(
-            vec![(0u32, vec![1u32])],
-            &[AbsCoord::new(0, 0), AbsCoord::new(0, 1)],
-        );
+        let csr = CsrEdges::from_adjacency(vec![(0u32, vec![1u32])], &[grid(0, 0), grid(0, 1)]);
         let mut delta = DeltaEdgeSlab::new();
 
         // Remove edge that doesn't exist
@@ -126,11 +110,7 @@ mod tests {
     fn test_delta_slab_apply_to_csr() {
         let csr = CsrEdges::from_adjacency(
             vec![(0u32, vec![1u32]), (1u32, vec![2u32]), (2u32, vec![])],
-            &[
-                AbsCoord::new(0, 0),
-                AbsCoord::new(0, 1),
-                AbsCoord::new(1, 0),
-            ],
+            &[grid(0, 0), grid(0, 1), grid(1, 0)],
         );
 
         let mut delta = DeltaEdgeSlab::new();
@@ -139,11 +119,7 @@ mod tests {
         delta.add_edge(VertexId(2), VertexId(0));
 
         // Apply delta and get new CSR
-        let coords = vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(1, 0),
-        ];
+        let coords = vec![grid(0, 0), grid(0, 1), grid(1, 0)];
         let vertex_ids = vec![0u32, 1u32, 2u32];
         let new_csr = delta.apply_to_csr(&csr, &coords, &vertex_ids);
 
@@ -154,11 +130,7 @@ mod tests {
 
     #[test]
     fn test_mutable_edges_auto_rebuild() {
-        let mut edges = CsrMutableEdges::with_coords(vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(1, 0),
-        ]);
+        let mut edges = CsrMutableEdges::with_coords(vec![grid(0, 0), grid(0, 1), grid(1, 0)]);
 
         // Add initial edges
         edges.add_edge(VertexId(0), VertexId(1));
@@ -186,9 +158,9 @@ mod tests {
 
         // Add vertices with IDs starting at FIRST_NORMAL_VERTEX (1024)
         let base_id = FIRST_NORMAL_VERTEX;
-        edges.add_vertex(AbsCoord::new(0, 0), base_id);
-        edges.add_vertex(AbsCoord::new(0, 1), base_id + 1);
-        edges.add_vertex(AbsCoord::new(1, 0), base_id + 2);
+        edges.add_vertex(grid(0, 0), base_id);
+        edges.add_vertex(grid(0, 1), base_id + 1);
+        edges.add_vertex(grid(1, 0), base_id + 2);
 
         // Add edges using offset IDs
         edges.add_edge(VertexId(base_id), VertexId(base_id + 1));
@@ -229,12 +201,12 @@ mod tests {
     fn test_csr_coord_update() {
         let mut edges = CsrMutableEdges::new();
 
-        edges.add_vertex(AbsCoord::new(1, 1), 1024);
-        edges.add_vertex(AbsCoord::new(2, 2), 1025);
+        edges.add_vertex(grid(1, 1), 1024);
+        edges.add_vertex(grid(2, 2), 1025);
         edges.add_edge(VertexId(1024), VertexId(1025));
 
         // Update coordinate
-        edges.update_coord(VertexId(1024), AbsCoord::new(5, 5));
+        edges.update_addr(VertexId(1024), grid(5, 5));
 
         // Verify sorting remains correct after rebuild
         edges.rebuild();
@@ -245,14 +217,12 @@ mod tests {
     #[test]
     fn update_coord_uses_vertex_position_index() {
         let mut edges = CsrMutableEdges::new();
-        let items: Vec<_> = (0..20_000u32)
-            .map(|id| (AbsCoord::new(id, id % 17), id))
-            .collect();
+        let items: Vec<_> = (0..20_000u32).map(|id| (grid(id, id % 17), id)).collect();
         edges.add_vertices_batch(&items);
 
         let started = std::time::Instant::now();
         for id in 15_000..20_000u32 {
-            edges.update_coord(VertexId(id), AbsCoord::new(id + 1, (id + 2) % 100));
+            edges.update_addr(VertexId(id), grid(id + 1, (id + 2) % 100));
         }
         let elapsed = started.elapsed();
 
@@ -266,13 +236,13 @@ mod tests {
         for id in 15_000..20_000u32 {
             let pos = edges.vertex_pos[&id];
             assert_eq!(edges.vertex_ids[pos], id);
-            assert_eq!(edges.coords[pos], AbsCoord::new(id + 1, (id + 2) % 100));
+            assert_eq!(edges.coords[pos], grid(id + 1, (id + 2) % 100));
         }
     }
 
     #[test]
     fn test_last_op_wins_add_then_remove() {
-        let csr = CsrEdges::from_adjacency(vec![(0u32, vec![])], &[AbsCoord::new(0, 0)]);
+        let csr = CsrEdges::from_adjacency(vec![(0u32, vec![])], &[grid(0, 0)]);
         let mut delta = DeltaEdgeSlab::new();
         delta.add_edge(VertexId(0), VertexId(1));
         delta.remove_edge(VertexId(0), VertexId(1));
@@ -282,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_last_op_wins_remove_then_add() {
-        let csr = CsrEdges::from_adjacency(vec![(0u32, vec![])], &[AbsCoord::new(0, 0)]);
+        let csr = CsrEdges::from_adjacency(vec![(0u32, vec![])], &[grid(0, 0)]);
         let mut delta = DeltaEdgeSlab::new();
         delta.remove_edge(VertexId(0), VertexId(1));
         delta.add_edge(VertexId(0), VertexId(1));
@@ -294,11 +264,7 @@ mod tests {
     fn test_dedup_additions_and_sorted() {
         let csr = CsrEdges::from_adjacency(
             vec![(0u32, vec![2u32])],
-            &[
-                AbsCoord::new(0, 0),
-                AbsCoord::new(0, 1),
-                AbsCoord::new(0, 2),
-            ],
+            &[grid(0, 0), grid(0, 1), grid(0, 2)],
         );
         let mut delta = DeltaEdgeSlab::new();
         // Add duplicates and out-of-order ids
@@ -314,12 +280,7 @@ mod tests {
     fn test_merged_in_view_add_and_remove() {
         let csr = CsrEdges::from_adjacency(
             vec![(0u32, vec![2u32]), (1u32, vec![2u32])],
-            &[
-                AbsCoord::new(0, 0),
-                AbsCoord::new(0, 1),
-                AbsCoord::new(0, 2),
-                AbsCoord::new(0, 3),
-            ],
+            &[grid(0, 0), grid(0, 1), grid(0, 2), grid(0, 3)],
         );
         let mut delta = DeltaEdgeSlab::new();
 
@@ -333,10 +294,7 @@ mod tests {
 
     #[test]
     fn test_merged_in_view_last_op_wins() {
-        let csr = CsrEdges::from_adjacency(
-            vec![(0u32, vec![1u32])],
-            &[AbsCoord::new(0, 0), AbsCoord::new(0, 1)],
-        );
+        let csr = CsrEdges::from_adjacency(vec![(0u32, vec![1u32])], &[grid(0, 0), grid(0, 1)]);
         let mut delta = DeltaEdgeSlab::new();
 
         delta.remove_edge(VertexId(0), VertexId(1));
@@ -350,11 +308,7 @@ mod tests {
 
     #[test]
     fn test_end_batch_below_threshold_defers_rebuild() {
-        let mut edges = CsrMutableEdges::with_coords(vec![
-            AbsCoord::new(0, 0),
-            AbsCoord::new(0, 1),
-            AbsCoord::new(0, 2),
-        ]);
+        let mut edges = CsrMutableEdges::with_coords(vec![grid(0, 0), grid(0, 1), grid(0, 2)]);
         let before = edges.rebuild_count();
 
         edges.begin_batch();
@@ -372,7 +326,7 @@ mod tests {
 
     #[test]
     fn test_end_batch_rebuilds_at_threshold() {
-        let coords: Vec<AbsCoord> = (0..1200u32).map(|i| AbsCoord::new(i, 0)).collect();
+        let coords: Vec<VertexAddr> = (0..1200u32).map(|i| grid(i, 0)).collect();
         let mut edges = CsrMutableEdges::with_coords(coords);
         let before = edges.rebuild_count();
 
@@ -391,8 +345,8 @@ mod tests {
     #[test]
     fn test_add_vertex_defers_rebuild() {
         let mut edges = CsrMutableEdges::new();
-        edges.add_vertex(AbsCoord::new(0, 0), 1024);
-        edges.add_vertex(AbsCoord::new(0, 1), 1025);
+        edges.add_vertex(grid(0, 0), 1024);
+        edges.add_vertex(grid(0, 1), 1025);
         assert_eq!(edges.rebuild_count(), 0);
 
         edges.add_edge(VertexId(1024), VertexId(1025));
@@ -408,10 +362,9 @@ mod tests {
 
     #[test]
     fn test_end_batch_rebuilds_on_coord_change_only() {
-        let mut edges =
-            CsrMutableEdges::with_coords(vec![AbsCoord::new(0, 0), AbsCoord::new(0, 1)]);
+        let mut edges = CsrMutableEdges::with_coords(vec![grid(0, 0), grid(0, 1)]);
         edges.begin_batch();
-        edges.update_coord(VertexId(0), AbsCoord::new(0, 2));
+        edges.update_addr(VertexId(0), grid(0, 2));
         // No ops, only coord changed; end_batch should rebuild due to coord_dirty
         edges.end_batch();
         // Smoke: out_edges call should not panic and reflect empty edges
@@ -572,7 +525,7 @@ impl DeltaEdgeSlab {
     pub fn apply_to_csr(
         &self,
         base: &CsrEdges,
-        coords: &[AbsCoord],
+        coords: &[VertexAddr],
         vertex_ids: &[u32],
     ) -> CsrEdges {
         let mut adjacency = Vec::with_capacity(vertex_ids.len());
@@ -610,8 +563,8 @@ pub struct CsrMutableEdges {
     /// Delta slab for mutations
     delta: DeltaEdgeSlab,
 
-    /// Vertex coordinates for deterministic ordering
-    coords: Vec<AbsCoord>,
+    /// Vertex addresses (grid position or symbol identity) for deterministic ordering
+    coords: Vec<VertexAddr>,
 
     /// Vertex IDs corresponding to coords array
     vertex_ids: Vec<u32>,
@@ -641,7 +594,7 @@ impl CsrMutableEdges {
     }
 
     /// Create with initial vertex coordinates
-    pub fn with_coords(coords: Vec<AbsCoord>) -> Self {
+    pub fn with_coords(coords: Vec<VertexAddr>) -> Self {
         let num_vertices = coords.len();
         let vertex_ids: Vec<u32> = (0..num_vertices as u32).collect();
         let adjacency: Vec<_> = vertex_ids.iter().map(|&id| (id, Vec::new())).collect();
@@ -852,25 +805,25 @@ impl CsrMutableEdges {
     /// base yet gracefully resolve to "no edges" plus any pending delta
     /// mutations, and the next rebuild picks the vertex up from
     /// `coords`/`vertex_ids` (#125).
-    pub fn add_vertex(&mut self, coord: AbsCoord, vertex_id: u32) -> usize {
+    pub fn add_vertex(&mut self, addr: VertexAddr, vertex_id: u32) -> usize {
         let idx = self.coords.len();
-        self.coords.push(coord);
+        self.coords.push(addr);
         self.vertex_ids.push(vertex_id);
         self.vertex_pos.insert(vertex_id, idx);
         idx
     }
 
     /// Add many vertices at once; single rebuild at end.
-    pub fn add_vertices_batch(&mut self, items: &[(AbsCoord, u32)]) {
+    pub fn add_vertices_batch(&mut self, items: &[(VertexAddr, u32)]) {
         if items.is_empty() {
             return;
         }
         let start_len = self.coords.len();
         self.coords.reserve(items.len());
         self.vertex_ids.reserve(items.len());
-        for (coord, vid) in items {
+        for (addr, vid) in items {
             let idx = self.coords.len();
-            self.coords.push(*coord);
+            self.coords.push(*addr);
             self.vertex_ids.push(*vid);
             self.vertex_pos.insert(*vid, idx);
         }
@@ -879,15 +832,15 @@ impl CsrMutableEdges {
         debug_assert_eq!(self.coords.len(), start_len + items.len());
     }
 
-    /// Update coordinate for a vertex in the cache
+    /// Update the stored address for a vertex in the cache
     /// Marks for rebuild to maintain sort order
-    pub fn update_coord(&mut self, vertex_id: VertexId, new_coord: AbsCoord) {
+    pub fn update_addr(&mut self, vertex_id: VertexId, new_addr: VertexAddr) {
         if let Some(&pos) = self.vertex_pos.get(&vertex_id.0) {
             debug_assert_eq!(
                 self.vertex_ids[pos], vertex_id.0,
                 "vertex_pos out of sync with vertex_ids at position {pos}"
             );
-            self.coords[pos] = new_coord;
+            self.coords[pos] = new_addr;
             // Force rebuild on next access to maintain sort invariants
             self.delta.mark_dirty();
         }
@@ -969,7 +922,7 @@ impl CsrMutableEdges {
     pub fn build_from_adjacency(
         &mut self,
         adjacency: Vec<(u32, Vec<u32>)>,
-        coords: Vec<AbsCoord>,
+        coords: Vec<VertexAddr>,
         vertex_ids: Vec<u32>,
     ) {
         self.base = CsrEdges::from_adjacency(adjacency, &coords);

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4008,8 +4008,11 @@ where
             Ok(_) => {
                 self.rename_staged_formula_sheet(&old_name, new_name);
                 // Success! Invalidate cache for the moved sheet
-                let sheet_vertices: Vec<VertexId> =
-                    self.graph.vertices_in_sheet(sheet_id).collect();
+                let sheet_vertices: Vec<VertexId> = self
+                    .graph
+                    .grid_vertices_in_sheet(sheet_id)
+                    .map(|(id, _)| id)
+                    .collect();
                 for v_id in sheet_vertices {
                     self.graph.mark_vertex_dirty(v_id);
                 }
@@ -15153,19 +15156,20 @@ where
                 ) {
                     continue;
                 }
-                let row0 = self.graph.vertex_coord(vid).row();
+                let Some(row0) = self.graph.vertex_grid_addr(vid).map(|addr| addr.row()) else {
+                    continue;
+                };
                 min_r0 = Some(min_r0.map(|m| m.min(row0)).unwrap_or(row0));
                 max_r0 = Some(max_r0.map(|m| m.max(row0)).unwrap_or(row0));
             }
         } else {
-            for vid in self.graph.vertices_in_sheet(sheet_id) {
+            for (vid, coord) in self.graph.grid_vertices_in_sheet(sheet_id) {
                 if !matches!(
                     self.graph.get_vertex_kind(vid),
                     VertexKind::FormulaScalar | VertexKind::FormulaArray
                 ) {
                     continue;
                 }
-                let coord = self.graph.vertex_coord(vid);
                 let col0 = coord.col();
                 if col0 < sc0 || col0 > ec0 {
                     continue;
@@ -15202,19 +15206,20 @@ where
                 ) {
                     continue;
                 }
-                let col0 = self.graph.vertex_coord(vid).col();
+                let Some(col0) = self.graph.vertex_grid_addr(vid).map(|addr| addr.col()) else {
+                    continue;
+                };
                 min_c0 = Some(min_c0.map(|m| m.min(col0)).unwrap_or(col0));
                 max_c0 = Some(max_c0.map(|m| m.max(col0)).unwrap_or(col0));
             }
         } else {
-            for vid in self.graph.vertices_in_sheet(sheet_id) {
+            for (vid, coord) in self.graph.grid_vertices_in_sheet(sheet_id) {
                 if !matches!(
                     self.graph.get_vertex_kind(vid),
                     VertexKind::FormulaScalar | VertexKind::FormulaArray
                 ) {
                     continue;
                 }
-                let coord = self.graph.vertex_coord(vid);
                 let row0 = coord.row();
                 if row0 < sr0 || row0 > er0 {
                     continue;
@@ -21580,10 +21585,13 @@ where
             .map_err(|_| target_root_allocation_error(root_count, request_id))?;
         for region in regions {
             for vertex in self.graph.formula_vertices() {
+                let Some(position) = self.graph.vertex_grid_addr(vertex) else {
+                    continue;
+                };
                 let key = crate::formula_plane::region_index::RegionKey {
                     sheet_id: self.graph.get_vertex_sheet_id(vertex),
-                    row: self.graph.vertex_coord(vertex).row(),
-                    col: self.graph.vertex_coord(vertex).col(),
+                    row: position.row(),
+                    col: position.col(),
                 };
                 if region.contains_key(key) {
                     extended.push(TargetProducer::Legacy(vertex)).map_err(|_| {

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -9831,22 +9831,17 @@ where
                     .get_cell_ref(vertex)
                     .and_then(|cell| engine.graph.spill_registry_anchor_for_cell(cell))
                     .unwrap_or(vertex);
-                match engine.graph.get_vertex_kind(vertex) {
-                    VertexKind::FormulaScalar | VertexKind::FormulaArray => {
-                        roots.push(TargetProducer::Legacy(vertex)).map_err(|_| {
-                            target_root_allocation_error(roots.len() + 1, request_id)
-                        })?;
-                    }
-                    VertexKind::NamedScalar
-                    | VertexKind::NamedArray
-                    | VertexKind::Range
-                    | VertexKind::InfiniteRange
-                    | VertexKind::Table => {
-                        roots.push(TargetProducer::Symbol(vertex)).map_err(|_| {
-                            target_root_allocation_error(roots.len() + 1, request_id)
-                        })?;
-                    }
-                    VertexKind::Empty | VertexKind::Cell | VertexKind::External => {}
+                // `vertices_in_region` is a sheet-index query and a sheet index holds only
+                // grid-addressed vertices, so a region can never yield a symbol: names,
+                // tables and external sources have no position for a region to cover.
+                // Symbol roots come from the by-name lookups below instead.
+                if matches!(
+                    engine.graph.get_vertex_kind(vertex),
+                    VertexKind::FormulaScalar | VertexKind::FormulaArray
+                ) {
+                    roots
+                        .push(TargetProducer::Legacy(vertex))
+                        .map_err(|_| target_root_allocation_error(roots.len() + 1, request_id))?;
                 }
             }
             if roots.len() == before

--- a/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/change_log.rs
@@ -6,11 +6,11 @@
 //! - ChangeLogger: Trait for pluggable logging strategies
 
 use crate::SheetId;
+use crate::engine::addr::GridAddr;
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::row_visibility::RowVisibilitySource;
 use crate::engine::vertex::VertexId;
 use crate::reference::CellRef;
-use formualizer_common::Coord as AbsCoord;
 use formualizer_common::LiteralValue;
 use formualizer_parse::parser::ASTNode;
 
@@ -59,7 +59,7 @@ pub enum ChangeEvent {
     /// Vertex creation snapshot (for undo). Minimal for now.
     AddVertex {
         id: VertexId,
-        coord: AbsCoord,
+        coord: GridAddr,
         sheet_id: SheetId,
         value: Option<LiteralValue>,
         formula: Option<ASTNode>,
@@ -73,7 +73,7 @@ pub enum ChangeEvent {
         old_formula: Option<ASTNode>,
         old_dependencies: Vec<VertexId>, // outgoing
         old_dependents: Vec<VertexId>,   // incoming
-        coord: Option<AbsCoord>,
+        coord: Option<GridAddr>,
         sheet_id: Option<SheetId>,
         kind: Option<crate::engine::vertex::VertexKind>,
         flags: Option<u8>,
@@ -92,8 +92,8 @@ pub enum ChangeEvent {
     VertexMoved {
         id: VertexId,
         sheet_id: SheetId,
-        old_coord: AbsCoord,
-        new_coord: AbsCoord,
+        old_coord: GridAddr,
+        new_coord: GridAddr,
     },
     FormulaAdjusted {
         id: VertexId,

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -738,11 +738,24 @@ impl<'g> VertexEditor<'g> {
     }
 
     /// Move a vertex to a new position
+    ///
+    /// The `GridAddr` argument says where the vertex is going, but the `VertexId` says
+    /// nothing about whether it is somewhere to begin with. A symbol has no position, so
+    /// moving one is meaningless: it is what turned a default-sheet insert into a
+    /// name-hijacked cell (#304). Every in-tree caller iterates `grid_vertices_in_sheet`
+    /// and so cannot reach this, but the method is public, so refuse explicitly.
     pub fn move_vertex(&mut self, id: VertexId, new_coord: GridAddr) -> Result<(), EditorError> {
         // Check if vertex exists
         if !self.graph.vertex_exists(id) {
             return Err(EditorError::Excel(
                 ExcelError::new(ExcelErrorKind::Ref).with_message("Vertex does not exist"),
+            ));
+        }
+        if self.graph.get_grid_addr(id).is_none() {
+            return Err(EditorError::Excel(
+                ExcelError::new(ExcelErrorKind::Ref).with_message(
+                    "Symbol vertices have no position and cannot be moved onto the grid",
+                ),
             ));
         }
 
@@ -787,6 +800,14 @@ impl<'g> VertexEditor<'g> {
         let mut summary = MetaUpdateSummary::default();
 
         if let Some(coord) = patch.coord {
+            // Same reasoning as `move_vertex`: a symbol has no position to patch.
+            if self.graph.get_grid_addr(id).is_none() {
+                return Err(EditorError::Excel(
+                    ExcelError::new(ExcelErrorKind::Ref).with_message(
+                        "Symbol vertices have no position and cannot be moved onto the grid",
+                    ),
+                ));
+            }
             self.graph.set_grid_addr(id, coord);
             self.graph.update_edge_grid_addr(id, coord);
             summary.coord_changed = true;

--- a/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
+++ b/crates/formualizer-eval/src/engine/graph/editor/vertex_editor.rs
@@ -1,4 +1,5 @@
 use crate::SheetId;
+use crate::engine::addr::GridAddr;
 use crate::engine::graph::DependencyGraph;
 use crate::engine::graph::editor::reference_adjuster::{
     MoveReferenceAdjuster, ReferenceAdjuster, ReferenceContext, RelativeReferenceAdjuster,
@@ -7,7 +8,6 @@ use crate::engine::graph::editor::reference_adjuster::{
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::{ChangeEvent, ChangeLogger, VertexId, VertexKind};
 use crate::reference::{CellRef, Coord};
-use formualizer_common::Coord as AbsCoord;
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::ASTNode;
 use rustc_hash::FxHashMap;
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Metadata for creating a new vertex
 #[derive(Debug, Clone)]
 pub struct VertexMeta {
-    pub coord: AbsCoord,
+    pub coord: GridAddr,
     pub sheet_id: SheetId,
     pub kind: VertexKind,
     pub flags: u8,
@@ -25,7 +25,7 @@ pub struct VertexMeta {
 impl VertexMeta {
     pub fn new(row: u32, col: u32, sheet_id: SheetId, kind: VertexKind) -> Self {
         Self {
-            coord: AbsCoord::new(row, col),
+            coord: GridAddr::new(row, col),
             sheet_id,
             kind,
             flags: 0,
@@ -52,7 +52,7 @@ impl VertexMeta {
 #[derive(Debug, Clone)]
 pub struct VertexMetaPatch {
     pub kind: Option<VertexKind>,
-    pub coord: Option<AbsCoord>,
+    pub coord: Option<GridAddr>,
     pub dirty: Option<bool>,
     pub volatile: Option<bool>,
 }
@@ -663,7 +663,7 @@ impl<'g> VertexEditor<'g> {
             kind,
             flags,
         ) = if self.has_logger() {
-            let coord = self.graph.get_coord(id);
+            let coord = self.graph.get_grid_addr(id);
             let sheet_id = self.graph.get_sheet_id(id);
             let kind = self.graph.get_vertex_kind(id);
             // flags not publicly exposed; set to 0 for now (future: expose getter)
@@ -673,7 +673,7 @@ impl<'g> VertexEditor<'g> {
                 self.get_formula_ast(id),
                 self.graph.get_dependencies(id), // outgoing deps
                 dependents.clone(),              // captured earlier
-                Some(coord),
+                coord,
                 Some(sheet_id),
                 Some(kind),
                 Some(flags),
@@ -738,7 +738,7 @@ impl<'g> VertexEditor<'g> {
     }
 
     /// Move a vertex to a new position
-    pub fn move_vertex(&mut self, id: VertexId, new_coord: AbsCoord) -> Result<(), EditorError> {
+    pub fn move_vertex(&mut self, id: VertexId, new_coord: GridAddr) -> Result<(), EditorError> {
         // Check if vertex exists
         if !self.graph.vertex_exists(id) {
             return Err(EditorError::Excel(
@@ -757,10 +757,10 @@ impl<'g> VertexEditor<'g> {
         );
 
         // Update coordinate in store
-        self.graph.set_coord(id, new_coord);
+        self.graph.set_grid_addr(id, new_coord);
 
         // Update edge cache coordinate if needed
-        self.graph.update_edge_coord(id, new_coord);
+        self.graph.update_edge_grid_addr(id, new_coord);
 
         // Update cell mapping
         self.graph
@@ -787,8 +787,8 @@ impl<'g> VertexEditor<'g> {
         let mut summary = MetaUpdateSummary::default();
 
         if let Some(coord) = patch.coord {
-            self.graph.set_coord(id, coord);
-            self.graph.update_edge_coord(id, coord);
+            self.graph.set_grid_addr(id, coord);
+            self.graph.update_edge_grid_addr(id, coord);
             summary.coord_changed = true;
         }
 
@@ -880,17 +880,10 @@ impl<'g> VertexEditor<'g> {
         self.begin_batch();
 
         // 1. Collect vertices to shift (those at or after the insert point)
-        let vertices_to_shift: Vec<(VertexId, AbsCoord)> = self
+        let vertices_to_shift: Vec<(VertexId, GridAddr)> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter_map(|id| {
-                let coord = self.graph.get_coord(id);
-                if coord.row() >= before {
-                    Some((id, coord))
-                } else {
-                    None
-                }
-            })
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| coord.row() >= before)
             .collect();
 
         if let Some(logger) = &mut self.change_logger {
@@ -900,7 +893,7 @@ impl<'g> VertexEditor<'g> {
         }
         // 2. Shift vertices down (emit VertexMoved)
         for (id, old_coord) in vertices_to_shift {
-            let new_coord = AbsCoord::new(old_coord.row() + count, old_coord.col());
+            let new_coord = GridAddr::new(old_coord.row() + count, old_coord.col());
             if self.has_logger() {
                 self.log_change(ChangeEvent::VertexMoved {
                     id,
@@ -1003,11 +996,9 @@ impl<'g> VertexEditor<'g> {
         // 1. Delete vertices in the range
         let vertices_to_delete: Vec<VertexId> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter(|&id| {
-                let coord = self.graph.get_coord(id);
-                coord.row() >= start && coord.row() < start + count
-            })
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| coord.row() >= start && coord.row() < start + count)
+            .map(|(id, _)| id)
             .collect();
         let range_dependents = self
             .graph
@@ -1023,21 +1014,14 @@ impl<'g> VertexEditor<'g> {
             summary.vertices_deleted.push(id);
         }
         // 2. Shift remaining vertices up (emit VertexMoved)
-        let vertices_to_shift: Vec<(VertexId, AbsCoord)> = self
+        let vertices_to_shift: Vec<(VertexId, GridAddr)> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter_map(|id| {
-                let coord = self.graph.get_coord(id);
-                if coord.row() >= start + count {
-                    Some((id, coord))
-                } else {
-                    None
-                }
-            })
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| coord.row() >= start + count)
             .collect();
 
         for (id, old_coord) in vertices_to_shift {
-            let new_coord = AbsCoord::new(old_coord.row() - count, old_coord.col());
+            let new_coord = GridAddr::new(old_coord.row() - count, old_coord.col());
             if self.has_logger() {
                 self.log_change(ChangeEvent::VertexMoved {
                     id,
@@ -1132,17 +1116,10 @@ impl<'g> VertexEditor<'g> {
         self.begin_batch();
 
         // 1. Collect vertices to shift (those at or after the insert point)
-        let vertices_to_shift: Vec<(VertexId, AbsCoord)> = self
+        let vertices_to_shift: Vec<(VertexId, GridAddr)> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter_map(|id| {
-                let coord = self.graph.get_coord(id);
-                if coord.col() >= before {
-                    Some((id, coord))
-                } else {
-                    None
-                }
-            })
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| coord.col() >= before)
             .collect();
 
         if let Some(logger) = &mut self.change_logger {
@@ -1152,7 +1129,7 @@ impl<'g> VertexEditor<'g> {
         }
         // 2. Shift vertices right (emit VertexMoved)
         for (id, old_coord) in vertices_to_shift {
-            let new_coord = AbsCoord::new(old_coord.row(), old_coord.col() + count);
+            let new_coord = GridAddr::new(old_coord.row(), old_coord.col() + count);
             if self.has_logger() {
                 self.log_change(ChangeEvent::VertexMoved {
                     id,
@@ -1255,11 +1232,9 @@ impl<'g> VertexEditor<'g> {
         // 1. Delete vertices in the range
         let vertices_to_delete: Vec<VertexId> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter(|&id| {
-                let coord = self.graph.get_coord(id);
-                coord.col() >= start && coord.col() < start + count
-            })
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| coord.col() >= start && coord.col() < start + count)
+            .map(|(id, _)| id)
             .collect();
         let range_dependents = self
             .graph
@@ -1275,21 +1250,14 @@ impl<'g> VertexEditor<'g> {
             summary.vertices_deleted.push(id);
         }
         // 2. Shift remaining vertices left (emit VertexMoved)
-        let vertices_to_shift: Vec<(VertexId, AbsCoord)> = self
+        let vertices_to_shift: Vec<(VertexId, GridAddr)> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter_map(|id| {
-                let coord = self.graph.get_coord(id);
-                if coord.col() >= start + count {
-                    Some((id, coord))
-                } else {
-                    None
-                }
-            })
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| coord.col() >= start + count)
             .collect();
 
         for (id, old_coord) in vertices_to_shift {
-            let new_coord = AbsCoord::new(old_coord.row(), old_coord.col() - count);
+            let new_coord = GridAddr::new(old_coord.row(), old_coord.col() - count);
             if self.has_logger() {
                 self.log_change(ChangeEvent::VertexMoved {
                     id,
@@ -1685,13 +1653,13 @@ impl<'g> VertexEditor<'g> {
         // Collect vertices in range
         let vertices_in_range: Vec<_> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter(|&id| {
-                let coord = self.graph.get_coord(id);
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| {
                 let row = coord.row();
                 let col = coord.col();
                 row >= start_row && row <= end_row && col >= start_col && col <= end_col
             })
+            .map(|(id, _)| id)
             .collect();
 
         for id in vertices_in_range {
@@ -1725,9 +1693,8 @@ impl<'g> VertexEditor<'g> {
         // Collect source data
         let vertices_in_range: Vec<_> = self
             .graph
-            .vertices_in_sheet(sheet_id)
-            .filter(|&id| {
-                let coord = self.graph.get_coord(id);
+            .grid_vertices_in_sheet(sheet_id)
+            .filter(|(_, coord)| {
                 let row = coord.row();
                 let col = coord.col();
                 row >= from_start_row
@@ -1737,8 +1704,7 @@ impl<'g> VertexEditor<'g> {
             })
             .collect();
 
-        for id in vertices_in_range {
-            let coord = self.graph.get_coord(id);
+        for (id, coord) in vertices_in_range {
             let row = coord.row();
             let col = coord.col();
 
@@ -2347,10 +2313,10 @@ mod tests {
         let vertex_id = editor.add_vertex(meta);
 
         // Move vertex returns Result
-        assert!(editor.move_vertex(vertex_id, AbsCoord::new(8, 12)).is_ok());
+        assert!(editor.move_vertex(vertex_id, GridAddr::new(8, 12)).is_ok());
 
         // Moving to same position should work
-        assert!(editor.move_vertex(vertex_id, AbsCoord::new(8, 12)).is_ok());
+        assert!(editor.move_vertex(vertex_id, GridAddr::new(8, 12)).is_ok());
     }
 
     #[test]

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -3328,20 +3328,11 @@ impl DependencyGraph {
 
     /// Updates the cached value of a formula vertex.
     pub(crate) fn update_vertex_value(&mut self, vertex_id: VertexId, value: LiteralValue) {
-        if !self.value_cache_enabled {
-            // Canonical mode: cell/formula vertices must not store values in the graph.
-            match self.store.kind(vertex_id) {
-                VertexKind::Cell
-                | VertexKind::FormulaScalar
-                | VertexKind::FormulaArray
-                | VertexKind::Empty => {
-                    self.vertex_values.remove(&vertex_id);
-                    return;
-                }
-                _ => {
-                    // Allow non-cell vertices to cache values (e.g. named-range formulas).
-                }
-            }
+        if !self.value_cache_enabled && self.is_grid_backed(vertex_id) {
+            // Canonical mode: grid-backed vertices must not store values in the graph.
+            // Symbols (e.g. named-range formulas) may still cache theirs.
+            self.vertex_values.remove(&vertex_id);
+            return;
         }
         let value_ref = self.data_store.store_value(normalize_stored_literal(value));
         self.vertex_values.insert(vertex_id, value_ref);
@@ -3795,22 +3786,17 @@ impl DependencyGraph {
     }
 
     fn collect_range_dependents_for_vertex(&self, vertex_id: VertexId) -> Vec<VertexId> {
-        match self.store.kind(vertex_id) {
-            VertexKind::Cell
-            | VertexKind::Empty
-            | VertexKind::FormulaScalar
-            | VertexKind::FormulaArray => {
-                let view = self.store.view(vertex_id);
-                self.collect_range_dependents_for_rect(
-                    view.sheet_id(),
-                    view.row(),
-                    view.col(),
-                    view.row(),
-                    view.col(),
-                )
-            }
-            _ => Vec::new(),
-        }
+        // Only a vertex with a position can sit inside a range. A symbol has none.
+        let Some(position) = self.store.grid_addr(vertex_id) else {
+            return Vec::new();
+        };
+        self.collect_range_dependents_for_rect(
+            self.store.sheet_id(vertex_id),
+            position.row(),
+            position.col(),
+            position.row(),
+            position.col(),
+        )
     }
 
     fn collect_range_dependents_for_rect(
@@ -3958,29 +3944,30 @@ impl DependencyGraph {
 
     /// Get the value stored for a vertex
     pub fn get_value(&self, vertex_id: VertexId) -> Option<LiteralValue> {
-        if !self.value_cache_enabled {
-            // In canonical mode, cell/formula values must not be read from the graph.
-            // Non-cell vertices (e.g. named ranges, external sources) may still use graph storage.
-            match self.store.kind(vertex_id) {
-                VertexKind::Cell
-                | VertexKind::FormulaScalar
-                | VertexKind::FormulaArray
-                | VertexKind::Empty => {
-                    #[cfg(debug_assertions)]
-                    {
-                        self.graph_value_read_attempts
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                    return None;
-                }
-                _ => {
-                    // Allow non-cell vertices to use vertex_values.
-                }
+        if !self.value_cache_enabled && self.is_grid_backed(vertex_id) {
+            // In canonical mode, grid-backed values must not be read from the graph.
+            // Symbols (named ranges, tables, external sources) may still use graph storage.
+            #[cfg(debug_assertions)]
+            {
+                self.graph_value_read_attempts
+                    .fetch_add(1, Ordering::Relaxed);
             }
+            return None;
         }
         self.vertex_values
             .get(&vertex_id)
             .map(|&value_ref| self.data_store.retrieve_value(value_ref))
+    }
+
+    /// True when the vertex occupies the grid, i.e. it is a cell, formula or empty
+    /// placeholder rather than a symbol.
+    ///
+    /// This replaces the `VertexKind` enumerations that used to spell out the grid-backed
+    /// kinds. "Has a position" is now a structural property of the address, so it cannot
+    /// drift out of step with the set of kinds.
+    #[inline]
+    fn is_grid_backed(&self, vertex_id: VertexId) -> bool {
+        self.store.grid_addr(vertex_id).is_some()
     }
 
     /// Get the cell reference for a vertex.
@@ -4144,23 +4131,13 @@ impl DependencyGraph {
     /// Internal: Mark vertex as having #REF! error
     #[doc(hidden)]
     pub fn mark_as_ref_error(&mut self, id: VertexId) {
-        if !self.value_cache_enabled {
-            match self.store.kind(id) {
-                VertexKind::Cell
-                | VertexKind::FormulaScalar
-                | VertexKind::FormulaArray
-                | VertexKind::Empty => {
-                    self.ref_error_vertices.insert(id);
-                    // Canonical-only: graph does not cache cell/formula values.
-                    // Ensure the dependent subgraph is dirtied so evaluation updates Arrow truth.
-                    self.vertex_values.remove(&id);
-                    let _ = self.mark_dirty(id);
-                    return;
-                }
-                _ => {
-                    // Allow non-cell vertices to use cached values.
-                }
-            }
+        if !self.value_cache_enabled && self.is_grid_backed(id) {
+            self.ref_error_vertices.insert(id);
+            // Canonical-only: graph does not cache grid-backed values.
+            // Ensure the dependent subgraph is dirtied so evaluation updates Arrow truth.
+            self.vertex_values.remove(&id);
+            let _ = self.mark_dirty(id);
+            return;
         }
         let error = LiteralValue::Error(ExcelError::new(ExcelErrorKind::Ref));
         let value_ref = self.data_store.store_value(error);
@@ -4170,18 +4147,8 @@ impl DependencyGraph {
 
     /// Check if a vertex has a #REF! error
     pub fn is_ref_error(&self, id: VertexId) -> bool {
-        if !self.value_cache_enabled {
-            match self.store.kind(id) {
-                VertexKind::Cell
-                | VertexKind::FormulaScalar
-                | VertexKind::FormulaArray
-                | VertexKind::Empty => {
-                    return self.ref_error_vertices.contains(&id);
-                }
-                _ => {
-                    // Non-cell vertices may still have cached values.
-                }
-            }
+        if !self.value_cache_enabled && self.is_grid_backed(id) {
+            return self.ref_error_vertices.contains(&id);
         }
         if let Some(value_ref) = self.vertex_values.get(&id) {
             let value = self.data_store.retrieve_value(*value_ref);

--- a/crates/formualizer-eval/src/engine/graph/mod.rs
+++ b/crates/formualizer-eval/src/engine/graph/mod.rs
@@ -38,6 +38,7 @@ mod sources;
 mod tables;
 pub(crate) use tables::TableEntry;
 
+use super::addr::{GridAddr, SymbolAddr, VertexAddr};
 use super::arena::{AstNodeId, DataStore, ValueRef};
 use super::delta_edges::CsrMutableEdges;
 use super::ingest_pipeline::{DependencyPlanRow, FormulaAstInput};
@@ -281,11 +282,12 @@ pub struct DependencyGraph {
     source_tables: FxHashMap<String, sources::SourceTableEntry>,
     source_vertex_lookup: FxHashMap<VertexId, String>,
 
-    /// Monotonic counter to assign synthetic coordinates to name vertices
-    name_vertex_seq: u32,
-
-    /// Monotonic counter to assign synthetic coordinates to source vertices
-    source_vertex_seq: u32,
+    /// Monotonic allocator for the symbol address space.
+    ///
+    /// Names, tables and external sources are identified by name and have no position, so
+    /// they are addressed by a dense index here rather than by fabricated grid coordinates
+    /// on a real sheet (#302, #304).
+    symbol_vertex_seq: u32,
 
     /// Mapping from cell vertices to named range vertices that depend on them
     cell_to_name_dependents: FxHashMap<VertexId, FxHashSet<VertexId>>,
@@ -521,7 +523,7 @@ impl DependencyGraph {
     pub fn ensure_vertices_batch(
         &mut self,
         coords: &[(SheetId, AbsCoord)],
-    ) -> Vec<(AbsCoord, u32)> {
+    ) -> Vec<(VertexAddr, u32)> {
         self.ensure_vertices_batch_ordered(coords).1
     }
 
@@ -531,7 +533,7 @@ impl DependencyGraph {
     pub fn ensure_vertices_batch_packed_ordered(
         &mut self,
         packed_cells: &[PackedSheetCell],
-    ) -> (Vec<VertexId>, Vec<(AbsCoord, u32)>) {
+    ) -> (Vec<VertexId>, Vec<(VertexAddr, u32)>) {
         #[cfg(feature = "perf_instrumentation")]
         use crate::instant::FzInstant as PerfInstant;
         use rustc_hash::FxHashMap;
@@ -550,7 +552,7 @@ impl DependencyGraph {
 
         let first_sid = packed_cells[0].sheet_id();
         let single_sheet = packed_cells.iter().all(|cell| cell.sheet_id() == first_sid);
-        let mut add_batch: Vec<(AbsCoord, u32)> = Vec::new();
+        let mut add_batch: Vec<(VertexAddr, u32)> = Vec::new();
 
         #[cfg(feature = "perf_instrumentation")]
         let mut packed_hits = 0usize;
@@ -624,9 +626,9 @@ impl DependencyGraph {
             if !missing_items.is_empty() {
                 self.ensure_touched_sheets.insert(sid);
 
-                let mut pcs: Vec<AbsCoord> = Vec::with_capacity(missing_items.len());
+                let mut pcs: Vec<VertexAddr> = Vec::with_capacity(missing_items.len());
                 for (_, packed) in &missing_items {
-                    pcs.push(AbsCoord::new(packed.row0(), packed.col0()));
+                    pcs.push(GridAddr::new(packed.row0(), packed.col0()).into());
                 }
 
                 #[cfg(feature = "perf_instrumentation")]
@@ -646,7 +648,7 @@ impl DependencyGraph {
                         {
                             let pc = AbsCoord::new(packed.row0(), packed.col0());
                             ordered[input_idx] = Some(vid);
-                            add_batch.push((pc, vid.0));
+                            add_batch.push((VertexAddr::grid(GridAddr::from_coord(pc)), vid.0));
 
                             #[cfg(feature = "perf_instrumentation")]
                             let tm0 = PerfInstant::now();
@@ -664,7 +666,8 @@ impl DependencyGraph {
 
                             #[cfg(feature = "perf_instrumentation")]
                             let ti0 = PerfInstant::now();
-                            self.sheet_index_mut(sid).add_vertex(pc, vid);
+                            self.sheet_index_mut(sid)
+                                .add_vertex(GridAddr::from_coord(pc), vid);
                             #[cfg(feature = "perf_instrumentation")]
                             {
                                 t_index_insert_us += ti0.elapsed().as_micros();
@@ -677,7 +680,7 @@ impl DependencyGraph {
                         {
                             let pc = AbsCoord::new(packed.row0(), packed.col0());
                             ordered[input_idx] = Some(vid);
-                            add_batch.push((pc, vid.0));
+                            add_batch.push((VertexAddr::grid(GridAddr::from_coord(pc)), vid.0));
 
                             #[cfg(feature = "perf_instrumentation")]
                             let tm0 = PerfInstant::now();
@@ -752,9 +755,9 @@ impl DependencyGraph {
                 }
                 self.ensure_touched_sheets.insert(sid);
 
-                let mut pcs: Vec<AbsCoord> = Vec::with_capacity(items.len());
+                let mut pcs: Vec<VertexAddr> = Vec::with_capacity(items.len());
                 for (_, packed) in &items {
-                    pcs.push(AbsCoord::new(packed.row0(), packed.col0()));
+                    pcs.push(GridAddr::new(packed.row0(), packed.col0()).into());
                 }
 
                 #[cfg(feature = "perf_instrumentation")]
@@ -768,7 +771,7 @@ impl DependencyGraph {
                 for ((input_idx, packed), vid) in items.into_iter().zip(vids.into_iter()) {
                     let pc = AbsCoord::new(packed.row0(), packed.col0());
                     ordered[input_idx] = Some(vid);
-                    add_batch.push((pc, vid.0));
+                    add_batch.push((VertexAddr::grid(GridAddr::from_coord(pc)), vid.0));
 
                     #[cfg(feature = "perf_instrumentation")]
                     let tm0 = PerfInstant::now();
@@ -788,7 +791,8 @@ impl DependencyGraph {
                         | crate::engine::SheetIndexMode::FastBatch => {
                             #[cfg(feature = "perf_instrumentation")]
                             let ti0 = PerfInstant::now();
-                            self.sheet_index_mut(sid).add_vertex(pc, vid);
+                            self.sheet_index_mut(sid)
+                                .add_vertex(GridAddr::from_coord(pc), vid);
                             #[cfg(feature = "perf_instrumentation")]
                             {
                                 t_index_insert_us += ti0.elapsed().as_micros();
@@ -843,7 +847,7 @@ impl DependencyGraph {
     pub fn ensure_vertices_batch_ordered(
         &mut self,
         coords: &[(SheetId, AbsCoord)],
-    ) -> (Vec<VertexId>, Vec<(AbsCoord, u32)>) {
+    ) -> (Vec<VertexId>, Vec<(VertexAddr, u32)>) {
         let mut packed: Vec<PackedSheetCell> = Vec::with_capacity(coords.len());
         for &(sid, coord) in coords {
             packed.push(Self::packed_cell_key(sid, coord));
@@ -993,9 +997,15 @@ impl DependencyGraph {
         self.store.all_vertices()
     }
 
-    /// Get current AbsCoord for a vertex
-    pub fn vertex_coord(&self, vid: VertexId) -> AbsCoord {
-        self.store.coord(vid)
+    /// Get the current address of a vertex: a grid position, or a symbol identity for
+    /// names, tables and external sources.
+    pub fn vertex_addr(&self, vid: VertexId) -> VertexAddr {
+        self.store.addr(vid)
+    }
+
+    /// Get the current grid position of a vertex, or `None` when it is a symbol.
+    pub fn vertex_grid_addr(&self, vid: VertexId) -> Option<GridAddr> {
+        self.store.grid_addr(vid)
     }
 
     /// Total number of allocated vertices (including deleted)
@@ -1007,7 +1017,7 @@ impl DependencyGraph {
     pub fn build_edges_from_adjacency(
         &mut self,
         adjacency: Vec<(u32, Vec<u32>)>,
-        coords: Vec<AbsCoord>,
+        coords: Vec<VertexAddr>,
         vertex_ids: Vec<u32>,
     ) {
         // Merge in base/delta out-edges for vertices the formula-target
@@ -1031,7 +1041,9 @@ impl DependencyGraph {
             let mut min_r: Option<u32> = None;
             let mut max_r: Option<u32> = None;
             for vid in index.vertices_in_col_range(start_col, end_col) {
-                let r = self.store.coord(vid).row();
+                let Some(r) = self.store.grid_addr(vid).map(|addr| addr.row()) else {
+                    continue;
+                };
                 min_r = Some(min_r.map(|m| m.min(r)).unwrap_or(r));
                 max_r = Some(max_r.map(|m| m.max(r)).unwrap_or(r));
             }
@@ -1079,18 +1091,18 @@ impl DependencyGraph {
 
     fn rebuild_sheet_index(&mut self, sheet_id: SheetId) {
         let mut idx = SheetIndex::new();
-        let mut batch: Vec<(AbsCoord, VertexId)> =
+        let mut batch: Vec<(GridAddr, VertexId)> =
             Vec::with_capacity(self.cell_to_vertex.len() + self.load_packed_to_vertex.len());
         for (cref, vid) in &self.cell_to_vertex {
             if cref.sheet_id == sheet_id {
-                batch.push((AbsCoord::new(cref.coord.row(), cref.coord.col()), *vid));
+                batch.push((GridAddr::new(cref.coord.row(), cref.coord.col()), *vid));
             }
         }
         for (&packed, &vid) in &self.load_packed_to_vertex {
             if packed.sheet_id() != sheet_id {
                 continue;
             }
-            let coord = AbsCoord::new(packed.row0(), packed.col0());
+            let coord = GridAddr::new(packed.row0(), packed.col0());
             let addr = CellRef::new(sheet_id, Coord::new(coord.row(), coord.col(), true, true));
             if self.cell_to_vertex.contains_key(&addr) {
                 continue;
@@ -1131,7 +1143,9 @@ impl DependencyGraph {
             let mut min_c: Option<u32> = None;
             let mut max_c: Option<u32> = None;
             for vid in index.vertices_in_row_range(start_row, end_row) {
-                let c = self.store.coord(vid).col();
+                let Some(c) = self.store.grid_addr(vid).map(|addr| addr.col()) else {
+                    continue;
+                };
                 min_c = Some(min_c.map(|m| m.min(c)).unwrap_or(c));
                 max_c = Some(max_c.map(|m| m.max(c)).unwrap_or(c));
             }
@@ -1225,8 +1239,7 @@ impl DependencyGraph {
             source_scalars: FxHashMap::default(),
             source_tables: FxHashMap::default(),
             source_vertex_lookup: FxHashMap::default(),
-            name_vertex_seq: 0,
-            source_vertex_seq: 0,
+            symbol_vertex_seq: 0,
             cell_to_name_dependents: FxHashMap::default(),
             name_to_cell_dependencies: FxHashMap::default(),
             config: config.clone(),
@@ -1879,15 +1892,18 @@ impl DependencyGraph {
         } else {
             // Create new vertex
             created_placeholders.push(addr);
-            let packed_coord = AbsCoord::from_excel(row, col);
-            let vertex_id = self.store.allocate(packed_coord, sheet_id, 0x01); // dirty flag
+            let position = GridAddr::from_coord(AbsCoord::from_excel(row, col));
+            let vertex_id = self
+                .store
+                .allocate(VertexAddr::grid(position), sheet_id, 0x01); // dirty flag
 
             // Add vertex coordinate for CSR
-            self.edges.add_vertex(packed_coord, vertex_id.0);
+            self.edges
+                .add_vertex(VertexAddr::grid(position), vertex_id.0);
 
             // Add to sheet index for O(log n + k) range queries
             self.sheet_index_mut(sheet_id)
-                .add_vertex(packed_coord, vertex_id);
+                .add_vertex(position, vertex_id);
 
             self.store.set_kind(vertex_id, VertexKind::Cell);
             if self.value_cache_enabled {
@@ -1956,11 +1972,14 @@ impl DependencyGraph {
             self.ref_error_vertices.remove(&existing_id);
             return Ok(());
         }
-        let packed_coord = AbsCoord::from_excel(row, col);
-        let vertex_id = self.store.allocate(packed_coord, sheet_id, 0x00); // not dirty
-        self.edges.add_vertex(packed_coord, vertex_id.0);
+        let position = GridAddr::from_coord(AbsCoord::from_excel(row, col));
+        let vertex_id = self
+            .store
+            .allocate(VertexAddr::grid(position), sheet_id, 0x00); // not dirty
+        self.edges
+            .add_vertex(VertexAddr::grid(position), vertex_id.0);
         self.sheet_index_mut(sheet_id)
-            .add_vertex(packed_coord, vertex_id);
+            .add_vertex(position, vertex_id);
         self.store.set_kind(vertex_id, VertexKind::Cell);
         self.ref_error_vertices.remove(&vertex_id);
         if self.value_cache_enabled {
@@ -1996,10 +2015,10 @@ impl DependencyGraph {
         }
         self.reserve_cells(collected.len());
         let t_reserve = Instant::now();
-        let mut new_vertices: Vec<(AbsCoord, u32)> = Vec::with_capacity(collected.len());
-        let mut index_items: Vec<(AbsCoord, VertexId)> = Vec::with_capacity(collected.len());
+        let mut new_vertices: Vec<(VertexAddr, u32)> = Vec::with_capacity(collected.len());
+        let mut index_items: Vec<(GridAddr, VertexId)> = Vec::with_capacity(collected.len());
         // For new allocations, accumulate values and assign after a single batch store
-        let mut new_value_coords: Vec<(AbsCoord, VertexId)> = Vec::with_capacity(collected.len());
+        let mut new_value_coords: Vec<(GridAddr, VertexId)> = Vec::with_capacity(collected.len());
         let mut new_value_literals: Vec<LiteralValue> = Vec::with_capacity(collected.len());
         // Detect fast path: during initial ingest, caller may guarantee most cells are new.
         let assume_new = self.first_load_assume_new
@@ -2031,14 +2050,16 @@ impl DependencyGraph {
                 self.store.set_kind(existing_id, VertexKind::Cell);
                 continue;
             }
-            let packed = AbsCoord::from_excel(row, col);
-            let vertex_id = self.store.allocate(packed, sheet_id, 0x00);
+            let packed = GridAddr::from_coord(AbsCoord::from_excel(row, col));
+            let vertex_id = self
+                .store
+                .allocate(VertexAddr::grid(packed), sheet_id, 0x00);
             self.store.set_kind(vertex_id, VertexKind::Cell);
             // Defer value arena storage to a single batch
             new_value_coords.push((packed, vertex_id));
             new_value_literals.push(value);
             self.cell_to_vertex.insert(addr, vertex_id);
-            new_vertices.push((packed, vertex_id.0));
+            new_vertices.push((VertexAddr::grid(packed), vertex_id.0));
             index_items.push((packed, vertex_id));
         }
         // Perform a single batch store for newly allocated values
@@ -2859,15 +2880,18 @@ impl DependencyGraph {
         }
 
         created_placeholders.push(*addr);
-        let packed_coord = AbsCoord::new(addr.coord.row(), addr.coord.col());
-        let vertex_id = self.store.allocate(packed_coord, addr.sheet_id, 0x00);
+        let position = GridAddr::new(addr.coord.row(), addr.coord.col());
+        let vertex_id = self
+            .store
+            .allocate(VertexAddr::grid(position), addr.sheet_id, 0x00);
 
         // Add vertex coordinate for CSR
-        self.edges.add_vertex(packed_coord, vertex_id.0);
+        self.edges
+            .add_vertex(VertexAddr::grid(position), vertex_id.0);
 
         // Add to sheet index for O(log n + k) range queries
         self.sheet_index_mut(addr.sheet_id)
-            .add_vertex(packed_coord, vertex_id);
+            .add_vertex(position, vertex_id);
 
         self.store.set_kind(vertex_id, VertexKind::Empty);
         self.cell_to_vertex.insert(*addr, vertex_id);
@@ -3959,11 +3983,14 @@ impl DependencyGraph {
             .map(|&value_ref| self.data_store.retrieve_value(value_ref))
     }
 
-    /// Get the cell reference for a vertex
+    /// Get the cell reference for a vertex.
+    ///
+    /// Returns `None` for symbol vertices (names, tables, external sources): they are
+    /// identified by name and have no position, so there is no address to return.
     pub(crate) fn get_cell_ref(&self, vertex_id: VertexId) -> Option<CellRef> {
-        let packed_coord = self.store.coord(vertex_id);
+        let grid = self.store.grid_addr(vertex_id)?;
         let sheet_id = self.store.sheet_id(vertex_id);
-        let coord = Coord::new(packed_coord.row(), packed_coord.col(), true, true);
+        let coord = Coord::new(grid.row(), grid.col(), true, true);
         Some(CellRef::new(sheet_id, coord))
     }
 
@@ -4063,7 +4090,7 @@ impl DependencyGraph {
     /// Internal: Create a snapshot of vertex state for rollback
     #[doc(hidden)]
     pub fn snapshot_vertex(&self, id: VertexId) -> crate::engine::VertexSnapshot {
-        let coord = self.store.coord(id);
+        let coord = self.store.grid_addr(id).unwrap_or_default();
         let sheet_id = self.store.sheet_id(id);
         let kind = self.store.kind(id);
         let flags = self.store.flags(id);
@@ -4186,16 +4213,19 @@ impl DependencyGraph {
         }
     }
 
-    /// Update vertex coordinate
+    /// Move a vertex to a new grid position.
+    ///
+    /// Takes a `GridAddr`, so a symbol vertex cannot be shifted onto the grid by a
+    /// structural edit (#304).
     #[doc(hidden)]
-    pub fn set_coord(&mut self, id: VertexId, coord: AbsCoord) {
-        self.store.set_coord(id, coord);
+    pub fn set_grid_addr(&mut self, id: VertexId, coord: GridAddr) {
+        self.store.set_addr(id, VertexAddr::grid(coord));
     }
 
     /// Update edge cache coordinate
     #[doc(hidden)]
-    pub fn update_edge_coord(&mut self, id: VertexId, coord: AbsCoord) {
-        self.edges.update_coord(id, coord);
+    pub fn update_edge_grid_addr(&mut self, id: VertexId, coord: GridAddr) {
+        self.edges.update_addr(id, VertexAddr::grid(coord));
     }
 
     /// Mark vertex as deleted (tombstone)
@@ -4272,9 +4302,12 @@ impl DependencyGraph {
         self.cell_to_vertex.get(addr).copied()
     }
 
-    /// Get coord for a vertex (public for VertexEditor)
-    pub fn get_coord(&self, id: VertexId) -> AbsCoord {
-        self.store.coord(id)
+    /// Get the grid position of a vertex (public for VertexEditor).
+    ///
+    /// `None` for symbol vertices, which have no position. Structural operations iterate
+    /// grid positions, so this is what keeps them away from names, tables and sources.
+    pub fn get_grid_addr(&self, id: VertexId) -> Option<GridAddr> {
+        self.store.grid_addr(id)
     }
 
     /// Get sheet_id for a vertex (public for VertexEditor)
@@ -4282,11 +4315,22 @@ impl DependencyGraph {
         self.store.sheet_id(id)
     }
 
-    /// Get all vertices in a sheet
-    pub fn vertices_in_sheet(&self, sheet_id: SheetId) -> impl Iterator<Item = VertexId> + '_ {
-        self.store
-            .all_vertices()
-            .filter(move |&id| self.vertex_exists(id) && self.store.sheet_id(id) == sheet_id)
+    /// Get every grid-resident vertex on a sheet, paired with its position.
+    ///
+    /// Symbol vertices (names, tables, external sources) are structurally absent: they have
+    /// no grid position, so they cannot be produced here. Structural edits drive off this
+    /// iterator, which is why a row or column operation can no longer delete or shift a
+    /// name vertex (#302, #304).
+    pub fn grid_vertices_in_sheet(
+        &self,
+        sheet_id: SheetId,
+    ) -> impl Iterator<Item = (VertexId, GridAddr)> + '_ {
+        self.store.all_vertices().filter_map(move |id| {
+            if !self.vertex_exists(id) || self.store.sheet_id(id) != sheet_id {
+                return None;
+            }
+            self.store.grid_addr(id).map(|addr| (id, addr))
+        })
     }
 
     /// Does a vertex have a formula associated
@@ -4385,7 +4429,7 @@ impl DependencyGraph {
 
     /// Get the cell reference for a vertex
     pub fn get_cell_ref_for_vertex(&self, id: VertexId) -> Option<CellRef> {
-        let coord = self.store.coord(id);
+        let coord = self.store.grid_addr(id)?;
         let sheet_id = self.store.sheet_id(id);
         // Find the cell reference in the mapping
         let cell_ref = CellRef::new(sheet_id, Coord::new(coord.row(), coord.col(), true, true));

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -131,24 +131,44 @@ impl DependencyGraph {
         }
     }
 
-    fn next_name_coord(&mut self) -> AbsCoord {
-        let seq = self.name_vertex_seq;
-        self.name_vertex_seq = self.name_vertex_seq.wrapping_add(1);
-        let row = (seq / 16_384).min(0x000F_FFFF);
-        let col = seq % 16_384;
-        AbsCoord::new(row, col)
+    /// Allocate the next address in the symbol space.
+    ///
+    /// Symbols are identified by name and have no position. They used to be handed
+    /// fabricated grid coordinates on a real sheet, which let grid operations reach them
+    /// (#302, #304); a `SymbolAddr` is not a position and cannot be reached that way.
+    pub(super) fn next_symbol_addr(&mut self) -> VertexAddr {
+        let seq = self.symbol_vertex_seq;
+        self.symbol_vertex_seq = self.symbol_vertex_seq.wrapping_add(1);
+        VertexAddr::symbol(SymbolAddr::new(seq))
+    }
+
+    /// Allocate a vertex in the symbol address space.
+    ///
+    /// `scope_sheet_id` is recorded as lookup metadata only: it says which scope the symbol
+    /// answers queries for, never where it lives. Symbol vertices are absent from
+    /// `cell_to_vertex` and from every sheet index by construction, because they have no
+    /// grid address to key them by.
+    pub(super) fn allocate_symbol_vertex(
+        &mut self,
+        kind: VertexKind,
+        scope_sheet_id: SheetId,
+    ) -> VertexId {
+        let addr = self.next_symbol_addr();
+        let vertex_id = self.store.allocate(addr, scope_sheet_id, 0x01);
+        self.store.set_kind(vertex_id, kind);
+        self.edges.add_vertex(addr, vertex_id.0);
+        vertex_id
     }
 
     pub(super) fn allocate_name_vertex(&mut self, scope: NameScope) -> VertexId {
-        let coord = self.next_name_coord();
-        let sheet_id = match scope {
+        // Scope is lookup metadata, not an address: a workbook-scoped name is not a
+        // resident of the default sheet.
+        let scope_sheet_id = match scope {
             NameScope::Sheet(id) => id,
             NameScope::Workbook => self.default_sheet_id,
         };
-        let vertex_id = self.store.allocate(coord, sheet_id, 0x01);
-        self.store.set_kind(vertex_id, VertexKind::NamedScalar);
+        let vertex_id = self.allocate_symbol_vertex(VertexKind::NamedScalar, scope_sheet_id);
         self.mark_vertex_dirty(vertex_id);
-        self.edges.add_vertex(coord, vertex_id.0);
         vertex_id
     }
 

--- a/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
+++ b/crates/formualizer-eval/src/engine/graph/prepared_legacy_graph.rs
@@ -661,16 +661,17 @@ impl DependencyGraph {
             .iter()
             .map(|(packed, _)| {
                 (
-                    AbsCoord::new(packed.row0(), packed.col0()),
+                    VertexAddr::grid(GridAddr::new(packed.row0(), packed.col0())),
                     packed.sheet_id(),
-                    0,
+                    0u8,
                 )
             })
             .collect();
         self.store.allocate_prevalidated_batch(&allocations);
-        for ((packed, id), (coord, _, _)) in plan.new_vertices.iter().zip(allocations) {
+        for ((packed, id), (addr, _, _)) in plan.new_vertices.iter().zip(allocations) {
             let id = *id;
-            self.edges.add_vertex(coord, id.0);
+            let coord = GridAddr::new(packed.row0(), packed.col0());
+            self.edges.add_vertex(addr, id.0);
             self.sheet_index_mut(packed.sheet_id())
                 .add_vertex(coord, id);
             self.store.set_kind(id, VertexKind::Empty);

--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -221,7 +221,10 @@ impl DependencyGraph {
         if self.store.sheet_id(dependent) != sheet_id {
             return false;
         }
-        let coord = self.store.coord(dependent);
+        // A symbol vertex has no position, so no range region can contain it.
+        let Some(coord) = self.store.grid_addr(dependent) else {
+            return false;
+        };
         let r0 = coord.row();
         let c0 = coord.col();
         s_row.is_none_or(|s| r0 >= s)
@@ -347,7 +350,8 @@ impl DependencyGraph {
             if row < 0 || col < 0 {
                 return Some(false);
             }
-            let coord = graph.store.coord(dependent);
+            // A symbol vertex has no position, so no range region can contain it.
+            let coord = graph.store.grid_addr(dependent)?;
             let contains = if row == 0 && col == 0 {
                 coord.row() >= sr && coord.row() <= er && coord.col() >= sc && coord.col() <= ec
             } else if col == 0 {

--- a/crates/formualizer-eval/src/engine/graph/sheets.rs
+++ b/crates/formualizer-eval/src/engine/graph/sheets.rs
@@ -36,7 +36,13 @@ impl DependencyGraph {
 
         self.begin_batch();
 
-        let vertices_to_delete: Vec<VertexId> = self.vertices_in_sheet(sheet_id).collect();
+        // Symbol vertices are not sheet residents: workbook names would otherwise be
+        // destroyed whenever the default sheet was removed. Sheet-scoped names on this
+        // sheet are retired below, through the name registry that owns them.
+        let vertices_to_delete: Vec<VertexId> = self
+            .grid_vertices_in_sheet(sheet_id)
+            .map(|(id, _)| id)
+            .collect();
 
         // Formulas can reference this sheet either through explicit dependency edges
         // (expanded refs) or compressed range deps. Track both.
@@ -138,8 +144,9 @@ impl DependencyGraph {
 
             self.remove_all_edges(vertex_id);
 
-            let coord = self.store.coord(vertex_id);
-            if let Some(index) = self.sheet_indexes.get_mut(&sheet_id) {
+            if let Some(coord) = self.store.grid_addr(vertex_id)
+                && let Some(index) = self.sheet_indexes.get_mut(&sheet_id)
+            {
                 index.remove_vertex(coord, vertex_id);
             }
 
@@ -312,10 +319,8 @@ impl DependencyGraph {
 
         self.begin_batch();
 
-        let source_vertices: Vec<(VertexId, AbsCoord)> = self
-            .vertices_in_sheet(source_sheet_id)
-            .map(|id| (id, self.store.coord(id)))
-            .collect();
+        let source_vertices: Vec<(VertexId, GridAddr)> =
+            self.grid_vertices_in_sheet(source_sheet_id).collect();
 
         let mut vertex_mapping = FxHashMap::default();
 
@@ -324,8 +329,10 @@ impl DependencyGraph {
             let col = coord.col();
             let kind = self.store.kind(*old_id);
 
-            let new_id = self.store.allocate(*coord, new_sheet_id, 0x01);
-            self.edges.add_vertex(*coord, new_id.0);
+            let new_id = self
+                .store
+                .allocate(VertexAddr::grid(*coord), new_sheet_id, 0x01);
+            self.edges.add_vertex(VertexAddr::grid(*coord), new_id.0);
             self.sheet_index_mut(new_sheet_id)
                 .add_vertex(*coord, new_id);
 

--- a/crates/formualizer-eval/src/engine/graph/snapshot.rs
+++ b/crates/formualizer-eval/src/engine/graph/snapshot.rs
@@ -1,14 +1,14 @@
 use super::{AstNodeId, ValueRef};
+use crate::engine::addr::GridAddr;
 use crate::{
     SheetId,
     engine::vertex::{VertexId, VertexKind},
 };
-use formualizer_common::Coord as AbsCoord;
 
 /// Snapshot of a vertex's complete state for rollback purposes
 #[derive(Debug, Clone)]
 pub struct VertexSnapshot {
-    pub coord: AbsCoord,
+    pub coord: GridAddr,
     pub sheet_id: SheetId,
     pub kind: VertexKind,
     pub flags: u8,

--- a/crates/formualizer-eval/src/engine/graph/sources.rs
+++ b/crates/formualizer-eval/src/engine/graph/sources.rs
@@ -2,7 +2,7 @@ use crate::SheetId;
 use crate::engine::graph::DependencyGraph;
 use crate::engine::named_range::NameScope;
 use crate::engine::vertex::{VertexId, VertexKind};
-use formualizer_common::{Coord as AbsCoord, ExcelError, ExcelErrorKind};
+use formualizer_common::{ExcelError, ExcelErrorKind};
 
 #[derive(Debug, Clone)]
 pub struct SourceScalarEntry {
@@ -19,27 +19,11 @@ pub struct SourceTableEntry {
 }
 
 impl DependencyGraph {
-    fn next_source_coord(&mut self) -> AbsCoord {
-        const COLS: u32 = 16_384;
-        const SOURCE_ROW_OFFSET: u32 = 524_288;
-
-        let seq = self.source_vertex_seq;
-        self.source_vertex_seq = self.source_vertex_seq.wrapping_add(1);
-
-        let row = (seq / COLS)
-            .saturating_add(SOURCE_ROW_OFFSET)
-            .min(0x000F_FFFF);
-        let col = seq % COLS;
-        AbsCoord::new(row, col)
-    }
-
     fn allocate_source_vertex(&mut self) -> VertexId {
-        let coord = self.next_source_coord();
-        let sheet_id: SheetId = self.default_sheet_id;
-        let vertex = self.store.allocate(coord, sheet_id, 0x01);
-        self.edges.add_vertex(coord, vertex.0);
-        self.store.set_kind(vertex, VertexKind::External);
-        vertex
+        // External sources are identified by name and have no position; the default sheet
+        // is recorded only as the scope their lookups answer for.
+        let scope_sheet_id: SheetId = self.default_sheet_id;
+        self.allocate_symbol_vertex(VertexKind::External, scope_sheet_id)
     }
 
     pub fn resolve_source_scalar_entry(&self, name: &str) -> Option<&SourceScalarEntry> {

--- a/crates/formualizer-eval/src/engine/graph/tables.rs
+++ b/crates/formualizer-eval/src/engine/graph/tables.rs
@@ -92,14 +92,12 @@ impl DependencyGraph {
             )));
         }
 
-        let anchor = range.start;
-        let sheet_id = anchor.sheet_id;
-        let packed_coord = formualizer_common::Coord::new(anchor.coord.row(), anchor.coord.col());
-        let vertex = self.store.allocate(packed_coord, sheet_id, 0x01);
-        self.edges.add_vertex(packed_coord, vertex.0);
-        self.sheet_index_mut(sheet_id)
-            .add_vertex(packed_coord, vertex);
-        self.store.set_kind(vertex, VertexKind::Table);
+        // A table has a range, but the *vertex* that represents the table symbol has no
+        // position: it is identified by name. Parking it on the range's anchor cell put it
+        // in the sheet index, where grid queries and structural edits could reach it (#304).
+        // Dependencies on the table's cells are carried by the stripe registration below.
+        let sheet_id = range.start.sheet_id;
+        let vertex = self.allocate_symbol_vertex(VertexKind::Table, sheet_id);
 
         // Register stripes for the full table region so cell edits inside the table
         // propagate to formulas that depend on the table.

--- a/crates/formualizer-eval/src/engine/ingest.rs
+++ b/crates/formualizer-eval/src/engine/ingest.rs
@@ -91,7 +91,12 @@ where
         if sheets.len() != 1 || sheets[0].0 != default_id {
             return false;
         }
-        if self.graph.vertices_in_sheet(default_id).next().is_some() {
+        if self
+            .graph
+            .grid_vertices_in_sheet(default_id)
+            .next()
+            .is_some()
+        {
             return false;
         }
         if self.graph.named_ranges_iter().next().is_some()

--- a/crates/formualizer-eval/src/engine/ingest_builder.rs
+++ b/crates/formualizer-eval/src/engine/ingest_builder.rs
@@ -368,7 +368,7 @@ impl<'g> BulkIngestBuilder<'g> {
         // Materialize per-sheet to keep caches warm and reduce cross-sheet churn
         // Accumulate a flat adjacency for a single-shot CSR build
         let mut edges_adj: Vec<(u32, Vec<u32>)> = Vec::new();
-        let mut coord_accum: Vec<AbsCoord> = Vec::new();
+        let mut coord_accum: Vec<crate::engine::addr::VertexAddr> = Vec::new();
         let mut id_accum: Vec<u32> = Vec::new();
         for (_sid, mut stage) in self.sheets.drain() {
             let t_sheet0 = Instant::now();
@@ -666,7 +666,7 @@ impl<'g> BulkIngestBuilder<'g> {
                     }
                     let t_coords0 = Instant::now();
                     for vid in self.g.iter_vertex_ids() {
-                        coord_accum.push(self.g.vertex_coord(vid));
+                        coord_accum.push(self.g.vertex_addr(vid));
                         id_accum.push(vid.0);
                     }
                     t_coords_ms = t_coords0.elapsed().as_millis();

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides incremental formula evaluation with dependency tracking.
 
+pub mod addr;
 pub mod arrow_ingest;
 pub mod cancel;
 pub(crate) mod convergence;

--- a/crates/formualizer-eval/src/engine/sheet_index.rs
+++ b/crates/formualizer-eval/src/engine/sheet_index.rs
@@ -1,6 +1,6 @@
+use super::addr::GridAddr;
 use super::interval_tree::IntervalTree;
 use super::vertex::VertexId;
-use formualizer_common::Coord as AbsCoord;
 use std::collections::HashSet;
 use std::ops::ControlFlow;
 #[cfg(test)]
@@ -76,7 +76,7 @@ impl SheetIndex {
     }
 
     /// Fast path build from sorted coordinates. Assumes items are row-major sorted.
-    pub fn build_from_sorted(&mut self, items: &[(AbsCoord, VertexId)]) {
+    pub fn build_from_sorted(&mut self, items: &[(GridAddr, VertexId)]) {
         self.add_vertices_batch(items);
     }
 
@@ -84,7 +84,7 @@ impl SheetIndex {
     ///
     /// ## Complexity
     /// O(log n) where n is the number of vertices in the index
-    pub fn add_vertex(&mut self, coord: AbsCoord, vertex_id: VertexId) {
+    pub fn add_vertex(&mut self, coord: GridAddr, vertex_id: VertexId) {
         let row = coord.row();
         let col = coord.col();
 
@@ -106,7 +106,7 @@ impl SheetIndex {
     }
 
     /// Add many vertices in a single pass. Assumes coords belong to same sheet index.
-    pub fn add_vertices_batch(&mut self, items: &[(AbsCoord, VertexId)]) {
+    pub fn add_vertices_batch(&mut self, items: &[(GridAddr, VertexId)]) {
         if items.is_empty() {
             return;
         }
@@ -148,7 +148,7 @@ impl SheetIndex {
     ///
     /// ## Complexity
     /// O(log n) where n is the number of vertices in the index
-    pub fn remove_vertex(&mut self, coord: AbsCoord, vertex_id: VertexId) {
+    pub fn remove_vertex(&mut self, coord: GridAddr, vertex_id: VertexId) {
         let row = coord.row();
         let col = coord.col();
 
@@ -164,7 +164,7 @@ impl SheetIndex {
     ///
     /// ## Complexity
     /// O(log n) for removal + O(log n) for insertion = O(log n)
-    pub fn update_vertex(&mut self, old_coord: AbsCoord, new_coord: AbsCoord, vertex_id: VertexId) {
+    pub fn update_vertex(&mut self, old_coord: GridAddr, new_coord: GridAddr, vertex_id: VertexId) {
         self.remove_vertex(old_coord, vertex_id);
         self.add_vertex(new_coord, vertex_id);
     }
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn test_add_and_query_single_vertex() {
         let mut index = SheetIndex::new();
-        let coord = AbsCoord::new(5, 10);
+        let coord = GridAddr::new(5, 10);
         let vertex_id = VertexId(1024);
 
         index.add_vertex(coord, vertex_id);
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn vertex_count_is_unique_and_consistent_across_incremental_and_batch_builds() {
         let vertex = VertexId(1024);
-        let items = [(AbsCoord::new(1, 1), vertex), (AbsCoord::new(1, 1), vertex)];
+        let items = [(GridAddr::new(1, 1), vertex), (GridAddr::new(1, 1), vertex)];
         let mut incremental = SheetIndex::new();
         for (coord, vertex) in items {
             incremental.add_vertex(coord, vertex);
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn test_remove_vertex() {
         let mut index = SheetIndex::new();
-        let coord = AbsCoord::new(5, 10);
+        let coord = GridAddr::new(5, 10);
         let vertex_id = VertexId(1024);
 
         index.add_vertex(coord, vertex_id);
@@ -395,8 +395,8 @@ mod tests {
     #[test]
     fn test_update_vertex_position() {
         let mut index = SheetIndex::new();
-        let old_coord = AbsCoord::new(5, 10);
-        let new_coord = AbsCoord::new(15, 20);
+        let old_coord = GridAddr::new(5, 10);
+        let new_coord = GridAddr::new(15, 20);
         let vertex_id = VertexId(1024);
 
         index.add_vertex(old_coord, vertex_id);
@@ -421,7 +421,7 @@ mod tests {
         // Add vertices in a pattern
         for row in 0..10 {
             for col in 0..5 {
-                let coord = AbsCoord::new(row, col);
+                let coord = GridAddr::new(row, col);
                 let vertex_id = VertexId(1024 + row * 5 + col);
                 index.add_vertex(coord, vertex_id);
             }
@@ -445,11 +445,11 @@ mod tests {
         let mut index = SheetIndex::new();
 
         // Simulate sparse sheet - only a few cells in a million-row range
-        index.add_vertex(AbsCoord::new(100, 5), VertexId(1024));
-        index.add_vertex(AbsCoord::new(50_000, 10), VertexId(1025));
-        index.add_vertex(AbsCoord::new(100_000, 15), VertexId(1026));
-        index.add_vertex(AbsCoord::new(500_000, 20), VertexId(1027));
-        index.add_vertex(AbsCoord::new(999_999, 25), VertexId(1028));
+        index.add_vertex(GridAddr::new(100, 5), VertexId(1024));
+        index.add_vertex(GridAddr::new(50_000, 10), VertexId(1025));
+        index.add_vertex(GridAddr::new(100_000, 15), VertexId(1026));
+        index.add_vertex(GridAddr::new(500_000, 20), VertexId(1027));
+        index.add_vertex(GridAddr::new(999_999, 25), VertexId(1028));
 
         assert_eq!(index.len(), 5);
 
@@ -468,7 +468,7 @@ mod tests {
 
         // Setup: cells at rows 10, 20, 30, 40, 50
         for row in [10, 20, 30, 40, 50] {
-            index.add_vertex(AbsCoord::new(row, 0), VertexId(1024 + row));
+            index.add_vertex(GridAddr::new(row, 0), VertexId(1024 + row));
         }
 
         // Simulate "insert 5 rows at row 25" - need to find all vertices with row >= 25
@@ -477,7 +477,7 @@ mod tests {
 
         // Simulate "delete columns B:D" - need to find all vertices in columns 1-3
         for col in 1..=3 {
-            index.add_vertex(AbsCoord::new(5, col), VertexId(2000 + col));
+            index.add_vertex(GridAddr::new(5, col), VertexId(2000 + col));
         }
 
         let vertices_to_delete = index.vertices_in_col_range(1, 3);
@@ -491,7 +491,7 @@ mod tests {
         // Simulate a spreadsheet with scattered data
         for row in (0..10000).step_by(100) {
             for col in 0..10 {
-                index.add_vertex(AbsCoord::new(row, col), VertexId(row * 10 + col));
+                index.add_vertex(GridAddr::new(row, col), VertexId(row * 10 + col));
             }
         }
 
@@ -506,7 +506,7 @@ mod tests {
     fn exact_cell_query_visits_only_exact_coordinate_buckets() {
         let mut index = SheetIndex::new();
         for row in 0..10_000 {
-            index.add_vertex(AbsCoord::new(row, 7), VertexId(1024 + row));
+            index.add_vertex(GridAddr::new(row, 7), VertexId(1024 + row));
         }
 
         index.reset_query_stats();
@@ -530,7 +530,7 @@ mod tests {
 
     fn assert_query_parity(
         index: &SheetIndex,
-        model: &[(AbsCoord, VertexId)],
+        model: &[(GridAddr, VertexId)],
         start_row: u32,
         end_row: u32,
         start_col: u32,
@@ -589,7 +589,7 @@ mod tests {
                     next() % 2_000
                 };
                 let col = if offset < 5 { offset * 20 } else { next() % 80 };
-                (AbsCoord::new(row, col), VertexId(1024 + offset))
+                (GridAddr::new(row, col), VertexId(1024 + offset))
             })
             .collect::<Vec<_>>();
 
@@ -611,7 +611,7 @@ mod tests {
 
         for (offset, entry) in model.iter_mut().take(40).enumerate() {
             let (old_coord, vertex) = *entry;
-            let new_coord = AbsCoord::new(3_000 + offset as u32, 100 + offset as u32 % 7);
+            let new_coord = GridAddr::new(3_000 + offset as u32, 100 + offset as u32 % 7);
             incremental.update_vertex(old_coord, new_coord, vertex);
             bulk.update_vertex(old_coord, new_coord, vertex);
             entry.0 = new_coord;

--- a/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
+++ b/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
@@ -1074,6 +1074,47 @@ fn default_sheet_inserts_never_bind_a_reference_to_a_symbol_vertex() {
     assert_structural_parity(&engine, 0xc0de_0304, 0);
 }
 
+/// The last hole the type system cannot close on its own: `VertexEditor::move_vertex` is public
+/// and takes an untyped `VertexId`, so it must refuse a symbol explicitly rather than parking it
+/// on the grid the way a default-sheet insert used to (#304).
+#[test]
+fn a_symbol_vertex_cannot_be_moved_onto_the_grid() {
+    use crate::engine::addr::GridAddr;
+    use crate::engine::graph::editor::vertex_editor::VertexEditor;
+
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    let sheet1 = engine.sheet_id("Sheet1").unwrap();
+    engine
+        .define_name(
+            "Tracked",
+            NamedDefinition::Cell(CellRef::new(sheet1, Coord::from_excel(4, 4, true, true))),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    let name_vertex = engine
+        .graph
+        .resolve_name_entry("Tracked", sheet1)
+        .expect("workbook name must resolve")
+        .vertex;
+
+    let mut editor = VertexEditor::new(&mut engine.graph);
+    assert!(
+        editor
+            .move_vertex(name_vertex, GridAddr::new(0, 0))
+            .is_err(),
+        "moving a symbol vertex onto A1 must be refused"
+    );
+    drop(editor);
+
+    assert_eq!(engine.graph.get_cell_ref(name_vertex), None);
+    assert_eq!(
+        engine
+            .graph
+            .get_vertex_for_cell(&CellRef::new(sheet1, Coord::from_excel(1, 1, true, true))),
+        None
+    );
+}
+
 /// The structural property the two issues share: a symbol vertex is never in `cell_to_vertex`,
 /// for any symbol kind, under any grid operation.
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
+++ b/crates/formualizer-eval/src/engine/tests/ast_edge_invariant.rs
@@ -22,14 +22,20 @@
 //! names, or tables; reversed ranges; and external, three-dimensional, or unsupported references.
 //! It is therefore vacuous for those references, while the phantom-edge direction remains covered.
 //!
-//! Pinned T2 findings, each an `#[ignore]`d test asserting the intended invariant and failing on
-//! the live divergence: `AST_EDGE_UNDO_STRUCTURAL_ADJUSTMENT` (undo of a populated row insert
-//! leaves data shifted and the edge one row above the AST reference),
-//! `AST_EDGE_UNRELATED_DELETE_NAME` (a default-sheet row or column delete drops a cross-sheet
-//! workbook-name edge), `AST_EDGE_UNDO_EMPTY_PLACEHOLDER` (undo and redo of a write to a
-//! referenced empty placeholder drop its edge), and `AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID`
-//! (a default-sheet insert shifts a name vertex onto an addressable cell, so later references to
-//! that address bind to the name vertex instead of the cell).
+//! Two T2 findings remain pinned as `#[ignore]`d tests asserting the intended invariant and
+//! failing on the live divergence: `AST_EDGE_UNDO_STRUCTURAL_ADJUSTMENT` (undo of a populated row
+//! insert leaves data shifted and the edge one row above the AST reference) and
+//! `AST_EDGE_UNDO_EMPTY_PLACEHOLDER` (undo and redo of a write to a referenced empty placeholder
+//! drop its edge).
+//!
+//! Two are fixed and now run as ordinary regression tests: `AST_EDGE_UNRELATED_DELETE_NAME`
+//! (issue #302 — a default-sheet row or column delete dropped a cross-sheet workbook-name edge)
+//! and `AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID` (issue #304 — a default-sheet insert
+//! shifted a name vertex onto an addressable cell, so later references to that address bound to
+//! the name vertex instead of the cell). Both had one root cause: symbol vertices held fabricated
+//! grid coordinates on a real sheet. They now hold a `SymbolAddr` in their own address space, so
+//! no grid operation can reach them, and the campaigns below no longer steer their default-sheet
+//! inserts clear of the name vertex.
 //!
 //! Campaign seeds are fixed constants below. They are intentionally not persisted: a failure
 //! prints its seed and operation index, which is enough to replay the deterministic campaign while
@@ -412,38 +418,6 @@ fn random_formula(rng: &mut SmallRng, sheets: &[String], current_sheet: &str) ->
     }
 }
 
-/// The workbook name's vertex physically occupies a cell on the default sheet. A default-sheet
-/// insert at or above that cell shifts the vertex onto an addressable grid cell, after which any
-/// later reference to that address binds to the name vertex instead of the cell — finding
-/// `AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID`, pinned by
-/// `default_sheet_insertion_keeps_the_name_vertex_off_the_addressable_grid`. Campaigns keep their
-/// default-sheet inserts strictly below and to the right of the name vertex so they exercise the
-/// healthy shape; every other default-sheet edit, including formula and value overwrite of shifted
-/// formulas, stays in play.
-fn insert_clear_of_name_vertex(
-    engine: &Engine<TestWorkbook>,
-    sheet: &str,
-    row: u32,
-    col: u32,
-) -> (u32, u32) {
-    let Some(sheet_id) = engine.sheet_id(sheet) else {
-        return (row, col);
-    };
-    let Some(named) = engine.graph.resolve_name_entry("Tracked", sheet_id) else {
-        return (row, col);
-    };
-    let Some(anchor) = engine.graph.get_cell_ref(named.vertex) else {
-        return (row, col);
-    };
-    if anchor.sheet_id != sheet_id {
-        return (row, col);
-    }
-    (
-        row.max(anchor.coord.row() + 2),
-        col.max(anchor.coord.col() + 2),
-    )
-}
-
 fn reset_history(log: &mut ChangeLog, undo: &mut UndoEngine, can_redo: &mut bool) {
     log.clear();
     *undo = UndoEngine::new();
@@ -527,10 +501,9 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 can_redo = false;
             }
             30..=40 => {
-                let (insert_row, _) = insert_clear_of_name_vertex(&engine, &sheet, row, col);
                 engine
                     .action_with_logger(&mut log, "campaign-insert-rows", |action| {
-                        action.insert_rows(&sheet, insert_row, 1).map(|_| ())
+                        action.insert_rows(&sheet, row, 1).map(|_| ())
                     })
                     .unwrap();
                 reset_history(&mut log, &mut undo, &mut can_redo);
@@ -541,10 +514,9 @@ fn run_campaign(campaign: Campaign) -> CampaignStats {
                 reset_history(&mut log, &mut undo, &mut can_redo);
             }
             52..=61 => {
-                let (_, insert_col) = insert_clear_of_name_vertex(&engine, &sheet, row, col);
                 engine
                     .action_with_logger(&mut log, "campaign-insert-columns", |action| {
-                        action.insert_columns(&sheet, insert_col, 1).map(|_| ())
+                        action.insert_columns(&sheet, col, 1).map(|_| ())
                     })
                     .unwrap();
                 reset_history(&mut log, &mut undo, &mut can_redo);
@@ -703,13 +675,14 @@ fn undoing_populated_row_insertion_restores_data_ast_and_edge_together() {
     );
 }
 
-// T2 finding AST_EDGE_UNRELATED_DELETE_NAME: see the matching entry in the T2 worker report.
-// GitHub issue #302's review extension covers both default-sheet row and column deletes. Either
-// shape removes a workbook-name edge and strands formulas on another sheet.
+// Regression pin for GitHub issue #302 (finding AST_EDGE_UNRELATED_DELETE_NAME).
+// A structural edit on a completely unrelated sheet used to drop the formula->name edge,
+// because the workbook name's vertex was parked on the default sheet's grid at `$A$1` and a
+// row-1/column-1 delete swept it up as an ordinary resident. Symbol vertices now live in
+// their own address space and cannot be reached by a grid operation.
 #[test]
-#[ignore = "known T2 divergence: unrelated default-sheet row or column delete drops a name edge"]
 fn deleting_unrelated_default_sheet_row_or_column_preserves_cross_sheet_name_edge() {
-    fn dependencies_after_delete(delete_row: bool) -> usize {
+    fn dependencies_around_delete(delete_row: bool) -> (usize, usize) {
         let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
         engine.add_sheet("Sheet2").unwrap();
         let target = CellRef::new(
@@ -730,24 +703,90 @@ fn deleting_unrelated_default_sheet_row_or_column_preserves_cross_sheet_name_edg
             .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(1.0))
             .unwrap();
         assert_structural_parity(&engine, 0xc0de_0006, 0);
+        let before = engine
+            .graph
+            .get_dependencies(engine.graph.formula_vertices()[0])
+            .len();
         if delete_row {
             engine.delete_rows("Sheet1", 1, 1).unwrap();
         } else {
             engine.delete_columns("Sheet1", 1, 1).unwrap();
         }
-        engine
+        assert_structural_parity(&engine, 0xc0de_0006, 1);
+        let after = engine
             .graph
             .get_dependencies(engine.graph.formula_vertices()[0])
-            .len()
+            .len();
+        (before, after)
     }
 
-    let after_column_delete = dependencies_after_delete(false);
-    let after_row_delete = dependencies_after_delete(true);
-    assert_eq!(after_column_delete, 0);
-    assert_eq!(after_row_delete, 0);
+    let (before_column_delete, after_column_delete) = dependencies_around_delete(false);
+    let (before_row_delete, after_row_delete) = dependencies_around_delete(true);
+    assert_eq!(
+        before_column_delete, 1,
+        "the cross-sheet formula must start with exactly its name edge"
+    );
+    assert_eq!(before_row_delete, 1);
+    assert_eq!(
+        after_column_delete, before_column_delete,
+        "a default-sheet column delete must preserve the cross-sheet name edge"
+    );
+    assert_eq!(
+        after_row_delete, before_row_delete,
+        "a default-sheet row delete must preserve the cross-sheet name edge"
+    );
+}
+
+// The consequence #302 named: once the edge survives, the name's target still dirties and
+// still recomputes the formula that consumes it.
+#[test]
+fn name_target_still_drives_recalculation_after_an_unrelated_default_sheet_delete() {
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.add_sheet("Sheet2").unwrap();
+    let sheet2 = engine.sheet_id("Sheet2").unwrap();
+    engine
+        .set_cell_value("Sheet2", 2, 6, LiteralValue::Number(5.0))
+        .unwrap();
+    engine
+        .define_name(
+            "Tracked",
+            NamedDefinition::Cell(CellRef::new(sheet2, Coord::from_excel(2, 6, true, true))),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet2", 10, 6, parse("=Tracked+1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(1.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet2", 10, 6),
+        Some(LiteralValue::Number(6.0))
+    );
+
+    engine.delete_columns("Sheet1", 1, 1).unwrap();
+    engine.evaluate_all().unwrap();
+
+    let consumer = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet2, Coord::from_excel(10, 6, true, true)))
+        .expect("the name-consuming formula must exist");
+    let formulas = engine.graph.formula_vertices();
+    engine.graph.clear_dirty_flags(&formulas);
+    engine
+        .set_cell_value("Sheet2", 2, 6, LiteralValue::Number(50.0))
+        .unwrap();
     assert!(
-        after_column_delete > 0 && after_row_delete > 0,
-        "default-sheet row and column deletes must both preserve the cross-sheet name edge"
+        engine.graph.is_dirty(consumer),
+        "editing the name target must still dirty its consumer"
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet2", 10, 6),
+        Some(LiteralValue::Number(51.0)),
+        "the consumer must serve a fresh value, not a silently stale one"
     );
 }
 
@@ -790,129 +829,397 @@ fn undoing_value_write_to_referenced_empty_placeholder_preserves_formula_edge() 
     );
 }
 
-// T2 finding AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID: see the matching T2 worker-report entry.
-// A workbook name's vertex physically occupies `Sheet1!$A$1` and is deliberately kept out of the
-// cell index while it sits there. A default-sheet insert at or above it shifts the vertex onto an
-// addressable grid cell and publishes it in the cell index, so every reference resolved afterwards
-// binds to the name vertex instead of the cell: a phantom symbol edge plus a missing direct cell
-// edge. No overwrite is involved, and the referring formula need not be one the insert shifted.
+// Regression pin for GitHub issue #304 (finding AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID).
+//
+// A workbook name's vertex used to physically occupy `Sheet1!$A$1`, kept off the grid only by
+// its deliberate absence from the cell index. A default-sheet insert at or above it shifted the
+// vertex onto an addressable cell *and* published it in that index, so every dependency resolved
+// afterwards against the address bound to the name instead of the cell. Symbol vertices now hold
+// a `SymbolAddr`, so no insert can give them a position and no cell lookup can reach them.
+//
+// The scenario below is the issue's full characterisation, with its matched control: a second
+// engine that differs only in the insert row (5 instead of 1, below the vertex's former home),
+// which was clean at every step on unmodified `main`. Every observation must now agree.
 #[test]
-#[ignore = "known T2 divergence: a default-sheet insert shifts a name vertex onto an addressable cell"]
 fn default_sheet_insertion_keeps_the_name_vertex_off_the_addressable_grid() {
+    // `insert_before_row` is the only difference between the subject and the control.
+    fn scenario(insert_before_row: u32) -> (bool, VertexKind, Option<LiteralValue>) {
+        let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+        engine.add_sheet("Sheet2").unwrap();
+        let sheet1 = engine.sheet_id("Sheet1").unwrap();
+        let sheet2 = engine.sheet_id("Sheet2").unwrap();
+        // The name's target lives on Sheet2, so the default-sheet insert cannot move the target
+        // and every value below is attributable to the vertex placement alone.
+        engine
+            .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(7.0))
+            .unwrap();
+        engine
+            .define_name(
+                "Tracked",
+                NamedDefinition::Cell(CellRef::new(sheet2, Coord::from_excel(4, 4, true, true))),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        engine
+            .set_cell_formula("Sheet2", 1, 1, parse("=Tracked+1").unwrap())
+            .unwrap();
+        assert_structural_parity(&engine, 0xc0de_0007, 0);
+
+        let name_vertex = engine
+            .graph
+            .resolve_name_entry("Tracked", sheet2)
+            .expect("workbook name must resolve")
+            .vertex;
+        let a1 = CellRef::new(sheet1, Coord::from_excel(1, 1, true, true));
+        let a2 = CellRef::new(sheet1, Coord::from_excel(2, 1, true, true));
+
+        // A symbol has no position, before or after any structural edit.
+        assert_eq!(engine.graph.get_cell_ref(name_vertex), None);
+        assert_eq!(engine.graph.get_vertex_for_cell(&a1), None);
+
+        engine.insert_rows("Sheet1", insert_before_row, 1).unwrap();
+        assert_eq!(engine.graph.get_cell_ref(name_vertex), None);
+        assert_eq!(engine.graph.get_vertex_for_cell(&a1), None);
+        assert_eq!(engine.graph.get_vertex_for_cell(&a2), None);
+
+        // A brand-new formula on a cell the insertion never touched, referencing the address the
+        // name vertex would formerly have been shifted onto.
+        engine
+            .set_cell_formula("Sheet1", 7, 7, parse("=A2+1").unwrap())
+            .unwrap();
+        let referring = engine
+            .graph
+            .get_vertex_for_cell(&CellRef::new(sheet1, Coord::from_excel(7, 7, true, true)))
+            .expect("the referring formula must exist");
+        let actual = graph_shape(&engine.graph, referring);
+        assert!(
+            actual.symbols.is_empty(),
+            "`=A2+1` must not acquire a phantom edge to the name vertex"
+        );
+        assert_eq!(
+            actual.cells,
+            BTreeSet::from([a2]),
+            "`=A2+1` must take a direct cell edge to Sheet1!A2"
+        );
+        assert_structural_parity(&engine, 0xc0de_0007, 1);
+
+        // Consequence 1 (was: spurious recompute). Editing the name's target must not dirty a
+        // formula that never mentions the name.
+        engine.evaluate_all().unwrap();
+        assert_eq!(
+            engine.get_cell_value("Sheet1", 7, 7),
+            Some(LiteralValue::Number(1.0))
+        );
+        let formulas = engine.graph.formula_vertices();
+        engine.graph.clear_dirty_flags(&formulas);
+        engine
+            .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(70.0))
+            .unwrap();
+        let spuriously_dirty = engine.graph.is_dirty(referring);
+        engine.evaluate_all().unwrap();
+
+        // Consequence 2 (was: silent name destruction). An ordinary data write at the address the
+        // vertex would have been shifted onto must not rewrite the name's own vertex.
+        engine
+            .set_cell_value("Sheet1", 2, 1, LiteralValue::Number(500.0))
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        let kind_after_write = engine.graph.get_vertex_kind(name_vertex);
+
+        // Consequence 3 (was: stale served value). Deleting that row must leave `=Tracked+1`
+        // tracking its own target.
+        engine.delete_rows("Sheet1", 2, 1).unwrap();
+        engine.evaluate_all().unwrap();
+        let tracked_formula = engine
+            .graph
+            .get_vertex_for_cell(&CellRef::new(sheet2, Coord::from_excel(1, 1, true, true)))
+            .expect("the name-consuming formula must exist");
+        assert!(
+            !engine.graph.get_dependencies(tracked_formula).is_empty(),
+            "`=Tracked+1` must retain its edge to the name vertex"
+        );
+        let formulas = engine.graph.formula_vertices();
+        engine.graph.clear_dirty_flags(&formulas);
+        engine
+            .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(700.0))
+            .unwrap();
+        assert!(
+            engine.graph.is_dirty(tracked_formula),
+            "the name target must still dirty `=Tracked+1`"
+        );
+        engine.evaluate_all().unwrap();
+        (
+            spuriously_dirty,
+            kind_after_write,
+            engine.get_cell_value("Sheet2", 1, 1),
+        )
+    }
+
+    // Subject: the insert that used to shift the name vertex onto `Sheet1!$A$2`.
+    let subject = scenario(1);
+    // Matched control: identical but for the insert row, and clean at every step on `main`.
+    let control = scenario(5);
+
+    assert_eq!(
+        subject, control,
+        "the insert row must make no observable difference to a name that has no position"
+    );
+    let (spuriously_dirty, kind_after_write, tracked_value) = subject;
+    assert!(
+        !spuriously_dirty,
+        "editing the name target must not dirty the unrelated default-sheet formula Sheet1!G7"
+    );
+    assert_eq!(
+        kind_after_write,
+        VertexKind::NamedScalar,
+        "a write to Sheet1!A2 must not overwrite the name's own vertex"
+    );
+    assert_eq!(
+        tracked_value,
+        Some(LiteralValue::Number(701.0)),
+        "`=Tracked+1` must recompute from Sheet2!D4 rather than serve a stale 71"
+    );
+}
+
+// The remaining #304 shapes: sheet-scoped names, tables, expanded ranges that merely *cover* the
+// address the symbol would have occupied, and repeated inserts. Each one used to bind a formula
+// to a symbol vertex through a grid address.
+#[test]
+fn default_sheet_inserts_never_bind_a_reference_to_a_symbol_vertex() {
     let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
     engine.add_sheet("Sheet2").unwrap();
     let sheet1 = engine.sheet_id("Sheet1").unwrap();
     let sheet2 = engine.sheet_id("Sheet2").unwrap();
-    // The name's target lives on Sheet2, so the default-sheet insert cannot move the target and
-    // every value below is attributable to the vertex placement alone.
+    let target = CellRef::new(sheet2, Coord::from_excel(4, 4, true, true));
     engine
         .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(7.0))
         .unwrap();
     engine
         .define_name(
             "Tracked",
-            NamedDefinition::Cell(CellRef::new(sheet2, Coord::from_excel(4, 4, true, true))),
+            NamedDefinition::Cell(target),
             NameScope::Workbook,
         )
         .unwrap();
     engine
-        .set_cell_formula("Sheet2", 1, 1, parse("=Tracked+1").unwrap())
+        .define_name(
+            "Local",
+            NamedDefinition::Cell(target),
+            NameScope::Sheet(sheet1),
+        )
         .unwrap();
-    assert_structural_parity(&engine, 0xc0de_0007, 0);
+    engine
+        .define_table(
+            "Sales",
+            RangeRef::new(
+                CellRef::new(sheet2, Coord::from_excel(1, 3, true, true)),
+                CellRef::new(sheet2, Coord::from_excel(3, 4, true, true)),
+            ),
+            true,
+            vec!["Item".into(), "Amount".into()],
+            false,
+        )
+        .unwrap();
+    engine.define_source_scalar("Feed", Some(1)).unwrap();
 
-    let name_vertex = engine
+    // Repeated inserts: on `main` each one moved the symbol vertices one row further down the
+    // default sheet's grid and republished them at their new addresses.
+    for _ in 0..3 {
+        engine.insert_rows("Sheet1", 1, 1).unwrap();
+        engine.insert_columns("Sheet1", 1, 1).unwrap();
+    }
+
+    // A formula whose expanded range merely *covers* the addresses the symbols would now occupy.
+    engine
+        .set_cell_formula("Sheet1", 20, 1, parse("=SUM(A1:E5)").unwrap())
+        .unwrap();
+    let covering = engine
         .graph
-        .resolve_name_entry("Tracked", sheet2)
-        .expect("workbook name must resolve")
-        .vertex;
-    let a1 = CellRef::new(sheet1, Coord::from_excel(1, 1, true, true));
-    let a2 = CellRef::new(sheet1, Coord::from_excel(2, 1, true, true));
-    assert_eq!(engine.graph.get_cell_ref(name_vertex), Some(a1));
-    assert_eq!(engine.graph.get_vertex_for_cell(&a1), None);
+        .get_vertex_for_cell(&CellRef::new(sheet1, Coord::from_excel(20, 1, true, true)))
+        .expect("the covering formula must exist");
+    assert!(
+        graph_shape(&engine.graph, covering).symbols.is_empty(),
+        "an expanded range must not pick up a symbol vertex"
+    );
+
+    // Every address a symbol would have been shifted onto resolves to a cell-like vertex — the
+    // empty placeholders the range above created — never to a symbol.
+    for (row, col) in [(1u32, 1u32), (2, 2), (3, 3), (4, 4), (5, 5)] {
+        let cell = CellRef::new(sheet1, Coord::from_excel(row, col, true, true));
+        let resolved = engine
+            .graph
+            .get_vertex_for_cell(&cell)
+            .expect("the covering range materialised a placeholder here");
+        assert!(
+            !engine.graph.vertex_addr(resolved).is_symbol(),
+            "Sheet1 row {row} col {col} must not resolve to a symbol vertex"
+        );
+        assert_eq!(
+            engine.graph.get_vertex_kind(resolved),
+            VertexKind::Empty,
+            "Sheet1 row {row} col {col} must resolve to an empty placeholder"
+        );
+    }
+    engine
+        .set_cell_formula("Sheet1", 21, 1, parse("=A1+B2+C3+D4+E5").unwrap())
+        .unwrap();
+    let direct = engine
+        .graph
+        .get_vertex_for_cell(&CellRef::new(sheet1, Coord::from_excel(21, 1, true, true)))
+        .expect("the direct formula must exist");
+    assert!(
+        graph_shape(&engine.graph, direct).symbols.is_empty(),
+        "direct cell references must not bind to a symbol vertex"
+    );
+    assert_structural_parity(&engine, 0xc0de_0304, 0);
+}
+
+/// The structural property the two issues share: a symbol vertex is never in `cell_to_vertex`,
+/// for any symbol kind, under any grid operation.
+#[test]
+fn symbol_vertices_are_absent_from_the_cell_index_under_every_grid_operation() {
+    fn symbol_vertices(engine: &Engine<TestWorkbook>) -> Vec<(&'static str, VertexId)> {
+        let sheet1 = engine.sheet_id("Sheet1").unwrap();
+        vec![
+            (
+                "NamedScalar",
+                engine
+                    .graph
+                    .resolve_name_entry("Tracked", sheet1)
+                    .expect("workbook name")
+                    .vertex,
+            ),
+            (
+                "NamedArray",
+                engine
+                    .graph
+                    .resolve_name_entry("Block", sheet1)
+                    .expect("workbook range name")
+                    .vertex,
+            ),
+            (
+                "SheetScopedName",
+                engine
+                    .graph
+                    .resolve_name_entry("Local", sheet1)
+                    .expect("sheet-scoped name")
+                    .vertex,
+            ),
+            (
+                "Table",
+                engine
+                    .graph
+                    .resolve_table_entry("Sales")
+                    .expect("table")
+                    .vertex,
+            ),
+            (
+                "External",
+                engine
+                    .graph
+                    .resolve_source_scalar_entry("Feed")
+                    .expect("external source")
+                    .vertex,
+            ),
+        ]
+    }
+
+    fn assert_off_the_grid(engine: &Engine<TestWorkbook>, stage: &str) {
+        let indexed: BTreeSet<VertexId> = engine.graph.cell_to_vertex().values().copied().collect();
+        for (label, vertex) in symbol_vertices(engine) {
+            assert!(
+                !indexed.contains(&vertex),
+                "{label} vertex {vertex:?} appeared in cell_to_vertex after {stage}"
+            );
+            assert_eq!(
+                engine.graph.get_cell_ref(vertex),
+                None,
+                "{label} vertex must have no address after {stage}"
+            );
+            assert!(
+                engine.graph.vertex_grid_addr(vertex).is_none(),
+                "{label} vertex must have no grid position after {stage}"
+            );
+            assert!(
+                engine.graph.vertex_addr(vertex).is_symbol(),
+                "{label} vertex must hold a symbol address after {stage}"
+            );
+        }
+    }
+
+    let mut engine = Engine::new(TestWorkbook::new(), EvalConfig::default());
+    engine.add_sheet("Sheet2").unwrap();
+    let sheet1 = engine.sheet_id("Sheet1").unwrap();
+    let sheet2 = engine.sheet_id("Sheet2").unwrap();
+    let target = CellRef::new(sheet2, Coord::from_excel(4, 4, true, true));
+    engine
+        .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(7.0))
+        .unwrap();
+    engine
+        .define_name(
+            "Tracked",
+            NamedDefinition::Cell(target),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .define_name(
+            "Block",
+            NamedDefinition::Range(RangeRef::new(
+                CellRef::new(sheet2, Coord::from_excel(1, 1, true, true)),
+                CellRef::new(sheet2, Coord::from_excel(2, 2, true, true)),
+            )),
+            NameScope::Workbook,
+        )
+        .unwrap();
+    engine
+        .define_name(
+            "Local",
+            NamedDefinition::Cell(target),
+            NameScope::Sheet(sheet1),
+        )
+        .unwrap();
+    engine
+        .define_table(
+            "Sales",
+            RangeRef::new(
+                CellRef::new(sheet2, Coord::from_excel(1, 3, true, true)),
+                CellRef::new(sheet2, Coord::from_excel(3, 4, true, true)),
+            ),
+            true,
+            vec!["Item".into(), "Amount".into()],
+            false,
+        )
+        .unwrap();
+    engine.define_source_scalar("Feed", Some(1)).unwrap();
+    assert_off_the_grid(&engine, "definition");
 
     engine.insert_rows("Sheet1", 1, 1).unwrap();
-    assert_eq!(engine.graph.get_cell_ref(name_vertex), Some(a2));
-    assert_eq!(engine.graph.get_vertex_for_cell(&a2), Some(name_vertex));
+    assert_off_the_grid(&engine, "a default-sheet row insert");
 
-    // A brand-new formula on a cell the insertion never touched, referencing the shifted address.
-    engine
-        .set_cell_formula("Sheet1", 7, 7, parse("=A2+1").unwrap())
-        .unwrap();
-    let referring = engine
-        .graph
-        .get_vertex_for_cell(&CellRef::new(sheet1, Coord::from_excel(7, 7, true, true)))
-        .expect("the referring formula must exist");
-    let actual = graph_shape(&engine.graph, referring);
-    let expected_cells = {
-        let expected = ast_shape(&engine.graph, referring);
-        assert!(expected.shape.symbols.is_empty());
-        expected.shape.cells.clone()
-    };
-    assert_eq!(actual.symbols, BTreeSet::from([name_vertex]));
-    assert!(actual.cells.is_empty());
-    assert_eq!(expected_cells, BTreeSet::from([a2]));
-    let structural_failure = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        assert_structural_parity(&engine, 0xc0de_0007, 1);
-    }));
-    assert!(
-        structural_failure.is_err(),
-        "the structural checker must detect the phantom name edge and the missing A2 edge"
-    );
+    engine.insert_columns("Sheet1", 1, 1).unwrap();
+    assert_off_the_grid(&engine, "a default-sheet column insert");
 
-    // Consequence 1: the referring formula is now a dependent of the name, so editing the name's
-    // target spuriously dirties a formula that never mentions the name.
-    engine.evaluate_all().unwrap();
-    assert_eq!(
-        engine.get_cell_value("Sheet1", 7, 7),
-        Some(LiteralValue::Number(1.0))
-    );
-    let formulas = engine.graph.formula_vertices();
-    engine.graph.clear_dirty_flags(&formulas);
     engine
-        .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(70.0))
+        .set_cell_value("Sheet2", 1, 1, LiteralValue::Number(1.0))
         .unwrap();
-    let spuriously_dirty = engine.graph.is_dirty(referring);
-    assert!(spuriously_dirty);
-    engine.evaluate_all().unwrap();
+    engine.delete_columns("Sheet2", 1, 1).unwrap();
+    assert_off_the_grid(&engine, "a structural edit on an unrelated sheet");
 
-    // Consequence 2: an ordinary data write at the shifted address overwrites the name's own
-    // vertex, so the name entry now resolves to a plain default-sheet cell.
-    engine
-        .set_cell_value("Sheet1", 2, 1, LiteralValue::Number(500.0))
-        .unwrap();
-    engine.evaluate_all().unwrap();
-    assert_eq!(engine.graph.get_vertex_kind(name_vertex), VertexKind::Cell);
-
-    // Consequence 3: deleting the row the hijacked vertex now occupies strands the name, and
-    // `=Tracked+1` stops tracking its own target.
-    engine.delete_rows("Sheet1", 2, 1).unwrap();
-    engine.evaluate_all().unwrap();
-    let tracked_formula = engine
-        .graph
-        .get_vertex_for_cell(&CellRef::new(sheet2, Coord::from_excel(1, 1, true, true)))
-        .expect("the name-consuming formula must exist");
-    assert!(engine.graph.get_dependencies(tracked_formula).is_empty());
-    let formulas = engine.graph.formula_vertices();
-    engine.graph.clear_dirty_flags(&formulas);
-    engine
-        .set_cell_value("Sheet2", 4, 4, LiteralValue::Number(700.0))
-        .unwrap();
-    assert!(!engine.graph.is_dirty(tracked_formula));
-    engine.evaluate_all().unwrap();
-    let evaluated = engine.get_cell_value("Sheet2", 1, 1);
-    eprintln!(
-        "AST_EDGE_INSERT_SHIFTS_NAME_VERTEX_ONTO_GRID: name vertex Sheet1!$A$1 -> Sheet1!$A$2; \
-Sheet1!G7 deps={:?} AST cells={:?}; name-target edit dirties Sheet1!G7={spuriously_dirty}; \
-name vertex kind after Sheet1!A2=500 is Cell; Sheet2!A1={evaluated:?}; correct Sheet2!A1=701",
-        actual.symbols, expected_cells,
-    );
-    assert_eq!(
-        evaluated,
-        Some(LiteralValue::Number(701.0)),
-        "a default-sheet insert must not park the name vertex on an addressable cell: \
-Sheet1!G7 must take a direct Sheet1!A2 edge, the name target must not dirty it, and \
-`=Tracked+1` must still recompute from Sheet2!D4"
-    );
+    // A write to every address a symbol would formerly have occupied.
+    for row in 1..=4u32 {
+        for col in 1..=4u32 {
+            engine
+                .set_cell_value(
+                    "Sheet1",
+                    row,
+                    col,
+                    LiteralValue::Number(f64::from(row * col)),
+                )
+                .unwrap();
+        }
+    }
+    assert_off_the_grid(&engine, "writes to the addresses symbols formerly occupied");
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/change_log.rs
+++ b/crates/formualizer-eval/src/engine/tests/change_log.rs
@@ -1,5 +1,7 @@
 //! Tests for the standalone ChangeLog implementation
 
+use crate::engine::addr::GridAddr;
+
 use crate::engine::graph::editor::change_log::{
     ChangeEvent, ChangeLog, ChangeLogger, NullChangeLogger,
 };
@@ -204,8 +206,8 @@ fn test_granular_change_events() {
     let move_event = ChangeEvent::VertexMoved {
         id: VertexId(1),
         sheet_id: 0,
-        old_coord: AbsCoord::new(5, 1),
-        new_coord: AbsCoord::new(7, 1),
+        old_coord: GridAddr::new(5, 1),
+        new_coord: GridAddr::new(7, 1),
     };
     log.record(move_event);
 

--- a/crates/formualizer-eval/src/engine/tests/change_log.rs
+++ b/crates/formualizer-eval/src/engine/tests/change_log.rs
@@ -197,7 +197,6 @@ fn test_change_log_with_formula_events() {
 #[test]
 fn test_granular_change_events() {
     use crate::engine::vertex::VertexId;
-    use formualizer_common::Coord as AbsCoord;
     use formualizer_parse::parser::parse;
 
     let mut log = ChangeLog::new();

--- a/crates/formualizer-eval/src/engine/tests/graph_internal_helpers.rs
+++ b/crates/formualizer-eval/src/engine/tests/graph_internal_helpers.rs
@@ -1,6 +1,5 @@
 use crate::engine::addr::GridAddr;
 use crate::engine::*;
-use formualizer_common::Coord as AbsCoord;
 use formualizer_common::LiteralValue;
 use formualizer_parse::parser::{ASTNode, ASTNodeType};
 

--- a/crates/formualizer-eval/src/engine/tests/graph_internal_helpers.rs
+++ b/crates/formualizer-eval/src/engine/tests/graph_internal_helpers.rs
@@ -1,3 +1,4 @@
+use crate::engine::addr::GridAddr;
 use crate::engine::*;
 use formualizer_common::Coord as AbsCoord;
 use formualizer_common::LiteralValue;
@@ -30,7 +31,7 @@ fn test_snapshot_vertex() {
     let snapshot = graph.snapshot_vertex(vertex_id);
 
     // Verify snapshot contents
-    assert_eq!(snapshot.coord, AbsCoord::new(0, 0));
+    assert_eq!(snapshot.coord, GridAddr::new(0, 0));
     assert_eq!(snapshot.kind, VertexKind::Cell);
     assert_eq!(snapshot.sheet_id, graph.sheet_id("Sheet1").unwrap());
 
@@ -58,7 +59,7 @@ fn test_snapshot_vertex_with_formula() {
     let snapshot = graph.snapshot_vertex(formula_vertex);
 
     // Verify formula was captured
-    assert_eq!(snapshot.coord, AbsCoord::new(1, 0));
+    assert_eq!(snapshot.coord, GridAddr::new(1, 0));
     assert_eq!(snapshot.kind, VertexKind::FormulaScalar);
 
     // Check dependencies are captured
@@ -251,7 +252,7 @@ fn test_snapshot_preserves_all_state() {
     let snapshot = graph.snapshot_vertex(vertex_id);
 
     // Verify all state is captured
-    assert_eq!(snapshot.coord, AbsCoord::new(2, 0));
+    assert_eq!(snapshot.coord, GridAddr::new(2, 0));
     assert_eq!(snapshot.kind, VertexKind::FormulaScalar);
     assert_eq!(snapshot.out_edges.len(), 2, "Should have 2 dependencies");
 

--- a/crates/formualizer-eval/src/engine/tests/target_preparation.rs
+++ b/crates/formualizer-eval/src/engine/tests/target_preparation.rs
@@ -2017,7 +2017,7 @@ fn replay_admission_deduplicates_vertex_and_cell_event_keys() {
     let events = vec![
         ChangeEvent::AddVertex {
             id: crate::engine::VertexId::new(10_000),
-            coord: formualizer_common::Coord::new(0, 0),
+            coord: crate::engine::addr::GridAddr::new(0, 0),
             sheet_id,
             value: None,
             formula: Some(ast.clone()),

--- a/crates/formualizer-eval/src/engine/tests/vertex_lifecycle.rs
+++ b/crates/formualizer-eval/src/engine/tests/vertex_lifecycle.rs
@@ -1,3 +1,4 @@
+use crate::engine::addr::GridAddr;
 use crate::engine::graph::DependencyGraph;
 use crate::engine::graph::editor::{
     EditorError, VertexDataPatch, VertexEditor, VertexMeta, VertexMetaPatch,
@@ -89,13 +90,13 @@ fn test_vertex_move_updates_mappings() {
     let id = editor.set_cell_value(cell_ref(0, 0, 0), lit_num(42.0));
 
     // Move to new location (5, 10)
-    assert!(editor.move_vertex(id, AbsCoord::new(5, 10)).is_ok());
+    assert!(editor.move_vertex(id, GridAddr::new(5, 10)).is_ok());
 
     // Drop editor to release borrow
     drop(editor);
 
     // Verify coordinate was updated
-    assert_eq!(graph.get_coord(id), AbsCoord::new(5, 10));
+    assert_eq!(graph.get_grid_addr(id), Some(GridAddr::new(5, 10)));
 
     // Address mapping should point to the moved vertex.
     let moved_addr = CellRef {
@@ -155,7 +156,7 @@ fn test_move_vertex_with_dependencies() {
     let b1 = editor.set_cell_formula(cell_ref(0, 0, 1), formula);
 
     // Move A1 to new location
-    assert!(editor.move_vertex(a1, AbsCoord::new(5, 5)).is_ok());
+    assert!(editor.move_vertex(a1, GridAddr::new(5, 5)).is_ok());
 
     // Drop editor to release borrow
     drop(editor);
@@ -174,7 +175,7 @@ fn test_patch_vertex_coord() {
 
     // Patch coordinate
     let patch = VertexMetaPatch {
-        coord: Some(AbsCoord::new(10, 20)),
+        coord: Some(GridAddr::new(10, 20)),
         kind: None,
         dirty: None,
         volatile: None,
@@ -189,7 +190,7 @@ fn test_patch_vertex_coord() {
     drop(editor);
 
     // Verify coordinate changed
-    assert_eq!(graph.get_coord(id), AbsCoord::new(10, 20));
+    assert_eq!(graph.get_grid_addr(id), Some(GridAddr::new(10, 20)));
 }
 
 #[test]
@@ -271,7 +272,7 @@ fn test_move_nonexistent_vertex() {
     let mut editor = VertexEditor::new(&mut graph);
 
     let fake_id = VertexId::new(99999);
-    let result = editor.move_vertex(fake_id, AbsCoord::new(1, 1));
+    let result = editor.move_vertex(fake_id, GridAddr::new(1, 1));
 
     assert!(result.is_err());
     match result {
@@ -340,7 +341,7 @@ fn test_batch_operations_with_lifecycle() {
     let v3 = editor.set_cell_value(cell_ref(0, 2, 0), lit_num(3.0));
 
     // Move one
-    editor.move_vertex(v1, AbsCoord::new(10, 10)).unwrap();
+    editor.move_vertex(v1, GridAddr::new(10, 10)).unwrap();
 
     // Remove one
     editor.remove_vertex(v2).unwrap();
@@ -358,7 +359,7 @@ fn test_batch_operations_with_lifecycle() {
     drop(editor);
 
     // Verify results
-    assert_eq!(graph.get_coord(v1), AbsCoord::new(10, 10));
+    assert_eq!(graph.get_grid_addr(v1), Some(GridAddr::new(10, 10)));
     assert!(graph.is_deleted(v2));
     assert!(!graph.is_deleted(v3));
 }

--- a/crates/formualizer-eval/src/engine/tests/vertex_lifecycle.rs
+++ b/crates/formualizer-eval/src/engine/tests/vertex_lifecycle.rs
@@ -5,7 +5,6 @@ use crate::engine::graph::editor::{
 };
 use crate::engine::vertex::{VertexId, VertexKind};
 use crate::reference::{CellRef, Coord};
-use formualizer_common::Coord as AbsCoord;
 use formualizer_common::{ExcelErrorKind, LiteralValue};
 use formualizer_parse::parse;
 

--- a/crates/formualizer-eval/src/engine/vertex_store.rs
+++ b/crates/formualizer-eval/src/engine/vertex_store.rs
@@ -1,17 +1,22 @@
+use super::addr::{GridAddr, VertexAddr};
 use super::vertex::{VertexId, VertexKind};
 use crate::SheetId;
-use formualizer_common::Coord as AbsCoord;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::addr::SymbolAddr;
+
+    fn grid(row: u32, col: u32) -> VertexAddr {
+        VertexAddr::grid(GridAddr::new(row, col))
+    }
 
     #[test]
     fn test_vertex_store_allocation() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(10, 20), 1, 0x01);
-        assert_eq!(store.coord(id), AbsCoord::new(10, 20));
+        let id = store.allocate(grid(10, 20), 1, 0x01);
+        assert_eq!(store.addr(id), grid(10, 20));
         assert_eq!(store.sheet_id(id), 1);
         assert_eq!(store.flags(id), 0x01);
     }
@@ -26,10 +31,7 @@ mod tests {
             store.flags.len(),
         );
         assert_eq!(
-            store.try_allocate_batch(
-                &[(AbsCoord::new(0, 0), 0, 0)],
-                &[VertexId(FIRST_NORMAL_VERTEX)],
-            ),
+            store.try_allocate_batch(&[(grid(0, 0), 0, 0)], &[VertexId(FIRST_NORMAL_VERTEX)],),
             Err(VertexBatchAllocationError::IdExhausted)
         );
         assert_eq!(
@@ -47,10 +49,7 @@ mod tests {
         let mut store = VertexStore::new();
         let before = (store.len(), store.coords.len(), store.flags.len());
         assert_eq!(
-            store.try_allocate_batch(
-                &[(AbsCoord::new(0, 0), 0, 0)],
-                &[VertexId(FIRST_NORMAL_VERTEX + 1)],
-            ),
+            store.try_allocate_batch(&[(grid(0, 0), 0, 0)], &[VertexId(FIRST_NORMAL_VERTEX + 1)],),
             Err(VertexBatchAllocationError::ReservedIdsMismatch)
         );
         assert_eq!(before, (store.len(), store.coords.len(), store.flags.len()));
@@ -60,7 +59,7 @@ mod tests {
     fn test_vertex_store_grow() {
         let mut store = VertexStore::with_capacity(1000);
         for i in 0..10_000 {
-            store.allocate(AbsCoord::new(i, i), 0, 0);
+            store.allocate(grid(i, i), 0, 0);
         }
         assert_eq!(store.len(), 10_000);
         // Note: While VertexStore itself is 64-byte aligned,
@@ -81,11 +80,14 @@ mod tests {
     #[test]
     fn test_vertex_store_accessors() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(5, 10), 3, 0x03);
+        let id = store.allocate(grid(5, 10), 3, 0x03);
 
         // Test coord access
-        assert_eq!(store.coord(id).row(), 5);
-        assert_eq!(store.coord(id).col(), 10);
+        let position = store
+            .grid_addr(id)
+            .expect("cell vertices carry a grid position");
+        assert_eq!(position.row(), 5);
+        assert_eq!(position.col(), 10);
 
         // Test sheet_id access
         assert_eq!(store.sheet_id(id), 3);
@@ -101,17 +103,40 @@ mod tests {
     }
 
     #[test]
+    fn symbol_vertices_have_no_grid_position() {
+        let mut store = VertexStore::new();
+        let cell = store.allocate(grid(3, 4), 0, 0);
+        let symbol = store.allocate(VertexAddr::symbol(SymbolAddr::new(0)), 0, 0);
+
+        assert_eq!(store.grid_addr(cell), Some(GridAddr::new(3, 4)));
+        assert_eq!(store.grid_addr(symbol), None);
+        assert!(store.addr(symbol).is_symbol());
+        assert_eq!(store.addr(symbol).as_symbol(), Some(SymbolAddr::new(0)));
+    }
+
+    /// The edge coordinate arrays and the vertex store hold one address per vertex,
+    /// parallel to adjacency. Tagging the symbol space must not widen that slot.
+    #[test]
+    fn stored_address_element_size_is_unchanged() {
+        assert_eq!(std::mem::size_of::<VertexAddr>(), 8);
+        assert_eq!(
+            std::mem::size_of::<VertexAddr>(),
+            std::mem::size_of::<formualizer_common::Coord>(),
+        );
+    }
+
+    #[test]
     fn test_reserved_vertex_range() {
         let mut store = VertexStore::new();
         // First allocation should be >= FIRST_NORMAL_VERTEX
-        let id = store.allocate(AbsCoord::new(0, 0), 0, 0);
+        let id = store.allocate(grid(0, 0), 0, 0);
         assert!(id.0 >= FIRST_NORMAL_VERTEX);
     }
 
     #[test]
     fn test_atomic_flag_operations() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(0, 0), 0, 0);
+        let id = store.allocate(grid(0, 0), 0, 0);
 
         // Test atomic flag updates
         store.set_dirty(id, true);
@@ -125,19 +150,19 @@ mod tests {
     }
 
     #[test]
-    fn test_vertex_store_set_coord() {
+    fn test_vertex_store_set_addr() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(1, 1), 0, 0);
+        let id = store.allocate(grid(1, 1), 0, 0);
 
         // Update coordinate
-        store.set_coord(id, AbsCoord::new(5, 10));
-        assert_eq!(store.coord(id), AbsCoord::new(5, 10));
+        store.set_addr(id, grid(5, 10));
+        assert_eq!(store.addr(id), grid(5, 10));
     }
 
     #[test]
     fn test_vertex_store_atomic_flags() {
         let mut store = VertexStore::new();
-        let id = store.allocate(AbsCoord::new(0, 0), 0, 0);
+        let id = store.allocate(grid(0, 0), 0, 0);
 
         // Test atomic flag operations
         store.set_dirty(id, true);
@@ -156,7 +181,7 @@ mod tests {
         let mut store = VertexStore::new();
 
         // Verify first allocation is >= FIRST_NORMAL_VERTEX
-        let id = store.allocate(AbsCoord::new(0, 0), 0, 0);
+        let id = store.allocate(grid(0, 0), 0, 0);
         assert!(id.0 >= FIRST_NORMAL_VERTEX);
 
         // Verify deletion uses tombstone, not physical removal
@@ -187,11 +212,11 @@ pub(crate) enum VertexBatchAllocationError {
 #[derive(Debug)]
 pub struct VertexStore {
     // Dense columnar arrays - 21B per vertex logical
-    coords: Vec<AbsCoord>, // 8B (packed row/col)
-    sheet_kind: Vec<u32>,  // 4B (16-bit sheet, 8-bit kind, 8-bit reserved)
-    flags: Vec<AtomicU8>,  // 1B (dirty|volatile|deleted|...)
-    value_ref: Vec<u32>,   // 4B (2-bit tag, 4-bit error, 26-bit index)
-    edge_offset: Vec<u32>, // 4B (CSR offset)
+    coords: Vec<VertexAddr>, // 8B (packed grid position or symbol identity)
+    sheet_kind: Vec<u32>,    // 4B (16-bit sheet, 8-bit kind, 8-bit reserved)
+    flags: Vec<AtomicU8>,    // 1B (dirty|volatile|deleted|...)
+    value_ref: Vec<u32>,     // 4B (2-bit tag, 4-bit error, 26-bit index)
+    edge_offset: Vec<u32>,   // 4B (CSR offset)
 
     // Length tracking
     len: usize,
@@ -252,11 +277,11 @@ impl VertexStore {
 
     /// Allocate a new vertex, returning its ID
     /// IDs start at FIRST_NORMAL_VERTEX to reserve 0-1023 for special vertices
-    pub fn allocate(&mut self, coord: AbsCoord, sheet: SheetId, flags: u8) -> VertexId {
+    pub fn allocate(&mut self, addr: VertexAddr, sheet: SheetId, flags: u8) -> VertexId {
         let id = VertexId(self.len as u32 + FIRST_NORMAL_VERTEX);
         debug_assert!(id.0 >= FIRST_NORMAL_VERTEX);
 
-        self.coords.push(coord);
+        self.coords.push(addr);
         self.sheet_kind.push((sheet as u32) << 16);
         self.flags.push(AtomicU8::new(flags));
         self.value_ref.push(0);
@@ -268,7 +293,7 @@ impl VertexStore {
 
     pub(crate) fn try_allocate_batch(
         &mut self,
-        vertices: &[(AbsCoord, SheetId, u8)],
+        vertices: &[(VertexAddr, SheetId, u8)],
         expected_ids: &[VertexId],
     ) -> Result<Vec<VertexId>, VertexBatchAllocationError> {
         if vertices.len() != expected_ids.len() {
@@ -290,8 +315,8 @@ impl VertexStore {
             return Err(VertexBatchAllocationError::ReservedIdsMismatch);
         }
         self.reserve(vertices.len());
-        for &(coord, sheet, flags) in vertices {
-            self.coords.push(coord);
+        for &(addr, sheet, flags) in vertices {
+            self.coords.push(addr);
             self.sheet_kind.push((u32::from(sheet)) << 16);
             self.flags.push(AtomicU8::new(flags));
             self.value_ref.push(0);
@@ -303,10 +328,10 @@ impl VertexStore {
 
     /// Allocate a batch whose identifiers were checked against the current
     /// store length by an exclusively-held prepared transaction.
-    pub(crate) fn allocate_prevalidated_batch(&mut self, vertices: &[(AbsCoord, SheetId, u8)]) {
+    pub(crate) fn allocate_prevalidated_batch(&mut self, vertices: &[(VertexAddr, SheetId, u8)]) {
         self.reserve(vertices.len());
-        for &(coord, sheet, flags) in vertices {
-            self.allocate(coord, sheet, flags);
+        for &(addr, sheet, flags) in vertices {
+            self.allocate(addr, sheet, flags);
         }
     }
 
@@ -315,16 +340,16 @@ impl VertexStore {
     pub fn allocate_contiguous(
         &mut self,
         sheet: SheetId,
-        coords: &[AbsCoord],
+        addrs: &[VertexAddr],
         flags: u8,
     ) -> Vec<VertexId> {
-        if coords.is_empty() {
+        if addrs.is_empty() {
             return Vec::new();
         }
-        self.reserve(coords.len());
-        let mut ids = Vec::with_capacity(coords.len());
-        for &coord in coords {
-            ids.push(self.allocate(coord, sheet, flags));
+        self.reserve(addrs.len());
+        let mut ids = Vec::with_capacity(addrs.len());
+        for &addr in addrs {
+            ids.push(self.allocate(addr, sheet, flags));
         }
         ids
     }
@@ -353,13 +378,23 @@ impl VertexStore {
     }
 
     // Accessors
+    /// The vertex's address: a grid position for cells and formulas, a symbol identity
+    /// for names, tables and external sources.
     #[inline]
-    pub fn coord(&self, id: VertexId) -> AbsCoord {
+    pub fn addr(&self, id: VertexId) -> VertexAddr {
         if let Some(idx) = self.vertex_id_to_index(id) {
             self.coords[idx]
         } else {
-            AbsCoord::new(0, 0) // Default for invalid vertices
+            VertexAddr::INVALID // Invalid vertices have no address at all
         }
+    }
+
+    /// The vertex's grid position, or `None` when it is a symbol.
+    ///
+    /// Grid-keyed structures go through this, so a symbol cannot reach them.
+    #[inline]
+    pub fn grid_addr(&self, id: VertexId) -> Option<GridAddr> {
+        self.addr(id).as_grid()
     }
 
     #[inline]
@@ -494,13 +529,13 @@ impl VertexStore {
         }
     }
 
-    /// Update the coordinate of a vertex
+    /// Update the address of a vertex
     /// # Safety
-    /// Caller must ensure CSR edge cache is updated via CsrMutableEdges::update_coord
+    /// Caller must ensure CSR edge cache is updated via CsrMutableEdges::update_addr
     #[doc(hidden)]
-    pub fn set_coord(&mut self, id: VertexId, coord: AbsCoord) {
+    pub fn set_addr(&mut self, id: VertexId, addr: VertexAddr) {
         if let Some(idx) = self.vertex_id_to_index(id) {
-            self.coords[idx] = coord;
+            self.coords[idx] = addr;
         }
     }
 

--- a/crates/formualizer-eval/src/engine/virtual_deps.rs
+++ b/crates/formualizer-eval/src/engine/virtual_deps.rs
@@ -58,7 +58,9 @@ impl<'a, R: EvaluationContext> DynamicRefCollector<'a, R> {
 
         let mut out = self.collected.lock().unwrap();
         for u in index.vertices_in_col_range(sc0, ec0) {
-            let row0 = self.engine.graph.vertex_coord(u).row();
+            let Some(row0) = self.engine.graph.vertex_grid_addr(u).map(|addr| addr.row()) else {
+                continue;
+            };
             if row0 < sr0 || row0 > er0 {
                 continue;
             }
@@ -325,7 +327,9 @@ impl RangeVirtualDepProvider {
                     let sc0 = sc.saturating_sub(1);
                     let ec0 = ec.saturating_sub(1);
                     for u in index.vertices_in_col_range(sc0, ec0) {
-                        let pc = engine.graph.vertex_coord(u);
+                        let Some(pc) = engine.graph.vertex_grid_addr(u) else {
+                            continue;
+                        };
                         let row0 = pc.row();
                         if row0 < sr0 || row0 > er0 {
                             continue;

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -292,6 +292,88 @@ pub mod formualizer_eval::engine
 pub use formualizer_eval::engine::DateSystem
 pub use formualizer_eval::engine::ResourceExhaustionDetail
 pub use formualizer_eval::engine::ResourceExhaustionReason
+pub mod formualizer_eval::engine::addr
+#[repr(transparent)] pub struct formualizer_eval::engine::addr::GridAddr(_)
+impl formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::col(self) -> u32
+pub const fn formualizer_eval::engine::addr::GridAddr::coord(self) -> formualizer_common::coord::Coord
+pub const fn formualizer_eval::engine::addr::GridAddr::from_coord(formualizer_common::coord::Coord) -> Self
+pub fn formualizer_eval::engine::addr::GridAddr::new(u32, u32) -> Self
+pub fn formualizer_eval::engine::addr::GridAddr::row(self) -> u32
+impl core::clone::Clone for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::clone(&self) -> formualizer_eval::engine::addr::GridAddr
+impl core::cmp::Eq for formualizer_eval::engine::addr::GridAddr
+impl core::cmp::Ord for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::cmp(&self, &Self) -> core::cmp::Ordering
+impl core::cmp::PartialEq for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::eq(&self, &formualizer_eval::engine::addr::GridAddr) -> bool
+impl core::cmp::PartialOrd for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::partial_cmp(&self, &Self) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<formualizer_common::coord::Coord> for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::from(formualizer_common::coord::Coord) -> Self
+impl core::convert::From<formualizer_eval::engine::addr::GridAddr> for formualizer_common::coord::Coord
+pub fn formualizer_common::coord::Coord::from(formualizer_eval::engine::addr::GridAddr) -> Self
+impl core::convert::From<formualizer_eval::engine::addr::GridAddr> for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::from(formualizer_eval::engine::addr::GridAddr) -> Self
+impl core::default::Default for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::default() -> Self
+impl core::fmt::Debug for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for formualizer_eval::engine::addr::GridAddr
+pub fn formualizer_eval::engine::addr::GridAddr::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for formualizer_eval::engine::addr::GridAddr
+impl core::marker::StructuralPartialEq for formualizer_eval::engine::addr::GridAddr
+#[repr(transparent)] pub struct formualizer_eval::engine::addr::SymbolAddr(_)
+impl formualizer_eval::engine::addr::SymbolAddr
+pub const fn formualizer_eval::engine::addr::SymbolAddr::index(self) -> u32
+pub const fn formualizer_eval::engine::addr::SymbolAddr::new(u32) -> Self
+impl core::clone::Clone for formualizer_eval::engine::addr::SymbolAddr
+pub fn formualizer_eval::engine::addr::SymbolAddr::clone(&self) -> formualizer_eval::engine::addr::SymbolAddr
+impl core::cmp::Eq for formualizer_eval::engine::addr::SymbolAddr
+impl core::cmp::Ord for formualizer_eval::engine::addr::SymbolAddr
+pub fn formualizer_eval::engine::addr::SymbolAddr::cmp(&self, &formualizer_eval::engine::addr::SymbolAddr) -> core::cmp::Ordering
+impl core::cmp::PartialEq for formualizer_eval::engine::addr::SymbolAddr
+pub fn formualizer_eval::engine::addr::SymbolAddr::eq(&self, &formualizer_eval::engine::addr::SymbolAddr) -> bool
+impl core::cmp::PartialOrd for formualizer_eval::engine::addr::SymbolAddr
+pub fn formualizer_eval::engine::addr::SymbolAddr::partial_cmp(&self, &formualizer_eval::engine::addr::SymbolAddr) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::From<formualizer_eval::engine::addr::SymbolAddr> for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::from(formualizer_eval::engine::addr::SymbolAddr) -> Self
+impl core::fmt::Debug for formualizer_eval::engine::addr::SymbolAddr
+pub fn formualizer_eval::engine::addr::SymbolAddr::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for formualizer_eval::engine::addr::SymbolAddr
+pub fn formualizer_eval::engine::addr::SymbolAddr::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for formualizer_eval::engine::addr::SymbolAddr
+impl core::marker::StructuralPartialEq for formualizer_eval::engine::addr::SymbolAddr
+#[repr(transparent)] pub struct formualizer_eval::engine::addr::VertexAddr(_)
+impl formualizer_eval::engine::addr::VertexAddr
+pub const formualizer_eval::engine::addr::VertexAddr::INVALID: Self
+pub fn formualizer_eval::engine::addr::VertexAddr::as_grid(self) -> core::option::Option<formualizer_eval::engine::addr::GridAddr>
+pub fn formualizer_eval::engine::addr::VertexAddr::as_symbol(self) -> core::option::Option<formualizer_eval::engine::addr::SymbolAddr>
+pub const fn formualizer_eval::engine::addr::VertexAddr::as_u64(self) -> u64
+pub fn formualizer_eval::engine::addr::VertexAddr::grid(formualizer_eval::engine::addr::GridAddr) -> Self
+pub fn formualizer_eval::engine::addr::VertexAddr::is_grid(self) -> bool
+pub fn formualizer_eval::engine::addr::VertexAddr::is_symbol(self) -> bool
+pub fn formualizer_eval::engine::addr::VertexAddr::order_key(self) -> (u32, u32)
+pub const fn formualizer_eval::engine::addr::VertexAddr::symbol(formualizer_eval::engine::addr::SymbolAddr) -> Self
+impl core::clone::Clone for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::clone(&self) -> formualizer_eval::engine::addr::VertexAddr
+impl core::cmp::Eq for formualizer_eval::engine::addr::VertexAddr
+impl core::cmp::PartialEq for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::eq(&self, &formualizer_eval::engine::addr::VertexAddr) -> bool
+impl core::convert::From<formualizer_common::coord::Coord> for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::from(formualizer_common::coord::Coord) -> Self
+impl core::convert::From<formualizer_eval::engine::addr::GridAddr> for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::from(formualizer_eval::engine::addr::GridAddr) -> Self
+impl core::convert::From<formualizer_eval::engine::addr::SymbolAddr> for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::from(formualizer_eval::engine::addr::SymbolAddr) -> Self
+impl core::default::Default for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::default() -> Self
+impl core::fmt::Debug for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for formualizer_eval::engine::addr::VertexAddr
+pub fn formualizer_eval::engine::addr::VertexAddr::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for formualizer_eval::engine::addr::VertexAddr
+impl core::marker::StructuralPartialEq for formualizer_eval::engine::addr::VertexAddr
 pub mod formualizer_eval::engine::arena
 pub mod formualizer_eval::engine::arena::array
 pub struct formualizer_eval::engine::arena::array::ArrayArena
@@ -1148,7 +1230,7 @@ pub mod formualizer_eval::engine::csr_edges
 pub struct formualizer_eval::engine::csr_edges::CsrBuilder
 impl formualizer_eval::engine::csr_edges::CsrBuilder
 pub fn formualizer_eval::engine::csr_edges::CsrBuilder::add_edge(&mut self, usize, usize)
-pub fn formualizer_eval::engine::csr_edges::CsrBuilder::add_vertex(&mut self, formualizer_common::coord::Coord) -> usize
+pub fn formualizer_eval::engine::csr_edges::CsrBuilder::add_vertex(&mut self, formualizer_eval::engine::addr::VertexAddr) -> usize
 pub fn formualizer_eval::engine::csr_edges::CsrBuilder::build(self) -> formualizer_eval::engine::csr_edges::CsrEdges
 pub fn formualizer_eval::engine::csr_edges::CsrBuilder::new() -> Self
 impl core::default::Default for formualizer_eval::engine::csr_edges::CsrBuilder
@@ -1157,7 +1239,7 @@ pub struct formualizer_eval::engine::csr_edges::CsrEdges
 impl formualizer_eval::engine::csr_edges::CsrEdges
 pub fn formualizer_eval::engine::csr_edges::CsrEdges::builder() -> formualizer_eval::engine::csr_edges::CsrBuilder
 pub fn formualizer_eval::engine::csr_edges::CsrEdges::empty() -> Self
-pub fn formualizer_eval::engine::csr_edges::CsrEdges::from_adjacency(alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, &[formualizer_common::coord::Coord]) -> Self
+pub fn formualizer_eval::engine::csr_edges::CsrEdges::from_adjacency(alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, &[formualizer_eval::engine::addr::VertexAddr]) -> Self
 pub fn formualizer_eval::engine::csr_edges::CsrEdges::has_edge(&self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::vertex::VertexId) -> bool
 pub fn formualizer_eval::engine::csr_edges::CsrEdges::in_degree(&self, formualizer_eval::engine::vertex::VertexId) -> usize
 pub fn formualizer_eval::engine::csr_edges::CsrEdges::in_edges(&self, formualizer_eval::engine::vertex::VertexId) -> &[formualizer_eval::engine::vertex::VertexId]
@@ -1215,11 +1297,11 @@ pub mod formualizer_eval::engine::delta_edges
 pub struct formualizer_eval::engine::delta_edges::CsrMutableEdges
 impl formualizer_eval::engine::delta_edges::CsrMutableEdges
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::add_edge(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::vertex::VertexId)
-pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::add_vertex(&mut self, formualizer_common::coord::Coord, u32) -> usize
-pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::add_vertices_batch(&mut self, &[(formualizer_common::coord::Coord, u32)])
+pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::add_vertex(&mut self, formualizer_eval::engine::addr::VertexAddr, u32) -> usize
+pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::add_vertices_batch(&mut self, &[(formualizer_eval::engine::addr::VertexAddr, u32)])
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::adjacency_with_carried_forward_edges(&self, alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>) -> alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::begin_batch(&mut self)
-pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::build_from_adjacency(&mut self, alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, alloc::vec::Vec<formualizer_common::coord::Coord>, alloc::vec::Vec<u32>)
+pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::build_from_adjacency(&mut self, alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, alloc::vec::Vec<formualizer_eval::engine::addr::VertexAddr>, alloc::vec::Vec<u32>)
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::delta_size(&self) -> usize
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::end_batch(&mut self)
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::in_edges(&self, formualizer_eval::engine::vertex::VertexId) -> &[formualizer_eval::engine::vertex::VertexId]
@@ -1232,8 +1314,8 @@ pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::out_edges_ref(&se
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::rebuild(&mut self)
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::rebuild_count(&self) -> u64
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::remove_edge(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::vertex::VertexId)
-pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::update_coord(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_common::coord::Coord)
-pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::with_coords(alloc::vec::Vec<formualizer_common::coord::Coord>) -> Self
+pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::update_addr(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::addr::VertexAddr)
+pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::with_coords(alloc::vec::Vec<formualizer_eval::engine::addr::VertexAddr>) -> Self
 impl core::default::Default for formualizer_eval::engine::delta_edges::CsrMutableEdges
 pub fn formualizer_eval::engine::delta_edges::CsrMutableEdges::default() -> Self
 impl core::fmt::Debug for formualizer_eval::engine::delta_edges::CsrMutableEdges
@@ -1242,7 +1324,7 @@ pub struct formualizer_eval::engine::delta_edges::DeltaEdgeSlab
 impl formualizer_eval::engine::delta_edges::DeltaEdgeSlab
 pub fn formualizer_eval::engine::delta_edges::DeltaEdgeSlab::add_edge(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::vertex::VertexId)
 pub fn formualizer_eval::engine::delta_edges::DeltaEdgeSlab::additions_iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&formualizer_eval::engine::vertex::VertexId, &rustc_hash::FxHashSet<formualizer_eval::engine::vertex::VertexId>)>
-pub fn formualizer_eval::engine::delta_edges::DeltaEdgeSlab::apply_to_csr(&self, &formualizer_eval::engine::csr_edges::CsrEdges, &[formualizer_common::coord::Coord], &[u32]) -> formualizer_eval::engine::csr_edges::CsrEdges
+pub fn formualizer_eval::engine::delta_edges::DeltaEdgeSlab::apply_to_csr(&self, &formualizer_eval::engine::csr_edges::CsrEdges, &[formualizer_eval::engine::addr::VertexAddr], &[u32]) -> formualizer_eval::engine::csr_edges::CsrEdges
 pub fn formualizer_eval::engine::delta_edges::DeltaEdgeSlab::clear(&mut self)
 pub fn formualizer_eval::engine::delta_edges::DeltaEdgeSlab::mark_dirty(&mut self)
 pub fn formualizer_eval::engine::delta_edges::DeltaEdgeSlab::merged_in_view(&self, &formualizer_eval::engine::csr_edges::CsrEdges, formualizer_eval::engine::vertex::VertexId) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
@@ -1795,7 +1877,7 @@ pub mod formualizer_eval::engine::graph::editor
 pub mod formualizer_eval::engine::graph::editor::change_log
 pub enum formualizer_eval::engine::graph::editor::change_log::ChangeEvent
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::AddVertex
-pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::AddVertex::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::AddVertex::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::AddVertex::flags: core::option::Option<u8>
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::AddVertex::formula: core::option::Option<formualizer_parse::parser::ASTNode>
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::AddVertex::id: formualizer_eval::engine::vertex::VertexId
@@ -1832,7 +1914,7 @@ pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::NamedRange
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::NamedRangeAdjusted::old_definition: formualizer_eval::engine::named_range::NamedDefinition
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::NamedRangeAdjusted::scope: formualizer_eval::engine::named_range::NameScope
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::RemoveVertex
-pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::RemoveVertex::coord: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::RemoveVertex::coord: core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::RemoveVertex::flags: core::option::Option<u8>
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::RemoveVertex::id: formualizer_eval::engine::vertex::VertexId
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::RemoveVertex::kind: core::option::Option<formualizer_eval::engine::vertex::VertexKind>
@@ -1877,8 +1959,8 @@ pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::UpdateName
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::UpdateName::scope: formualizer_eval::engine::named_range::NameScope
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::VertexMoved
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::VertexMoved::id: formualizer_eval::engine::vertex::VertexId
-pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::VertexMoved::new_coord: formualizer_common::coord::Coord
-pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::VertexMoved::old_coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::VertexMoved::new_coord: formualizer_eval::engine::addr::GridAddr
+pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::VertexMoved::old_coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::graph::editor::change_log::ChangeEvent::VertexMoved::sheet_id: formualizer_eval::reference::SheetId
 impl core::clone::Clone for formualizer_eval::engine::graph::editor::change_log::ChangeEvent
 pub fn formualizer_eval::engine::graph::editor::change_log::ChangeEvent::clone(&self) -> formualizer_eval::engine::graph::editor::change_log::ChangeEvent
@@ -2131,7 +2213,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>:
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::insert_columns(&mut self, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::ShiftSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::insert_rows(&mut self, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::ShiftSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_range(&mut self, formualizer_eval::reference::SheetId, u32, u32, u32, u32, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::RangeSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
-pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_vertex(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_common::coord::Coord) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
+pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_vertex(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::addr::GridAddr) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::new(&'g mut formualizer_eval::engine::graph::DependencyGraph) -> Self
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::patch_vertex_data(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::graph::editor::vertex_editor::VertexDataPatch) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::DataUpdateSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::patch_vertex_meta(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::MetaUpdateSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
@@ -2152,7 +2234,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>:
 impl<'g> core::ops::drop::Drop for formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::drop(&mut self)
 pub struct formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta
-pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::flags: u8
 pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::kind: formualizer_eval::engine::vertex::VertexKind
 pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::sheet_id: formualizer_eval::reference::SheetId
@@ -2166,7 +2248,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::clone
 impl core::fmt::Debug for formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch
-pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::coord: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::coord: core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::dirty: core::option::Option<bool>
 pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::kind: core::option::Option<formualizer_eval::engine::vertex::VertexKind>
 pub formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::volatile: core::option::Option<bool>
@@ -2282,7 +2364,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>:
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::insert_columns(&mut self, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::ShiftSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::insert_rows(&mut self, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::ShiftSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_range(&mut self, formualizer_eval::reference::SheetId, u32, u32, u32, u32, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::RangeSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
-pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_vertex(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_common::coord::Coord) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
+pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_vertex(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::addr::GridAddr) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::new(&'g mut formualizer_eval::engine::graph::DependencyGraph) -> Self
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::patch_vertex_data(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::graph::editor::vertex_editor::VertexDataPatch) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::DataUpdateSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::patch_vertex_meta(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::MetaUpdateSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
@@ -2303,7 +2385,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>:
 impl<'g> core::ops::drop::Drop for formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::drop(&mut self)
 pub struct formualizer_eval::engine::graph::editor::VertexMeta
-pub formualizer_eval::engine::graph::editor::VertexMeta::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::graph::editor::VertexMeta::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::graph::editor::VertexMeta::flags: u8
 pub formualizer_eval::engine::graph::editor::VertexMeta::kind: formualizer_eval::engine::vertex::VertexKind
 pub formualizer_eval::engine::graph::editor::VertexMeta::sheet_id: formualizer_eval::reference::SheetId
@@ -2317,7 +2399,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::clone
 impl core::fmt::Debug for formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct formualizer_eval::engine::graph::editor::VertexMetaPatch
-pub formualizer_eval::engine::graph::editor::VertexMetaPatch::coord: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::graph::editor::VertexMetaPatch::coord: core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub formualizer_eval::engine::graph::editor::VertexMetaPatch::dirty: core::option::Option<bool>
 pub formualizer_eval::engine::graph::editor::VertexMetaPatch::kind: core::option::Option<formualizer_eval::engine::vertex::VertexKind>
 pub formualizer_eval::engine::graph::editor::VertexMetaPatch::volatile: core::option::Option<bool>
@@ -2327,7 +2409,7 @@ impl core::fmt::Debug for formualizer_eval::engine::graph::editor::vertex_editor
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub mod formualizer_eval::engine::graph::snapshot
 pub struct formualizer_eval::engine::graph::snapshot::VertexSnapshot
-pub formualizer_eval::engine::graph::snapshot::VertexSnapshot::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::graph::snapshot::VertexSnapshot::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::graph::snapshot::VertexSnapshot::flags: u8
 pub formualizer_eval::engine::graph::snapshot::VertexSnapshot::formula_ref: core::option::Option<formualizer_eval::engine::arena::ast::AstNodeId>
 pub formualizer_eval::engine::graph::snapshot::VertexSnapshot::kind: formualizer_eval::engine::vertex::VertexKind
@@ -2340,7 +2422,7 @@ impl core::fmt::Debug for formualizer_eval::engine::graph::snapshot::VertexSnaps
 pub fn formualizer_eval::engine::graph::snapshot::VertexSnapshot::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub enum formualizer_eval::engine::graph::ChangeEvent
 pub formualizer_eval::engine::graph::ChangeEvent::AddVertex
-pub formualizer_eval::engine::graph::ChangeEvent::AddVertex::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::graph::ChangeEvent::AddVertex::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::graph::ChangeEvent::AddVertex::flags: core::option::Option<u8>
 pub formualizer_eval::engine::graph::ChangeEvent::AddVertex::formula: core::option::Option<formualizer_parse::parser::ASTNode>
 pub formualizer_eval::engine::graph::ChangeEvent::AddVertex::id: formualizer_eval::engine::vertex::VertexId
@@ -2377,7 +2459,7 @@ pub formualizer_eval::engine::graph::ChangeEvent::NamedRangeAdjusted::new_defini
 pub formualizer_eval::engine::graph::ChangeEvent::NamedRangeAdjusted::old_definition: formualizer_eval::engine::named_range::NamedDefinition
 pub formualizer_eval::engine::graph::ChangeEvent::NamedRangeAdjusted::scope: formualizer_eval::engine::named_range::NameScope
 pub formualizer_eval::engine::graph::ChangeEvent::RemoveVertex
-pub formualizer_eval::engine::graph::ChangeEvent::RemoveVertex::coord: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::graph::ChangeEvent::RemoveVertex::coord: core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub formualizer_eval::engine::graph::ChangeEvent::RemoveVertex::flags: core::option::Option<u8>
 pub formualizer_eval::engine::graph::ChangeEvent::RemoveVertex::id: formualizer_eval::engine::vertex::VertexId
 pub formualizer_eval::engine::graph::ChangeEvent::RemoveVertex::kind: core::option::Option<formualizer_eval::engine::vertex::VertexKind>
@@ -2422,8 +2504,8 @@ pub formualizer_eval::engine::graph::ChangeEvent::UpdateName::old_definition: fo
 pub formualizer_eval::engine::graph::ChangeEvent::UpdateName::scope: formualizer_eval::engine::named_range::NameScope
 pub formualizer_eval::engine::graph::ChangeEvent::VertexMoved
 pub formualizer_eval::engine::graph::ChangeEvent::VertexMoved::id: formualizer_eval::engine::vertex::VertexId
-pub formualizer_eval::engine::graph::ChangeEvent::VertexMoved::new_coord: formualizer_common::coord::Coord
-pub formualizer_eval::engine::graph::ChangeEvent::VertexMoved::old_coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::graph::ChangeEvent::VertexMoved::new_coord: formualizer_eval::engine::addr::GridAddr
+pub formualizer_eval::engine::graph::ChangeEvent::VertexMoved::old_coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::graph::ChangeEvent::VertexMoved::sheet_id: formualizer_eval::reference::SheetId
 impl core::clone::Clone for formualizer_eval::engine::graph::editor::change_log::ChangeEvent
 pub fn formualizer_eval::engine::graph::editor::change_log::ChangeEvent::clone(&self) -> formualizer_eval::engine::graph::editor::change_log::ChangeEvent
@@ -2512,7 +2594,7 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::assign_formula_vertex_l
 pub fn formualizer_eval::engine::graph::DependencyGraph::baseline_stats(&self) -> formualizer_eval::engine::graph::GraphBaselineStats
 pub fn formualizer_eval::engine::graph::DependencyGraph::begin_batch(&mut self)
 pub fn formualizer_eval::engine::graph::DependencyGraph::begin_deferred_dirty(&mut self)
-pub fn formualizer_eval::engine::graph::DependencyGraph::build_edges_from_adjacency(&mut self, alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, alloc::vec::Vec<formualizer_common::coord::Coord>, alloc::vec::Vec<u32>)
+pub fn formualizer_eval::engine::graph::DependencyGraph::build_edges_from_adjacency(&mut self, alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, alloc::vec::Vec<formualizer_eval::engine::addr::VertexAddr>, alloc::vec::Vec<u32>)
 pub fn formualizer_eval::engine::graph::DependencyGraph::bulk_insert_values<I>(&mut self, &str, I) -> core::result::Result<(), formualizer_common::error::ExcelError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, u32, formualizer_common::value::LiteralValue)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::bulk_set_formulas<I>(&mut self, &str, I) -> core::result::Result<usize, formualizer_common::error::ExcelError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, u32, formualizer_parse::parser::ASTNode)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::bulk_set_formulas_with_volatility(&mut self, &str, alloc::vec::Vec<(u32, u32, formualizer_parse::parser::ASTNode)>, alloc::vec::Vec<bool>) -> core::result::Result<usize, formualizer_common::error::ExcelError>
@@ -2526,26 +2608,27 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::default_sheet_name(&sel
 pub fn formualizer_eval::engine::graph::DependencyGraph::deferred_dirty_active(&self) -> bool
 pub fn formualizer_eval::engine::graph::DependencyGraph::end_batch(&mut self)
 pub fn formualizer_eval::engine::graph::DependencyGraph::end_deferred_dirty(&mut self) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
-pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> alloc::vec::Vec<(formualizer_common::coord::Coord, u32)>
-pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_ordered(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_common::coord::Coord, u32)>)
-pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_packed_ordered(&mut self, &[formualizer_common::address::PackedSheetCell]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_common::coord::Coord, u32)>)
+pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> alloc::vec::Vec<(formualizer_eval::engine::addr::VertexAddr, u32)>
+pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_ordered(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_eval::engine::addr::VertexAddr, u32)>)
+pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_packed_ordered(&mut self, &[formualizer_common::address::PackedSheetCell]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_eval::engine::addr::VertexAddr, u32)>)
 pub fn formualizer_eval::engine::graph::DependencyGraph::finalize_sheet_index(&mut self, &str)
 pub fn formualizer_eval::engine::graph::DependencyGraph::flush_pending_edge_deltas(&mut self)
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_cell_ref_for_vertex(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::reference::CellRef>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_cell_value(&self, &str, u32, u32) -> core::option::Option<formualizer_common::value::LiteralValue>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_cell_value_ref(&self, formualizer_common::address::SheetCellRef<'_>) -> core::option::Option<formualizer_common::value::LiteralValue>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_config(&self) -> &formualizer_eval::engine::EvalConfig
-pub fn formualizer_eval::engine::graph::DependencyGraph::get_coord(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_common::coord::Coord
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_evaluation_vertices(&self) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_parse::parser::ASTNode>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_id(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::engine::arena::ast::AstNodeId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_id_and_volatile(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<(formualizer_eval::engine::arena::ast::AstNodeId, bool)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_node(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<&formualizer_eval::engine::arena::ast::AstNodeData>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_node_and_volatile(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<(&formualizer_eval::engine::arena::ast::AstNodeData, bool)>
+pub fn formualizer_eval::engine::graph::DependencyGraph::get_grid_addr(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_sheet_id(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_eval::reference::SheetId
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_value(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_common::value::LiteralValue>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_vertex_for_cell(&self, &formualizer_eval::reference::CellRef) -> core::option::Option<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_vertex_id_for_address(&self, &formualizer_eval::reference::CellRef) -> core::option::Option<&formualizer_eval::engine::vertex::VertexId>
+pub fn formualizer_eval::engine::graph::DependencyGraph::grid_vertices_in_sheet(&self, formualizer_eval::reference::SheetId) -> impl core::iter::traits::iterator::Iterator<Item = (formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::addr::GridAddr)> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::is_ref_error(&self, formualizer_eval::engine::vertex::VertexId) -> bool
 pub fn formualizer_eval::engine::graph::DependencyGraph::iter_vertex_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = formualizer_eval::engine::vertex::VertexId> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::make_cell_ref(&self, &str, u32, u32) -> formualizer_eval::reference::CellRef
@@ -2585,10 +2668,10 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::update_cell_mapping(&mu
 pub fn formualizer_eval::engine::graph::DependencyGraph::update_vertex_formula(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_parse::parser::ASTNode) -> core::result::Result<(), formualizer_common::error::ExcelError>
 pub fn formualizer_eval::engine::graph::DependencyGraph::used_col_bounds_for_rows(&self, formualizer_eval::reference::SheetId, u32, u32) -> core::option::Option<(u32, u32)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::used_row_bounds_for_columns(&self, formualizer_eval::reference::SheetId, u32, u32) -> core::option::Option<(u32, u32)>
-pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_coord(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_common::coord::Coord
+pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_addr(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_eval::engine::addr::VertexAddr
 pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_count(&self) -> usize
+pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_grid_addr(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_has_formula(&self, formualizer_eval::engine::vertex::VertexId) -> bool
-pub fn formualizer_eval::engine::graph::DependencyGraph::vertices_in_sheet(&self, formualizer_eval::reference::SheetId) -> impl core::iter::traits::iterator::Iterator<Item = formualizer_eval::engine::vertex::VertexId> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::vertices_with_formulas(&self) -> impl core::iter::traits::iterator::Iterator<Item = formualizer_eval::engine::vertex::VertexId> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::vid_for_plan_idx(&self, &formualizer_eval::engine::plan::DependencyPlan, u32) -> core::option::Option<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::vid_for_sid_pc(&self, formualizer_eval::reference::SheetId, formualizer_common::coord::Coord) -> core::option::Option<formualizer_eval::engine::vertex::VertexId>
@@ -4387,15 +4470,15 @@ pub fn formualizer_eval::engine::scheduler::Scheduler<'a>::tarjan_scc(&self, &[f
 pub mod formualizer_eval::engine::sheet_index
 pub struct formualizer_eval::engine::sheet_index::SheetIndex
 impl formualizer_eval::engine::sheet_index::SheetIndex
-pub fn formualizer_eval::engine::sheet_index::SheetIndex::add_vertex(&mut self, formualizer_common::coord::Coord, formualizer_eval::engine::vertex::VertexId)
-pub fn formualizer_eval::engine::sheet_index::SheetIndex::add_vertices_batch(&mut self, &[(formualizer_common::coord::Coord, formualizer_eval::engine::vertex::VertexId)])
-pub fn formualizer_eval::engine::sheet_index::SheetIndex::build_from_sorted(&mut self, &[(formualizer_common::coord::Coord, formualizer_eval::engine::vertex::VertexId)])
+pub fn formualizer_eval::engine::sheet_index::SheetIndex::add_vertex(&mut self, formualizer_eval::engine::addr::GridAddr, formualizer_eval::engine::vertex::VertexId)
+pub fn formualizer_eval::engine::sheet_index::SheetIndex::add_vertices_batch(&mut self, &[(formualizer_eval::engine::addr::GridAddr, formualizer_eval::engine::vertex::VertexId)])
+pub fn formualizer_eval::engine::sheet_index::SheetIndex::build_from_sorted(&mut self, &[(formualizer_eval::engine::addr::GridAddr, formualizer_eval::engine::vertex::VertexId)])
 pub fn formualizer_eval::engine::sheet_index::SheetIndex::clear(&mut self)
 pub fn formualizer_eval::engine::sheet_index::SheetIndex::is_empty(&self) -> bool
 pub fn formualizer_eval::engine::sheet_index::SheetIndex::len(&self) -> usize
 pub fn formualizer_eval::engine::sheet_index::SheetIndex::new() -> Self
-pub fn formualizer_eval::engine::sheet_index::SheetIndex::remove_vertex(&mut self, formualizer_common::coord::Coord, formualizer_eval::engine::vertex::VertexId)
-pub fn formualizer_eval::engine::sheet_index::SheetIndex::update_vertex(&mut self, formualizer_common::coord::Coord, formualizer_common::coord::Coord, formualizer_eval::engine::vertex::VertexId)
+pub fn formualizer_eval::engine::sheet_index::SheetIndex::remove_vertex(&mut self, formualizer_eval::engine::addr::GridAddr, formualizer_eval::engine::vertex::VertexId)
+pub fn formualizer_eval::engine::sheet_index::SheetIndex::update_vertex(&mut self, formualizer_eval::engine::addr::GridAddr, formualizer_eval::engine::addr::GridAddr, formualizer_eval::engine::vertex::VertexId)
 pub fn formualizer_eval::engine::sheet_index::SheetIndex::vertices_in_col_range(&self, u32, u32) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::sheet_index::SheetIndex::vertices_in_rect(&self, u32, u32, u32, u32) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::sheet_index::SheetIndex::vertices_in_row_range(&self, u32, u32) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
@@ -4604,12 +4687,13 @@ pub fn formualizer_eval::engine::topo::GraphAdapter<'_>::successors(&self, formu
 pub mod formualizer_eval::engine::vertex_store
 #[repr(C, align(64))] pub struct formualizer_eval::engine::vertex_store::VertexStore
 impl formualizer_eval::engine::vertex_store::VertexStore
+pub fn formualizer_eval::engine::vertex_store::VertexStore::addr(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_eval::engine::addr::VertexAddr
 pub fn formualizer_eval::engine::vertex_store::VertexStore::all_vertices(&self) -> impl core::iter::traits::iterator::Iterator<Item = formualizer_eval::engine::vertex::VertexId> + '_
-pub fn formualizer_eval::engine::vertex_store::VertexStore::allocate(&mut self, formualizer_common::coord::Coord, formualizer_eval::reference::SheetId, u8) -> formualizer_eval::engine::vertex::VertexId
-pub fn formualizer_eval::engine::vertex_store::VertexStore::allocate_contiguous(&mut self, formualizer_eval::reference::SheetId, &[formualizer_common::coord::Coord], u8) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
-pub fn formualizer_eval::engine::vertex_store::VertexStore::coord(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_common::coord::Coord
+pub fn formualizer_eval::engine::vertex_store::VertexStore::allocate(&mut self, formualizer_eval::engine::addr::VertexAddr, formualizer_eval::reference::SheetId, u8) -> formualizer_eval::engine::vertex::VertexId
+pub fn formualizer_eval::engine::vertex_store::VertexStore::allocate_contiguous(&mut self, formualizer_eval::reference::SheetId, &[formualizer_eval::engine::addr::VertexAddr], u8) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::vertex_store::VertexStore::edge_offset(&self, formualizer_eval::engine::vertex::VertexId) -> u32
 pub fn formualizer_eval::engine::vertex_store::VertexStore::flags(&self, formualizer_eval::engine::vertex::VertexId) -> u8
+pub fn formualizer_eval::engine::vertex_store::VertexStore::grid_addr(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub fn formualizer_eval::engine::vertex_store::VertexStore::is_deleted(&self, formualizer_eval::engine::vertex::VertexId) -> bool
 pub fn formualizer_eval::engine::vertex_store::VertexStore::is_dirty(&self, formualizer_eval::engine::vertex::VertexId) -> bool
 pub fn formualizer_eval::engine::vertex_store::VertexStore::is_dynamic(&self, formualizer_eval::engine::vertex::VertexId) -> bool
@@ -4741,7 +4825,7 @@ pub fn formualizer_eval::engine::journal::ArrowOp::fmt(&self, &mut core::fmt::Fo
 impl core::marker::StructuralPartialEq for formualizer_eval::engine::journal::ArrowOp
 pub enum formualizer_eval::engine::ChangeEvent
 pub formualizer_eval::engine::ChangeEvent::AddVertex
-pub formualizer_eval::engine::ChangeEvent::AddVertex::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::ChangeEvent::AddVertex::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::ChangeEvent::AddVertex::flags: core::option::Option<u8>
 pub formualizer_eval::engine::ChangeEvent::AddVertex::formula: core::option::Option<formualizer_parse::parser::ASTNode>
 pub formualizer_eval::engine::ChangeEvent::AddVertex::id: formualizer_eval::engine::vertex::VertexId
@@ -4778,7 +4862,7 @@ pub formualizer_eval::engine::ChangeEvent::NamedRangeAdjusted::new_definition: f
 pub formualizer_eval::engine::ChangeEvent::NamedRangeAdjusted::old_definition: formualizer_eval::engine::named_range::NamedDefinition
 pub formualizer_eval::engine::ChangeEvent::NamedRangeAdjusted::scope: formualizer_eval::engine::named_range::NameScope
 pub formualizer_eval::engine::ChangeEvent::RemoveVertex
-pub formualizer_eval::engine::ChangeEvent::RemoveVertex::coord: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::ChangeEvent::RemoveVertex::coord: core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub formualizer_eval::engine::ChangeEvent::RemoveVertex::flags: core::option::Option<u8>
 pub formualizer_eval::engine::ChangeEvent::RemoveVertex::id: formualizer_eval::engine::vertex::VertexId
 pub formualizer_eval::engine::ChangeEvent::RemoveVertex::kind: core::option::Option<formualizer_eval::engine::vertex::VertexKind>
@@ -4823,8 +4907,8 @@ pub formualizer_eval::engine::ChangeEvent::UpdateName::old_definition: formualiz
 pub formualizer_eval::engine::ChangeEvent::UpdateName::scope: formualizer_eval::engine::named_range::NameScope
 pub formualizer_eval::engine::ChangeEvent::VertexMoved
 pub formualizer_eval::engine::ChangeEvent::VertexMoved::id: formualizer_eval::engine::vertex::VertexId
-pub formualizer_eval::engine::ChangeEvent::VertexMoved::new_coord: formualizer_common::coord::Coord
-pub formualizer_eval::engine::ChangeEvent::VertexMoved::old_coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::ChangeEvent::VertexMoved::new_coord: formualizer_eval::engine::addr::GridAddr
+pub formualizer_eval::engine::ChangeEvent::VertexMoved::old_coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::ChangeEvent::VertexMoved::sheet_id: formualizer_eval::reference::SheetId
 impl core::clone::Clone for formualizer_eval::engine::graph::editor::change_log::ChangeEvent
 pub fn formualizer_eval::engine::graph::editor::change_log::ChangeEvent::clone(&self) -> formualizer_eval::engine::graph::editor::change_log::ChangeEvent
@@ -5782,7 +5866,7 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::assign_formula_vertex_l
 pub fn formualizer_eval::engine::graph::DependencyGraph::baseline_stats(&self) -> formualizer_eval::engine::graph::GraphBaselineStats
 pub fn formualizer_eval::engine::graph::DependencyGraph::begin_batch(&mut self)
 pub fn formualizer_eval::engine::graph::DependencyGraph::begin_deferred_dirty(&mut self)
-pub fn formualizer_eval::engine::graph::DependencyGraph::build_edges_from_adjacency(&mut self, alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, alloc::vec::Vec<formualizer_common::coord::Coord>, alloc::vec::Vec<u32>)
+pub fn formualizer_eval::engine::graph::DependencyGraph::build_edges_from_adjacency(&mut self, alloc::vec::Vec<(u32, alloc::vec::Vec<u32>)>, alloc::vec::Vec<formualizer_eval::engine::addr::VertexAddr>, alloc::vec::Vec<u32>)
 pub fn formualizer_eval::engine::graph::DependencyGraph::bulk_insert_values<I>(&mut self, &str, I) -> core::result::Result<(), formualizer_common::error::ExcelError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, u32, formualizer_common::value::LiteralValue)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::bulk_set_formulas<I>(&mut self, &str, I) -> core::result::Result<usize, formualizer_common::error::ExcelError> where I: core::iter::traits::collect::IntoIterator<Item = (u32, u32, formualizer_parse::parser::ASTNode)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::bulk_set_formulas_with_volatility(&mut self, &str, alloc::vec::Vec<(u32, u32, formualizer_parse::parser::ASTNode)>, alloc::vec::Vec<bool>) -> core::result::Result<usize, formualizer_common::error::ExcelError>
@@ -5796,26 +5880,27 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::default_sheet_name(&sel
 pub fn formualizer_eval::engine::graph::DependencyGraph::deferred_dirty_active(&self) -> bool
 pub fn formualizer_eval::engine::graph::DependencyGraph::end_batch(&mut self)
 pub fn formualizer_eval::engine::graph::DependencyGraph::end_deferred_dirty(&mut self) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
-pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> alloc::vec::Vec<(formualizer_common::coord::Coord, u32)>
-pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_ordered(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_common::coord::Coord, u32)>)
-pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_packed_ordered(&mut self, &[formualizer_common::address::PackedSheetCell]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_common::coord::Coord, u32)>)
+pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> alloc::vec::Vec<(formualizer_eval::engine::addr::VertexAddr, u32)>
+pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_ordered(&mut self, &[(formualizer_eval::reference::SheetId, formualizer_common::coord::Coord)]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_eval::engine::addr::VertexAddr, u32)>)
+pub fn formualizer_eval::engine::graph::DependencyGraph::ensure_vertices_batch_packed_ordered(&mut self, &[formualizer_common::address::PackedSheetCell]) -> (alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>, alloc::vec::Vec<(formualizer_eval::engine::addr::VertexAddr, u32)>)
 pub fn formualizer_eval::engine::graph::DependencyGraph::finalize_sheet_index(&mut self, &str)
 pub fn formualizer_eval::engine::graph::DependencyGraph::flush_pending_edge_deltas(&mut self)
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_cell_ref_for_vertex(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::reference::CellRef>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_cell_value(&self, &str, u32, u32) -> core::option::Option<formualizer_common::value::LiteralValue>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_cell_value_ref(&self, formualizer_common::address::SheetCellRef<'_>) -> core::option::Option<formualizer_common::value::LiteralValue>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_config(&self) -> &formualizer_eval::engine::EvalConfig
-pub fn formualizer_eval::engine::graph::DependencyGraph::get_coord(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_common::coord::Coord
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_evaluation_vertices(&self) -> alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_parse::parser::ASTNode>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_id(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::engine::arena::ast::AstNodeId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_id_and_volatile(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<(formualizer_eval::engine::arena::ast::AstNodeId, bool)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_node(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<&formualizer_eval::engine::arena::ast::AstNodeData>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_formula_node_and_volatile(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<(&formualizer_eval::engine::arena::ast::AstNodeData, bool)>
+pub fn formualizer_eval::engine::graph::DependencyGraph::get_grid_addr(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_sheet_id(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_eval::reference::SheetId
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_value(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_common::value::LiteralValue>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_vertex_for_cell(&self, &formualizer_eval::reference::CellRef) -> core::option::Option<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::get_vertex_id_for_address(&self, &formualizer_eval::reference::CellRef) -> core::option::Option<&formualizer_eval::engine::vertex::VertexId>
+pub fn formualizer_eval::engine::graph::DependencyGraph::grid_vertices_in_sheet(&self, formualizer_eval::reference::SheetId) -> impl core::iter::traits::iterator::Iterator<Item = (formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::addr::GridAddr)> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::is_ref_error(&self, formualizer_eval::engine::vertex::VertexId) -> bool
 pub fn formualizer_eval::engine::graph::DependencyGraph::iter_vertex_ids(&self) -> impl core::iter::traits::iterator::Iterator<Item = formualizer_eval::engine::vertex::VertexId> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::make_cell_ref(&self, &str, u32, u32) -> formualizer_eval::reference::CellRef
@@ -5855,10 +5940,10 @@ pub fn formualizer_eval::engine::graph::DependencyGraph::update_cell_mapping(&mu
 pub fn formualizer_eval::engine::graph::DependencyGraph::update_vertex_formula(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_parse::parser::ASTNode) -> core::result::Result<(), formualizer_common::error::ExcelError>
 pub fn formualizer_eval::engine::graph::DependencyGraph::used_col_bounds_for_rows(&self, formualizer_eval::reference::SheetId, u32, u32) -> core::option::Option<(u32, u32)>
 pub fn formualizer_eval::engine::graph::DependencyGraph::used_row_bounds_for_columns(&self, formualizer_eval::reference::SheetId, u32, u32) -> core::option::Option<(u32, u32)>
-pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_coord(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_common::coord::Coord
+pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_addr(&self, formualizer_eval::engine::vertex::VertexId) -> formualizer_eval::engine::addr::VertexAddr
 pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_count(&self) -> usize
+pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_grid_addr(&self, formualizer_eval::engine::vertex::VertexId) -> core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub fn formualizer_eval::engine::graph::DependencyGraph::vertex_has_formula(&self, formualizer_eval::engine::vertex::VertexId) -> bool
-pub fn formualizer_eval::engine::graph::DependencyGraph::vertices_in_sheet(&self, formualizer_eval::reference::SheetId) -> impl core::iter::traits::iterator::Iterator<Item = formualizer_eval::engine::vertex::VertexId> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::vertices_with_formulas(&self) -> impl core::iter::traits::iterator::Iterator<Item = formualizer_eval::engine::vertex::VertexId> + '_
 pub fn formualizer_eval::engine::graph::DependencyGraph::vid_for_plan_idx(&self, &formualizer_eval::engine::plan::DependencyPlan, u32) -> core::option::Option<formualizer_eval::engine::vertex::VertexId>
 pub fn formualizer_eval::engine::graph::DependencyGraph::vid_for_sid_pc(&self, formualizer_eval::reference::SheetId, formualizer_common::coord::Coord) -> core::option::Option<formualizer_eval::engine::vertex::VertexId>
@@ -6948,7 +7033,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>:
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::insert_columns(&mut self, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::ShiftSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::insert_rows(&mut self, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::ShiftSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_range(&mut self, formualizer_eval::reference::SheetId, u32, u32, u32, u32, formualizer_eval::reference::SheetId, u32, u32) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::RangeSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
-pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_vertex(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_common::coord::Coord) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
+pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::move_vertex(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::addr::GridAddr) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::new(&'g mut formualizer_eval::engine::graph::DependencyGraph) -> Self
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::patch_vertex_data(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::graph::editor::vertex_editor::VertexDataPatch) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::DataUpdateSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'g>::patch_vertex_meta(&mut self, formualizer_eval::engine::vertex::VertexId, formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch) -> core::result::Result<formualizer_eval::engine::graph::editor::vertex_editor::MetaUpdateSummary, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
@@ -6989,7 +7074,7 @@ pub fn formualizer_eval::engine::topo::GraphAdapter<'_>::exists(&self, formualiz
 pub fn formualizer_eval::engine::topo::GraphAdapter<'_>::predecessors(&self, formualizer_eval::engine::vertex::VertexId, &mut alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>)
 pub fn formualizer_eval::engine::topo::GraphAdapter<'_>::successors(&self, formualizer_eval::engine::vertex::VertexId, &mut alloc::vec::Vec<formualizer_eval::engine::vertex::VertexId>)
 pub struct formualizer_eval::engine::VertexMeta
-pub formualizer_eval::engine::VertexMeta::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::VertexMeta::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::VertexMeta::flags: u8
 pub formualizer_eval::engine::VertexMeta::kind: formualizer_eval::engine::vertex::VertexKind
 pub formualizer_eval::engine::VertexMeta::sheet_id: formualizer_eval::reference::SheetId
@@ -7003,7 +7088,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::clone
 impl core::fmt::Debug for formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMeta::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct formualizer_eval::engine::VertexMetaPatch
-pub formualizer_eval::engine::VertexMetaPatch::coord: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::VertexMetaPatch::coord: core::option::Option<formualizer_eval::engine::addr::GridAddr>
 pub formualizer_eval::engine::VertexMetaPatch::dirty: core::option::Option<bool>
 pub formualizer_eval::engine::VertexMetaPatch::kind: core::option::Option<formualizer_eval::engine::vertex::VertexKind>
 pub formualizer_eval::engine::VertexMetaPatch::volatile: core::option::Option<bool>
@@ -7012,7 +7097,7 @@ pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::
 impl core::fmt::Debug for formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch
 pub fn formualizer_eval::engine::graph::editor::vertex_editor::VertexMetaPatch::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct formualizer_eval::engine::VertexSnapshot
-pub formualizer_eval::engine::VertexSnapshot::coord: formualizer_common::coord::Coord
+pub formualizer_eval::engine::VertexSnapshot::coord: formualizer_eval::engine::addr::GridAddr
 pub formualizer_eval::engine::VertexSnapshot::flags: u8
 pub formualizer_eval::engine::VertexSnapshot::formula_ref: core::option::Option<formualizer_eval::engine::arena::ast::AstNodeId>
 pub formualizer_eval::engine::VertexSnapshot::kind: formualizer_eval::engine::vertex::VertexKind


### PR DESCRIPTION
Symbol vertices get their own address space. Closes #302 and #304, which are one root cause with two symptoms.

## The problem

The graph had a single address space, `(SheetId, row, col)`. Cells belong in it — their address *is* their identity. Names, tables and external sources do not: they are identified by name and have no position, yet `next_name_coord()` fabricated grid coordinates for them on a real user-visible sheet. The first workbook name landed on `Sheet1!$A$1`, the second on `$B$1`; a table landed on its range's anchor cell, and was additionally registered in that sheet's range index.

The only thing separating such a vertex from the actual cell at that address was its deliberate absence from `cell_to_vertex`. That is a convention, not a structural property, and any code path can violate it. Two did.

Measured on `main@56f5ef29` with a probe compiled into both trees:

```
BASELINE #302 after delete_columns(Sheet1,1,1): name vertex kind=Empty deleted=true deps=0
BASELINE #304 after insert_rows(Sheet1,1,1):    addr=$A$2  index[A2]=Some(VertexId(1024))
```

**#302** — a column-1 or row-1 delete on the default sheet swept the name vertex up as an ordinary resident of that row or column and tombstoned it, taking its edges with it. The formula's dependency count went 1 → 0, and it then served silently stale values, even though both the formula and the name's target lived on another sheet entirely.

**#304** — a default-sheet insert shifted the vertex onto an addressable cell *and published it in the cell index there*. Every dependency resolved afterwards against that address bound to the name instead of the cell: a phantom symbol edge plus a missing direct cell edge, in one step.

Same probe on this branch:

```
BRANCH #302 after delete_columns(Sheet1,1,1): name vertex kind=NamedScalar deleted=false deps=1
BRANCH #304 after insert_rows(Sheet1,1,1):    addr=None  index[A2]=None
```

## The design

Two principles: **exclude at insertion, not at query**, and **enforce with types, not branches**.

Three `#[repr(transparent)]` newtypes in the new `engine::addr` module:

- `GridAddr` — a real `(row, col)`. What cells have.
- `SymbolAddr` — a dense symbol identity. No position.
- `VertexAddr` — the tagged union actually stored, in **8 bytes**.

`VertexAddr` uses the niche the coordinate encoding already reserves. Rows saturate 20 bits and columns 14, leaving the top 20 bits (`0xFFFFF000_00000000`) always zero for a real position; a symbol sets bit 63 only, with its index in the low 44. `u64::MAX` — the existing `Coord::INVALID` sentinel — has the whole reserved field set and so is neither grid nor symbol, preserving the `is_valid()`/`normalize()` discipline rather than overloading it.

No `Option<AbsCoord>` and no 16-byte address entered the vertex store or either edge coordinate array. They are `Vec` parallel to adjacency; widening them would have doubled hot memory and defeated the point. `vertex_store::tests::stored_address_element_size_is_unchanged` pins `size_of::<VertexAddr>() == size_of::<Coord>() == 8`.

The single route from a stored vertex address to a `(row, col)` is `VertexAddr::as_grid() -> Option<GridAddr>`. Every grid-keyed structure takes `GridAddr` — the per-sheet range index, the coordinate mutators, the change-log and snapshot coordinate fields, `VertexEditor::move_vertex` — and `cell_to_vertex` is reached only through `get_cell_ref(id) -> Option<CellRef>`, which now returns `None` for a symbol. Inserting a symbol into a grid structure is a compile error.

`vertices_in_sheet(sheet) -> Iterator<VertexId>` became `grid_vertices_in_sheet(sheet) -> Iterator<(VertexId, GridAddr)>`. That is the choke point: every row/column insert and delete, `clear_range` and `copy_range` drives off it, so none of them can reach a symbol, and each caller gets the position it was about to look up anyway.

`NameScope` is now purely lookup metadata. It no longer decides where a vertex lives; sheet-scoped names moved into the symbol space too, retaining their scope as data.

## Guards

One removed as unreachable: the region-query root classification in `eval.rs` routed `NamedScalar | NamedArray | Range | InfiniteRange | Table` from `vertices_in_region` — a pure sheet-index query — to `TargetProducer::Symbol`. A sheet index now holds only grid-addressed vertices. Worth noting this was live, not dead: table vertices *were* in the index, so a region overlapping a table's anchor produced the table symbol as a target root, which is the same defect class as #304.

Five converted from a `VertexKind` enumeration to the structural test. The four Arrow-canonical value-routing guards and `collect_range_dependents_for_vertex` all spelled out `Cell | FormulaScalar | FormulaArray | Empty` to ask "is this vertex grid-backed?". That is now a property of the address, so they read `store.grid_addr(id).is_some()` and cannot drift as kinds are added. Exactly equivalent today: `VertexKind::Range` and `InfiniteRange` are never assigned anywhere in the workspace.

Eight of the spec's candidate sites are kept, because they are evaluation *dispatch*, not symbol exclusion: the demand-subgraph BFS must traverse name vertices (they are pass-through nodes whose dependencies point at real formula cells); `mark_dirty_many` and `get_evaluation_vertices` must include names because names are formula-like and evaluatable; `name_depends_on_vertex` follows name→name chains; two are exhaustive `match` arms whose removal would cost the compile error when a kind is added. Each is justified in the report.

One added. `VertexEditor::move_vertex` and `patch_vertex_meta` are public and take an untyped `VertexId`, which types cannot constrain. Both now refuse a positionless vertex explicitly rather than parking it on the grid.

## Tests

Both pins were characterisations — they asserted the broken observation *and then* the intended one (`assert_eq!(after_column_delete, 0)` followed by `assert!(after_column_delete > 0)`), so neither could ever have been green. The broken-state assertions are removed, every intent assertion is kept, and both are un-ignored. Nothing was weakened; each gained assertions the original did not have.

`default_sheet_insertion_keeps_the_name_vertex_off_the_addressable_grid` now runs #304's full characterisation twice — subject at insert row 1, and the issue's matched control at row 5 — and asserts the two are observationally identical, plus each named consequence: no spurious recompute, no silent name destruction, no phantom symbol edge, and `701` rather than a stale `71`.

New alongside them: coverage of sheet-scoped names, tables, external sources, expanded ranges that merely *cover* the address, and repeated inserts; a structural test that no symbol kind is reachable through `cell_to_vertex` after definition, a row insert, a column insert, an unrelated-sheet edit, or a write to the address it would formerly have occupied; and a pin on the `move_vertex` refusal.

`insert_clear_of_name_vertex` is deleted. It existed only to steer the randomized campaigns' default-sheet inserts clear of the name vertex, because #304 made that shape fail. The campaigns now insert freely and pass.

The two remaining `#[ignore]`d ast-edge findings (#301's empty-placeholder undo/redo, and the undo-structural-adjustment divergence) are different root causes, untouched and still failing.

## Verification

- `cargo test --workspace` — 3561 passed, 0 failed, 22 ignored.
- The first commit, the entire type migration, ran the eval lib at 2676 passed / 19 ignored — the same 19 `main` carries. The whole address-space change landed without one behavioural test moving.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets` — clean.
- `scripts/public-api.sh check` — current for all eight crates. Contrary to the build spec's expectation, the pinned toolchain is available locally, so the snapshot was regenerated and verified here rather than deferred to CI.

**No-regression measurement**, same harness compiled against both trees, release, median of 20 reps, four runs each:

| | `main@56f5ef29` | this branch |
|---|---|---|
| dirty propagation over a 20k chain (ms) | 0.877 / 0.851 / 0.868 / 0.845 | 0.831 / 0.854 / 0.845 / 0.832 |
| row insert on a 400×50 populated sheet (ms) | 6.957 / 6.837 / 6.829 / 6.852 | 6.753 / 6.800 / 6.798 / 6.763 |

Dirty propagation overlaps; the row insert is consistently ~1% faster, which I am not claiming as an improvement. Nothing regressed.

**Persistence.** The build spec asks to verify, not assume, that nothing persisted carries a `VertexId` or a vertex address. I scanned every serde-derived item in `crates/` and `bindings/`, brace-matched each body, and checked every field's declared type against `VertexId | VertexAddr | GridAddr | SymbolAddr | Coord | RelativeCoord | CellRef | RangeRef`. Zero hits. `ChangeLog`, `VertexSnapshot`, `journal.rs` and `eval_delta.rs` derive no serde traits at all, so the change-log coordinate fields retyped here are in-memory undo state. No migration and no compatibility window.

## Public API

Only `public-api/formualizer-eval.txt` changed. Additions: the `engine::addr` module and the new address accessors on `DependencyGraph`. Removals: `get_coord`, `vertex_coord`, `vertices_in_sheet`, `set_coord`, `update_edge_coord`, `CsrMutableEdges::update_coord`. Type changes: `Coord` → `VertexAddr` in the edge constructors and batch-ensure methods, `Coord` → `GridAddr` in `move_vertex`, `VertexMeta`, `VertexMetaPatch` and `VertexSnapshot`.

These are breaking, and they are the minimum the change requires: each is a place where a caller could previously hand a vertex a position, which is exactly what had to stop being expressible. `formualizer-eval` is pre-1.0.

## Out of scope

T3/T4 of the default-sheet elimination programme (`Engine::new`/`Workbook::new` seeding is untouched — this removes the *reason* the default sheet was load-bearing for symbols, not implicit default-sheet creation); T2b's three unused `graph::*_ref` methods; unifying `formualizer_common::SheetLocator` with `crate::reference::SharedSheetLocator`.

One judgement call for review: `CellRef` was **not** retyped. The literal reading of "`cell_to_vertex` must key on a type reachable only from `GridAddr`" would change `CellRef::coord`, but `CellRef` is a published cross-crate cell address used by the parser boundary, the workbook crate and the bindings — and a symbol has had no `CellRef` since `get_cell_ref` became fallible. The boundary that produced both bugs, vertex → address, is typed. The literal form is a separate, larger, mostly mechanical change.

drafted with love by (agent) Manfred, with approval from Frankie
