### PR TITLE
fix(eval): IF, IFS, and CHOOSE return selected references

### DIFF
--- a/crates/formualizer-eval/src/builtins/logical.rs
+++ b/crates/formualizer-eval/src/builtins/logical.rs
@@ -2,7 +2,7 @@
 
 use super::utils::ARG_ANY_ONE;
 use crate::args::ArgSchema;
-use crate::function::Function;
+use crate::function::{Function, FunctionResolution, resolution_to_reference};
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::{ExcelError, LiteralValue};
 use formualizer_macros::func_caps;
@@ -432,7 +432,7 @@ pub struct IfFn;
 /// Variadic: true
 /// Signature: IF(arg1...: any@scalar)
 /// Arg schema: arg1{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}
-/// Caps: PURE, SHORT_CIRCUIT
+/// Caps: PURE, RETURNS_REFERENCE, SHORT_CIRCUIT
 /// [formualizer-docgen:schema:end]
 impl Function for IfFn {
     fn propagate_format(
@@ -442,7 +442,7 @@ impl Function for IfFn {
         result.format_id()
     }
 
-    func_caps!(PURE, SHORT_CIRCUIT, MAY_SPILL);
+    func_caps!(PURE, SHORT_CIRCUIT, RETURNS_REFERENCE, MAY_SPILL);
 
     fn name(&self) -> &'static str {
         "IF"
@@ -459,6 +459,30 @@ impl Function for IfFn {
         // Single variadic any schema so we can enforce precise 2 or 3 arity inside eval()
         static ONE: LazyLock<Vec<ArgSchema>> = LazyLock::new(|| vec![ArgSchema::any()]);
         &ONE[..]
+    }
+
+    fn eval_reference<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        _ctx: &dyn FunctionContext<'b>,
+    ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
+        match try_resolve_if_reference_or_value(args) {
+            Ok(Some(result)) => resolution_to_reference(Ok(result)),
+            Ok(None) => None,
+            Err(error) => Some(Err(error)),
+        }
+    }
+
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        _ctx: &dyn FunctionContext<'b>,
+        value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        match try_resolve_if_reference_or_value(args)? {
+            Some(result) => Ok(result),
+            None => value_fallback().map(FunctionResolution::Value),
+        }
     }
 
     fn eval<'a, 'b, 'c>(
@@ -495,6 +519,48 @@ impl Function for IfFn {
                 false,
             )))
         }
+    }
+}
+
+fn try_resolve_if_reference_or_value<'b>(
+    args: &[ArgumentHandle<'_, 'b>],
+) -> Result<Option<FunctionResolution<'b>>, ExcelError> {
+    if args.len() < 2 || args.len() > 3 {
+        return Ok(Some(FunctionResolution::Value(
+            crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                ExcelError::new_value()
+                    .with_message(format!("IF expects 2 or 3 arguments, got {}", args.len())),
+            )),
+        )));
+    }
+    let condition = args[0].value()?.into_literal();
+    let selected = match condition {
+        LiteralValue::Boolean(value) => value,
+        LiteralValue::Number(value) => value != 0.0,
+        LiteralValue::Int(value) => value != 0,
+        LiteralValue::Empty => false,
+        LiteralValue::Error(error) => {
+            return Ok(Some(FunctionResolution::Value(
+                crate::traits::CalcValue::Scalar(LiteralValue::Error(error)),
+            )));
+        }
+        LiteralValue::Array(_) => return Ok(None),
+        _ => {
+            return Ok(Some(FunctionResolution::Value(
+                crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                    ExcelError::new_value().with_message("IF condition must be boolean or number"),
+                )),
+            )));
+        }
+    };
+    if selected {
+        args[1].resolve_reference_or_value().map(Some)
+    } else if let Some(arg) = args.get(2) {
+        arg.resolve_reference_or_value().map(Some)
+    } else {
+        Ok(Some(FunctionResolution::Value(
+            crate::traits::CalcValue::Scalar(LiteralValue::Boolean(false)),
+        )))
     }
 }
 

--- a/crates/formualizer-eval/src/builtins/logical_ext.rs
+++ b/crates/formualizer-eval/src/builtins/logical_ext.rs
@@ -1,6 +1,6 @@
 use super::utils::ARG_ANY_ONE;
 use crate::args::ArgSchema;
