### PR TITLE
fix(python): accept NImpl and Error kinds in LiteralValue.error

### DIFF
--- a/bindings/python/src/value.rs
+++ b/bindings/python/src/value.rs
@@ -192,6 +192,8 @@ impl PyLiteralValue {
             "Calc" => ExcelErrorKind::Calc,
             "Circ" => ExcelErrorKind::Circ,
             "Cancelled" => ExcelErrorKind::Cancelled,
+            "Error" => ExcelErrorKind::Error,
+            "NImpl" => ExcelErrorKind::NImpl,
             _ => {
                 return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
                     "Invalid error kind: {kind}"

--- a/bindings/python/tests/test_literal_conversions.py
+++ b/bindings/python/tests/test_literal_conversions.py
@@ -79,6 +79,30 @@ def test_error_dict_roundtrip_and_context():
     assert result.get("sheet") == "Sheet1"
 
 
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "Div",
+        "Ref",
+        "Name",
+        "Value",
+        "Num",
+        "Null",
+        "Na",
+        "Spill",
+        "Calc",
+        "Circ",
+        "Cancelled",
+        "Error",
+        "NImpl",
+    ],
+)
+def test_literal_error_kind_roundtrip(kind):
+    value = fz.LiteralValue.error(kind, "boom")
+
+    assert value.error_kind == kind
+
+
 def test_legacy_literal_dicts_still_supported():
     sheet = make_sheet()
 


### PR DESCRIPTION
## What was wrong

`LiteralValue.error()` in the Python bindings rejects two error
kinds the engine itself produces:

```python
LiteralValue.error("NImpl", "...")   → ValueError: Invalid error kind: NImpl
LiteralValue.error("Error", "...")   → ValueError: Invalid error kind: Error
```

Evaluation emits `NImpl` routinely (any unimplemented builtin), and
`error_kind()` reports it as the string `"NImpl"` — so the API
cannot round-trip its own output. Any workflow that reads evaluated
values and writes them back through the literal API (caching,
snapshotting, spill materialization) dies on the first
unimplemented-function cell.

## Why

`error()`'s match arms drifted out of sync with the bindings' other
two kind parsers. `errors.rs` accepts the full set including
`"Error"` and `"NImpl"`; the dict-based value path in `value.rs`
itself (the `kind_key` match further down the same file) accepts
`"nimpl" | "n/impl" | "#n/impl!"`. Only the `error()` constructor
stops at `"Cancelled"` and falls through to the rejection.

## The fix

Add the two missing arms to `error()`, restoring parity with
`errors.rs`:

```rust
"Error" => ExcelErrorKind::Error,
"NImpl" => ExcelErrorKind::NImpl,
```

No other behavior changes; the catch-all rejection for genuinely
unknown strings is untouched.

## Verification

New parametrized test `test_literal_error_kind_roundtrip` in
`bindings/python/tests/test_literal_conversions.py` covers all 13
canonical kind strings: construct via `LiteralValue.error(kind)`,
assert `error_kind` returns the same string. The `NImpl` and
`Error` cases fail on unmodified `main` with the ValueError above.

Local gates (macOS aarch64, rustc 1.97.1):

```
cargo fmt --all --check                                    clean
python -m pytest bindings/python/tests/ -q                 129 passed
cargo clippy -p formualizer-python --all-targets -- -D warnings
```

Clippy under `-D warnings` fires 18 pre-existing diagnostics, all
in `formualizer-eval` (sort_by_key, useless into_iter, collapsible
match/if), byte-identical on unmodified `main` at the branch point
(3dd97ac3); the branch introduces no new diagnostic. No public API
change: both hunks are inside an existing method body plus one new
test.

## How this was found

An evaluation harness that replays engine-evaluated cross-workbook
call results back into dependent workbooks: a census of one
production-shaped workbook surfaced 633 `NImpl` cells, and
write-back failed on the first one. Drafted by Claude (agent),
verified by execution; submission reviewed and approved by a human.
