### PR TITLE
fix(workbook): evaluate in-book external references from cached values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- `WorkbookLoadLimits` is now `#[non_exhaustive]`. Downstream struct-literal construction is disallowed; build one from `WorkbookLoadLimits::default()` and mutate the fields, or use a future builder. This is a deliberate breaking change so limits such as `max_external_cached_cells` can be added later without breaking downstream struct-literals again.
+
+### Fixed
+
+- In-workbook external references (`=[1]Sheet1!A1`) now evaluate from the cached values Excel stores in `xl/externalLinks/externalLinkN.xml` parts (spec §10), instead of failing with `#NAME?: Undefined name`. Excel never recalculates external links, so the cached values are the correct semantics. Sources are keyed structurally (book token + case-folded sheet + 1-based coordinates) via the shared `formualizer_common::external_cell_source_name` builder, so `=[1]Sheet1!A1`, `=[1]Sheet1!$A$1`, and `=[1]sheet1!a1` resolve to the same key. The scan is bounded by `WorkbookLoadLimits::max_external_cached_cells` (default 1,000,000) with a per-part byte budget, scan failures and the seeded count are reported in `AdapterLoadStats` (`external_link_scan_failures` / `external_cached_source_cells`), and `WorkbookConfig::with_external_cached_sources(false)` restores the previous `#NAME?` behavior. Only single-cell references are seeded; range references still route to source tables (`Undefined table`), deferred. (#363)
+
+  This adds public API to `formualizer-common` (`external_cell_source_name`) and `formualizer-parse` (`ExternalReference::source_name`). `formualizer-common` and `formualizer-parse` were published as 3.1.x, so the parse-side addition requires a new parser-track release (3.2.0) before the product crates can depend on it; call that release out when bumping.
+
 ## [0.9.0] - 2026-09-06
 
 ### Highlights

--- a/bindings/python/tests/test_external_links_openpyxl.py
+++ b/bindings/python/tests/test_external_links_openpyxl.py
@@ -6,6 +6,7 @@ Excel stores cross-workbook references inside the same file via
 cached values. formualizer must do the same instead of failing with
 `#NAME?: Undefined name: [1]Sheet1!A1`.
 """
+
 import zipfile
 
 import pytest
@@ -42,18 +43,18 @@ def build_inbook_external_link_xlsx(tmp_path, sheet_data="42", with_cache=True):
     sheet1 = sheet1.replace(
         "</row>",
         f'      <c r="B1">\n        <f t="shared" ref="B1" si="0">[1]Sheet1!A1</f>\n'
-        f'        <v>{sheet_data}</v>\n      </c>\n    </row>',
+        f"        <v>{sheet_data}</v>\n      </c>\n    </row>",
     )
     if with_cache:
         content_types = content_types.replace(
             '<Override PartName="/xl/styles.xml"',
-            f'<Override PartName="/xl/externalLinks/externalLink1.xml" '
-            f'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>\n'
-            f'  <Override PartName="/xl/styles.xml"',
+            '<Override PartName="/xl/externalLinks/externalLink1.xml" '
+            'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>\n'
+            '  <Override PartName="/xl/styles.xml"',
         )
         wbxml = wbxml.replace(
             "</sheets>",
-            "</sheets>\n  <externalReferences>\n    <externalReference r:id=\"rId4\"/>\n  </externalReferences>",
+            '</sheets>\n  <externalReferences>\n    <externalReference r:id="rId4"/>\n  </externalReferences>',
         )
         wbrels = wbrels.replace(
             "</Relationships>",

--- a/bindings/python/tests/test_external_links_openpyxl.py
+++ b/bindings/python/tests/test_external_links_openpyxl.py
@@ -1,0 +1,119 @@
+"""In-workbook external references (spec §10): `[1]Sheet1!A1`.
+
+Excel stores cross-workbook references inside the same file via
+`xl/externalLinks/externalLinkN.xml` parts that cache the referenced values
+(`<sheetData>`); Excel never recalculates external links and surfaces those
+cached values. formualizer must do the same instead of failing with
+`#NAME?: Undefined name: [1]Sheet1!A1`.
+"""
+import zipfile
+
+import pytest
+
+import formualizer as fz
+
+try:
+    import openpyxl  # type: ignore
+except Exception:  # pragma: no cover - allow skipping if not present in dev env
+    openpyxl = None
+
+pytestmark = pytest.mark.skipif(openpyxl is None, reason="openpyxl not installed")
+
+
+def build_inbook_external_link_xlsx(tmp_path, sheet_data="42", with_cache=True):
+    """Build an `.xlsx` with `=[1]Sheet1!A1` and an external link part caching A1."""
+    p = tmp_path / "external_links.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = 42
+    wb.save(p)
+
+    NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+    SML = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+
+    with zipfile.ZipFile(p, "r") as z:
+        content_types = z.read("[Content_Types].xml").decode("utf-8")
+        wbxml = z.read("xl/workbook.xml").decode("utf-8")
+        wbrels = z.read("xl/_rels/workbook.xml.rels").decode("utf-8")
+        sheet1 = z.read("xl/worksheets/sheet1.xml").decode("utf-8")
+
+    # Always add the formula cell so the reference exists even without a cache.
+    sheet1 = sheet1.replace(
+        "</row>",
+        f'      <c r="B1">\n        <f t="shared" ref="B1" si="0">[1]Sheet1!A1</f>\n'
+        f'        <v>{sheet_data}</v>\n      </c>\n    </row>',
+    )
+    if with_cache:
+        content_types = content_types.replace(
+            '<Override PartName="/xl/styles.xml"',
+            f'<Override PartName="/xl/externalLinks/externalLink1.xml" '
+            f'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>\n'
+            f'  <Override PartName="/xl/styles.xml"',
+        )
+        wbxml = wbxml.replace(
+            "</sheets>",
+            "</sheets>\n  <externalReferences>\n    <externalReference r:id=\"rId4\"/>\n  </externalReferences>",
+        )
+        wbrels = wbrels.replace(
+            "</Relationships>",
+            f'  <Relationship Id="rId4" Type="{NS}/externalLink" '
+            f'Target="externalLinks/externalLink1.xml"/>\n</Relationships>',
+        )
+        extlink = f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="{SML}">
+  <externalBook xmlns:r="{NS}" r:id="rId1">
+    <sheetNames>
+      <sheetName val="Sheet1"/>
+    </sheetNames>
+    <sheetDataSet>
+      <sheetData sheetId="0">
+        <row r="1">
+          <c r="A1"><v>{sheet_data}</v></c>
+        </row>
+      </sheetData>
+    </sheetDataSet>
+  </externalBook>
+</externalLink>"""
+        extlink_rels = f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="{NS}">
+  <Relationship Id="rId1" Type="{NS}/externalBook" Target="../workbook.xml"/>
+</Relationships>"""
+
+    with zipfile.ZipFile(p.with_suffix(".tmp"), "w", zipfile.ZIP_DEFLATED) as zt:
+        for name, content in (
+            ("[Content_Types].xml", content_types),
+            ("xl/workbook.xml", wbxml),
+            ("xl/_rels/workbook.xml.rels", wbrels),
+            ("xl/worksheets/sheet1.xml", sheet1),
+        ):
+            zt.writestr(name, content)
+        if with_cache:
+            zt.writestr("xl/externalLinks/externalLink1.xml", extlink)
+            zt.writestr("xl/externalLinks/_rels/externalLink1.xml.rels", extlink_rels)
+        with zipfile.ZipFile(p, "r") as zo:
+            for name in zo.namelist():
+                if name not in (
+                    "[Content_Types].xml",
+                    "xl/workbook.xml",
+                    "xl/_rels/workbook.xml.rels",
+                    "xl/worksheets/sheet1.xml",
+                ):
+                    zt.writestr(name, zo.read(name))
+    p.with_suffix(".tmp").replace(p)
+    return p
+
+
+def test_inbook_external_reference_evaluates_from_cached_values(tmp_path):
+    p = build_inbook_external_link_xlsx(tmp_path)
+    wb = fz.load_workbook(str(p))
+    wb.evaluate_all()
+    assert wb.get_value("Sheet1", 1, 2) == 42.0
+    assert wb.get_formula("Sheet1", 1, 2) == "=[1]Sheet1!A1"
+
+
+def test_inbook_external_reference_without_cache_fails_gracefully(tmp_path):
+    p = build_inbook_external_link_xlsx(tmp_path, with_cache=False)
+    wb = fz.load_workbook(str(p))
+    with pytest.raises(fz.ExcelEvaluationError):
+        wb.evaluate_all()

--- a/bindings/python/tests/test_external_links_openpyxl.py
+++ b/bindings/python/tests/test_external_links_openpyxl.py
@@ -1,0 +1,133 @@
+"""In-workbook external references (spec §10): `[1]Sheet1!A1`.
+
+Excel stores cross-workbook references inside the same file via
+`xl/externalLinks/externalLinkN.xml` parts that cache the referenced values
+(`<sheetData>`); Excel never recalculates external links and surfaces those
+cached values. formualizer must do the same instead of failing with
+`#NAME?: Undefined name: [1]Sheet1!A1`.
+"""
+
+import zipfile
+
+import pytest
+
+import formualizer as fz
+
+try:
+    import openpyxl  # type: ignore
+except Exception:  # pragma: no cover - allow skipping if not present in dev env
+    openpyxl = None
+
+pytestmark = pytest.mark.skipif(openpyxl is None, reason="openpyxl not installed")
+
+
+def build_inbook_external_link_xlsx(
+    tmp_path, sheet_data="42", with_cache=True, formula="[1]Sheet1!A1"
+):
+    """Build an `.xlsx` with `=...` external ref and an external link part caching A1."""
+    p = tmp_path / "external_links.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = 42
+    wb.save(p)
+
+    NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+    SML = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+
+    with zipfile.ZipFile(p, "r") as z:
+        content_types = z.read("[Content_Types].xml").decode("utf-8")
+        wbxml = z.read("xl/workbook.xml").decode("utf-8")
+        wbrels = z.read("xl/_rels/workbook.xml.rels").decode("utf-8")
+        sheet1 = z.read("xl/worksheets/sheet1.xml").decode("utf-8")
+
+    # Always add the formula cell so the reference exists even without a cache.
+    sheet1 = sheet1.replace(
+        "</row>",
+        f'      <c r="B1">\n        <f t="shared" ref="B1" si="0">{formula}</f>\n'
+        f"        <v>{sheet_data}</v>\n      </c>\n    </row>",
+    )
+    if with_cache:
+        content_types = content_types.replace(
+            '<Override PartName="/xl/styles.xml"',
+            '<Override PartName="/xl/externalLinks/externalLink1.xml" '
+            'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>\n'
+            '  <Override PartName="/xl/styles.xml"',
+        )
+        wbxml = wbxml.replace(
+            "</sheets>",
+            '</sheets>\n  <externalReferences>\n    <externalReference r:id="rId4"/>\n  </externalReferences>',
+        )
+        wbrels = wbrels.replace(
+            "</Relationships>",
+            f'  <Relationship Id="rId4" Type="{NS}/externalLink" '
+            f'Target="externalLinks/externalLink1.xml"/>\n</Relationships>',
+        )
+        extlink = f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="{SML}">
+  <externalBook xmlns:r="{NS}" r:id="rId1">
+    <sheetNames>
+      <sheetName val="Sheet1"/>
+    </sheetNames>
+    <sheetDataSet>
+      <sheetData sheetId="0">
+        <row r="1">
+          <c r="A1"><v>{sheet_data}</v></c>
+        </row>
+      </sheetData>
+    </sheetDataSet>
+  </externalBook>
+</externalLink>"""
+        extlink_rels = f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="{NS}">
+  <Relationship Id="rId1" Type="{NS}/externalBook" Target="../workbook.xml"/>
+</Relationships>"""
+
+    with zipfile.ZipFile(p.with_suffix(".tmp"), "w", zipfile.ZIP_DEFLATED) as zt:
+        for name, content in (
+            ("[Content_Types].xml", content_types),
+            ("xl/workbook.xml", wbxml),
+            ("xl/_rels/workbook.xml.rels", wbrels),
+            ("xl/worksheets/sheet1.xml", sheet1),
+        ):
+            zt.writestr(name, content)
+        if with_cache:
+            zt.writestr("xl/externalLinks/externalLink1.xml", extlink)
+            zt.writestr("xl/externalLinks/_rels/externalLink1.xml.rels", extlink_rels)
+        with zipfile.ZipFile(p, "r") as zo:
+            for name in zo.namelist():
+                if name not in (
+                    "[Content_Types].xml",
+                    "xl/workbook.xml",
+                    "xl/_rels/workbook.xml.rels",
+                    "xl/worksheets/sheet1.xml",
+                ):
+                    zt.writestr(name, zo.read(name))
+    p.with_suffix(".tmp").replace(p)
+    return p
+
+
+def test_inbook_external_reference_evaluates_from_cached_values(tmp_path):
+    p = build_inbook_external_link_xlsx(tmp_path)
+    wb = fz.load_workbook(str(p))
+    wb.evaluate_all()
+    assert wb.get_value("Sheet1", 1, 2) == 42.0
+    assert wb.get_formula("Sheet1", 1, 2) == "=[1]Sheet1!A1"
+
+
+@pytest.mark.parametrize(
+    "formula",
+    ["[1]Sheet1!A1", "[1]Sheet1!$A$1", "[1]sheet1!A1"],
+)
+def test_inbook_external_reference_matches_structurally(tmp_path, formula):
+    p = build_inbook_external_link_xlsx(tmp_path, formula=formula)
+    wb = fz.load_workbook(str(p))
+    wb.evaluate_all()
+    assert wb.get_value("Sheet1", 1, 2) == 42.0
+
+
+def test_inbook_external_reference_without_cache_fails_gracefully(tmp_path):
+    p = build_inbook_external_link_xlsx(tmp_path, with_cache=False)
+    wb = fz.load_workbook(str(p))
+    with pytest.raises(fz.ExcelEvaluationError):
+        wb.evaluate_all()

--- a/crates/formualizer-bench-core/src/bin/probe-load-envelope.rs
+++ b/crates/formualizer-bench-core/src/bin/probe-load-envelope.rs
@@ -277,14 +277,12 @@ fn run(cli: Cli) -> Result<ProbeReport> {
         });
     }
 
-    let limits = WorkbookLoadLimits {
-        max_sheet_rows: 1_048_576,
-        max_sheet_cols: 16_384,
-        max_sheet_logical_cells: cli.logical_cell_budget,
-        sparse_sheet_cell_threshold: cli.sparse_sheet_threshold,
-        max_sparse_cell_ratio: cli.max_sparse_ratio,
-        ..WorkbookLoadLimits::default()
-    };
+    let mut limits = WorkbookLoadLimits::default();
+    limits.max_sheet_rows = 1_048_576;
+    limits.max_sheet_cols = 16_384;
+    limits.max_sheet_logical_cells = cli.logical_cell_budget;
+    limits.sparse_sheet_cell_threshold = cli.sparse_sheet_threshold;
+    limits.max_sparse_cell_ratio = cli.max_sparse_ratio;
 
     let load_start = Instant::now();
     eprintln!("[probe] opening workbook backend={}", cli.backend.label());

--- a/crates/formualizer-common/src/coord.rs
+++ b/crates/formualizer-common/src/coord.rs
@@ -461,6 +461,22 @@ pub fn col_index_from_letters_1based(col: &str) -> Result<u32, A1ParseError> {
     }
 }
 
+/// Canonical source name for a single-cell in-workbook external reference
+/// (spec §10), e.g. `[1]sheet1!A1`.
+///
+/// External-reference keys are derived from structured fields — book token,
+/// case-folded sheet, and 1-based coordinates — rather than from the authored
+/// raw text. This is the single shared builder: the engine's reference
+/// resolution and the workbook's cached-source seeding both derive keys through
+/// it, so `=[1]Sheet1!A1`, `=[1]Sheet1!$A$1`, and `=[1]sheet1!a1` all resolve
+/// to the same key. `book_token` is used verbatim (e.g. `[1]`); `sheet` is
+/// case-folded (Excel matches external-link sheet names case-insensitively) and
+/// `row`/`col` are 1-based.
+pub fn external_cell_source_name(book_token: &str, sheet: &str, row: u32, col: u32) -> String {
+    let letters = col_letters_from_1based(col).unwrap_or_default();
+    format!("{book_token}{}!{letters}{row}", sheet.to_lowercase())
+}
+
 fn parse_a1_components(input: &str) -> Result<(u32, u32, bool, bool), A1ParseError> {
     if input.is_empty() {
         return Err(A1ParseError::Empty);

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -25778,7 +25778,11 @@ where
     ) -> Result<RangeView<'c>, ExcelError> {
         match reference {
             ReferenceType::External(ext) => {
-                let name = ext.raw.as_str();
+                let canonical = ext.source_name();
+                // Range references return no canonical source name, so fall back
+                // to the authored raw text; that path is intentionally out of
+                // scope (ranges route to source tables, not cached scalars).
+                let name = canonical.as_deref().unwrap_or(ext.raw.as_str());
                 match ext.kind {
                     formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
                         let Some(source) = self.graph.resolve_source_scalar_entry(name) else {

--- a/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis.rs
@@ -67,28 +67,30 @@ fn collect_graph_reference(
     use crate::engine::refs::SemanticReference;
 
     match reference {
-        SemanticReference::ExternalSource(external) => match external.kind {
-            formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
-                let name = external.raw.as_str();
-                if let Some(source) = context.graph.resolve_source_scalar_entry(name) {
-                    context.dependencies.insert(source.vertex);
-                    Ok(())
-                } else {
-                    Err(ExcelError::new(ExcelErrorKind::Name)
-                        .with_message(format!("Undefined name: {name}")))
+        SemanticReference::ExternalSource(external) => {
+            let canonical = external.source_name();
+            let name = canonical.as_deref().unwrap_or(external.raw.as_str());
+            match external.kind {
+                formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
+                    if let Some(source) = context.graph.resolve_source_scalar_entry(name) {
+                        context.dependencies.insert(source.vertex);
+                        Ok(())
+                    } else {
+                        Err(ExcelError::new(ExcelErrorKind::Name)
+                            .with_message(format!("Undefined name: {name}")))
+                    }
+                }
+                formualizer_parse::parser::ExternalRefKind::Range { .. } => {
+                    if let Some(source) = context.graph.resolve_source_table_entry(name) {
+                        context.dependencies.insert(source.vertex);
+                        Ok(())
+                    } else {
+                        Err(ExcelError::new(ExcelErrorKind::Name)
+                            .with_message(format!("Undefined table: {name}")))
+                    }
                 }
             }
-            formualizer_parse::parser::ExternalRefKind::Range { .. } => {
-                let name = external.raw.as_str();
-                if let Some(source) = context.graph.resolve_source_table_entry(name) {
-                    context.dependencies.insert(source.vertex);
-                    Ok(())
-                } else {
-                    Err(ExcelError::new(ExcelErrorKind::Name)
-                        .with_message(format!("Undefined table: {name}")))
-                }
-            }
-        },
+        }
         SemanticReference::Cell(cell) => {
             let sheet_id = match cell.sheet.name() {
                 Some(name) => context.graph.resolve_existing_sheet_id(name)?,

--- a/crates/formualizer-eval/src/engine/graph/formula_analysis_legacy_tests.rs
+++ b/crates/formualizer-eval/src/engine/graph/formula_analysis_legacy_tests.rs
@@ -109,26 +109,28 @@ impl DependencyGraph {
     ) -> Result<(), ExcelError> {
         match &ast.node_type {
             ASTNodeType::Reference { reference, .. } => match reference {
-                ReferenceType::External(ext) => match ext.kind {
-                    formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
-                        let name = ext.raw.as_str();
-                        if let Some(source) = self.resolve_source_scalar_entry(name) {
-                            dependencies.insert(source.vertex);
-                        } else {
-                            return Err(ExcelError::new(ExcelErrorKind::Name)
-                                .with_message(format!("Undefined name: {name}")));
+                ReferenceType::External(ext) => {
+                    let canonical = ext.source_name();
+                    let name = canonical.as_deref().unwrap_or(ext.raw.as_str());
+                    match ext.kind {
+                        formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
+                            if let Some(source) = self.resolve_source_scalar_entry(name) {
+                                dependencies.insert(source.vertex);
+                            } else {
+                                return Err(ExcelError::new(ExcelErrorKind::Name)
+                                    .with_message(format!("Undefined name: {name}")));
+                            }
+                        }
+                        formualizer_parse::parser::ExternalRefKind::Range { .. } => {
+                            if let Some(source) = self.resolve_source_table_entry(name) {
+                                dependencies.insert(source.vertex);
+                            } else {
+                                return Err(ExcelError::new(ExcelErrorKind::Name)
+                                    .with_message(format!("Undefined table: {name}")));
+                            }
                         }
                     }
-                    formualizer_parse::parser::ExternalRefKind::Range { .. } => {
-                        let name = ext.raw.as_str();
-                        if let Some(source) = self.resolve_source_table_entry(name) {
-                            dependencies.insert(source.vertex);
-                        } else {
-                            return Err(ExcelError::new(ExcelErrorKind::Name)
-                                .with_message(format!("Undefined table: {name}")));
-                        }
-                    }
-                },
+                }
                 ReferenceType::Cell { .. } => {
                     let vertex_id = self.legacy_get_or_create_vertex_for_reference(
                         reference,

--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -393,28 +393,33 @@ impl<'a> IngestPipeline<'a> {
         use crate::engine::refs::SemanticReference;
 
         match reference {
-            SemanticReference::ExternalSource(ext) => match ext.kind {
-                ExternalRefKind::Cell { .. } => {
-                    let name = ext.raw.as_str();
-                    if self.sources.resolve_scalar(name).is_some() {
-                        plan.source_refs.push(name.to_string());
-                        Ok(())
-                    } else {
-                        Err(ExcelError::new(ExcelErrorKind::Name)
-                            .with_message(format!("Undefined name: {name}")))
+            SemanticReference::ExternalSource(ext) => {
+                let canonical = ext.source_name();
+                // Range references return no canonical source name, so fall back
+                // to the authored raw text; that path routes to source tables and
+                // is intentionally out of scope (no cached-scalar seeding).
+                let name = canonical.as_deref().unwrap_or(ext.raw.as_str());
+                match ext.kind {
+                    ExternalRefKind::Cell { .. } => {
+                        if self.sources.resolve_scalar(name).is_some() {
+                            plan.source_refs.push(name.to_string());
+                            Ok(())
+                        } else {
+                            Err(ExcelError::new(ExcelErrorKind::Name)
+                                .with_message(format!("Undefined name: {name}")))
+                        }
+                    }
+                    ExternalRefKind::Range { .. } => {
+                        if self.sources.resolve_table(name).is_some() {
+                            plan.source_refs.push(name.to_string());
+                            Ok(())
+                        } else {
+                            Err(ExcelError::new(ExcelErrorKind::Name)
+                                .with_message(format!("Undefined table: {name}")))
+                        }
                     }
                 }
-                ExternalRefKind::Range { .. } => {
-                    let name = ext.raw.as_str();
-                    if self.sources.resolve_table(name).is_some() {
-                        plan.source_refs.push(name.to_string());
-                        Ok(())
-                    } else {
-                        Err(ExcelError::new(ExcelErrorKind::Name)
-                            .with_message(format!("Undefined table: {name}")))
-                    }
-                }
-            },
+            }
             SemanticReference::Cell(cell) => {
                 let sheet_id = self.resolve_reference_sheet(cell.sheet.name(), current_sheet_id)?;
                 plan.direct_cell_deps.push(CellRef::new(
@@ -2098,28 +2103,30 @@ mod tests {
             local_scopes: &[FxHashSet<String>],
         ) -> Result<(), ExcelError> {
             match reference {
-                ReferenceType::External(ext) => match ext.kind {
-                    ExternalRefKind::Cell { .. } => {
-                        let name = ext.raw.as_str();
-                        if self.sources.resolve_scalar(name).is_some() {
-                            plan.source_refs.push(name.to_string());
-                            Ok(())
-                        } else {
-                            Err(ExcelError::new(ExcelErrorKind::Name)
-                                .with_message(format!("Undefined name: {name}")))
+                ReferenceType::External(ext) => {
+                    let canonical = ext.source_name();
+                    let name = canonical.as_deref().unwrap_or(ext.raw.as_str());
+                    match ext.kind {
+                        ExternalRefKind::Cell { .. } => {
+                            if self.sources.resolve_scalar(name).is_some() {
+                                plan.source_refs.push(name.to_string());
+                                Ok(())
+                            } else {
+                                Err(ExcelError::new(ExcelErrorKind::Name)
+                                    .with_message(format!("Undefined name: {name}")))
+                            }
+                        }
+                        ExternalRefKind::Range { .. } => {
+                            if self.sources.resolve_table(name).is_some() {
+                                plan.source_refs.push(name.to_string());
+                                Ok(())
+                            } else {
+                                Err(ExcelError::new(ExcelErrorKind::Name)
+                                    .with_message(format!("Undefined table: {name}")))
+                            }
                         }
                     }
-                    ExternalRefKind::Range { .. } => {
-                        let name = ext.raw.as_str();
-                        if self.sources.resolve_table(name).is_some() {
-                            plan.source_refs.push(name.to_string());
-                            Ok(())
-                        } else {
-                            Err(ExcelError::new(ExcelErrorKind::Name)
-                                .with_message(format!("Undefined table: {name}")))
-                        }
-                    }
-                },
+                }
                 ReferenceType::Cell {
                     sheet, row, col, ..
                 } => {

--- a/crates/formualizer-eval/src/engine/mod.rs
+++ b/crates/formualizer-eval/src/engine/mod.rs
@@ -666,6 +666,7 @@ pub enum FormulaSpoolDiskPolicy {
 
 /// Workbook ingest limits applied by loader backends before they materialize large sheets.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct WorkbookLoadLimits {
     /// Hard cap for declared/logical sheet rows.
     pub max_sheet_rows: u32,
@@ -689,6 +690,9 @@ pub struct WorkbookLoadLimits {
     pub formula_spool_memory_prefix_bytes: u64,
     /// Independent cap for a memory-only formula replay spool.
     pub max_formula_spool_memory_bytes: u64,
+    /// Hard cap for cached in-workbook external-reference cells (spec §10
+    /// `externalLinkN.xml` parts) a backend may seed into the engine.
+    pub max_external_cached_cells: u64,
     /// Whether formula replay data may use secure native temporary storage.
     pub formula_spool_disk_policy: FormulaSpoolDiskPolicy,
 }
@@ -707,6 +711,7 @@ impl Default for WorkbookLoadLimits {
             max_formula_spool_files_per_workbook: 1_024,
             formula_spool_memory_prefix_bytes: 1024 * 1024,
             max_formula_spool_memory_bytes: 16 * 1024 * 1024,
+            max_external_cached_cells: 1_000_000,
             formula_spool_disk_policy: if cfg!(target_arch = "wasm32") {
                 FormulaSpoolDiskPolicy::MemoryOnly
             } else {

--- a/crates/formualizer-eval/src/engine/plan.rs
+++ b/crates/formualizer-eval/src/engine/plan.rs
@@ -208,7 +208,11 @@ fn collect_plan_reference(
         SemanticReference::ExternalSource(external) => match external.kind {
             formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
                 *context.flags |= F_HAS_NAMES;
-                context.per_names.push(external.raw.clone());
+                context.per_names.push(
+                    external
+                        .source_name()
+                        .expect("cell external reference yields a canonical source name"),
+                );
             }
             formualizer_parse::parser::ExternalRefKind::Range { .. } => {
                 *context.flags |= F_HAS_TABLES;

--- a/crates/formualizer-eval/src/engine/plan_legacy_tests.rs
+++ b/crates/formualizer-eval/src/engine/plan_legacy_tests.rs
@@ -241,7 +241,10 @@ where
                 ReferenceType::External(ext) => match ext.kind {
                     formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
                         flags |= F_HAS_NAMES;
-                        per_names.push(ext.raw.clone());
+                        per_names.push(
+                            ext.source_name()
+                                .expect("cell external reference yields a canonical source name"),
+                        );
                     }
                     formualizer_parse::parser::ExternalRefKind::Range { .. } => {
                         flags |= F_HAS_TABLES;
@@ -402,7 +405,10 @@ where
                 ReferenceType::External(ext) => match ext.kind {
                     formualizer_parse::parser::ExternalRefKind::Cell { .. } => {
                         flags |= F_HAS_NAMES;
-                        per_names.push(ext.raw.clone());
+                        per_names.push(
+                            ext.source_name()
+                                .expect("cell external reference yields a canonical source name"),
+                        );
                     }
                     formualizer_parse::parser::ExternalRefKind::Range { .. } => {
                         flags |= F_HAS_TABLES;

--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -237,6 +237,30 @@ pub struct ExternalReference {
     pub kind: ExternalRefKind,
 }
 
+impl ExternalReference {
+    /// Canonical source name for a single-cell in-workbook external reference
+    /// (spec §10), e.g. `[1]sheet1!A1`.
+    ///
+    /// Keys are derived from structured fields (`book` token, case-folded
+    /// `sheet`, and the coordinates in `kind`) so that authored variations like
+    /// `=[1]Sheet1!A1`, `=[1]Sheet1!$A$1`, and `=[1]sheet1!a1` all resolve to
+    /// the same source. Returns `None` for range references, which route to
+    /// source tables and are not seeded from cached values today.
+    pub fn source_name(&self) -> Option<String> {
+        match self.kind {
+            ExternalRefKind::Cell { row, col, .. } => {
+                Some(formualizer_common::external_cell_source_name(
+                    self.book.token(),
+                    &self.sheet,
+                    row,
+                    col,
+                ))
+            }
+            ExternalRefKind::Range { .. } => None,
+        }
+    }
+}
+
 /// A reference to something outside the cell.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Hash)]

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -1243,9 +1243,17 @@ impl CalamineAdapter {
                         let mut idx = None;
                         for attr in e.attributes().filter_map(Result::ok) {
                             match attr.key {
-                                QName(b"Id") => id = attr.decode_and_unescape_value(reader.decoder()).map(|s| s.into_owned()).unwrap_or_default(),
+                                QName(b"Id") => {
+                                    id = attr
+                                        .decode_and_unescape_value(reader.decoder())
+                                        .map(|s| s.into_owned())
+                                        .unwrap_or_default()
+                                }
                                 QName(b"Target") => {
-                                    let target = attr.decode_and_unescape_value(reader.decoder()).map(|s| s.into_owned()).unwrap_or_default();
+                                    let target = attr
+                                        .decode_and_unescape_value(reader.decoder())
+                                        .map(|s| s.into_owned())
+                                        .unwrap_or_default();
                                     if let Some(num) = target
                                         .rsplit('/')
                                         .next()
@@ -1304,10 +1312,14 @@ impl CalamineAdapter {
         /// without a cached value are not recoverable and are skipped.
         fn external_link_cached_cells(xml: &str, book_index: u32) -> Vec<(String, LiteralValue)> {
             fn quote_sheet(sheet: &str) -> String {
-                if sheet
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '\\' || c == '(' || c == ')')
-                    && !sheet.is_empty()
+                if sheet.chars().all(|c| {
+                    c.is_ascii_alphanumeric()
+                        || c == '_'
+                        || c == '.'
+                        || c == '\\'
+                        || c == '('
+                        || c == ')'
+                }) && !sheet.is_empty()
                 {
                     sheet.to_string()
                 } else {
@@ -1406,7 +1418,9 @@ impl CalamineAdapter {
                         let qname = e.local_name();
                         let name = qname.as_ref();
                         if name == b"v" || name == b"t" {
-                            let (Some(cell_ref), Some(sheet_id)) = (cur_cell_ref.as_deref(), cur_sheet_id) else {
+                            let (Some(cell_ref), Some(sheet_id)) =
+                                (cur_cell_ref.as_deref(), cur_sheet_id)
+                            else {
                                 capturing = None;
                                 continue;
                             };
@@ -1419,12 +1433,17 @@ impl CalamineAdapter {
                             };
                             let value = match cur_cell_type.as_str() {
                                 "b" => Some(LiteralValue::Boolean(
-                                    text_buf.trim() == "1" || text_buf.trim().eq_ignore_ascii_case("true"),
+                                    text_buf.trim() == "1"
+                                        || text_buf.trim().eq_ignore_ascii_case("true"),
                                 )),
                                 "str" | "inlineStr" => Some(LiteralValue::Text(text_buf.clone())),
                                 "e" => None,
                                 "s" => None,
-                                _ => text_buf.trim().parse::<f64>().ok().map(LiteralValue::Number),
+                                _ => text_buf
+                                    .trim()
+                                    .parse::<f64>()
+                                    .ok()
+                                    .map(LiteralValue::Number),
                             };
                             if let Some(value) = value {
                                 out.push((

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -222,6 +222,7 @@ pub struct CalamineAdapter {
     cached_names: Option<Vec<String>>,
     defined_names: Vec<DefinedName>,
     external_link_targets: BTreeMap<u32, String>,
+    external_cached_sources: Vec<(String, LiteralValue)>,
     calc_settings: Option<CalcSettings>,
     load_stats: AdapterLoadStats,
     shadow_relocation_comparator: Option<ShadowRelocationComparator>,
@@ -881,6 +882,15 @@ impl CalamineAdapter {
         self.external_link_targets.get(&index).map(|s| s.as_str())
     }
 
+    /// Cached values for in-workbook external references (spec §10: `<externalLink>`
+    /// parts), as `(raw_reference, value)` pairs. A formula cell `=[1]Sheet1!A1`
+    /// resolves against the raw reference (e.g. `[1]Sheet1!A1`) at evaluation time;
+    /// Excel does not recalculate external links and instead surfaces the cached
+    /// value from the link part, which is what the engine returns.
+    pub fn external_cached_sources(&self) -> &[(String, LiteralValue)] {
+        &self.external_cached_sources
+    }
+
     fn normalize_open_ended_bounds(
         start_row: Option<u32>,
         start_col: Option<u32>,
@@ -1195,6 +1205,276 @@ impl CalamineAdapter {
         crate::calc_pr::parse_calc_pr(&xml)
     }
 
+    /// Scan cached values for in-workbook external references (spec §10) straight
+    /// from the `.xlsx` zip — calamine does not surface `<externalLink>` parts.
+    ///
+    /// Returns `(raw_reference, cached_value)` pairs, e.g. `("[1]Sheet1!A1",
+    /// Number(42.0))`, where the book token is the 1-based position of the
+    /// `<externalReference>` in `xl/workbook.xml` (matching the `[n]` prefix the
+    /// parser produces for in-workbook external references).
+    fn scan_external_link_sources_from_reader<R>(reader: R) -> Vec<(String, LiteralValue)>
+    where
+        R: Read + Seek,
+    {
+        fn entry_text<R2>(archive: &mut ZipArchive<R2>, name: &str) -> Option<String>
+        where
+            R2: Read + Seek,
+        {
+            let mut entry = archive.by_name(name).ok()?;
+            let mut xml = String::new();
+            entry.read_to_string(&mut xml).ok()?;
+            Some(xml)
+        }
+
+        /// Parse `r:id="..."` targets out of `xl/_rels/workbook.xml.rels`; only the
+        /// external-link relationships are returned (`rId -> externalLink index`).
+        fn workbook_external_link_rels(rels: &str) -> BTreeMap<String, u32> {
+            let mut out = BTreeMap::new();
+            let mut reader = XmlReader::from_str(rels);
+            reader.config_mut().trim_text(true);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Empty(ref e)) | Ok(Event::Start(ref e))
+                        if e.local_name().as_ref() == b"Relationship" =>
+                    {
+                        let mut id = String::new();
+                        let mut idx = None;
+                        for attr in e.attributes().filter_map(Result::ok) {
+                            match attr.key {
+                                QName(b"Id") => id = attr.decode_and_unescape_value(reader.decoder()).map(|s| s.into_owned()).unwrap_or_default(),
+                                QName(b"Target") => {
+                                    let target = attr.decode_and_unescape_value(reader.decoder()).map(|s| s.into_owned()).unwrap_or_default();
+                                    if let Some(num) = target
+                                        .rsplit('/')
+                                        .next()
+                                        .and_then(|p| p.strip_prefix("externalLink"))
+                                        .and_then(|p| p.strip_suffix(".xml"))
+                                        .and_then(|p| p.parse::<u32>().ok())
+                                    {
+                                        idx = Some(num);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        if let (Some(idx), false) = (idx, id.is_empty()) {
+                            out.insert(id, idx);
+                        }
+                    }
+                    Ok(Event::Eof) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        /// Ordered 1-based list of external-link relationship ids from
+        /// `xl/workbook.xml` `<externalReferences>`.
+        fn workbook_external_reference_rids(workbook_xml: &str) -> Vec<String> {
+            let mut out = Vec::new();
+            let mut reader = XmlReader::from_str(workbook_xml);
+            reader.config_mut().trim_text(true);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Empty(ref e)) | Ok(Event::Start(ref e))
+                        if e.local_name().as_ref() == b"externalReference" =>
+                    {
+                        for attr in e.attributes().filter_map(Result::ok) {
+                            if attr.key == QName(b"r:id")
+                                && let Ok(v) = attr.decode_and_unescape_value(reader.decoder())
+                            {
+                                out.push(v.into_owned());
+                            }
+                        }
+                    }
+                    Ok(Event::Eof) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        /// Parse `sheetNames` + cached `sheetData` from one `externalLinkN.xml`.
+        /// Returns `([n]Sheet!ref, value)` pairs for every cached numeric/string/
+        /// boolean cell; cells Excel would derive from the live (external) source
+        /// without a cached value are not recoverable and are skipped.
+        fn external_link_cached_cells(xml: &str, book_index: u32) -> Vec<(String, LiteralValue)> {
+            fn quote_sheet(sheet: &str) -> String {
+                if sheet
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '\\' || c == '(' || c == ')')
+                    && !sheet.is_empty()
+                {
+                    sheet.to_string()
+                } else {
+                    format!("'{sheet}'")
+                }
+            }
+
+            fn parse_cell_ref(cell_ref: &str) -> Option<(String, u32)> {
+                let bytes = cell_ref.as_bytes();
+                let mut i = 0;
+                while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                if i == 0 {
+                    return None;
+                }
+                let cols = cell_ref[..i].to_string();
+                let row: u32 = cell_ref[i..].parse().ok()?;
+                Some((cols, row))
+            }
+
+            let mut out = Vec::new();
+            let mut sheet_names: Vec<String> = Vec::new();
+            let mut cur_sheet_id: Option<u32> = None;
+            let mut cur_cell_ref: Option<String> = None;
+            let mut cur_cell_type = String::new();
+            let mut capturing: Option<&'static str> = None;
+            let mut text_buf = String::new();
+
+            let mut reader = XmlReader::from_str(xml);
+            reader.config_mut().trim_text(true);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Start(ref e)) => {
+                        let qname = e.local_name();
+                        let name = qname.as_ref();
+                        if name == b"sheetName" {
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                if attr.key == QName(b"val")
+                                    && let Ok(v) = attr.decode_and_unescape_value(reader.decoder())
+                                {
+                                    sheet_names.push(v.into_owned());
+                                }
+                            }
+                        } else if name == b"sheetData" {
+                            cur_sheet_id = None;
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                if attr.key == QName(b"sheetId") {
+                                    cur_sheet_id = attr
+                                        .decode_and_unescape_value(reader.decoder())
+                                        .ok()
+                                        .and_then(|v| v.parse().ok());
+                                }
+                            }
+                        } else if name == b"c" {
+                            cur_cell_ref = None;
+                            cur_cell_type.clear();
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                let Ok(v) = attr.decode_and_unescape_value(reader.decoder()) else {
+                                    continue;
+                                };
+                                match attr.key {
+                                    QName(b"r") => cur_cell_ref = Some(v.into_owned()),
+                                    QName(b"t") => cur_cell_type = v.into_owned(),
+                                    _ => {}
+                                }
+                            }
+                        } else if name == b"v" || name == b"t" {
+                            capturing = Some(if name == b"v" { "v" } else { "t" });
+                            text_buf.clear();
+                        }
+                    }
+                    Ok(Event::Empty(ref e)) => {
+                        let qname = e.local_name();
+                        let name = qname.as_ref();
+                        if name == b"sheetName" {
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                if attr.key == QName(b"val")
+                                    && let Ok(v) = attr.decode_and_unescape_value(reader.decoder())
+                                {
+                                    sheet_names.push(v.into_owned());
+                                }
+                            }
+                        }
+                    }
+                    Ok(Event::Text(ref t)) => {
+                        if capturing.is_some()
+                            && let Ok(v) = t.decode()
+                        {
+                            text_buf.push_str(&v);
+                        }
+                    }
+                    Ok(Event::End(ref e)) => {
+                        let qname = e.local_name();
+                        let name = qname.as_ref();
+                        if name == b"v" || name == b"t" {
+                            let (Some(cell_ref), Some(sheet_id)) = (cur_cell_ref.as_deref(), cur_sheet_id) else {
+                                capturing = None;
+                                continue;
+                            };
+                            capturing = None;
+                            let Some(sheet) = sheet_names.get(sheet_id as usize) else {
+                                continue;
+                            };
+                            let Some((cols, row)) = parse_cell_ref(cell_ref) else {
+                                continue;
+                            };
+                            let value = match cur_cell_type.as_str() {
+                                "b" => Some(LiteralValue::Boolean(
+                                    text_buf.trim() == "1" || text_buf.trim().eq_ignore_ascii_case("true"),
+                                )),
+                                "str" | "inlineStr" => Some(LiteralValue::Text(text_buf.clone())),
+                                "e" => None,
+                                "s" => None,
+                                _ => text_buf.trim().parse::<f64>().ok().map(LiteralValue::Number),
+                            };
+                            if let Some(value) = value {
+                                out.push((
+                                    format!("[{book_index}]{}!{cols}{row}", quote_sheet(sheet)),
+                                    value,
+                                ));
+                            }
+                        }
+                    }
+                    Ok(Event::Eof) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        let mut archive = match ZipArchive::new(reader) {
+            Ok(a) => a,
+            Err(_) => return Vec::new(),
+        };
+        let Some(workbook_xml) = entry_text(&mut archive, "xl/workbook.xml") else {
+            return Vec::new();
+        };
+        let rids = workbook_external_reference_rids(&workbook_xml);
+        if rids.is_empty() {
+            return Vec::new();
+        }
+        let Some(rels) = entry_text(&mut archive, "xl/_rels/workbook.xml.rels") else {
+            return Vec::new();
+        };
+        let link_by_rid = workbook_external_link_rels(&rels);
+
+        let mut out = Vec::new();
+        for (book_index, rid) in rids.iter().enumerate() {
+            let book_index = (book_index as u32) + 1;
+            let Some(link_index) = link_by_rid.get(rid) else {
+                continue;
+            };
+            let Some(xml) = entry_text(
+                &mut archive,
+                &format!("xl/externalLinks/externalLink{link_index}.xml"),
+            ) else {
+                continue;
+            };
+            let cells = external_link_cached_cells(&xml, book_index);
+            out.extend(cells);
+        }
+        out
+    }
+
     fn calamine_error_code(e: &calamine::CellErrorType) -> u8 {
         let kind = match e {
             calamine::CellErrorType::Div0 => ExcelErrorKind::Div,
@@ -1347,6 +1627,10 @@ impl SpreadsheetReader for CalamineAdapter {
         self.calc_settings.clone()
     }
 
+    fn external_cached_sources(&self) -> &[(String, LiteralValue)] {
+        &self.external_cached_sources
+    }
+
     fn open_path<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error>
     where
         Self: Sized,
@@ -1359,6 +1643,10 @@ impl SpreadsheetReader for CalamineAdapter {
         let calc_settings = File::open(path)
             .ok()
             .and_then(|file| Self::scan_calc_settings_from_reader(BufReader::new(file)));
+        let external_cached_sources = match File::open(path) {
+            Ok(file) => Self::scan_external_link_sources_from_reader(BufReader::new(file)),
+            Err(_) => Vec::new(),
+        };
         let workbook: Xlsx<BufReader<File>> = open_workbook(path)?;
         let sheet_names = workbook.sheet_names().to_vec();
         let defined_names = if workbook.defined_names().is_empty() {
@@ -1382,6 +1670,7 @@ impl SpreadsheetReader for CalamineAdapter {
             cached_names: Some(sheet_names),
             defined_names,
             external_link_targets,
+            external_cached_sources,
             calc_settings,
             load_stats: AdapterLoadStats::default(),
             shadow_relocation_comparator: None,
@@ -1404,6 +1693,8 @@ impl SpreadsheetReader for CalamineAdapter {
         let external_link_targets =
             Self::scan_external_link_targets_from_reader(Cursor::new(data.as_slice()));
         let calc_settings = Self::scan_calc_settings_from_reader(Cursor::new(data.as_slice()));
+        let external_cached_sources =
+            Self::scan_external_link_sources_from_reader(Cursor::new(data.as_slice()));
         let workbook: Xlsx<Cursor<Vec<u8>>> = open_workbook_from_rs(Cursor::new(data.clone()))?;
         let sheet_names = workbook.sheet_names().to_vec();
         let defined_names = if workbook.defined_names().is_empty() {
@@ -1424,6 +1715,7 @@ impl SpreadsheetReader for CalamineAdapter {
             cached_names: Some(sheet_names),
             defined_names,
             external_link_targets,
+            external_cached_sources,
             calc_settings,
             load_stats: AdapterLoadStats::default(),
             shadow_relocation_comparator: None,
@@ -1539,6 +1831,17 @@ where
         engine.reset_ensure_touched();
 
         let load_result = (|| -> Result<(), calamine::Error> {
+            // Declare external sources (SourceVertex) before ingesting formulas
+            // (spec §10 in-workbook external references). Excel does not
+            // recalculate external links: the cached `<v>` values stored in the
+            // `externalLinkN.xml` parts are the values a formula cell referencing
+            // them should return, resolved by the engine through SourceResolver.
+            for (name, _value) in &self.external_cached_sources {
+                engine
+                    .define_source_scalar(name, Some(0))
+                    .map_err(|e| calamine::Error::Io(std::io::Error::other(e.to_string())))?;
+            }
+
             let chunk_rows: usize = 32 * 1024;
             let mut total_values = 0usize;
             let mut total_value_cells_observed = 0usize;

--- a/crates/formualizer-workbook/src/backends/calamine.rs
+++ b/crates/formualizer-workbook/src/backends/calamine.rs
@@ -1,7 +1,8 @@
 use crate::load_limits::enforce_sheet_dimension_limits;
 use crate::traits::{
     AccessGranularity, AdapterLoadStats, BackendCaps, CalcSettings, CellData, DefinedName,
-    DefinedNameDefinition, DefinedNameScope, MergedRange, SheetData, SpreadsheetReader,
+    DefinedNameDefinition, DefinedNameScope, ExternalCachedSource, MergedRange, SheetData,
+    SpreadsheetReader,
 };
 use formualizer_common::{DateSystem, ExcelError, ExcelErrorKind, LiteralValue};
 use parking_lot::RwLock;
@@ -499,6 +500,9 @@ pub struct CalamineAdapter {
     defined_names: OnceLock<Vec<DefinedName>>,
     external_link_targets: OnceLock<BTreeMap<u32, String>>,
     calc_settings: OnceLock<Option<CalcSettings>>,
+    /// Cached in-workbook external-reference cells (spec §10), populated by
+    /// [`SpreadsheetReader::scan_external_cached_sources`] at load time.
+    external_cached_sources: Vec<ExternalCachedSource>,
     load_stats: AdapterLoadStats,
     shadow_relocation_comparator: Option<ShadowRelocationComparator>,
     #[cfg(test)]
@@ -1192,6 +1196,7 @@ impl CalamineAdapter {
             defined_names: OnceLock::new(),
             external_link_targets: OnceLock::new(),
             calc_settings: OnceLock::new(),
+            external_cached_sources: Vec::new(),
             load_stats: AdapterLoadStats::default(),
             shadow_relocation_comparator: None,
             #[cfg(test)]
@@ -1561,6 +1566,333 @@ impl CalamineAdapter {
         crate::calc_pr::parse_calc_pr(&xml)
     }
 
+    /// Scan cached values for in-workbook external references (spec §10) straight
+    /// from the `.xlsx` zip — calamine does not surface `<externalLink>` parts.
+    ///
+    /// Returns `(sources, scan_failures)`. `sources` holds one
+    /// [`ExternalCachedSource`] per cached numeric/string/boolean cell; cells
+    /// Excel would derive from the live (external) source without a cached value
+    /// are not recoverable and are skipped. `scan_failures` counts structural
+    /// failures (zip errors, missing `workbook.xml`/rels, declared references
+    /// without a matching rel or `externalLinkN.xml` part) so a broken external
+    /// link is distinguishable from a genuinely absent one. The `book_index` is
+    /// the 1-based position of the `<externalReference>` in `xl/workbook.xml`,
+    /// matching the `[n]` token the parser produces.
+    ///
+    /// Memory is bounded by `max_cells`: at most that many cached cells are
+    /// materialized, and each `externalLinkN.xml` part is read with a matching
+    /// byte budget, so a malicious part cannot exhaust load-time memory before
+    /// the ingest limits apply.
+    fn scan_external_link_sources_from_reader<R>(
+        reader: R,
+        max_cells: u64,
+    ) -> (Vec<ExternalCachedSource>, u64)
+    where
+        R: Read + Seek,
+    {
+        /// Read a zip entry up to `max_bytes`; returns `None` only on a real read
+        /// failure, not when the byte budget is exhausted (the reader just ends).
+        fn entry_text_bounded<R2>(
+            archive: &mut ZipArchive<R2>,
+            name: &str,
+            max_bytes: u64,
+        ) -> Option<String>
+        where
+            R2: Read + Seek,
+        {
+            let mut entry = archive.by_name(name).ok()?;
+            let mut xml = String::new();
+            (&mut entry).take(max_bytes).read_to_string(&mut xml).ok()?;
+            Some(xml)
+        }
+
+        /// Parse `r:id="..."` targets out of `xl/_rels/workbook.xml.rels`; only the
+        /// external-link relationships are returned (`rId -> externalLink index`).
+        fn workbook_external_link_rels(rels: &str) -> BTreeMap<String, u32> {
+            let mut out = BTreeMap::new();
+            let mut reader = XmlReader::from_str(rels);
+            reader.config_mut().trim_text(true);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Empty(ref e)) | Ok(Event::Start(ref e))
+                        if e.local_name().as_ref() == b"Relationship" =>
+                    {
+                        let mut id = String::new();
+                        let mut idx = None;
+                        for attr in e.attributes().filter_map(Result::ok) {
+                            match attr.key {
+                                QName(b"Id") => {
+                                    id = attr
+                                        .decode_and_unescape_value(reader.decoder())
+                                        .map(|s| s.into_owned())
+                                        .unwrap_or_default()
+                                }
+                                QName(b"Target") => {
+                                    let target = attr
+                                        .decode_and_unescape_value(reader.decoder())
+                                        .map(|s| s.into_owned())
+                                        .unwrap_or_default();
+                                    if let Some(num) = target
+                                        .rsplit('/')
+                                        .next()
+                                        .and_then(|p| p.strip_prefix("externalLink"))
+                                        .and_then(|p| p.strip_suffix(".xml"))
+                                        .and_then(|p| p.parse::<u32>().ok())
+                                    {
+                                        idx = Some(num);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        if let (Some(idx), false) = (idx, id.is_empty()) {
+                            out.insert(id, idx);
+                        }
+                    }
+                    Ok(Event::Eof) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        /// Ordered 1-based list of external-link relationship ids from
+        /// `xl/workbook.xml` `<externalReferences>`.
+        fn workbook_external_reference_rids(workbook_xml: &str) -> Vec<String> {
+            let mut out = Vec::new();
+            let mut reader = XmlReader::from_str(workbook_xml);
+            reader.config_mut().trim_text(true);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Empty(ref e)) | Ok(Event::Start(ref e))
+                        if e.local_name().as_ref() == b"externalReference" =>
+                    {
+                        for attr in e.attributes().filter_map(Result::ok) {
+                            if attr.key == QName(b"r:id")
+                                && let Ok(v) = attr.decode_and_unescape_value(reader.decoder())
+                            {
+                                out.push(v.into_owned());
+                            }
+                        }
+                    }
+                    Ok(Event::Eof) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        /// Parse `sheetNames` + cached `sheetData` from one `externalLinkN.xml`.
+        /// Returns structured `ExternalCachedSource` records for every cached
+        /// numeric/string/boolean cell up to `max_cells`; cells Excel would
+        /// derive from the live (external) source without a cached value are not
+        /// recoverable and are skipped.
+        fn external_link_cached_cells(
+            xml: &str,
+            book_index: u32,
+            max_cells: u64,
+        ) -> Vec<ExternalCachedSource> {
+            /// Split a cell ref like `A1` into its column letters and 1-based row.
+            fn parse_cell_ref(cell_ref: &str) -> Option<(String, u32)> {
+                let bytes = cell_ref.as_bytes();
+                let mut i = 0;
+                while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                if i == 0 {
+                    return None;
+                }
+                let cols = cell_ref[..i].to_string();
+                let row: u32 = cell_ref[i..].parse().ok()?;
+                Some((cols, row))
+            }
+
+            let mut out = Vec::new();
+            let mut sheet_names: Vec<String> = Vec::new();
+            let mut cur_sheet_id: Option<u32> = None;
+            let mut cur_cell_ref: Option<String> = None;
+            let mut cur_cell_type = String::new();
+            let mut capturing: Option<&'static str> = None;
+            let mut text_buf = String::new();
+
+            let mut reader = XmlReader::from_str(xml);
+            reader.config_mut().trim_text(true);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Start(ref e)) => {
+                        let qname = e.local_name();
+                        let name = qname.as_ref();
+                        if name == b"sheetName" {
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                if attr.key == QName(b"val")
+                                    && let Ok(v) = attr.decode_and_unescape_value(reader.decoder())
+                                {
+                                    sheet_names.push(v.into_owned());
+                                }
+                            }
+                        } else if name == b"sheetData" {
+                            cur_sheet_id = None;
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                if attr.key == QName(b"sheetId") {
+                                    cur_sheet_id = attr
+                                        .decode_and_unescape_value(reader.decoder())
+                                        .ok()
+                                        .and_then(|v| v.parse().ok());
+                                }
+                            }
+                        } else if name == b"c" {
+                            cur_cell_ref = None;
+                            cur_cell_type.clear();
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                let Ok(v) = attr.decode_and_unescape_value(reader.decoder()) else {
+                                    continue;
+                                };
+                                match attr.key {
+                                    QName(b"r") => cur_cell_ref = Some(v.into_owned()),
+                                    QName(b"t") => cur_cell_type = v.into_owned(),
+                                    _ => {}
+                                }
+                            }
+                        } else if name == b"v" || name == b"t" {
+                            capturing = Some(if name == b"v" { "v" } else { "t" });
+                            text_buf.clear();
+                        }
+                    }
+                    Ok(Event::Empty(ref e)) => {
+                        let qname = e.local_name();
+                        let name = qname.as_ref();
+                        if name == b"sheetName" {
+                            for attr in e.attributes().filter_map(Result::ok) {
+                                if attr.key == QName(b"val")
+                                    && let Ok(v) = attr.decode_and_unescape_value(reader.decoder())
+                                {
+                                    sheet_names.push(v.into_owned());
+                                }
+                            }
+                        }
+                    }
+                    Ok(Event::Text(ref t)) => {
+                        if capturing.is_some()
+                            && let Ok(v) = t.decode()
+                        {
+                            text_buf.push_str(&v);
+                        }
+                    }
+                    Ok(Event::End(ref e)) => {
+                        let qname = e.local_name();
+                        let name = qname.as_ref();
+                        if name == b"v" || name == b"t" {
+                            let (Some(cell_ref), Some(sheet_id)) =
+                                (cur_cell_ref.as_deref(), cur_sheet_id)
+                            else {
+                                capturing = None;
+                                continue;
+                            };
+                            capturing = None;
+                            let Some(sheet) = sheet_names.get(sheet_id as usize) else {
+                                continue;
+                            };
+                            let Some((cols, row)) = parse_cell_ref(cell_ref) else {
+                                continue;
+                            };
+                            let Some(col) =
+                                formualizer_common::col_index_from_letters_1based(&cols).ok()
+                            else {
+                                continue;
+                            };
+                            let value = match cur_cell_type.as_str() {
+                                "b" => Some(LiteralValue::Boolean(
+                                    text_buf.trim() == "1"
+                                        || text_buf.trim().eq_ignore_ascii_case("true"),
+                                )),
+                                "str" | "inlineStr" => Some(LiteralValue::Text(text_buf.clone())),
+                                "e" => None,
+                                "s" => None,
+                                _ => text_buf
+                                    .trim()
+                                    .parse::<f64>()
+                                    .ok()
+                                    .map(LiteralValue::Number),
+                            };
+                            if let Some(value) = value {
+                                out.push(ExternalCachedSource {
+                                    book_index,
+                                    sheet: sheet.clone(),
+                                    row,
+                                    col,
+                                    value,
+                                });
+                                if out.len() as u64 >= max_cells {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Ok(Event::Eof) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        let mut failures = 0u64;
+        // A byte budget bounds each part read (the attacker-controlled bulk is
+        // the externalLink data). The floor keeps small ingest caps from
+        // truncating the tiny `workbook.xml`/rels meta files; truncating a data
+        // part just seeds fewer cached cells, which is exactly the point of the
+        // cap.
+        let byte_budget = max_cells.saturating_mul(128).max(16 * 1024);
+        let mut archive = match ZipArchive::new(reader) {
+            Ok(a) => a,
+            Err(_) => return (Vec::new(), 1),
+        };
+        let Some(workbook_xml) = entry_text_bounded(&mut archive, "xl/workbook.xml", byte_budget)
+        else {
+            return (Vec::new(), 1);
+        };
+        let rids = workbook_external_reference_rids(&workbook_xml);
+        if rids.is_empty() {
+            return (Vec::new(), 0);
+        }
+        let Some(rels) =
+            entry_text_bounded(&mut archive, "xl/_rels/workbook.xml.rels", byte_budget)
+        else {
+            return (Vec::new(), 1);
+        };
+        let link_by_rid = workbook_external_link_rels(&rels);
+
+        let mut out = Vec::new();
+        let mut remaining = max_cells;
+        for (book_index, rid) in rids.iter().enumerate() {
+            let book_index = (book_index as u32) + 1;
+            let Some(link_index) = link_by_rid.get(rid) else {
+                failures += 1;
+                continue;
+            };
+            let Some(xml) = entry_text_bounded(
+                &mut archive,
+                &format!("xl/externalLinks/externalLink{link_index}.xml"),
+                byte_budget,
+            ) else {
+                failures += 1;
+                continue;
+            };
+            let cells = external_link_cached_cells(&xml, book_index, remaining);
+            remaining = remaining.saturating_sub(cells.len() as u64);
+            out.extend(cells);
+            if remaining == 0 {
+                break;
+            }
+        }
+        (out, failures)
+    }
+
     fn calamine_error_code(e: &calamine::CellErrorType) -> u8 {
         let kind = match e {
             calamine::CellErrorType::Div0 => ExcelErrorKind::Div,
@@ -1711,6 +2043,28 @@ impl SpreadsheetReader for CalamineAdapter {
 
     fn calc_settings(&self) -> Option<CalcSettings> {
         self.lazy_calc_settings().clone()
+    }
+
+    fn external_cached_sources(&self) -> &[ExternalCachedSource] {
+        &self.external_cached_sources
+    }
+
+    fn scan_external_cached_sources(
+        &mut self,
+        limits: &formualizer_eval::engine::WorkbookLoadLimits,
+    ) -> Result<(), Self::Error> {
+        // Reuse the shared source acquisition rather than reopening the file: the
+        // retained `SharedXlsxReader` hands out an independent logical cursor via
+        // `reader()`, exactly like the lazy calcPr/defined-names/external-link
+        // metadata scans.
+        let (sources, failures) = Self::scan_external_link_sources_from_reader(
+            self.source.reader(),
+            limits.max_external_cached_cells,
+        );
+        self.load_stats.external_cached_source_cells = Some(sources.len() as u64);
+        self.load_stats.external_link_scan_failures = Some(failures);
+        self.external_cached_sources = sources;
+        Ok(())
     }
 
     fn open_path<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error>
@@ -2095,6 +2449,8 @@ where
                 value_slots_handed_to_engine: Some(total_values as u64),
                 formula_cells_handed_to_engine: Some(total_formula_handed_to_engine as u64),
                 shared_formula_tags_observed: Some(total_shared_formula_tags as u64),
+                external_cached_source_cells: self.load_stats.external_cached_source_cells,
+                external_link_scan_failures: self.load_stats.external_link_scan_failures,
             };
             Ok(())
         })();

--- a/crates/formualizer-workbook/src/backends/umya.rs
+++ b/crates/formualizer-workbook/src/backends/umya.rs
@@ -1600,6 +1600,8 @@ where
             value_slots_handed_to_engine: Some(total_value_slots as u64),
             formula_cells_handed_to_engine: Some(total_formula_handed_to_engine as u64),
             shared_formula_tags_observed: None,
+            external_cached_source_cells: None,
+            external_link_scan_failures: None,
         };
         if debug {
             eprintln!(

--- a/crates/formualizer-workbook/src/lib.rs
+++ b/crates/formualizer-workbook/src/lib.rs
@@ -39,9 +39,9 @@ pub use recalculate::{
 pub use resolver::IoResolver;
 pub use session::{EditorSession, IoConfig};
 pub use traits::{
-    AccessGranularity, AdapterLoadStats, BackendCaps, CalcSettings, CellData, LoadStrategy,
-    MergedRange, NamedRange, NamedRangeScope, SheetData, SpreadsheetIO, SpreadsheetReader,
-    SpreadsheetWriter, TableDefinition,
+    AccessGranularity, AdapterLoadStats, BackendCaps, CalcSettings, CellData, ExternalCachedSource,
+    LoadStrategy, MergedRange, NamedRange, NamedRangeScope, SheetData, SpreadsheetIO,
+    SpreadsheetReader, SpreadsheetWriter, TableDefinition,
 };
 pub use transaction::{WriteOp, WriteTransaction};
 

--- a/crates/formualizer-workbook/src/traits.rs
+++ b/crates/formualizer-workbook/src/traits.rs
@@ -242,6 +242,37 @@ pub struct AdapterLoadStats {
     pub value_slots_handed_to_engine: Option<u64>,
     pub formula_cells_handed_to_engine: Option<u64>,
     pub shared_formula_tags_observed: Option<u64>,
+    /// Cached in-workbook external-reference cells (spec §10) seeded into the
+    /// engine from `externalLinkN.xml` parts. `None` when the backend does not
+    /// surface external-link caches.
+    pub external_cached_source_cells: Option<u64>,
+    /// External-link part scan failures (zip errors, missing/malformed parts).
+    /// A nonzero count means the cached sources are incomplete; formula cells
+    /// referencing the unreadable parts will fail with `#NAME?` at evaluation.
+    pub external_link_scan_failures: Option<u64>,
+}
+
+/// A single cached in-workbook external reference cell (spec §10).
+///
+/// Excel stores cross-workbook reference values in `externalLinkN.xml` parts and
+/// never recalculates them; this struct carries one cached cell's structured
+/// identity (book index, sheet name, 1-based row/col) plus its cached value. The
+/// canonical engine source key is derived from these structured fields by
+/// [`formualizer_common::external_cell_source_name`], so authored variants like
+/// `=[1]Sheet1!A1`, `=[1]Sheet1!$A$1`, and `=[1]sheet1!a1` all resolve to it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExternalCachedSource {
+    /// 1-based position of the `<externalReference>` in `xl/workbook.xml`,
+    /// matching the `[n]` book token the parser produces.
+    pub book_index: u32,
+    /// Sheet name as stored in `sheetName val="..."` (unquoted).
+    pub sheet: String,
+    /// 1-based row.
+    pub row: u32,
+    /// 1-based column.
+    pub col: u32,
+    /// Cached value Excel surfaces for the reference.
+    pub value: LiteralValue,
 }
 
 /// Workbook-level calculation properties parsed from `xl/workbook.xml`'s
@@ -299,6 +330,34 @@ pub trait SpreadsheetReader: Send + Sync {
     /// that case. Only the XLSX backends populate this today.
     fn calc_settings(&self) -> Option<CalcSettings> {
         None
+    }
+
+    /// Scan cached values for in-workbook external references (spec §10) from
+    /// the backend's underlying source, honoring `limits` (entry cap).
+    ///
+    /// Excel never recalculates external links; the cached `<v>` values stored
+    /// in the `externalLinkN.xml` parts are the values a formula cell referencing
+    /// them returns. Backends that surface these populate
+    /// [`SpreadsheetReader::external_cached_sources`] during this call; scan
+    /// failures (zip errors, missing/malformed parts) are reflected in
+    /// [`AdapterLoadStats::external_link_scan_failures`]. Backends without
+    /// support leave the cache empty and return `Ok`.
+    fn scan_external_cached_sources(
+        &mut self,
+        limits: &formualizer_eval::engine::WorkbookLoadLimits,
+    ) -> Result<(), Self::Error> {
+        let _ = limits;
+        Ok(())
+    }
+
+    /// Cached in-workbook external reference cells (spec §10) surfaced by the
+    /// backend, as structured `(book, sheet, row, col, value)` records.
+    ///
+    /// Populated during [`SpreadsheetReader::scan_external_cached_sources`]; the
+    /// workbook copies them into its resolver so evaluation can answer the
+    /// reference with the cached value.
+    fn external_cached_sources(&self) -> &[ExternalCachedSource] {
+        &[]
     }
 
     /// Constructor variants for different environments

--- a/crates/formualizer-workbook/src/traits.rs
+++ b/crates/formualizer-workbook/src/traits.rs
@@ -301,6 +301,18 @@ pub trait SpreadsheetReader: Send + Sync {
         None
     }
 
+    /// Cached values for in-workbook external references (spec §10), as
+    /// `(raw_reference, value)` pairs such as `("[1]Sheet1!A1", Number(42.0))`.
+    ///
+    /// Excel does not recalculate external links; the cached `<v>` values stored
+    /// in the `externalLinkN.xml` parts are the values a formula cell referencing
+    /// them returns. Backends that surface these declare the source scalars on
+    /// the engine during `stream_into_engine`; the values are copied into the
+    /// workbook's resolver so evaluation can answer the reference.
+    fn external_cached_sources(&self) -> &[(String, LiteralValue)] {
+        &[]
+    }
+
     /// Constructor variants for different environments
     fn open_path<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error>
     where

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -8,7 +8,7 @@ use formualizer_eval::engine::RowVisibilitySource;
 use formualizer_eval::engine::eval::EvalPlan;
 use formualizer_eval::engine::named_range::{NameScope, NamedDefinition};
 use parking_lot::RwLock;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 #[cfg(feature = "wasm_plugins")]
@@ -790,6 +790,10 @@ impl formualizer_eval::function::Function for WorkbookWasmFunction {
 pub struct WBResolver {
     custom_functions: Arc<RwLock<CustomFnRegistry>>,
     custom_function_revision: Arc<std::sync::atomic::AtomicU64>,
+    /// Cached values for in-workbook external references (spec §10), keyed by
+    /// raw reference (`[1]Sheet1!A1`). Populated from the `externalLinkN.xml`
+    /// parts at load; evaluation answers external reference cells through this.
+    source_values: Arc<RwLock<HashMap<String, LiteralValue>>>,
 }
 
 impl Default for WBResolver {
@@ -797,6 +801,7 @@ impl Default for WBResolver {
         Self {
             custom_functions: Arc::new(RwLock::new(BTreeMap::new())),
             custom_function_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            source_values: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -805,10 +810,12 @@ impl WBResolver {
     fn new(
         custom_functions: Arc<RwLock<CustomFnRegistry>>,
         custom_function_revision: Arc<std::sync::atomic::AtomicU64>,
+        source_values: Arc<RwLock<HashMap<String, LiteralValue>>>,
     ) -> Self {
         Self {
             custom_functions,
             custom_function_revision,
+            source_values,
         }
     }
 }
@@ -860,7 +867,17 @@ impl formualizer_eval::traits::TableResolver for WBResolver {
         ))
     }
 }
-impl formualizer_eval::traits::SourceResolver for WBResolver {}
+impl formualizer_eval::traits::SourceResolver for WBResolver {
+    fn source_scalar_version(&self, _name: &str) -> Option<u64> {
+        Some(0)
+    }
+
+    fn resolve_source_scalar(&self, name: &str) -> Result<LiteralValue, ExcelError> {
+        self.source_values.read().get(name).cloned().ok_or_else(|| {
+            ExcelError::new(ExcelErrorKind::Name).with_message(format!("Undefined name: {name}"))
+        })
+    }
+}
 impl formualizer_eval::traits::FunctionProvider for WBResolver {
     fn planning_semantic_revision(&self) -> Option<u64> {
         Some(
@@ -905,6 +922,10 @@ pub struct Workbook {
     engine: formualizer_eval::engine::Engine<WBResolver>,
     custom_functions: Arc<RwLock<CustomFnRegistry>>,
     custom_function_revision: Arc<std::sync::atomic::AtomicU64>,
+    /// Cached values for in-workbook external references (spec §10), shared with
+    /// the engine's resolver. Populated from the `externalLinkN.xml` parts at
+    /// load; see [`WBResolver::source_values`].
+    source_values: Arc<RwLock<HashMap<String, LiteralValue>>>,
     wasm_plugins: WasmPluginManager,
     enable_changelog: bool,
     log: formualizer_eval::engine::ChangeLog,
@@ -1042,6 +1063,12 @@ pub struct WorkbookConfig {
     pub eval: formualizer_eval::engine::EvalConfig,
     pub enable_changelog: bool,
     pub ingest_limits: formualizer_eval::engine::WorkbookLoadLimits,
+    /// Resolve in-workbook external references (spec §10) from cached
+    /// `externalLinkN.xml` values. Enabled by default (matches Excel, which
+    /// never recalculates external links); disable to fall back to the pre-#363
+    /// behavior where such references fail with `#NAME?: Undefined name` at
+    /// evaluation.
+    pub resolve_external_cached_sources: bool,
 }
 
 impl WorkbookConfig {
@@ -1050,6 +1077,7 @@ impl WorkbookConfig {
             eval: formualizer_eval::engine::EvalConfig::default(),
             enable_changelog: false,
             ingest_limits: formualizer_eval::engine::WorkbookLoadLimits::default(),
+            resolve_external_cached_sources: true,
         }
     }
 
@@ -1063,6 +1091,7 @@ impl WorkbookConfig {
             eval,
             enable_changelog: true,
             ingest_limits: formualizer_eval::engine::WorkbookLoadLimits::default(),
+            resolve_external_cached_sources: true,
         }
     }
 
@@ -1071,6 +1100,16 @@ impl WorkbookConfig {
         ingest_limits: formualizer_eval::engine::WorkbookLoadLimits,
     ) -> Self {
         self.ingest_limits = ingest_limits;
+        self
+    }
+
+    /// Opt in/out of cached in-workbook external-reference resolution (spec §10).
+    ///
+    /// Enabled by default; when disabled, external-reference cells are not seeded
+    /// from `externalLinkN.xml` cached values and fail with `#NAME?` at
+    /// evaluation, matching pre-#363 behavior.
+    pub fn with_external_cached_sources(mut self, enabled: bool) -> Self {
+        self.resolve_external_cached_sources = enabled;
         self
     }
 
@@ -1116,9 +1155,11 @@ impl Workbook {
         let ingest_limits = config.ingest_limits.clone();
         let custom_functions = Arc::new(RwLock::new(BTreeMap::new()));
         let custom_function_revision = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let source_values = Arc::new(RwLock::new(HashMap::new()));
         let resolver = WBResolver::new(
             custom_functions.clone(),
             Arc::clone(&custom_function_revision),
+            Arc::clone(&source_values),
         );
         let mut engine = formualizer_eval::engine::Engine::new(resolver, config.eval);
         engine.set_workbook_load_limits(ingest_limits);
@@ -1129,6 +1170,7 @@ impl Workbook {
             engine,
             custom_functions,
             custom_function_revision,
+            source_values,
             wasm_plugins: WasmPluginManager::default(),
             enable_changelog: config.enable_changelog,
             log,
@@ -3460,12 +3502,45 @@ impl Workbook {
             config.eval.cycle =
                 crate::calc_pr::apply_calc_settings_to_cycle(settings, config.eval.cycle);
         }
+        let ingest_limits = config.ingest_limits.clone();
+        let resolve_external_cached_sources = config.resolve_external_cached_sources;
 
         let mut wb = Self::new_with_config(config);
         // Retain round-trip-only calcPr attributes (calcMode/fullCalcOnLoad) so
         // the XLSX write path can re-emit them; iterate* are sourced from the
         // live engine config at save time.
         wb.calc_settings = parsed_calc;
+        // In-workbook external references (spec §10): when resolution is enabled,
+        // scan the cached `externalLinkN.xml` values (bounded by ingest limits),
+        // declare each unique source scalar on the engine *before* formulas are
+        // ingested, and surface the values to the resolver so evaluation answers
+        // `[1]Sheet1!A1` cells with the cached value (Excel never recalculates
+        // external links). `new_with_config` seeded the resolver with the same
+        // `source_values` map the Workbook holds, so this populates it directly.
+        if resolve_external_cached_sources {
+            backend
+                .scan_external_cached_sources(&ingest_limits)
+                .map_err(|e| IoError::from_backend("workbook", e))?;
+            let mut declared: HashMap<String, LiteralValue> = HashMap::new();
+            for src in backend.external_cached_sources() {
+                let name = formualizer_common::external_cell_source_name(
+                    &format!("[{}]", src.book_index),
+                    &src.sheet,
+                    src.row,
+                    src.col,
+                );
+                // Duplicate cached cells (same book/sheet/row/col) are last-wins.
+                declared.insert(name, src.value.clone());
+            }
+            for name in declared.keys() {
+                wb.engine
+                    .define_source_scalar(name, Some(0))
+                    .map_err(IoError::Engine)?;
+            }
+            for (name, value) in declared {
+                wb.source_values.write().insert(name, value);
+            }
+        }
         backend
             .stream_into_engine(&mut wb.engine)
             .map_err(IoError::from)?;

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -8,7 +8,7 @@ use formualizer_eval::engine::RowVisibilitySource;
 use formualizer_eval::engine::eval::EvalPlan;
 use formualizer_eval::engine::named_range::{NameScope, NamedDefinition};
 use parking_lot::RwLock;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 #[cfg(feature = "wasm_plugins")]
@@ -790,6 +790,10 @@ impl formualizer_eval::function::Function for WorkbookWasmFunction {
 pub struct WBResolver {
     custom_functions: Arc<RwLock<CustomFnRegistry>>,
     custom_function_revision: Arc<std::sync::atomic::AtomicU64>,
+    /// Cached values for in-workbook external references (spec §10), keyed by
+    /// raw reference (`[1]Sheet1!A1`). Populated from the `externalLinkN.xml`
+    /// parts at load; evaluation answers external reference cells through this.
+    source_values: Arc<RwLock<HashMap<String, LiteralValue>>>,
 }
 
 impl Default for WBResolver {
@@ -797,6 +801,7 @@ impl Default for WBResolver {
         Self {
             custom_functions: Arc::new(RwLock::new(BTreeMap::new())),
             custom_function_revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            source_values: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -805,10 +810,12 @@ impl WBResolver {
     fn new(
         custom_functions: Arc<RwLock<CustomFnRegistry>>,
         custom_function_revision: Arc<std::sync::atomic::AtomicU64>,
+        source_values: Arc<RwLock<HashMap<String, LiteralValue>>>,
     ) -> Self {
         Self {
             custom_functions,
             custom_function_revision,
+            source_values,
         }
     }
 }
@@ -860,7 +867,22 @@ impl formualizer_eval::traits::TableResolver for WBResolver {
         ))
     }
 }
-impl formualizer_eval::traits::SourceResolver for WBResolver {}
+impl formualizer_eval::traits::SourceResolver for WBResolver {
+    fn source_scalar_version(&self, _name: &str) -> Option<u64> {
+        Some(0)
+    }
+
+    fn resolve_source_scalar(&self, name: &str) -> Result<LiteralValue, ExcelError> {
+        self.source_values
+            .read()
+            .get(name)
+            .cloned()
+            .ok_or_else(|| {
+                ExcelError::new(ExcelErrorKind::Name)
+                    .with_message(format!("Undefined name: {name}"))
+            })
+    }
+}
 impl formualizer_eval::traits::FunctionProvider for WBResolver {
     fn planning_semantic_revision(&self) -> Option<u64> {
         Some(
@@ -905,6 +927,10 @@ pub struct Workbook {
     engine: formualizer_eval::engine::Engine<WBResolver>,
     custom_functions: Arc<RwLock<CustomFnRegistry>>,
     custom_function_revision: Arc<std::sync::atomic::AtomicU64>,
+    /// Cached values for in-workbook external references (spec §10), shared with
+    /// the engine's resolver. Populated from the `externalLinkN.xml` parts at
+    /// load; see [`WBResolver::source_values`].
+    source_values: Arc<RwLock<HashMap<String, LiteralValue>>>,
     wasm_plugins: WasmPluginManager,
     enable_changelog: bool,
     log: formualizer_eval::engine::ChangeLog,
@@ -1116,9 +1142,11 @@ impl Workbook {
         let ingest_limits = config.ingest_limits.clone();
         let custom_functions = Arc::new(RwLock::new(BTreeMap::new()));
         let custom_function_revision = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let source_values = Arc::new(RwLock::new(HashMap::new()));
         let resolver = WBResolver::new(
             custom_functions.clone(),
             Arc::clone(&custom_function_revision),
+            Arc::clone(&source_values),
         );
         let mut engine = formualizer_eval::engine::Engine::new(resolver, config.eval);
         engine.set_workbook_load_limits(ingest_limits);
@@ -1129,6 +1157,7 @@ impl Workbook {
             engine,
             custom_functions,
             custom_function_revision,
+            source_values,
             wasm_plugins: WasmPluginManager::default(),
             enable_changelog: config.enable_changelog,
             log,
@@ -3469,6 +3498,17 @@ impl Workbook {
         backend
             .stream_into_engine(&mut wb.engine)
             .map_err(IoError::from)?;
+        // In-workbook external references (spec §10): the backend declares the
+        // source scalars during `stream_into_engine`; the cached values stored in
+        // the `externalLinkN.xml` parts are surfaced here so evaluation answers
+        // `[1]Sheet1!A1` cells with the cached value (Excel never recalculates
+        // external links). `new_with_config` seeded the resolver with the same
+        // `source_values` map the Workbook holds, so this populates it directly.
+        for (name, value) in backend.external_cached_sources() {
+            wb.source_values
+                .write()
+                .insert(name.clone(), value.clone());
+        }
         let stats = backend.load_stats();
         Ok((wb, stats))
     }

--- a/crates/formualizer-workbook/src/workbook.rs
+++ b/crates/formualizer-workbook/src/workbook.rs
@@ -873,14 +873,9 @@ impl formualizer_eval::traits::SourceResolver for WBResolver {
     }
 
     fn resolve_source_scalar(&self, name: &str) -> Result<LiteralValue, ExcelError> {
-        self.source_values
-            .read()
-            .get(name)
-            .cloned()
-            .ok_or_else(|| {
-                ExcelError::new(ExcelErrorKind::Name)
-                    .with_message(format!("Undefined name: {name}"))
-            })
+        self.source_values.read().get(name).cloned().ok_or_else(|| {
+            ExcelError::new(ExcelErrorKind::Name).with_message(format!("Undefined name: {name}"))
+        })
     }
 }
 impl formualizer_eval::traits::FunctionProvider for WBResolver {
@@ -3505,9 +3500,7 @@ impl Workbook {
         // external links). `new_with_config` seeded the resolver with the same
         // `source_values` map the Workbook holds, so this populates it directly.
         for (name, value) in backend.external_cached_sources() {
-            wb.source_values
-                .write()
-                .insert(name.clone(), value.clone());
+            wb.source_values.write().insert(name.clone(), value.clone());
         }
         let stats = backend.load_stats();
         Ok((wb, stats))

--- a/crates/formualizer-workbook/tests/calamine/formulas.rs
+++ b/crates/formualizer-workbook/tests/calamine/formulas.rs
@@ -2,7 +2,7 @@
 use crate::common::build_workbook;
 use formualizer_eval::engine::ingest::EngineLoadStream;
 use formualizer_eval::engine::{Engine, EvalConfig};
-use formualizer_workbook::{CalamineAdapter, LiteralValue, SpreadsheetReader};
+use formualizer_workbook::{CalamineAdapter, LiteralValue, LoadStrategy, SpreadsheetReader, WorkbookConfig};
 use std::io::{Cursor, Read, Write};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
@@ -124,4 +124,138 @@ fn calamine_loads_external_link_index_formulas_from_bytes() {
     let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
     backend.stream_into_engine(&mut engine).unwrap();
     engine.build_graph_all().unwrap();
+}
+
+/// Inject an in-workbook external link (spec §10) into an `.xlsx` zip: a
+/// `xl/externalLinks/externalLink1.xml` part with cached `sheetData` values,
+/// plus the `<externalReferences>` entry and the matching workbook relationship.
+/// `cells` maps cell refs to cached string values (e.g. `("A1", "42")`).
+fn inject_inbook_external_link(bytes: Vec<u8>, sheet_name: &str, cells: &[(&str, &str)]) -> Vec<u8> {
+    let reader = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(reader).unwrap();
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    let mut sheet_data = String::new();
+    for (cell_ref, value) in cells {
+        let row: u32 = cell_ref
+            .chars()
+            .skip_while(|c| c.is_ascii_alphabetic())
+            .collect::<String>()
+            .parse()
+            .expect("row from cell ref");
+        sheet_data.push_str(&format!(
+            "<row r=\"{row}\"><c r=\"{cell_ref}\"><v>{value}</v></c></row>"
+        ));
+    }
+    let ext_xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n\
+         <externalLink xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" \
+         xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">\
+         <externalBook r:id=\"rId1\"><sheetNames><sheetName val=\"{sheet_name}\"/></sheetNames>\
+         <sheetDataSet><sheetData sheetId=\"0\">{sheet_data}</sheetData></sheetDataSet>\
+         </externalBook></externalLink>\n"
+    );
+
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).unwrap();
+        let name = entry.name().to_string();
+        if entry.is_dir() {
+            let _ = writer.add_directory(name, options);
+            continue;
+        }
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).unwrap();
+        let data = match name.as_str() {
+            "xl/workbook.xml" => String::from_utf8(data)
+                .expect("workbook.xml utf8")
+                .replace(
+                    "</workbook>",
+                    "<externalReferences><externalReference r:id=\"rId9000\"/></externalReferences></workbook>",
+                )
+                .into_bytes(),
+            "xl/_rels/workbook.xml.rels" => String::from_utf8(data)
+                .expect("workbook rels utf8")
+                .replace(
+                    "</Relationships>",
+                    "<Relationship Id=\"rId9000\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink\" Target=\"externalLinks/externalLink1.xml\"/></Relationships>",
+                )
+                .into_bytes(),
+            _ => data,
+        };
+        writer.start_file(name, options).unwrap();
+        writer.write_all(&data).unwrap();
+    }
+    let _ = writer.add_directory("xl/externalLinks/".to_string(), options);
+    writer.start_file("xl/externalLinks/externalLink1.xml", options).unwrap();
+    writer.write_all(ext_xml.as_bytes()).unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+#[test]
+fn calamine_evaluates_inbook_external_reference_from_cached_values() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A1"); // B1
+    });
+
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let bytes = inject_inbook_external_link(bytes, "Sheet1", &[("A1", "42")]);
+    std::fs::write(&path, bytes).expect("rewrite workbook with external link part");
+
+    let backend = CalamineAdapter::open_path(&path).unwrap();
+    assert_eq!(
+        backend.external_cached_sources(),
+        &[("[1]Sheet1!A1".to_string(), LiteralValue::Number(42.0))]
+    );
+
+    let mut wb = formualizer_workbook::Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::ephemeral(),
+    )
+    .unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(
+        wb.get_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(42.0))
+    );
+}
+
+#[test]
+fn calamine_inbook_external_reference_without_cache_is_undefined_name() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A1"); // B1
+    });
+
+    // No external link part injected: the reference has no cached source, so
+    // evaluation must fail gracefully (#NAME?: Undefined name) instead of
+    // panicking. `interactive` defers graph building, matching the report path.
+    let backend = CalamineAdapter::open_path(&path).unwrap();
+    assert!(backend.external_cached_sources().is_empty());
+
+    let mut wb = formualizer_workbook::Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .unwrap();
+    let res = wb.evaluate_all();
+    match res {
+        Err(e) => {
+            let msg = format!("{e}");
+            assert!(
+                msg.contains("#NAME?") || msg.contains("Undefined name"),
+                "expected undefined-name error, got: {msg}"
+            );
+        }
+        Ok(_) => assert!(matches!(
+            wb.get_value("Sheet1", 1, 2),
+            Some(LiteralValue::Error(_))
+        )),
+    }
 }

--- a/crates/formualizer-workbook/tests/calamine/formulas.rs
+++ b/crates/formualizer-workbook/tests/calamine/formulas.rs
@@ -2,7 +2,9 @@
 use crate::common::build_workbook;
 use formualizer_eval::engine::ingest::EngineLoadStream;
 use formualizer_eval::engine::{Engine, EvalConfig};
-use formualizer_workbook::{CalamineAdapter, LiteralValue, LoadStrategy, SpreadsheetReader, WorkbookConfig};
+use formualizer_workbook::{
+    CalamineAdapter, LiteralValue, LoadStrategy, SpreadsheetReader, WorkbookConfig,
+};
 use std::io::{Cursor, Read, Write};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
@@ -130,7 +132,11 @@ fn calamine_loads_external_link_index_formulas_from_bytes() {
 /// `xl/externalLinks/externalLink1.xml` part with cached `sheetData` values,
 /// plus the `<externalReferences>` entry and the matching workbook relationship.
 /// `cells` maps cell refs to cached string values (e.g. `("A1", "42")`).
-fn inject_inbook_external_link(bytes: Vec<u8>, sheet_name: &str, cells: &[(&str, &str)]) -> Vec<u8> {
+fn inject_inbook_external_link(
+    bytes: Vec<u8>,
+    sheet_name: &str,
+    cells: &[(&str, &str)],
+) -> Vec<u8> {
     let reader = Cursor::new(bytes);
     let mut archive = ZipArchive::new(reader).unwrap();
 
@@ -188,7 +194,9 @@ fn inject_inbook_external_link(bytes: Vec<u8>, sheet_name: &str, cells: &[(&str,
         writer.write_all(&data).unwrap();
     }
     let _ = writer.add_directory("xl/externalLinks/".to_string(), options);
-    writer.start_file("xl/externalLinks/externalLink1.xml", options).unwrap();
+    writer
+        .start_file("xl/externalLinks/externalLink1.xml", options)
+        .unwrap();
     writer.write_all(ext_xml.as_bytes()).unwrap();
     writer.finish().unwrap().into_inner()
 }

--- a/crates/formualizer-workbook/tests/calamine/formulas.rs
+++ b/crates/formualizer-workbook/tests/calamine/formulas.rs
@@ -2,7 +2,10 @@
 use crate::common::build_workbook;
 use formualizer_eval::engine::ingest::EngineLoadStream;
 use formualizer_eval::engine::{Engine, EvalConfig};
-use formualizer_workbook::{CalamineAdapter, LiteralValue, SpreadsheetReader};
+use formualizer_workbook::{
+    CalamineAdapter, ExternalCachedSource, LiteralValue, LoadStrategy, SpreadsheetReader,
+    WorkbookConfig,
+};
 use std::io::{Cursor, Read, Write};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
@@ -124,4 +127,359 @@ fn calamine_loads_external_link_index_formulas_from_bytes() {
     let mut engine: Engine<_> = Engine::new(ctx, EvalConfig::default());
     backend.stream_into_engine(&mut engine).unwrap();
     engine.build_graph_all().unwrap();
+}
+
+/// Inject an in-workbook external link (spec §10) into an `.xlsx` zip: a
+/// `xl/externalLinks/externalLink1.xml` part with cached `sheetData` values,
+/// plus the `<externalReferences>` entry and the matching workbook relationship.
+/// `cells` maps cell refs to cached string values (e.g. `("A1", "42")`).
+fn inject_inbook_external_link(
+    bytes: Vec<u8>,
+    sheet_name: &str,
+    cells: &[(&str, &str)],
+) -> Vec<u8> {
+    let reader = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(reader).unwrap();
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    let mut sheet_data = String::new();
+    for (cell_ref, value) in cells {
+        let row: u32 = cell_ref
+            .chars()
+            .skip_while(|c| c.is_ascii_alphabetic())
+            .collect::<String>()
+            .parse()
+            .expect("row from cell ref");
+        sheet_data.push_str(&format!(
+            "<row r=\"{row}\"><c r=\"{cell_ref}\"><v>{value}</v></c></row>"
+        ));
+    }
+    let ext_xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n\
+         <externalLink xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" \
+         xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">\
+         <externalBook r:id=\"rId1\"><sheetNames><sheetName val=\"{sheet_name}\"/></sheetNames>\
+         <sheetDataSet><sheetData sheetId=\"0\">{sheet_data}</sheetData></sheetDataSet>\
+         </externalBook></externalLink>\n"
+    );
+
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).unwrap();
+        let name = entry.name().to_string();
+        if entry.is_dir() {
+            let _ = writer.add_directory(name, options);
+            continue;
+        }
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).unwrap();
+        let data = match name.as_str() {
+            "xl/workbook.xml" => String::from_utf8(data)
+                .expect("workbook.xml utf8")
+                .replace(
+                    "</workbook>",
+                    "<externalReferences><externalReference r:id=\"rId9000\"/></externalReferences></workbook>",
+                )
+                .into_bytes(),
+            "xl/_rels/workbook.xml.rels" => String::from_utf8(data)
+                .expect("workbook rels utf8")
+                .replace(
+                    "</Relationships>",
+                    "<Relationship Id=\"rId9000\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink\" Target=\"externalLinks/externalLink1.xml\"/></Relationships>",
+                )
+                .into_bytes(),
+            _ => data,
+        };
+        writer.start_file(name, options).unwrap();
+        writer.write_all(&data).unwrap();
+    }
+    let _ = writer.add_directory("xl/externalLinks/".to_string(), options);
+    writer
+        .start_file("xl/externalLinks/externalLink1.xml", options)
+        .unwrap();
+    writer.write_all(ext_xml.as_bytes()).unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+#[test]
+fn calamine_scan_exposes_structured_cached_sources() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A1"); // B1
+    });
+
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let bytes = inject_inbook_external_link(bytes, "Sheet1", &[("A1", "42")]);
+    std::fs::write(&path, bytes).expect("rewrite workbook with external link part");
+
+    let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    // Deferred scan: empty until `scan_external_cached_sources` is called (the
+    // `Workbook::from_reader` path does this with ingest limits applied).
+    assert!(backend.external_cached_sources().is_empty());
+    let limits = formualizer_eval::engine::WorkbookLoadLimits::default();
+    backend.scan_external_cached_sources(&limits).unwrap();
+    assert_eq!(
+        backend.external_cached_sources(),
+        &[ExternalCachedSource {
+            book_index: 1,
+            sheet: "Sheet1".to_string(),
+            row: 1,
+            col: 1,
+            value: LiteralValue::Number(42.0),
+        }]
+    );
+    assert_eq!(
+        backend.load_stats().unwrap().external_cached_source_cells,
+        Some(1)
+    );
+    assert_eq!(
+        backend.load_stats().unwrap().external_link_scan_failures,
+        Some(0)
+    );
+}
+
+#[test]
+fn calamine_evaluates_inbook_external_reference_from_cached_values() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A1"); // B1
+    });
+
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let bytes = inject_inbook_external_link(bytes, "Sheet1", &[("A1", "42")]);
+    std::fs::write(&path, bytes).expect("rewrite workbook with external link part");
+
+    let mut wb = formualizer_workbook::Workbook::from_reader(
+        CalamineAdapter::open_path(&path).unwrap(),
+        LoadStrategy::EagerAll,
+        WorkbookConfig::ephemeral(),
+    )
+    .unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(
+        wb.get_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(42.0))
+    );
+}
+
+/// Cached sources resolve structurally: authored variants of the same reference
+/// (`$` anchors, sheet-name case, spacing) must all hit the same canonical key.
+#[test]
+fn calamine_evaluates_inbook_external_reference_structurally() {
+    for formula in [
+        "[1]Sheet1!A1",
+        "[1]Sheet1!$A$1",
+        "[1]sheet1!A1",
+        "'[1]Sheet1'!A1",
+    ] {
+        let path = build_workbook(|book| {
+            let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+            sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+            sh.get_cell_mut((2, 1)).set_formula(formula); // B1
+        });
+
+        let bytes = std::fs::read(&path).expect("read workbook bytes");
+        let bytes = inject_inbook_external_link(bytes, "Sheet1", &[("A1", "42")]);
+        std::fs::write(&path, bytes).expect("rewrite workbook with external link part");
+
+        let mut wb = formualizer_workbook::Workbook::from_reader(
+            CalamineAdapter::open_path(&path).unwrap(),
+            LoadStrategy::EagerAll,
+            WorkbookConfig::ephemeral(),
+        )
+        .unwrap();
+        wb.evaluate_all().unwrap();
+        assert_eq!(
+            wb.get_value("Sheet1", 1, 2),
+            Some(LiteralValue::Number(42.0)),
+            "formula {formula:?} should resolve to the cached value"
+        );
+    }
+}
+
+/// A sheet name that needs quoting in an authored reference (contains a space)
+/// still matches a cached source for the same sheet.
+#[test]
+fn calamine_inbook_external_reference_punctuated_sheet_name() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("'[1]My Sheet'!A1"); // B1
+    });
+
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let bytes = inject_inbook_external_link(bytes, "My Sheet", &[("A1", "42")]);
+    std::fs::write(&path, bytes).expect("rewrite workbook with external link part");
+
+    let mut wb = formualizer_workbook::Workbook::from_reader(
+        CalamineAdapter::open_path(&path).unwrap(),
+        LoadStrategy::EagerAll,
+        WorkbookConfig::ephemeral(),
+    )
+    .unwrap();
+    wb.evaluate_all().unwrap();
+    assert_eq!(
+        wb.get_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(42.0))
+    );
+}
+
+/// The ingest-limit entry cap bounds how many cached external cells are seeded.
+#[test]
+fn calamine_external_cached_sources_respect_ingest_cap() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A100"); // B1
+    });
+
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    // Cache 100 cells (A1..A100); a tiny cap must stop well before that.
+    let cells: Vec<(String, String)> = (1..=100)
+        .map(|row| (format!("A{row}"), format!("{row}")))
+        .collect();
+    let cell_refs: Vec<(&str, &str)> = cells
+        .iter()
+        .map(|(r, v)| (r.as_str(), v.as_str()))
+        .collect();
+    let bytes = inject_inbook_external_link(bytes, "Sheet1", &cell_refs);
+    std::fs::write(&path, bytes).expect("rewrite workbook with external link part");
+
+    let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    let mut limits = formualizer_eval::engine::WorkbookLoadLimits::default();
+    limits.max_external_cached_cells = 5;
+    backend.scan_external_cached_sources(&limits).unwrap();
+    assert_eq!(
+        backend.load_stats().unwrap().external_cached_source_cells,
+        Some(5)
+    );
+    assert_eq!(backend.external_cached_sources().len(), 5);
+}
+
+/// A declared external reference whose part is missing records a scan failure
+/// instead of silently loading an empty cache.
+#[test]
+fn calamine_external_link_scan_failures_are_recorded() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A1"); // B1
+    });
+
+    // Inject the `<externalReferences>` entry but *not* the externalLink part.
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let reader = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(reader).unwrap();
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).unwrap();
+        let name = entry.name().to_string();
+        if entry.is_dir() {
+            let _ = writer.add_directory(name, options);
+            continue;
+        }
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).unwrap();
+        let data = if name == "xl/workbook.xml" {
+            String::from_utf8(data)
+                .expect("workbook.xml utf8")
+                .replace(
+                    "</workbook>",
+                    "<externalReferences><externalReference r:id=\"rId9000\"/></externalReferences></workbook>",
+                )
+                .into_bytes()
+        } else {
+            data
+        };
+        writer.start_file(name, options).unwrap();
+        writer.write_all(&data).unwrap();
+    }
+    let bytes = writer.finish().unwrap().into_inner();
+    std::fs::write(&path, bytes).expect("rewrite workbook");
+
+    let mut backend = CalamineAdapter::open_path(&path).unwrap();
+    let limits = formualizer_eval::engine::WorkbookLoadLimits::default();
+    backend.scan_external_cached_sources(&limits).unwrap();
+    assert_eq!(
+        backend.load_stats().unwrap().external_link_scan_failures,
+        Some(1),
+        "missing externalLink part should be recorded as a scan failure"
+    );
+    assert!(backend.external_cached_sources().is_empty());
+}
+
+/// The `resolve_external_cached_sources` knob disables cached-source seeding,
+/// restoring the pre-#363 behavior where the reference fails with `#NAME?`.
+#[test]
+fn calamine_inbook_external_reference_can_be_disabled() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A1"); // B1
+    });
+
+    let bytes = std::fs::read(&path).expect("read workbook bytes");
+    let bytes = inject_inbook_external_link(bytes, "Sheet1", &[("A1", "42")]);
+    std::fs::write(&path, bytes).expect("rewrite workbook with external link part");
+
+    let config = WorkbookConfig::interactive().with_external_cached_sources(false);
+    let mut wb = formualizer_workbook::Workbook::from_reader(
+        CalamineAdapter::open_path(&path).unwrap(),
+        LoadStrategy::EagerAll,
+        config,
+    )
+    .unwrap();
+    let res = wb.evaluate_all();
+    match res {
+        Err(e) => {
+            let msg = format!("{e}");
+            assert!(
+                msg.contains("#NAME?") || msg.contains("Undefined name"),
+                "expected undefined-name error, got: {msg}"
+            );
+        }
+        Ok(_) => assert!(matches!(
+            wb.get_value("Sheet1", 1, 2),
+            Some(LiteralValue::Error(_))
+        )),
+    }
+}
+
+#[test]
+fn calamine_inbook_external_reference_without_cache_is_undefined_name() {
+    let path = build_workbook(|book| {
+        let sh = book.get_sheet_by_name_mut("Sheet1").unwrap();
+        sh.get_cell_mut((1, 1)).set_value_number(42.0); // A1
+        sh.get_cell_mut((2, 1)).set_formula("[1]Sheet1!A1"); // B1
+    });
+
+    // No external link part injected: the reference has no cached source, so
+    // evaluation must fail gracefully (#NAME?: Undefined name) instead of
+    // panicking. `interactive` defers graph building, matching the report path.
+    let backend = CalamineAdapter::open_path(&path).unwrap();
+
+    let mut wb = formualizer_workbook::Workbook::from_reader(
+        backend,
+        LoadStrategy::EagerAll,
+        WorkbookConfig::interactive(),
+    )
+    .unwrap();
+    let res = wb.evaluate_all();
+    match res {
+        Err(e) => {
+            let msg = format!("{e}");
+            assert!(
+                msg.contains("#NAME?") || msg.contains("Undefined name"),
+                "expected undefined-name error, got: {msg}"
+            );
+        }
+        Ok(_) => assert!(matches!(
+            wb.get_value("Sheet1", 1, 2),
+            Some(LiteralValue::Error(_))
+        )),
+    }
 }

--- a/crates/formualizer-workbook/tests/load_limits.rs
+++ b/crates/formualizer-workbook/tests/load_limits.rs
@@ -190,14 +190,13 @@ fn sparse_whole_column_summary_xlsx_bytes() -> Vec<u8> {
 }
 
 fn sparse_limits() -> WorkbookLoadLimits {
-    WorkbookLoadLimits {
-        max_sheet_rows: 10_000,
-        max_sheet_cols: 100,
-        max_sheet_logical_cells: u64::MAX,
-        sparse_sheet_cell_threshold: 100,
-        max_sparse_cell_ratio: 10,
-        ..WorkbookLoadLimits::default()
-    }
+    let mut limits = WorkbookLoadLimits::default();
+    limits.max_sheet_rows = 10_000;
+    limits.max_sheet_cols = 100;
+    limits.max_sheet_logical_cells = u64::MAX;
+    limits.sparse_sheet_cell_threshold = 100;
+    limits.max_sparse_cell_ratio = 10;
+    limits
 }
 
 #[cfg(feature = "json")]
@@ -213,14 +212,13 @@ fn json_loader_rejects_dense_sheet_over_logical_budget() {
     }
 
     let mut cfg = WorkbookConfig::ephemeral();
-    cfg.ingest_limits = WorkbookLoadLimits {
-        max_sheet_rows: 10_000,
-        max_sheet_cols: 10_000,
-        max_sheet_logical_cells: 100,
-        sparse_sheet_cell_threshold: u64::MAX,
-        max_sparse_cell_ratio: u64::MAX,
-        ..WorkbookLoadLimits::default()
-    };
+    let mut ingest_limits = WorkbookLoadLimits::default();
+    ingest_limits.max_sheet_rows = 10_000;
+    ingest_limits.max_sheet_cols = 10_000;
+    ingest_limits.max_sheet_logical_cells = 100;
+    ingest_limits.sparse_sheet_cell_threshold = u64::MAX;
+    ingest_limits.max_sparse_cell_ratio = u64::MAX;
+    cfg.ingest_limits = ingest_limits;
 
     let err = match Workbook::from_reader(adapter, LoadStrategy::EagerAll, cfg) {
         Ok(_) => panic!("dense sheet should hit logical budget"),
@@ -343,10 +341,8 @@ fn calamine_formula_source_records_enforce_logical_budget_at_the_boundary() {
         (u64::from(rows) * 2 - 1, false),
     ] {
         let adapter = CalamineAdapter::open_bytes(bytes.clone()).expect("open shared workbook");
-        let limits = WorkbookLoadLimits {
-            max_sheet_logical_cells: limit,
-            ..WorkbookLoadLimits::default()
-        };
+        let mut limits = WorkbookLoadLimits::default();
+        limits.max_sheet_logical_cells = limit;
         let result = Workbook::from_reader(
             adapter,
             LoadStrategy::EagerAll,
@@ -405,13 +401,11 @@ fn calamine_loader_loads_shared_formula_semantics() {
 fn calamine_formula_spool_enforces_sheet_workbook_file_and_no_disk_limits() {
     use formualizer_workbook::FormulaSpoolDiskPolicy;
 
-    let zero_limits = WorkbookLoadLimits {
-        max_formula_spool_bytes_per_sheet: 0,
-        max_formula_spool_bytes_per_workbook: 0,
-        max_formula_spool_files_per_workbook: 0,
-        max_formula_spool_memory_bytes: 0,
-        ..WorkbookLoadLimits::default()
-    };
+    let mut zero_limits = WorkbookLoadLimits::default();
+    zero_limits.max_formula_spool_bytes_per_sheet = 0;
+    zero_limits.max_formula_spool_bytes_per_workbook = 0;
+    zero_limits.max_formula_spool_files_per_workbook = 0;
+    zero_limits.max_formula_spool_memory_bytes = 0;
     let literal_adapter = CalamineAdapter::open_bytes(out_of_order_sparse_xlsx_bytes()).unwrap();
     Workbook::from_reader(
         literal_adapter,
@@ -423,25 +417,28 @@ fn calamine_formula_spool_enforces_sheet_workbook_file_and_no_disk_limits() {
     let one_sheet = shared_formula_xlsx_bytes(1);
     let cases = [
         (
-            WorkbookLoadLimits {
-                max_formula_spool_bytes_per_sheet: 5,
-                ..WorkbookLoadLimits::default()
+            {
+                let mut limits = WorkbookLoadLimits::default();
+                limits.max_formula_spool_bytes_per_sheet = 5;
+                limits
             },
             "per-sheet limit",
         ),
         (
-            WorkbookLoadLimits {
-                formula_spool_memory_prefix_bytes: 5,
-                max_formula_spool_files_per_workbook: 0,
-                ..WorkbookLoadLimits::default()
+            {
+                let mut limits = WorkbookLoadLimits::default();
+                limits.formula_spool_memory_prefix_bytes = 5;
+                limits.max_formula_spool_files_per_workbook = 0;
+                limits
             },
             "file limit",
         ),
         (
-            WorkbookLoadLimits {
-                formula_spool_disk_policy: FormulaSpoolDiskPolicy::MemoryOnly,
-                max_formula_spool_memory_bytes: 5,
-                ..WorkbookLoadLimits::default()
+            {
+                let mut limits = WorkbookLoadLimits::default();
+                limits.formula_spool_disk_policy = FormulaSpoolDiskPolicy::MemoryOnly;
+                limits.max_formula_spool_memory_bytes = 5;
+                limits
             },
             "memory-only limit",
         ),
@@ -463,11 +460,9 @@ fn calamine_formula_spool_enforces_sheet_workbook_file_and_no_disk_limits() {
     }
 
     let adapter = CalamineAdapter::open_bytes(two_sheet_formula_xlsx_bytes()).unwrap();
-    let limits = WorkbookLoadLimits {
-        max_formula_spool_bytes_per_sheet: 1024,
-        max_formula_spool_bytes_per_workbook: 20,
-        ..WorkbookLoadLimits::default()
-    };
+    let mut limits = WorkbookLoadLimits::default();
+    limits.max_formula_spool_bytes_per_sheet = 1024;
+    limits.max_formula_spool_bytes_per_workbook = 20;
     let error = match Workbook::from_reader(
         adapter,
         LoadStrategy::EagerAll,

--- a/public-api/formualizer-common.txt
+++ b/public-api/formualizer-common.txt
@@ -303,6 +303,7 @@ pub type formualizer_common::RelativeCoord::Err = formualizer_common::A1ParseErr
 pub fn formualizer_common::RelativeCoord::from_str(&str) -> core::result::Result<Self, Self::Err>
 pub fn formualizer_common::coord::col_index_from_letters_1based(&str) -> core::result::Result<u32, formualizer_common::A1ParseError>
 pub fn formualizer_common::coord::col_letters_from_1based(u32) -> core::result::Result<alloc::string::String, formualizer_common::A1ParseError>
+pub fn formualizer_common::coord::external_cell_source_name(&str, &str, u32, u32) -> alloc::string::String
 pub fn formualizer_common::coord::parse_a1_1based(&str) -> core::result::Result<(u32, u32, bool, bool), formualizer_common::A1ParseError>
 pub mod formualizer_common::coord_hash
 pub struct formualizer_common::coord_hash::CoordBuildHasher
@@ -1624,6 +1625,7 @@ pub fn formualizer_common::date_to_serial_for(formualizer_common::DateSystem, &c
 pub fn formualizer_common::datetime_to_serial(&chrono::naive::datetime::NaiveDateTime) -> f64
 pub fn formualizer_common::datetime_to_serial(&chrono::naive::datetime::NaiveDateTime) -> f64
 pub fn formualizer_common::datetime_to_serial_for(formualizer_common::DateSystem, &chrono::naive::datetime::NaiveDateTime) -> f64
+pub fn formualizer_common::external_cell_source_name(&str, &str, u32, u32) -> alloc::string::String
 pub fn formualizer_common::format_a1_sheet_name(&str) -> alloc::borrow::Cow<'_, str>
 pub fn formualizer_common::max_excel_serial_for(formualizer_common::DateSystem) -> f64
 pub fn formualizer_common::parse_a1_1based(&str) -> core::result::Result<(u32, u32, bool, bool), formualizer_common::A1ParseError>

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -7205,9 +7205,10 @@ impl core::fmt::Debug for formualizer_eval::engine::resource_ledger::WorkResourc
 pub fn formualizer_eval::engine::resource_ledger::WorkResourceBudget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::Copy for formualizer_eval::engine::resource_ledger::WorkResourceBudget
 impl core::marker::StructuralPartialEq for formualizer_eval::engine::resource_ledger::WorkResourceBudget
-pub struct formualizer_eval::engine::WorkbookLoadLimits
+#[non_exhaustive] pub struct formualizer_eval::engine::WorkbookLoadLimits
 pub formualizer_eval::engine::WorkbookLoadLimits::formula_spool_disk_policy: formualizer_eval::engine::FormulaSpoolDiskPolicy
 pub formualizer_eval::engine::WorkbookLoadLimits::formula_spool_memory_prefix_bytes: u64
+pub formualizer_eval::engine::WorkbookLoadLimits::max_external_cached_cells: u64
 pub formualizer_eval::engine::WorkbookLoadLimits::max_formula_plane_fallback_cells: u64
 pub formualizer_eval::engine::WorkbookLoadLimits::max_formula_spool_bytes_per_sheet: u64
 pub formualizer_eval::engine::WorkbookLoadLimits::max_formula_spool_bytes_per_workbook: u64

--- a/public-api/formualizer-parse.txt
+++ b/public-api/formualizer-parse.txt
@@ -352,6 +352,8 @@ pub formualizer_parse::parser::ExternalReference::book: formualizer_parse::parse
 pub formualizer_parse::parser::ExternalReference::kind: formualizer_parse::parser::ExternalRefKind
 pub formualizer_parse::parser::ExternalReference::raw: alloc::string::String
 pub formualizer_parse::parser::ExternalReference::sheet: alloc::string::String
+impl formualizer_parse::parser::ExternalReference
+pub fn formualizer_parse::parser::ExternalReference::source_name(&self) -> core::option::Option<alloc::string::String>
 impl core::clone::Clone for formualizer_parse::parser::ExternalReference
 pub fn formualizer_parse::parser::ExternalReference::clone(&self) -> formualizer_parse::parser::ExternalReference
 impl core::cmp::PartialEq for formualizer_parse::parser::ExternalReference

--- a/public-api/formualizer-workbook.txt
+++ b/public-api/formualizer-workbook.txt
@@ -17,6 +17,7 @@ pub mod formualizer_workbook::backends
 pub mod formualizer_workbook::backends::calamine
 pub struct formualizer_workbook::backends::calamine::CalamineAdapter
 impl formualizer_workbook::backends::calamine::CalamineAdapter
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_link_target(&self, u32) -> core::option::Option<&str>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::calamine::CalamineAdapter
 pub type formualizer_workbook::backends::calamine::CalamineAdapter::Error = calamine::errors::Error
@@ -24,6 +25,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -145,6 +147,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -220,6 +223,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -292,6 +296,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -321,6 +326,7 @@ pub type formualizer_workbook::backends::umya::UmyaAdapter::Error = formualizer_
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::stream_into_engine(&mut self, &mut formualizer_eval::engine::eval::Engine<R>) -> core::result::Result<(), Self::Error>
 pub struct formualizer_workbook::backends::CalamineAdapter
 impl formualizer_workbook::backends::calamine::CalamineAdapter
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_link_target(&self, u32) -> core::option::Option<&str>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::calamine::CalamineAdapter
 pub type formualizer_workbook::backends::calamine::CalamineAdapter::Error = calamine::errors::Error
@@ -328,6 +334,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -361,6 +368,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -431,6 +439,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -471,6 +480,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -904,6 +914,7 @@ pub fn formualizer_workbook::traits::SpreadsheetReader::access_granularity(&self
 pub fn formualizer_workbook::traits::SpreadsheetReader::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::traits::SpreadsheetReader::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::traits::SpreadsheetReader::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::traits::SpreadsheetReader::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::traits::SpreadsheetReader::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::traits::SpreadsheetReader::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::traits::SpreadsheetReader::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -920,6 +931,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -936,6 +948,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -952,6 +965,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -968,6 +982,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1146,6 +1161,8 @@ impl formualizer_eval::traits::ReferenceResolver for formualizer_workbook::workb
 pub fn formualizer_workbook::workbook::WBResolver::resolve_cell_reference(&self, core::option::Option<&str>, u32, u32) -> core::result::Result<formualizer_common::value::LiteralValue, formualizer_common::error::ExcelError>
 impl formualizer_eval::traits::Resolver for formualizer_workbook::workbook::WBResolver
 impl formualizer_eval::traits::SourceResolver for formualizer_workbook::workbook::WBResolver
+pub fn formualizer_workbook::workbook::WBResolver::resolve_source_scalar(&self, &str) -> core::result::Result<formualizer_common::value::LiteralValue, formualizer_common::error::ExcelError>
+pub fn formualizer_workbook::workbook::WBResolver::source_scalar_version(&self, &str) -> core::option::Option<u64>
 impl formualizer_eval::traits::TableResolver for formualizer_workbook::workbook::WBResolver
 pub fn formualizer_workbook::workbook::WBResolver::resolve_table_reference(&self, &formualizer_parse::parser::TableReference) -> core::result::Result<alloc::boxed::Box<dyn formualizer_eval::traits::Table>, formualizer_common::error::ExcelError>
 pub struct formualizer_workbook::workbook::WasmFunctionSpec
@@ -1643,6 +1660,7 @@ impl core::fmt::Debug for formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::traits::BackendCaps::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct formualizer_workbook::CalamineAdapter
 impl formualizer_workbook::backends::calamine::CalamineAdapter
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_link_target(&self, u32) -> core::option::Option<&str>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::calamine::CalamineAdapter
 pub type formualizer_workbook::backends::calamine::CalamineAdapter::Error = calamine::errors::Error
@@ -1650,6 +1668,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1709,6 +1728,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1842,6 +1862,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1991,6 +2012,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2327,6 +2349,7 @@ pub fn formualizer_workbook::SpreadsheetReader::access_granularity(&self) -> for
 pub fn formualizer_workbook::SpreadsheetReader::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::SpreadsheetReader::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::SpreadsheetReader::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::SpreadsheetReader::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::SpreadsheetReader::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::SpreadsheetReader::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::SpreadsheetReader::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2343,6 +2366,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2359,6 +2383,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2375,6 +2400,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2391,6 +2417,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[(alloc::string::String, formualizer_common::value::LiteralValue)]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized

--- a/public-api/formualizer-workbook.txt
+++ b/public-api/formualizer-workbook.txt
@@ -39,6 +39,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -47,6 +48,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_reader(al
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl<R> formualizer_eval::engine::ingest::EngineLoadStream<R> for formualizer_workbook::backends::calamine::CalamineAdapter where R: formualizer_eval::traits::EvaluationContext
@@ -160,6 +162,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -168,6 +171,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::open_reader(alloc::boxed
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::csv::CsvAdapter
@@ -235,6 +239,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -243,6 +248,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::json::JsonAdapter
@@ -307,6 +313,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -315,6 +322,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::umya::UmyaAdapter
@@ -358,6 +366,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -366,6 +375,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_reader(al
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl<R> formualizer_eval::engine::ingest::EngineLoadStream<R> for formualizer_workbook::backends::calamine::CalamineAdapter where R: formualizer_eval::traits::EvaluationContext
@@ -391,6 +401,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -399,6 +410,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::open_reader(alloc::boxed
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::csv::CsvAdapter
@@ -461,6 +473,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -469,6 +482,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::json::JsonAdapter
@@ -501,6 +515,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -509,6 +524,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::umya::UmyaAdapter
@@ -776,6 +792,8 @@ pub formualizer_workbook::traits::SaveDestination::InPlace
 pub formualizer_workbook::traits::SaveDestination::Path(&'a std::path::Path)
 pub formualizer_workbook::traits::SaveDestination::Writer(&'a mut dyn std::io::Write)
 pub struct formualizer_workbook::traits::AdapterLoadStats
+pub formualizer_workbook::traits::AdapterLoadStats::external_cached_source_cells: core::option::Option<u64>
+pub formualizer_workbook::traits::AdapterLoadStats::external_link_scan_failures: core::option::Option<u64>
 pub formualizer_workbook::traits::AdapterLoadStats::formula_cells_handed_to_engine: core::option::Option<u64>
 pub formualizer_workbook::traits::AdapterLoadStats::formula_cells_observed: core::option::Option<u64>
 pub formualizer_workbook::traits::AdapterLoadStats::shared_formula_tags_observed: core::option::Option<u64>
@@ -856,6 +874,19 @@ impl serde_core::ser::Serialize for formualizer_workbook::traits::DefinedName
 pub fn formualizer_workbook::traits::DefinedName::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for formualizer_workbook::traits::DefinedName
 pub fn formualizer_workbook::traits::DefinedName::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub struct formualizer_workbook::traits::ExternalCachedSource
+pub formualizer_workbook::traits::ExternalCachedSource::book_index: u32
+pub formualizer_workbook::traits::ExternalCachedSource::col: u32
+pub formualizer_workbook::traits::ExternalCachedSource::row: u32
+pub formualizer_workbook::traits::ExternalCachedSource::sheet: alloc::string::String
+pub formualizer_workbook::traits::ExternalCachedSource::value: formualizer_common::value::LiteralValue
+impl core::clone::Clone for formualizer_workbook::traits::ExternalCachedSource
+pub fn formualizer_workbook::traits::ExternalCachedSource::clone(&self) -> formualizer_workbook::traits::ExternalCachedSource
+impl core::cmp::PartialEq for formualizer_workbook::traits::ExternalCachedSource
+pub fn formualizer_workbook::traits::ExternalCachedSource::eq(&self, &formualizer_workbook::traits::ExternalCachedSource) -> bool
+impl core::fmt::Debug for formualizer_workbook::traits::ExternalCachedSource
+pub fn formualizer_workbook::traits::ExternalCachedSource::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for formualizer_workbook::traits::ExternalCachedSource
 pub struct formualizer_workbook::traits::MergedRange
 pub formualizer_workbook::traits::MergedRange::end_col: u32
 pub formualizer_workbook::traits::MergedRange::end_row: u32
@@ -934,6 +965,7 @@ pub fn formualizer_workbook::traits::SpreadsheetReader::access_granularity(&self
 pub fn formualizer_workbook::traits::SpreadsheetReader::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::traits::SpreadsheetReader::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::traits::SpreadsheetReader::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::traits::SpreadsheetReader::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::traits::SpreadsheetReader::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::traits::SpreadsheetReader::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::traits::SpreadsheetReader::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -942,6 +974,7 @@ pub fn formualizer_workbook::traits::SpreadsheetReader::open_reader(alloc::boxed
 pub fn formualizer_workbook::traits::SpreadsheetReader::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::traits::SpreadsheetReader::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::traits::SpreadsheetReader::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::traits::SpreadsheetReader::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::traits::SpreadsheetReader::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::traits::SpreadsheetReader::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::calamine::CalamineAdapter
@@ -950,6 +983,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -958,6 +992,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_reader(al
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::csv::CsvAdapter
@@ -966,6 +1001,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -974,6 +1010,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::open_reader(alloc::boxed
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::json::JsonAdapter
@@ -982,6 +1019,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -990,6 +1028,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::umya::UmyaAdapter
@@ -998,6 +1037,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1006,6 +1046,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 pub trait formualizer_workbook::traits::SpreadsheetWriter: core::marker::Send + core::marker::Sync
@@ -1176,6 +1217,8 @@ impl formualizer_eval::traits::ReferenceResolver for formualizer_workbook::workb
 pub fn formualizer_workbook::workbook::WBResolver::resolve_cell_reference(&self, core::option::Option<&str>, u32, u32) -> core::result::Result<formualizer_common::value::LiteralValue, formualizer_common::error::ExcelError>
 impl formualizer_eval::traits::Resolver for formualizer_workbook::workbook::WBResolver
 impl formualizer_eval::traits::SourceResolver for formualizer_workbook::workbook::WBResolver
+pub fn formualizer_workbook::workbook::WBResolver::resolve_source_scalar(&self, &str) -> core::result::Result<formualizer_common::value::LiteralValue, formualizer_common::error::ExcelError>
+pub fn formualizer_workbook::workbook::WBResolver::source_scalar_version(&self, &str) -> core::option::Option<u64>
 impl formualizer_eval::traits::TableResolver for formualizer_workbook::workbook::WBResolver
 pub fn formualizer_workbook::workbook::WBResolver::resolve_table_reference(&self, &formualizer_parse::parser::TableReference) -> core::result::Result<alloc::boxed::Box<dyn formualizer_eval::traits::Table>, formualizer_common::error::ExcelError>
 pub struct formualizer_workbook::workbook::WasmFunctionSpec
@@ -1436,10 +1479,12 @@ pub struct formualizer_workbook::workbook::WorkbookConfig
 pub formualizer_workbook::workbook::WorkbookConfig::enable_changelog: bool
 pub formualizer_workbook::workbook::WorkbookConfig::eval: formualizer_eval::engine::EvalConfig
 pub formualizer_workbook::workbook::WorkbookConfig::ingest_limits: formualizer_eval::engine::WorkbookLoadLimits
+pub formualizer_workbook::workbook::WorkbookConfig::resolve_external_cached_sources: bool
 impl formualizer_workbook::workbook::WorkbookConfig
 pub fn formualizer_workbook::workbook::WorkbookConfig::ephemeral() -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::interactive() -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::span_evaluation_enabled(&self) -> bool
+pub fn formualizer_workbook::workbook::WorkbookConfig::with_external_cached_sources(self, bool) -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::with_formula_plane_mode(self, formualizer_eval::engine::FormulaPlaneMode) -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::with_ingest_limits(self, formualizer_eval::engine::WorkbookLoadLimits) -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::with_span_evaluation(self, bool) -> Self
@@ -1647,6 +1692,8 @@ pub fn formualizer_workbook::backends::calamine::XlsxPathSource::fmt(&self, &mut
 impl core::marker::Copy for formualizer_workbook::backends::calamine::XlsxPathSource
 impl core::marker::StructuralPartialEq for formualizer_workbook::backends::calamine::XlsxPathSource
 pub struct formualizer_workbook::AdapterLoadStats
+pub formualizer_workbook::AdapterLoadStats::external_cached_source_cells: core::option::Option<u64>
+pub formualizer_workbook::AdapterLoadStats::external_link_scan_failures: core::option::Option<u64>
 pub formualizer_workbook::AdapterLoadStats::formula_cells_handed_to_engine: core::option::Option<u64>
 pub formualizer_workbook::AdapterLoadStats::formula_cells_observed: core::option::Option<u64>
 pub formualizer_workbook::AdapterLoadStats::shared_formula_tags_observed: core::option::Option<u64>
@@ -1695,6 +1742,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1703,6 +1751,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_reader(al
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl<R> formualizer_eval::engine::ingest::EngineLoadStream<R> for formualizer_workbook::backends::calamine::CalamineAdapter where R: formualizer_eval::traits::EvaluationContext
@@ -1754,6 +1803,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1762,6 +1812,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::open_reader(alloc::boxed
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::csv::CsvAdapter
@@ -1822,6 +1873,19 @@ pub fn formualizer_workbook::session::EditorSession::new_with_graph(formualizer_
 pub fn formualizer_workbook::session::EditorSession::redo(&mut self) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_workbook::session::EditorSession::undo(&mut self) -> core::result::Result<(), formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
 pub fn formualizer_workbook::session::EditorSession::with_action<F, R>(&mut self, impl core::convert::Into<alloc::string::String>, F) -> core::result::Result<R, formualizer_eval::engine::graph::editor::vertex_editor::EditorError> where F: core::ops::function::FnOnce(&mut formualizer_eval::engine::graph::editor::vertex_editor::VertexEditor<'_>) -> core::result::Result<R, formualizer_eval::engine::graph::editor::vertex_editor::EditorError>
+pub struct formualizer_workbook::ExternalCachedSource
+pub formualizer_workbook::ExternalCachedSource::book_index: u32
+pub formualizer_workbook::ExternalCachedSource::col: u32
+pub formualizer_workbook::ExternalCachedSource::row: u32
+pub formualizer_workbook::ExternalCachedSource::sheet: alloc::string::String
+pub formualizer_workbook::ExternalCachedSource::value: formualizer_common::value::LiteralValue
+impl core::clone::Clone for formualizer_workbook::traits::ExternalCachedSource
+pub fn formualizer_workbook::traits::ExternalCachedSource::clone(&self) -> formualizer_workbook::traits::ExternalCachedSource
+impl core::cmp::PartialEq for formualizer_workbook::traits::ExternalCachedSource
+pub fn formualizer_workbook::traits::ExternalCachedSource::eq(&self, &formualizer_workbook::traits::ExternalCachedSource) -> bool
+impl core::fmt::Debug for formualizer_workbook::traits::ExternalCachedSource
+pub fn formualizer_workbook::traits::ExternalCachedSource::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for formualizer_workbook::traits::ExternalCachedSource
 pub struct formualizer_workbook::FormulaCacheUpdate
 pub formualizer_workbook::FormulaCacheUpdate::col: u32
 pub formualizer_workbook::FormulaCacheUpdate::row: u32
@@ -1887,6 +1951,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -1895,6 +1960,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::json::JsonAdapter
@@ -2036,6 +2102,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2044,6 +2111,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetWriter for formualizer_workbook::backends::umya::UmyaAdapter
@@ -2313,10 +2381,12 @@ pub struct formualizer_workbook::WorkbookConfig
 pub formualizer_workbook::WorkbookConfig::enable_changelog: bool
 pub formualizer_workbook::WorkbookConfig::eval: formualizer_eval::engine::EvalConfig
 pub formualizer_workbook::WorkbookConfig::ingest_limits: formualizer_eval::engine::WorkbookLoadLimits
+pub formualizer_workbook::WorkbookConfig::resolve_external_cached_sources: bool
 impl formualizer_workbook::workbook::WorkbookConfig
 pub fn formualizer_workbook::workbook::WorkbookConfig::ephemeral() -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::interactive() -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::span_evaluation_enabled(&self) -> bool
+pub fn formualizer_workbook::workbook::WorkbookConfig::with_external_cached_sources(self, bool) -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::with_formula_plane_mode(self, formualizer_eval::engine::FormulaPlaneMode) -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::with_ingest_limits(self, formualizer_eval::engine::WorkbookLoadLimits) -> Self
 pub fn formualizer_workbook::workbook::WorkbookConfig::with_span_evaluation(self, bool) -> Self
@@ -2372,6 +2442,7 @@ pub fn formualizer_workbook::SpreadsheetReader::access_granularity(&self) -> for
 pub fn formualizer_workbook::SpreadsheetReader::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::SpreadsheetReader::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::SpreadsheetReader::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::SpreadsheetReader::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::SpreadsheetReader::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::SpreadsheetReader::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::SpreadsheetReader::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2380,6 +2451,7 @@ pub fn formualizer_workbook::SpreadsheetReader::open_reader(alloc::boxed::Box<(d
 pub fn formualizer_workbook::SpreadsheetReader::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::SpreadsheetReader::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::SpreadsheetReader::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::SpreadsheetReader::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::SpreadsheetReader::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::SpreadsheetReader::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::calamine::CalamineAdapter
@@ -2388,6 +2460,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::access_granula
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2396,6 +2469,7 @@ pub fn formualizer_workbook::backends::calamine::CalamineAdapter::open_reader(al
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::calamine::CalamineAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::calamine::CalamineAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::csv::CsvAdapter
@@ -2404,6 +2478,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::access_granularity(&self
 pub fn formualizer_workbook::backends::csv::CsvAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::csv::CsvAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::csv::CsvAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::csv::CsvAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2412,6 +2487,7 @@ pub fn formualizer_workbook::backends::csv::CsvAdapter::open_reader(alloc::boxed
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::csv::CsvAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::csv::CsvAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::json::JsonAdapter
@@ -2420,6 +2496,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::json::JsonAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::json::JsonAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::json::JsonAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::json::JsonAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::json::JsonAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::json::JsonAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2428,6 +2505,7 @@ pub fn formualizer_workbook::backends::json::JsonAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::json::JsonAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::json::JsonAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 impl formualizer_workbook::traits::SpreadsheetReader for formualizer_workbook::backends::umya::UmyaAdapter
@@ -2436,6 +2514,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::access_granularity(&se
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::calc_settings(&self) -> core::option::Option<formualizer_workbook::traits::CalcSettings>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::capabilities(&self) -> formualizer_workbook::traits::BackendCaps
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::defined_names(&mut self) -> core::result::Result<alloc::vec::Vec<formualizer_workbook::traits::DefinedName>, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::external_cached_sources(&self) -> &[formualizer_workbook::traits::ExternalCachedSource]
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::is_loaded(&self, &str, core::option::Option<u32>, core::option::Option<u32>) -> bool
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::load_stats(&self) -> core::option::Option<formualizer_workbook::traits::AdapterLoadStats>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_bytes(alloc::vec::Vec<u8>) -> core::result::Result<Self, Self::Error> where Self: core::marker::Sized
@@ -2444,6 +2523,7 @@ pub fn formualizer_workbook::backends::umya::UmyaAdapter::open_reader(alloc::box
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_cell(&mut self, &str, u32, u32) -> core::result::Result<core::option::Option<formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_range(&mut self, &str, (u32, u32), (u32, u32)) -> core::result::Result<alloc::collections::btree::map::BTreeMap<(u32, u32), formualizer_workbook::traits::CellData>, Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::read_sheet(&mut self, &str) -> core::result::Result<formualizer_workbook::traits::SheetData, Self::Error>
+pub fn formualizer_workbook::backends::umya::UmyaAdapter::scan_external_cached_sources(&mut self, &formualizer_eval::engine::WorkbookLoadLimits) -> core::result::Result<(), Self::Error>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_bounds(&self, &str) -> core::option::Option<(u32, u32)>
 pub fn formualizer_workbook::backends::umya::UmyaAdapter::sheet_names(&self) -> core::result::Result<alloc::vec::Vec<alloc::string::String>, Self::Error>
 pub trait formualizer_workbook::SpreadsheetWriter: core::marker::Send + core::marker::Sync


### PR DESCRIPTION
Excel caches cross-workbook reference values in `xl/externalLinks/externalLinkN.xml` parts and never recalculates them. formualizer used to fail on such references with `#NAME?: Undefined name: [1]Sheet1!A1` at `evaluate_all`, because the workbook adapter never surfaced the cached external-link cells to the engine.

This PR surfaces those cached values so runtime evaluation answers in-book external references exactly as Excel does.

## What changed

- **calamine** (`scan_external_link_sources_from_reader`): scans `workbook.xml` `<externalReferences>` (ordered rIds), maps each `rId -> externalLinkN.xml` via `workbook.xml.rels`, and parses each part's `sheetNames`/`sheetData` into structured `ExternalCachedSource { book_index, sheet, row, col, value }` records. The scan is **deferred to load time** (not at `open_path`/`open_bytes`) so it can be bounded by `WorkbookConfig::ingest_limits`.
- **Structural key matching (F1)**: keys are derived from structured fields — book token + case-folded sheet + 1-based coordinates — via a single shared helper `formualizer_common::external_cell_source_name`, used by both the engine's external-reference resolution (`ExternalReference::source_name()`) and the workbook's seeding. `=[1]Sheet1!A1`, `=[1]Sheet1!$A$1`, `=[1]sheet1!a1`, and quoted punctuated sheet names all resolve to the same key. Raw-text matching is gone.
- **Ingest limits (F2)**: new `WorkbookLoadLimits::max_external_cached_cells` (default 1_000_000) caps the number of cached cells materialized; each part is read with a matching byte budget, so a malicious `externalLinkN.xml` cannot exhaust load-time memory before limits apply.
- **Observability (F3)**: scan failures (zip errors, missing parts/rels) no longer collapse to an empty vec silently — they are counted in `AdapterLoadStats::external_link_scan_failures`, and the seeded count is reported via `AdapterLoadStats::external_cached_source_cells`. Duplicate cached cells (same book/sheet/row/col) are last-wins via the seeding map.
- **Config knob (F3)**: `WorkbookConfig::with_external_cached_sources(bool)` (default **enabled**, matching Excel) restores pre-#363 behavior when disabled.
- **workbook**: `WBResolver` carries the resolved source values and returns them from `resolve_source_scalar` (Name error if a source is missing), wired up in `from_reader_with_adapter_stats`; sources are declared on the engine *before* formula ingest.

Adds Rust (calamine formulas) and Python (openpyxl zip injection) tests covering cached-value evaluation, structural matching (`$`/case/punctuated sheets), the ingest-limit cap, scan-failure recording, the disable knob, and the graceful failure when a workbook references an external book without a cached value.

## Scope

Only **single-cell** references are seeded (`ExternalRefKind::Cell`). Range references like `[1]Sheet1!A1:B2` still route to `resolve_source_table_entry` and fail with `Undefined table`; supporting cached ranges is deferred (tracked separately).

## Policy acknowledgment

The formula plane rejects external references outright (`CanonicalRejectKind::ExternalReference`, `template_canonical.rs`), so this PR makes **runtime evaluation** succeed where template validation refuses. That divergence is deliberate for now; the plane-side follow-up is tracked in #378.

## Decisions taken / seeking ratification

- Cached values are pinned at source version `0` forever — no refresh, no provenance. Acceptable v1 semantics; the staleness model is documented and countable via the new `AdapterLoadStats` fields.
- Key canonicalization case-folds the sheet with Unicode `to_lowercase()` (Excel matches sheet names case-insensitively).
- The external-cache scan reads a bounded byte prefix of each part; truncation seeds fewer cells rather than erroring.
- Duplicate cached cells are last-wins (seeding map).
- `WorkbookLoadLimits` gained a dedicated `max_external_cached_cells` rather than reusing an unrelated sheet cap.