-use crate::function::Function;
+use crate::function::{Function, FunctionResolution, resolution_to_reference};
 use crate::function_contract::FunctionDependencyContract;
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::{ExcelError, LiteralValue};
@@ -469,7 +469,7 @@ pub struct IfsFn; // IFS(cond1, val1, cond2, val2, ...)
 /// Variadic: true
 /// Signature: IFS(arg1...: any@scalar)
 /// Arg schema: arg1{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}
-/// Caps: PURE, SHORT_CIRCUIT
+/// Caps: PURE, RETURNS_REFERENCE, SHORT_CIRCUIT
 /// [formualizer-docgen:schema:end]
 impl Function for IfsFn {
     fn propagate_format(
@@ -479,7 +479,7 @@ impl Function for IfsFn {
         result.format_id()
     }
 
-    func_caps!(PURE, SHORT_CIRCUIT, MAY_SPILL);
+    func_caps!(PURE, SHORT_CIRCUIT, RETURNS_REFERENCE, MAY_SPILL);
     fn name(&self) -> &'static str {
         "IFS"
     }
@@ -491,6 +491,21 @@ impl Function for IfsFn {
     }
     fn arg_schema(&self) -> &'static [ArgSchema] {
         &ARG_ANY_ONE[..]
+    }
+    fn eval_reference<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
+        resolution_to_reference(resolve_ifs_reference_or_value(args, ctx))
+    }
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+        _value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        resolve_ifs_reference_or_value(args, ctx)
     }
     fn eval<'a, 'b, 'c>(
         &self,
@@ -526,6 +541,49 @@ impl Function for IfsFn {
             ExcelError::new_na(),
         )))
     }
+}
+
+fn resolve_selected_non_if<'b>(
+    selected: &ArgumentHandle<'_, 'b>,
+    _ctx: &dyn FunctionContext<'b>,
+) -> Result<FunctionResolution<'b>, ExcelError> {
+    selected.resolve_reference_or_value()
+}
+
+fn value_error_resolution<'b>() -> FunctionResolution<'b> {
+    FunctionResolution::Value(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+        ExcelError::new_value(),
+    )))
+}
+
+fn resolve_ifs_reference_or_value<'b>(
+    args: &[ArgumentHandle<'_, 'b>],
+    ctx: &dyn FunctionContext<'b>,
+) -> Result<FunctionResolution<'b>, ExcelError> {
+    if args.len() < 2 || !args.len().is_multiple_of(2) {
+        return Ok(value_error_resolution());
+    }
+    for pair in args.chunks(2) {
+        let condition = pair[0].value()?.into_literal();
+        let selected = match condition {
+            LiteralValue::Boolean(value) => value,
+            LiteralValue::Number(value) => value != 0.0,
+            LiteralValue::Int(value) => value != 0,
+            LiteralValue::Empty => false,
+            LiteralValue::Error(error) => {
+                return Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(
+                    LiteralValue::Error(error),
+                )));
+            }
+            _ => return Ok(value_error_resolution()),
+        };
+        if selected {
+            return resolve_selected_non_if(&pair[1], ctx);
+        }
+    }
+    Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(
+        LiteralValue::Error(ExcelError::new_na()),
+    )))
 }
 
 /// Returns the result corresponding to the first matching candidate value.

--- a/crates/formualizer-eval/src/builtins/lookup/choose.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/choose.rs
@@ -8,7 +8,7 @@
 
 use crate::args::{ArgSchema, CoercionPolicy, ShapeKind};
 use crate::builtins::utils::collapse_if_scalar;
-use crate::function::Function;
+use crate::function::{Function, FunctionResolution, resolution_to_reference};
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::{ArgKind, ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_macros::func_caps;
@@ -115,6 +115,23 @@ impl Function for ChooseFn {
         &SCHEMA
     }
 
+    fn eval_reference<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
+        resolution_to_reference(resolve_choose_reference_or_value(args, ctx))
+    }
+
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+        _value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        resolve_choose_reference_or_value(args, ctx)
+    }
+
     fn eval<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
@@ -156,6 +173,36 @@ impl Function for ChooseFn {
         let selected_arg = &args[index as usize];
         selected_arg.value()
     }
