### PR TITLE
fix(eval): MATCH/XLOOKUP exact mode no longer coerces blank to 0 (#319)

### DIFF
--- a/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/lookup_utils.rs
@@ -514,12 +514,8 @@ fn find_exact_number_in_view(
         }
     }
 
-    // Excel-like semantics: Empty cells compare equal to numeric zero.
-    if n.abs() < 1e-12
-        && let Some(idx) = find_exact_empty_in_view(view, vertical)?
-    {
-        return Ok(Some(idx));
-    }
+    // Excel exact-match semantics: blank cells are NOT equal to numeric
+    // zero. MATCH(0, {blank,1,2}, 0) returns #N/A, not a position. (#319)
 
     Ok(None)
 }
@@ -797,6 +793,52 @@ mod tests {
         );
         assert_eq!(
             find_exact_index_in_view(&view, &wildcard, true, DateSystem::Excel1900).unwrap(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn find_exact_number_in_view_does_not_match_blank_as_zero() {
+        // Regression test for #319: MATCH(0, {blank, 1, 2}, 0) must return
+        // None (which surfaces as #N/A), not match the blank cell.
+        let values = vec![
+            LiteralValue::Empty,
+            LiteralValue::Number(1.0),
+            LiteralValue::Number(2.0),
+        ];
+        let engine = build_vertical_text_engine(&values, 8);
+        let range = ReferenceType::range(
+            Some("Sheet1".to_string()),
+            Some(1),
+            Some(1),
+            Some(3),
+            Some(1),
+        );
+        let view = engine.resolve_range_view(&range, "Sheet1").unwrap();
+
+        // Searching for 0 must NOT match the blank cell at index 0.
+        assert_eq!(
+            find_exact_index_in_view(&view, &LiteralValue::Number(0.0), false, DateSystem::Excel1900)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            find_exact_index_in_view(&view, &LiteralValue::Int(0), false, DateSystem::Excel1900)
+                .unwrap(),
+            None
+        );
+
+        // Searching for Empty should still find the blank cell.
+        assert_eq!(
+            find_exact_index_in_view(&view, &LiteralValue::Empty, false, DateSystem::Excel1900)
+                .unwrap(),
+            Some(0)
+        );
+
+        // Searching for 1 still works normally.
+        assert_eq!(
+            find_exact_index_in_view(&view, &LiteralValue::Number(1.0), false, DateSystem::Excel1900)
+                .unwrap(),
             Some(1)
         );
     }

--- a/crates/formualizer-eval/src/engine/tests/dynamic_lookup_arrow.rs
+++ b/crates/formualizer-eval/src/engine/tests/dynamic_lookup_arrow.rs
@@ -13,8 +13,9 @@ fn xlookup_whole_column_empty_lookup_matches_first_cell() {
         .set_cell_value("Sheet1", 1, 2, LiteralValue::Int(42))
         .unwrap();
 
-    // Lookup column A has no used rows; XLOOKUP should still be able to resolve A:A without
-    // materializing the entire million-row range.
+    // Lookup column A has no used rows; XLOOKUP(0,...) should NOT match blank
+    // cells because Excel's exact match distinguishes blank from zero (#319).
+    // The "not found" value "NF" is returned.
     engine
         .set_cell_formula("Sheet1", 1, 3, parse("=XLOOKUP(0,A:A,B:B,\"NF\")").unwrap())
         .unwrap();
@@ -22,7 +23,7 @@ fn xlookup_whole_column_empty_lookup_matches_first_cell() {
     engine.evaluate_all().unwrap();
     assert_eq!(
         engine.get_cell_value("Sheet1", 1, 3),
-        Some(LiteralValue::Number(42.0))
+        Some(LiteralValue::Text("NF".to_string()))
     );
 }
 


### PR DESCRIPTION
Excel's exact-match lookup functions (MATCH with match_type=0, XLOOKUP, VLOOKUP with range_lookup=FALSE) distinguish blank cells from numeric zero. MATCH(0, {blank,1,2}, 0) returns #N/A in Excel, not position 1.

Previously, find_exact_number_in_view() fell through to find_exact_empty_in_view() when searching for 0, causing blank cells to match as if they contained zero. This affected MATCH, VLOOKUP, HLOOKUP, and XLOOKUP in exact mode.

Remove the blank-equals-zero fallthrough. Searching for Empty still works via find_exact_empty_in_view (called when the needle is Empty).

Closes #319