+}
+
+fn resolve_choose_reference_or_value<'b>(
+    args: &[ArgumentHandle<'_, 'b>],
+    _ctx: &dyn FunctionContext<'b>,
+) -> Result<FunctionResolution<'b>, ExcelError> {
+    let value_error = || {
+        FunctionResolution::Value(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+            ExcelError::new(ExcelErrorKind::Value),
+        )))
+    };
+    if args.len() < 2 {
+        return Ok(value_error());
+    }
+    let index_value = args[0].value()?.into_literal();
+    let index = match index_value {
+        LiteralValue::Number(value) => value as i64,
+        LiteralValue::Int(value) => value,
+        LiteralValue::Error(error) => {
+            return Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(
+                LiteralValue::Error(error),
+            )));
+        }
+        _ => return Ok(value_error()),
+    };
+    if index < 1 || index as usize > args.len() - 1 {
+        return Ok(value_error());
+    }
+    let selected = &args[index as usize];
+    selected.resolve_reference_or_value()
 }
 
 /* ───────────────────────── CHOOSECOLS() / CHOOSEROWS() ───────────────────────── */

--- a/crates/formualizer-eval/src/function.rs
+++ b/crates/formualizer-eval/src/function.rs
@@ -9,6 +9,29 @@ use crate::{
     traits::ArgumentHandle,
 };
 use formualizer_common::{ExcelError, LiteralValue};
+use formualizer_parse::parser::ReferenceType;
+
+/// One-pass result for a function used where either a reference or a value is valid.
+#[doc(hidden)]
+#[derive(Clone)]
+pub enum FunctionResolution<'a> {
+    Reference(ReferenceType),
+    ReferenceError(ExcelError),
+    Value(crate::traits::CalcValue<'a>),
+}
+
+pub(crate) fn resolution_to_reference(
+    result: Result<FunctionResolution<'_>, ExcelError>,
+) -> Option<Result<ReferenceType, ExcelError>> {
+    match result {
+        Ok(FunctionResolution::Reference(reference)) => Some(Ok(reference)),
+        Ok(FunctionResolution::ReferenceError(error)) | Err(error) => Some(Err(error)),
+        Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+            error,
+        )))) => Some(Err(error)),
+        Ok(FunctionResolution::Value(_)) => None,
+    }
+}
 
 bitflags::bitflags! {
     /// Describes the capabilities and properties of a function.
@@ -187,6 +210,25 @@ pub trait Function: Send + Sync + 'static {
         _ctx: &dyn crate::traits::FunctionContext<'b>,
     ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
         None
+    }
+
+    /// Resolve a reference-capable function while preserving scalar-selector caching.
+    ///
+    /// The fallback deliberately re-enters the caller's ordinary value path. That
+    /// preserves dispatch validation and array lifting for existing functions whose
+    /// `eval_reference` declines a particular argument shape. Array-valued selectors
+    /// may be evaluated once by each path.
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn crate::traits::FunctionContext<'b>,
+        value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        match self.eval_reference(args, ctx) {
+            Some(Ok(reference)) => Ok(FunctionResolution::Reference(reference)),
+            Some(Err(error)) => Ok(FunctionResolution::ReferenceError(error)),
+            None => value_fallback().map(FunctionResolution::Value),
+        }
     }
 
     /// Dispatch to the unified evaluation path with automatic argument validation.

--- a/crates/formualizer-eval/src/tests/functions.rs
+++ b/crates/formualizer-eval/src/tests/functions.rs
@@ -561,3 +561,279 @@ fn interpreter_incompatible_broadcast_is_value_error() {
         v => panic!("expected value error, got {v:?}"),
     }
 }
+
+fn reference_returning_engine(g1: i64) -> crate::engine::Engine<TestWorkbook> {
+    use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, EvalConfig};
+
+    let cfg = EvalConfig::default().with_cycle(CycleConfig {
+        detection: CycleDetection::Runtime,
+        policy: CyclePolicy::Error,
+    });
+    let mut engine = crate::engine::Engine::new(TestWorkbook::new(), cfg);
+    for row in 1..=20 {
+        for (col, value) in [
+            (1, row as i64),
+            (2, 100 + row as i64),
+            (3, 200 + row as i64),
+            (4, row as i64),
+            (5, 400 + row as i64),
+            (6, 500 + row as i64),
+        ] {
+            engine
+                .set_cell_value("Sheet1", row, col, LiteralValue::Int(value))
+                .expect("set reference fixture value");
+        }
+    }
+    engine
+        .set_cell_value("Sheet1", 1, 7, LiteralValue::Int(g1))
+        .expect("set selector");
+    engine
+}
+
+fn evaluate_reference_returning_formula(g1: i64, formula: &str) -> LiteralValue {
+    let mut engine = reference_returning_engine(g1);
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            10,
+            formualizer_parse::parser::parse(formula).expect("valid reference-returning formula"),
+        )
+        .expect("set reference-returning formula");
+    engine
+        .evaluate_all()
+        .expect("evaluate reference-returning formula");
+    engine
+        .get_cell_value("Sheet1", 1, 10)
+        .expect("formula result")
+}
+
+#[test]
+fn reference_returning_if_offset_index() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=OFFSET(INDEX(IF(G1=1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(0, "=OFFSET(INDEX(IF(G1=1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_if_offset_direct() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=OFFSET(IF(G1=1,A1:C20,D1:F20),1,1)"),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(0, "=OFFSET(IF(G1=1,A1:C20,D1:F20),1,1)"),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_ifs_offset_index() {
+    assert_eq!(
+        evaluate_reference_returning_formula(
+            1,
+            "=OFFSET(INDEX(IFS(G1=1,A1:C20,TRUE,D1:F20),2,1),0,1)",
+        ),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(
+            0,
+            "=OFFSET(INDEX(IFS(G1=1,A1:C20,TRUE,D1:F20),2,1),0,1)",
+        ),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_choose_offset_index() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=OFFSET(INDEX(CHOOSE(G1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(2, "=OFFSET(INDEX(CHOOSE(G1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_if_family_value_paths() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=SUM(IF(G1=1,A1:A20,D1:D20))"),
+        LiteralValue::Number(210.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=VLOOKUP(5,CHOOSE(1,A1:B20,D1:E20),2,FALSE)",),
+        LiteralValue::Number(105.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=INDEX(IFERROR(1/0,A1:C20),3,3)"),
+        LiteralValue::Number(203.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=IF(G1=1,5,A1:A3)"),
+        LiteralValue::Number(5.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(0, "=SUM(IF(G1=1,5,A1:A3))"),
+        LiteralValue::Number(6.0)
+    );
+}
+
+#[test]
+fn if_family_selector_evaluation_count() {
+    use crate::function::{FnCaps, Function};
+    use crate::traits::{FunctionContext, ResolvedArgument};
+    use formualizer_common::ExcelError;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    #[derive(Debug)]
+    struct CountSelectorFn {
+        array: Arc<AtomicBool>,
+        calls: Arc<AtomicUsize>,
+        selected: Arc<AtomicBool>,
+    }
+
+    impl Function for CountSelectorFn {
+        fn caps(&self) -> FnCaps {
+            FnCaps::empty()
+        }
+
+        fn name(&self) -> &'static str {
+            "COUNTSELECTOR"
+        }
+
+        fn arg_schema(&self) -> &'static [crate::args::ArgSchema] {
+            &[]
+        }
+
+        fn eval<'a, 'b, 'c>(
+            &self,
+            _args: &'c [ArgumentHandle<'a, 'b>],
+            _ctx: &dyn FunctionContext<'b>,
+        ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.array.load(Ordering::SeqCst) {
+                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Array(vec![
+                    vec![LiteralValue::Boolean(true), LiteralValue::Boolean(false)],
+                ])));
+            }
+            Ok(crate::traits::CalcValue::Scalar(LiteralValue::Boolean(
+                self.selected.load(Ordering::SeqCst),
+            )))
+        }
+    }
+
+    fn workbook(
+        array: Arc<AtomicBool>,
+        calls: Arc<AtomicUsize>,
+        selected: Arc<AtomicBool>,
+    ) -> TestWorkbook {
+        TestWorkbook::new()
+            .with_range(
+                "Sheet1",
+                1,
+                1,
+                vec![
+                    vec![LiteralValue::Int(1)],
+                    vec![LiteralValue::Int(2)],
+                    vec![LiteralValue::Int(3)],
+                ],
+            )
+            .with_function(Arc::new(CountSelectorFn {
+                array,
+                calls,
+                selected,
+            }))
+    }
+
+    crate::builtins::load_builtins();
+    let array = Arc::new(AtomicBool::new(false));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let selected = Arc::new(AtomicBool::new(true));
+
+    let wb = workbook(
+        Arc::clone(&array),
+        Arc::clone(&calls),
+        Arc::clone(&selected),
+    );
+    let interpreter = wb.interpreter();
+    let ast = formualizer_parse::parser::parse("=IF(COUNTSELECTOR(),A1:A3,5)")
+        .expect("valid AST selector formula");
+    let handle = ArgumentHandle::new(&ast, &interpreter);
+    assert!(matches!(
+        handle.resolve_once(),
+        Ok(ResolvedArgument::Range(_))
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "AST reference arm");
+
+    calls.store(0, Ordering::SeqCst);
+    selected.store(false, Ordering::SeqCst);
+    let ast = formualizer_parse::parser::parse("=IF(COUNTSELECTOR(),A1:A3,5)")
+        .expect("valid AST selector formula");
+    let handle = ArgumentHandle::new(&ast, &interpreter);
+    assert!(matches!(
+        handle.resolve_once(),
+        Ok(ResolvedArgument::Value(crate::traits::CalcValue::Scalar(
+            LiteralValue::Number(5.0)
+        )))
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "AST value arm");
+
+    for (select_reference, expected) in [(true, 6.0), (false, 5.0)] {
+        calls.store(0, Ordering::SeqCst);
+        selected.store(select_reference, Ordering::SeqCst);
+        let wb = workbook(
+            Arc::clone(&array),
+            Arc::clone(&calls),
+            Arc::clone(&selected),
+        );
+        let mut engine = crate::engine::Engine::new(
+            wb,
+            crate::engine::EvalConfig::default().with_cycle(crate::engine::CycleConfig {
+                detection: crate::engine::CycleDetection::Runtime,
+                policy: crate::engine::CyclePolicy::Error,
+            }),
+        );
+        for (row, value) in [(1, 1), (2, 2), (3, 3)] {
+            engine
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Int(value))
+                .expect("set arena reference value");
+        }
+        engine
+            .set_cell_formula(
+                "Sheet1",
+                1,
+                10,
+                formualizer_parse::parser::parse("=SUM(IF(COUNTSELECTOR(),A1:A3,5))")
+                    .expect("valid arena selector formula"),
+            )
+            .expect("set arena selector formula");
+        engine
+            .evaluate_all()
+            .expect("evaluate arena selector formula");
+        assert_eq!(
+            engine.get_cell_value("Sheet1", 1, 10),
+            Some(LiteralValue::Number(expected))
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "Arena {} arm",
+            if select_reference {
+                "reference"
+            } else {
+                "value"
+            }
+        );
+    }
+}

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -294,6 +294,8 @@ pub struct ArgumentHandle<'a, 'b> {
     interp: &'a Interpreter<'b>,
     cached_ast: std::cell::OnceCell<ASTNode>,
     cached_ref: std::cell::OnceCell<ReferenceType>,
+    cached_reference_or_value:
+        std::cell::OnceCell<Result<crate::function::FunctionResolution<'b>, ExcelError>>,
     cached_resolved: std::cell::OnceCell<Result<ResolvedArgument<'b>, ExcelError>>,
     /// Memoized result of [`Self::value`]. `Function::dispatch` evaluates
     /// every argument once during schema validation and the function's `eval`
@@ -313,6 +315,7 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
             interp,
             cached_ast: std::cell::OnceCell::new(),
             cached_ref: std::cell::OnceCell::new(),
+            cached_reference_or_value: std::cell::OnceCell::new(),
             cached_resolved: std::cell::OnceCell::new(),
             cached_value: std::cell::OnceCell::new(),
         }
@@ -333,6 +336,7 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
             interp,
             cached_ast: std::cell::OnceCell::new(),
             cached_ref: std::cell::OnceCell::new(),
+            cached_reference_or_value: std::cell::OnceCell::new(),
             cached_resolved: std::cell::OnceCell::new(),
             cached_value: std::cell::OnceCell::new(),
         }
@@ -532,6 +536,96 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         }
     }
 
+    fn function_resolution_attempt(
+        &self,
+    ) -> Option<Result<crate::function::FunctionResolution<'b>, ExcelError>> {
+        match &self.expr {
+            ArgumentExpr::Ast(node) => {
+                let ASTNodeType::Function { name, args } = &node.node_type else {
+                    return None;
+                };
+                if !self
+                    .interp
+                    .context
+                    .function_capabilities("", name)
+                    .is_some_and(|caps| caps.contains(crate::function::FnCaps::RETURNS_REFERENCE))
+                {
+                    return None;
+                }
+                let fun = match self.interp.context.get_function("", name) {
+                    Some(fun) => fun,
+                    None => {
+                        return Some(Err(ExcelError::new(ExcelErrorKind::Name)
+                            .with_message(format!("Unknown function: {name}"))));
+                    }
+                };
+                let handles: Vec<_> = args
+                    .iter()
+                    .map(|arg| ArgumentHandle::new(arg, self.interp))
+                    .collect();
+                let ctx = DefaultFunctionContext::new_with_sheet(
+                    self.interp.context,
+                    None,
+                    self.interp.current_sheet(),
+                );
+                Some(fun.resolve_reference_or_value(&handles, &ctx, &|| self.value()))
+            }
+            ArgumentExpr::Arena {
+                id,
+                data_store,
+                sheet_registry,
+            } => {
+                let node = match data_store.get_node(*id) {
+                    Some(node) => node,
+                    None => {
+                        return Some(Err(
+                            ExcelError::new(ExcelErrorKind::Value).with_message("Missing AST node")
+                        ));
+                    }
+                };
+                let crate::engine::arena::AstNodeData::Function { name_id, .. } = node else {
+                    return None;
+                };
+                let name = data_store.resolve_ast_string(*name_id);
+                if !self
+                    .interp
+                    .context
+                    .function_capabilities("", name)
+                    .is_some_and(|caps| caps.contains(crate::function::FnCaps::RETURNS_REFERENCE))
+                {
+                    return None;
+                }
+                let fun = match self.interp.context.get_function("", name) {
+                    Some(fun) => fun,
+                    None => {
+                        return Some(Err(ExcelError::new(ExcelErrorKind::Name)
+                            .with_message(format!("Unknown function: {name}"))));
+                    }
+                };
+                let args = match data_store.get_args(*id) {
+                    Some(args) => args,
+                    None => {
+                        return Some(Err(ExcelError::new(ExcelErrorKind::Value)
+                            .with_message("Missing function args")));
+                    }
+                };
+                let handles: Vec<_> = args
+                    .iter()
+                    .copied()
+                    .map(|arg_id| {
+                        ArgumentHandle::new_arena(arg_id, self.interp, data_store, sheet_registry)
+                    })
+                    .collect();
+                let ctx = DefaultFunctionContext::new_with_sheet(
+                    self.interp.context,
+                    None,
+                    self.interp.current_sheet(),
+                );
+                Some(fun.resolve_reference_or_value(&handles, &ctx, &|| self.value()))
+            }
+        }
+    }
+
     fn reference_attempt(&self) -> Option<Result<ReferenceType, ExcelError>> {
         match &self.expr {
             ArgumentExpr::Ast(node) => match &node.node_type {
@@ -607,6 +701,34 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         }
     }
 
+    pub(crate) fn resolve_reference_or_value(
+        &self,
+    ) -> Result<crate::function::FunctionResolution<'b>, ExcelError> {
+        let resolved = self
+            .cached_reference_or_value
+            .get_or_init(|| self.compute_reference_or_value())
+            .clone();
+        if let Ok(crate::function::FunctionResolution::Value(value)) = &resolved {
+            let _ = self.cached_value.set(Ok(value.clone()));
+        }
+        resolved
+    }
+
+    fn compute_reference_or_value(
+        &self,
+    ) -> Result<crate::function::FunctionResolution<'b>, ExcelError> {
+        if let Some(result) = self.function_resolution_attempt() {
+            return result;
+        }
+        if let Some(reference) = self.reference_attempt() {
+            return Ok(match reference {
+                Ok(reference) => crate::function::FunctionResolution::Reference(reference),
+                Err(error) => crate::function::FunctionResolution::ReferenceError(error),
+            });
+        }
+        self.value().map(crate::function::FunctionResolution::Value)
+    }
+
     /// Resolve this argument once without using a failed range conversion as type dispatch.
     ///
     /// Direct references and the `:` operator take the reference path. Functions
@@ -626,26 +748,32 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
     }
 
     fn compute_resolved_argument(&self) -> Result<ResolvedArgument<'b>, ExcelError> {
-        if let Some(attempt) = self.reference_attempt() {
-            let reference = match attempt {
-                Ok(reference) => reference,
-                Err(error) if error.kind == ExcelErrorKind::Cancelled => return Err(error),
-                Err(error) => return Ok(ResolvedArgument::ReferenceError(error)),
-            };
-            return match self
-                .interp
-                .context
-                .resolve_range_view(&reference, self.interp.current_sheet())
+        let value = match self.resolve_reference_or_value()? {
+            crate::function::FunctionResolution::Reference(reference) => {
+                return match self
+                    .interp
+                    .context
+                    .resolve_range_view(&reference, self.interp.current_sheet())
+                {
+                    Ok(view) => Ok(ResolvedArgument::Range(
+                        self.with_context_cancel_token(view),
+                    )),
+                    Err(error) if error.kind == ExcelErrorKind::Cancelled => Err(error),
+                    Err(error) => Ok(ResolvedArgument::ReferenceError(error)),
+                };
+            }
+            crate::function::FunctionResolution::ReferenceError(error)
+                if error.kind == ExcelErrorKind::Cancelled =>
             {
-                Ok(view) => Ok(ResolvedArgument::Range(
-                    self.with_context_cancel_token(view),
-                )),
-                Err(error) if error.kind == ExcelErrorKind::Cancelled => Err(error),
-                Err(error) => Ok(ResolvedArgument::ReferenceError(error)),
-            };
-        }
+                return Err(error);
+            }
+            crate::function::FunctionResolution::ReferenceError(error) => {
+                return Ok(ResolvedArgument::ReferenceError(error));
+            }
+            crate::function::FunctionResolution::Value(value) => value,
+        };
 
-        match self.value()? {
+        match value {
             CalcValue::Range(view) => Ok(ResolvedArgument::Range(
                 self.with_context_cancel_token(view),
             )),

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -8721,6 +8721,7 @@ pub fn formualizer_eval::function::Function::min_args(&self) -> usize
 pub fn formualizer_eval::function::Function::name(&self) -> &'static str
 pub fn formualizer_eval::function::Function::namespace(&self) -> &'static str
 pub fn formualizer_eval::function::Function::propagate_format(&self, &formualizer_eval::traits::CalcValue<'_>) -> core::option::Option<formualizer_eval::format::FormatId>
+pub fn formualizer_eval::function::Function::resolve_reference_or_value<'a, 'b, 'c>(&self, &'c [formualizer_eval::traits::ArgumentHandle<'a, 'b>], &dyn formualizer_eval::traits::FunctionContext<'b>, &dyn core::ops::function::Fn() -> core::result::Result<formualizer_eval::traits::CalcValue<'b>, formualizer_common::error::ExcelError>) -> core::result::Result<FunctionResolution<'b>, formualizer_common::error::ExcelError>
 pub fn formualizer_eval::function::Function::semantic_contract(&self, usize) -> core::option::Option<formualizer_eval::function_contract::FunctionSemanticContract>
 pub fn formualizer_eval::function::Function::variadic(&self) -> bool
 pub fn formualizer_eval::function::Function::volatile(&self) -> bool
@@ -9615,6 +9616,7 @@ pub fn formualizer_eval::traits::Function::min_args(&self) -> usize
 pub fn formualizer_eval::traits::Function::name(&self) -> &'static str
 pub fn formualizer_eval::traits::Function::namespace(&self) -> &'static str
 pub fn formualizer_eval::traits::Function::propagate_format(&self, &formualizer_eval::traits::CalcValue<'_>) -> core::option::Option<formualizer_eval::format::FormatId>
+pub fn formualizer_eval::traits::Function::resolve_reference_or_value<'a, 'b, 'c>(&self, &'c [formualizer_eval::traits::ArgumentHandle<'a, 'b>], &dyn formualizer_eval::traits::FunctionContext<'b>, &dyn core::ops::function::Fn() -> core::result::Result<formualizer_eval::traits::CalcValue<'b>, formualizer_common::error::ExcelError>) -> core::result::Result<FunctionResolution<'b>, formualizer_common::error::ExcelError>
 pub fn formualizer_eval::traits::Function::semantic_contract(&self, usize) -> core::option::Option<formualizer_eval::function_contract::FunctionSemanticContract>
 pub fn formualizer_eval::traits::Function::variadic(&self) -> bool
 pub fn formualizer_eval::traits::Function::volatile(&self) -> bool


### PR DESCRIPTION
## What was wrong

IF, IFS, and CHOOSE always resolved through their value paths. When one selected a cell or range and another function needed that reference, the reference identity had already been discarded. OFFSET then received a value and returned `#REF!` instead of reading the offset cell.

## Excel behaviour

Measured on Microsoft Excel 16.105.3, Microsoft 365 for Mac, in a synthetic workbook with `A1:A5 = 10..50` and `B1:B5 = 1..5`:

| Formula | Excel | main @ 82a0b0d8 |
| --- | --- | --- |
| `=OFFSET(IF(TRUE,A1,B1),2,0)` | 30 | `Error(Ref)` |
| `=OFFSET(CHOOSE(1,A1,B1),1,0)` (file-load) | 20 | `Error(Ref)` |
| `=OFFSET(IFS(TRUE,A1),1,0)` (replace-entry) | 20 | `Error(Ref)` |
| control `=INDEX(IF(TRUE,A1:A5,B1:B5),3,1)` | 30 | 30 |

IFERROR and IFNA were separately refuted as reference-returning functions: Excel rejected both forms at entry, and legacy-intersection rows confirmed both take their arguments as values. IFERROR also failed replace-based entry, was stripped during file repair, and produced `#VALUE!` when composed through INDEX. This PR is limited to IF, IFS, and CHOOSE.

## The fix

The function contract can now resolve either a reference or a value. Argument handles cache scalar resolution. IF, IFS, and CHOOSE advertise `RETURNS_REFERENCE`, implement reference selection, and retain their existing scalar and array value paths. The repository schema task regenerated all three capability blocks.

This adds the public, doc-hidden `FunctionResolution` enum and provided public `Function::resolve_reference_or_value` method.

## Scope

This branch is standalone on `main`. IFERROR and IFNA are excluded by the Excel oracle. Array-valued selectors retain the accepted two-evaluation residual; the companion INDEX PR pins AST and Arena counts at two. Scalar selectors remain one evaluation.

One temporary seam is explicit: this reference path preserves the original condition error, while the ordinary value path keeps main's `#VALUE!` conversion until the companion IF-error propagation PR merges.

## Verification

The regressions use a separate synthetic engine fixture (a 20-row grid of six value columns) rather than the oracle workbook, so their expected reads are `102`/`402`. All four fail on main with `Error(Ref)` in place of the expected number and pass here. The value-path and scalar selector-count controls pass. Reverting an IF, IFS, or CHOOSE hunk fails its matching regression; all four regressions plus selector coverage pin the shared resolution/cache hunks.

The public-API snapshot was regenerated with `scripts/public-api.sh` on x86_64 Linux under the pinned toolchains and is included as a separate `chore(api)` commit; `scripts/public-api.sh check` exits clean at this tip. The addition is a provided trait method plus its return type, an additive change.

Executed with `rustc 1.97.1`:

```text
cargo fmt --all                                      exit 0; diff clean
cargo clippy --workspace --all-targets -- -D warnings exit 101; same 20 fingerprints as unmodified main
cargo test -p formualizer-eval                      2740 passed; the only failures are the IMEXP/IMSIN/IMCOS cases that fail identically on unmodified main
cargo run -p xtask -- schema --functions IF,IFS,CHOOSE exit 0; 3 matched, 0 stale
cargo run -p xtask -- audit --strict                exit 1; byte-identical base set of 366 missing-example findings, zero naming IF/IFS/CHOOSE
```

## Deliberately not in this PR

No IFERROR/IFNA reference behavior, array-selector optimization, unrelated conditional change, or macOS-generated public snapshot is included.

## How this was found

A workbook exposed OFFSET and INDEX compositions that lost a selected reference. The public regressions reduce that behavior to synthetic addresses and literals.

Drafted by Claude (agent), verified by execution against a real Excel oracle, reviewed by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
