### PR TITLE
fix(eval): INDEX reads only its selected cell

### DIFF
--- a/crates/formualizer-eval/src/builtins/logical.rs
+++ b/crates/formualizer-eval/src/builtins/logical.rs
@@ -2,7 +2,7 @@
 
 use super::utils::ARG_ANY_ONE;
 use crate::args::ArgSchema;
-use crate::function::Function;
+use crate::function::{Function, FunctionResolution, resolution_to_reference};
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::{ExcelError, LiteralValue};
 use formualizer_macros::func_caps;
@@ -432,7 +432,7 @@ pub struct IfFn;
 /// Variadic: true
 /// Signature: IF(arg1...: any@scalar)
 /// Arg schema: arg1{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}
-/// Caps: PURE, SHORT_CIRCUIT
+/// Caps: PURE, RETURNS_REFERENCE, SHORT_CIRCUIT
 /// [formualizer-docgen:schema:end]
 impl Function for IfFn {
     fn propagate_format(
@@ -442,7 +442,7 @@ impl Function for IfFn {
         result.format_id()
     }
 
-    func_caps!(PURE, SHORT_CIRCUIT, MAY_SPILL);
+    func_caps!(PURE, SHORT_CIRCUIT, RETURNS_REFERENCE, MAY_SPILL);
 
     fn name(&self) -> &'static str {
         "IF"
@@ -459,6 +459,30 @@ impl Function for IfFn {
         // Single variadic any schema so we can enforce precise 2 or 3 arity inside eval()
         static ONE: LazyLock<Vec<ArgSchema>> = LazyLock::new(|| vec![ArgSchema::any()]);
         &ONE[..]
+    }
+
+    fn eval_reference<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        _ctx: &dyn FunctionContext<'b>,
+    ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
+        match try_resolve_if_reference_or_value(args) {
+            Ok(Some(result)) => resolution_to_reference(Ok(result)),
+            Ok(None) => None,
+            Err(error) => Some(Err(error)),
+        }
+    }
+
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        _ctx: &dyn FunctionContext<'b>,
+        value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        match try_resolve_if_reference_or_value(args)? {
+            Some(result) => Ok(result),
+            None => value_fallback().map(FunctionResolution::Value),
+        }
     }
 
     fn eval<'a, 'b, 'c>(
@@ -495,6 +519,48 @@ impl Function for IfFn {
                 false,
             )))
         }
+    }
+}
+
+fn try_resolve_if_reference_or_value<'b>(
+    args: &[ArgumentHandle<'_, 'b>],
+) -> Result<Option<FunctionResolution<'b>>, ExcelError> {
+    if args.len() < 2 || args.len() > 3 {
+        return Ok(Some(FunctionResolution::Value(
+            crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                ExcelError::new_value()
+                    .with_message(format!("IF expects 2 or 3 arguments, got {}", args.len())),
+            )),
+        )));
+    }
+    let condition = args[0].value()?.into_literal();
+    let selected = match condition {
+        LiteralValue::Boolean(value) => value,
+        LiteralValue::Number(value) => value != 0.0,
+        LiteralValue::Int(value) => value != 0,
+        LiteralValue::Empty => false,
+        LiteralValue::Error(error) => {
+            return Ok(Some(FunctionResolution::Value(
+                crate::traits::CalcValue::Scalar(LiteralValue::Error(error)),
+            )));
+        }
+        LiteralValue::Array(_) => return Ok(None),
+        _ => {
+            return Ok(Some(FunctionResolution::Value(
+                crate::traits::CalcValue::Scalar(LiteralValue::Error(
+                    ExcelError::new_value().with_message("IF condition must be boolean or number"),
+                )),
+            )));
+        }
+    };
+    if selected {
+        args[1].resolve_reference_or_value().map(Some)
+    } else if let Some(arg) = args.get(2) {
+        arg.resolve_reference_or_value().map(Some)
+    } else {
+        Ok(Some(FunctionResolution::Value(
+            crate::traits::CalcValue::Scalar(LiteralValue::Boolean(false)),
+        )))
     }
 }
 

--- a/crates/formualizer-eval/src/builtins/logical_ext.rs
+++ b/crates/formualizer-eval/src/builtins/logical_ext.rs
@@ -1,6 +1,6 @@
 use super::utils::ARG_ANY_ONE;
 use crate::args::ArgSchema;
-use crate::function::Function;
+use crate::function::{Function, FunctionResolution, resolution_to_reference};
 use crate::function_contract::FunctionDependencyContract;
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::{ExcelError, LiteralValue};
@@ -469,7 +469,7 @@ pub struct IfsFn; // IFS(cond1, val1, cond2, val2, ...)
 /// Variadic: true
 /// Signature: IFS(arg1...: any@scalar)
 /// Arg schema: arg1{kinds=any,required=true,shape=scalar,by_ref=false,coercion=None,max=None,repeating=None,default=false}
-/// Caps: PURE, SHORT_CIRCUIT
+/// Caps: PURE, RETURNS_REFERENCE, SHORT_CIRCUIT
 /// [formualizer-docgen:schema:end]
 impl Function for IfsFn {
     fn propagate_format(
@@ -479,7 +479,7 @@ impl Function for IfsFn {
         result.format_id()
     }
 
-    func_caps!(PURE, SHORT_CIRCUIT, MAY_SPILL);
+    func_caps!(PURE, SHORT_CIRCUIT, RETURNS_REFERENCE, MAY_SPILL);
     fn name(&self) -> &'static str {
         "IFS"
     }
@@ -491,6 +491,21 @@ impl Function for IfsFn {
     }
     fn arg_schema(&self) -> &'static [ArgSchema] {
         &ARG_ANY_ONE[..]
+    }
+    fn eval_reference<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
+        resolution_to_reference(resolve_ifs_reference_or_value(args, ctx))
+    }
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+        _value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        resolve_ifs_reference_or_value(args, ctx)
     }
     fn eval<'a, 'b, 'c>(
         &self,
@@ -526,6 +541,49 @@ impl Function for IfsFn {
             ExcelError::new_na(),
         )))
     }
+}
+
+fn resolve_selected_non_if<'b>(
+    selected: &ArgumentHandle<'_, 'b>,
+    _ctx: &dyn FunctionContext<'b>,
+) -> Result<FunctionResolution<'b>, ExcelError> {
+    selected.resolve_reference_or_value()
+}
+
+fn value_error_resolution<'b>() -> FunctionResolution<'b> {
+    FunctionResolution::Value(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+        ExcelError::new_value(),
+    )))
+}
+
+fn resolve_ifs_reference_or_value<'b>(
+    args: &[ArgumentHandle<'_, 'b>],
+    ctx: &dyn FunctionContext<'b>,
+) -> Result<FunctionResolution<'b>, ExcelError> {
+    if args.len() < 2 || !args.len().is_multiple_of(2) {
+        return Ok(value_error_resolution());
+    }
+    for pair in args.chunks(2) {
+        let condition = pair[0].value()?.into_literal();
+        let selected = match condition {
+            LiteralValue::Boolean(value) => value,
+            LiteralValue::Number(value) => value != 0.0,
+            LiteralValue::Int(value) => value != 0,
+            LiteralValue::Empty => false,
+            LiteralValue::Error(error) => {
+                return Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(
+                    LiteralValue::Error(error),
+                )));
+            }
+            _ => return Ok(value_error_resolution()),
+        };
+        if selected {
+            return resolve_selected_non_if(&pair[1], ctx);
+        }
+    }
+    Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(
+        LiteralValue::Error(ExcelError::new_na()),
+    )))
 }
 
 /// Returns the result corresponding to the first matching candidate value.

--- a/crates/formualizer-eval/src/builtins/lookup/choose.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/choose.rs
@@ -8,7 +8,7 @@
 
 use crate::args::{ArgSchema, CoercionPolicy, ShapeKind};
 use crate::builtins::utils::collapse_if_scalar;
-use crate::function::Function;
+use crate::function::{Function, FunctionResolution, resolution_to_reference};
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::{ArgKind, ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_macros::func_caps;
@@ -115,6 +115,23 @@ impl Function for ChooseFn {
         &SCHEMA
     }
 
+    fn eval_reference<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
+        resolution_to_reference(resolve_choose_reference_or_value(args, ctx))
+    }
+
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+        _value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        resolve_choose_reference_or_value(args, ctx)
+    }
+
     fn eval<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
@@ -156,6 +173,36 @@ impl Function for ChooseFn {
         let selected_arg = &args[index as usize];
         selected_arg.value()
     }
+}
+
+fn resolve_choose_reference_or_value<'b>(
+    args: &[ArgumentHandle<'_, 'b>],
+    _ctx: &dyn FunctionContext<'b>,
+) -> Result<FunctionResolution<'b>, ExcelError> {
+    let value_error = || {
+        FunctionResolution::Value(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+            ExcelError::new(ExcelErrorKind::Value),
+        )))
+    };
+    if args.len() < 2 {
+        return Ok(value_error());
+    }
+    let index_value = args[0].value()?.into_literal();
+    let index = match index_value {
+        LiteralValue::Number(value) => value as i64,
+        LiteralValue::Int(value) => value,
+        LiteralValue::Error(error) => {
+            return Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(
+                LiteralValue::Error(error),
+            )));
+        }
+        _ => return Ok(value_error()),
+    };
+    if index < 1 || index as usize > args.len() - 1 {
+        return Ok(value_error());
+    }
+    let selected = &args[index as usize];
+    selected.resolve_reference_or_value()
 }
 
 /* ───────────────────────── CHOOSECOLS() / CHOOSEROWS() ───────────────────────── */

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -1,5 +1,5 @@
 use crate::args::{ArgSchema, CoercionPolicy, ShapeKind};
-use crate::function::{FnCaps, Function};
+use crate::function::{FnCaps, Function, FunctionResolution};
 use crate::traits::{ArgumentHandle, FunctionContext};
 use formualizer_common::{ArgKind, ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::ReferenceType;
@@ -132,6 +132,185 @@ fn resolve_reference_bounds<'b>(
 #[derive(Debug)]
 pub struct IndexFn;
 
+impl IndexFn {
+    fn index_argument<'a, 'b>(arg: &ArgumentHandle<'a, 'b>) -> Result<Option<i64>, ExcelError> {
+        if arg.is_omitted() {
+            return Ok(Some(0));
+        }
+        match arg.value()? {
+            crate::traits::CalcValue::Range(_)
+            | crate::traits::CalcValue::Scalar(LiteralValue::Array(_)) => Ok(None),
+            value => match value.into_literal() {
+                LiteralValue::Number(number) => Ok(Some(number as i64)),
+                LiteralValue::Int(integer) => Ok(Some(integer)),
+                _ => Err(ExcelError::new(ExcelErrorKind::Value)),
+            },
+        }
+    }
+
+    fn bounded_dimensions(base: &ReferenceType) -> Option<(u32, u32)> {
+        match base {
+            ReferenceType::Cell { .. } => Some((1, 1)),
+            ReferenceType::Range {
+                start_row: Some(start_row),
+                start_col: Some(start_col),
+                end_row: Some(end_row),
+                end_col: Some(end_col),
+                ..
+            } => Some((
+                end_row.checked_sub(*start_row)?.checked_add(1)?,
+                end_col.checked_sub(*start_col)?.checked_add(1)?,
+            )),
+            _ => None,
+        }
+    }
+
+    fn precise_single_cell_selection<'a, 'b>(
+        args: &[ArgumentHandle<'a, 'b>],
+        rows: u32,
+        cols: u32,
+    ) -> bool {
+        if !(2..=3).contains(&args.len()) {
+            return false;
+        }
+        let Ok(Some(position)) = Self::index_argument(&args[1]) else {
+            return false;
+        };
+        if args.len() == 3 {
+            let Ok(Some(column)) = Self::index_argument(&args[2]) else {
+                return false;
+            };
+            if args[1].is_omitted() {
+                column > 0 && rows == 1 && u32::try_from(column).is_ok_and(|col| col <= cols)
+            } else if args[2].is_omitted() {
+                position > 0 && cols == 1 && u32::try_from(position).is_ok_and(|row| row <= rows)
+            } else {
+                position > 0
+                    && column > 0
+                    && u32::try_from(position).is_ok_and(|row| row <= rows)
+                    && u32::try_from(column).is_ok_and(|col| col <= cols)
+            }
+        } else if rows == 1 {
+            position > 0 && u32::try_from(position).is_ok_and(|col| col <= cols)
+        } else if cols == 1 {
+            position > 0 && u32::try_from(position).is_ok_and(|row| row <= rows)
+        } else {
+            false
+        }
+    }
+
+    fn reference_from_base<'a, 'b>(
+        args: &[ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+        base: ReferenceType,
+    ) -> Option<Result<ReferenceType, ExcelError>> {
+        let position = match Self::index_argument(&args[1]) {
+            Ok(Some(position)) => position,
+            Ok(None) => return None,
+            Err(error) => return Some(Err(error)),
+        };
+        let explicit_col = if args.len() >= 3 {
+            match Self::index_argument(&args[2]) {
+                Ok(Some(column)) => Some(column),
+                Ok(None) => return None,
+                Err(error) => return Some(Err(error)),
+            }
+        } else {
+            None
+        };
+
+        let (sheet, sr, sc, er, ec) = match resolve_reference_bounds(ctx, &base) {
+            Ok(bounds) => bounds,
+            Err(error) => return Some(Err(error)),
+        };
+        let (row, col) = match explicit_col {
+            Some(col) => (position, col),
+            None if sr == er => (1, position),
+            None => (position, 1),
+        };
+        if row < 0 || col < 0 {
+            return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
+        }
+        let range_ref = |sheet, sr, sc, er, ec| ReferenceType::Range {
+            sheet,
+            start_row: Some(sr),
+            start_col: Some(sc),
+            end_row: Some(er),
+            end_col: Some(ec),
+            start_row_abs: false,
+            start_col_abs: false,
+            end_row_abs: false,
+            end_col_abs: false,
+        };
+        if col == 0 {
+            if row == 0 {
+                return Some(Ok(range_ref(sheet, sr, sc, er, ec)));
+            }
+            let r = sr + (row as u32) - 1;
+            if r > er {
+                return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
+            }
+            return Some(Ok(if sc == ec {
+                ReferenceType::cell(sheet, r, sc)
+            } else {
+                range_ref(sheet, r, sc, r, ec)
+            }));
+        }
+        if row == 0 {
+            let c = sc + (col as u32) - 1;
+            if c > ec {
+                return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
+            }
+            return Some(Ok(if sr == er {
+                ReferenceType::cell(sheet, sr, c)
+            } else {
+                range_ref(sheet, sr, c, er, c)
+            }));
+        }
+        let r = sr + (row as u32) - 1;
+        let c = sc + (col as u32) - 1;
+        if r > er || c > ec {
+            return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
+        }
+        Some(Ok(ReferenceType::cell(sheet, r, c)))
+    }
+
+    fn materialize_reference<'b>(
+        ctx: &dyn FunctionContext<'b>,
+        reference: &ReferenceType,
+    ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+        let view = ctx.resolve_range_view(reference, ctx.current_sheet())?;
+        let (rows, cols) = view.dims();
+        if rows == 1 && cols == 1 {
+            Ok(crate::traits::CalcValue::Scalar(
+                view.as_1x1().unwrap_or(LiteralValue::Empty),
+            ))
+        } else {
+            Ok(crate::traits::CalcValue::Range(view))
+        }
+    }
+
+    fn validated_dispatch<'a, 'b>(
+        &self,
+        args: &[ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+        use crate::args::{ValidationOptions, validate_and_prepare};
+        if let Err(error) = validate_and_prepare(
+            args,
+            self.arg_schema(),
+            ValidationOptions {
+                warn_only: false,
+                min_args: self.min_args(),
+            },
+        ) {
+            return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(error)));
+        }
+        self.eval(args, ctx)
+            .map(|result| self.apply_format_propagation(result))
+    }
+}
+
 /// Returns the value or reference at a 1-based row and column within an array or range.
 ///
 /// `INDEX` can operate on both references and array literals. When the first argument is
@@ -209,125 +388,40 @@ impl Function for IndexFn {
         &SCHEMA
     }
 
+    fn dispatch<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+        if let Some(argument) = args.first()
+            && argument.may_return_reference()
+            && let Ok(FunctionResolution::Reference(base)) = argument.resolve_reference_or_value()
+            && let Some((rows, cols)) = Self::bounded_dimensions(&base)
+            && Self::precise_single_cell_selection(args, rows, cols)
+            && let Some(Ok(reference @ ReferenceType::Cell { .. })) =
+                Self::reference_from_base(args, ctx, base)
+            && let Ok(value) = Self::materialize_reference(ctx, &reference)
+        {
+            return Ok(self.apply_format_propagation(value));
+        }
+        self.validated_dispatch(args, ctx)
+    }
+
     fn eval_reference<'a, 'b, 'c>(
         &self,
         args: &'c [ArgumentHandle<'a, 'b>],
         ctx: &dyn FunctionContext<'b>,
     ) -> Option<Result<ReferenceType, ExcelError>> {
-        // args: array(by_ref), row, col (col optional for 1D)
         if args.len() < 2 {
             return Some(Err(ExcelError::new(ExcelErrorKind::Value)));
         }
-        // Return None for array literals so eval() handles them
-        let base = match args[0].as_reference_or_eval() {
-            Ok(r) => r,
-            Err(_) => return None,
-        };
-        // Defensive: value() currently materializes omitted indexes as Number(0), so these
-        // row/column checks are redundant while documenting whole-row/column intent.
-        let position = if args[1].is_omitted() {
-            0
-        } else {
-            match args[1].value() {
-                Ok(cv) => match cv.into_literal() {
-                    LiteralValue::Number(n) => n as i64,
-                    LiteralValue::Int(i) => i,
-                    _ => return Some(Err(ExcelError::new(ExcelErrorKind::Value))),
-                },
-                Err(e) => return Some(Err(e)),
+        let base = match args[0].resolve_reference_or_value() {
+            Ok(FunctionResolution::Reference(reference)) => reference,
+            Ok(FunctionResolution::ReferenceError(_) | FunctionResolution::Value(_)) | Err(_) => {
+                return None;
             }
         };
-        let explicit_col = if args.len() >= 3 {
-            Some(if args[2].is_omitted() {
-                0
-            } else {
-                match args[2].value() {
-                    Ok(cv) => match cv.into_literal() {
-                        LiteralValue::Number(n) => n as i64,
-                        LiteralValue::Int(i) => i,
-                        _ => return Some(Err(ExcelError::new(ExcelErrorKind::Value))),
-                    },
-                    Err(e) => return Some(Err(e)),
-                }
-            })
-        } else {
-            None
-        };
-
-        // Only Range/Cell supported for now; unbounded ranges (e.g. B:B, 2:2)
-        // are clamped to the used region instead of erroring.
-        let (sheet, sr, sc, er, ec) = match resolve_reference_bounds(ctx, &base) {
-            Ok(bounds) => bounds,
-            Err(e) => return Some(Err(e)),
-        };
-
-        let (row, col) = match explicit_col {
-            Some(col) => (position, col),
-            None if sr == er => {
-                // Excel treats INDEX(single_row_range, n) as horizontal indexing.
-                (1, position)
-            }
-            None => {
-                // Excel treats INDEX(single_col_range, n) as vertical indexing and defaults
-                // 2-D ranges to the first column when column_num is omitted.
-                (position, 1)
-            }
-        };
-
-        // 1-based indexing per Excel. A 0 means "the entire row" (column_num == 0)
-        // or "the entire column" (row_num == 0); 0 for both yields the whole range.
-        // Negative indices are #REF!.
-        if row < 0 || col < 0 {
-            return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
-        }
-        let range_ref = |sheet, sr, sc, er, ec| ReferenceType::Range {
-            sheet,
-            start_row: Some(sr),
-            start_col: Some(sc),
-            end_row: Some(er),
-            end_col: Some(ec),
-            start_row_abs: false,
-            start_col_abs: false,
-            end_row_abs: false,
-            end_col_abs: false,
-        };
-        if col == 0 {
-            if row == 0 {
-                // INDEX(range, 0, 0) -> the entire range.
-                return Some(Ok(range_ref(sheet, sr, sc, er, ec)));
-            }
-            // INDEX(range, r, 0) -> the entire row r (degenerates to a cell for a
-            // single-column range).
-            let r = sr + (row as u32) - 1;
-            if r > er {
-                return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
-            }
-            return Some(Ok(if sc == ec {
-                ReferenceType::cell(sheet, r, sc)
-            } else {
-                range_ref(sheet, r, sc, r, ec)
-            }));
-        }
-        if row == 0 {
-            // INDEX(range, 0, c) -> the entire column c (degenerates to a cell for a
-            // single-row range).
-            let c = sc + (col as u32) - 1;
-            if c > ec {
-                return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
-            }
-            return Some(Ok(if sr == er {
-                ReferenceType::cell(sheet, sr, c)
-            } else {
-                range_ref(sheet, sr, c, er, c)
-            }));
-        }
-        let r = sr + (row as u32) - 1;
-        let c = sc + (col as u32) - 1;
-        if r > er || c > ec {
-            return Some(Err(ExcelError::new(ExcelErrorKind::Ref)));
-        }
-
-        Some(Ok(ReferenceType::cell(sheet, r, c)))
+        Self::reference_from_base(args, ctx, base)
     }
 
     fn eval<'a, 'b, 'c>(
@@ -338,23 +432,9 @@ impl Function for IndexFn {
         // First try to handle as a reference
         if let Some(result) = self.eval_reference(args, ctx) {
             match result {
-                Ok(r) => {
-                    // Materialize to value
-                    let current_sheet = ctx.current_sheet();
-                    match ctx.resolve_range_view(&r, current_sheet) {
-                        Ok(rv) => {
-                            let (rows, cols) = rv.dims();
-                            if rows == 1 && cols == 1 {
-                                Ok(crate::traits::CalcValue::Scalar(
-                                    rv.as_1x1().unwrap_or(LiteralValue::Empty),
-                                ))
-                            } else {
-                                Ok(crate::traits::CalcValue::Range(rv))
-                            }
-                        }
-                        Err(e) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e))),
-                    }
-                }
+                Ok(reference) => Self::materialize_reference(ctx, &reference).or_else(|error| {
+                    Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(error)))
+                }),
                 Err(e) => Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(e))),
             }
         } else {

--- a/crates/formualizer-eval/src/engine/tests/live_edge_precision.rs
+++ b/crates/formualizer-eval/src/engine/tests/live_edge_precision.rs
@@ -1,0 +1,220 @@
+use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use chrono::NaiveDate;
+use formualizer_common::{ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+fn runtime_engine() -> Engine<TestWorkbook> {
+    let cycle = CycleConfig {
+        detection: CycleDetection::Runtime,
+        policy: CyclePolicy::Error,
+    };
+    Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default()
+            .with_cycle(cycle)
+            .with_virtual_dep_telemetry(true),
+    )
+}
+
+fn set_formula(engine: &mut Engine<TestWorkbook>, row: u32, col: u32, formula: &str) {
+    engine
+        .set_cell_formula("Sheet1", row, col, parse(formula).expect("parse formula"))
+        .expect("set formula");
+}
+
+fn is_circ(engine: &Engine<TestWorkbook>, row: u32, col: u32) -> bool {
+    matches!(
+        engine.get_cell_value("Sheet1", row, col),
+        Some(LiteralValue::Error(error)) if error.kind == ExcelErrorKind::Circ
+    )
+}
+
+fn build_guarded_chain(consumer_formula: &str) -> Engine<TestWorkbook> {
+    let mut engine = runtime_engine();
+    for row in 1..=100 {
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Int(i64::from(row)))
+            .expect("set row number");
+        set_formula(&mut engine, row, 5, &format!("=IF(B{row}>=29,$C$9,0)"));
+        if row == 1 {
+            set_formula(&mut engine, row, 17, "=E1");
+        } else {
+            set_formula(&mut engine, row, 17, &format!("=Q{}+E{row}", row - 1));
+        }
+    }
+    set_formula(&mut engine, 9, 3, consumer_formula);
+    engine
+}
+
+#[test]
+fn index_rect_edge_precision_acyclic_chain() {
+    let mut engine = build_guarded_chain("=INDEX(Q1:Q100,24)");
+    engine.evaluate_all().expect("evaluate");
+
+    let c9 = engine.get_cell_value("Sheet1", 9, 3);
+    let c9_is_zero = matches!(c9, Some(LiteralValue::Number(0.0) | LiteralValue::Int(0)));
+    let circ_count = (1..=100)
+        .flat_map(|row| (1..=17).map(move |col| (row, col)))
+        .filter(|&(row, col)| is_circ(&engine, row, col))
+        .count();
+    assert!(
+        c9_is_zero && circ_count == 0,
+        "C9 expected numeric zero, got {c9:?}; expected zero Circ cells, got {circ_count}"
+    );
+}
+
+#[test]
+fn index_rect_edge_precision_if_selected_base() {
+    let mut engine = build_guarded_chain("=INDEX(IF(B1=1,Q1:Q100,A1:A100),24,1)");
+    engine.evaluate_all().expect("evaluate");
+
+    let c9 = engine.get_cell_value("Sheet1", 9, 3);
+    let c9_is_zero = matches!(c9, Some(LiteralValue::Number(0.0) | LiteralValue::Int(0)));
+    let circ_count = (1..=100)
+        .flat_map(|row| (1..=17).map(move |col| (row, col)))
+        .filter(|&(row, col)| is_circ(&engine, row, col))
+        .count();
+    assert!(
+        c9_is_zero && circ_count == 0,
+        "C9 through IF-selected reference expected numeric zero, got {c9:?}; expected zero Circ cells, got {circ_count}"
+    );
+}
+
+#[test]
+fn index_rect_edge_precision_omitted_column_single_vector() {
+    let mut engine = build_guarded_chain("=INDEX(Q1:Q100,24,)");
+    engine.evaluate_all().expect("evaluate");
+    assert!(
+        matches!(
+            engine.get_cell_value("Sheet1", 9, 3),
+            Some(LiteralValue::Number(0.0) | LiteralValue::Int(0))
+        ),
+        "vertical vector with omitted column must resolve one cell"
+    );
+    assert_eq!(
+        (1..=100)
+            .flat_map(|row| (1..=17).map(move |col| (row, col)))
+            .filter(|&(row, col)| is_circ(&engine, row, col))
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn index_rect_edge_precision_omitted_row_single_vector() {
+    let mut engine = runtime_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 17, LiteralValue::Int(0))
+        .expect("set Q1");
+    engine
+        .set_cell_value("Sheet1", 1, 18, LiteralValue::Int(0))
+        .expect("set R1");
+    set_formula(&mut engine, 1, 19, "=$C$9");
+    set_formula(&mut engine, 9, 3, "=INDEX(Q1:S1,,2)");
+    engine.evaluate_all().expect("evaluate");
+    assert!(
+        matches!(
+            engine.get_cell_value("Sheet1", 9, 3),
+            Some(LiteralValue::Number(0.0) | LiteralValue::Int(0))
+        ),
+        "horizontal vector with omitted row must resolve one cell"
+    );
+    assert!(!is_circ(&engine, 1, 19));
+}
+
+#[test]
+fn index_rect_edge_genuine_cycle_still_detected() {
+    let mut engine = build_guarded_chain("=INDEX(Q1:Q100,40)");
+    engine.evaluate_all().expect("evaluate");
+    assert!(is_circ(&engine, 9, 3), "C9 must remain Circ");
+}
+
+#[test]
+fn index_selected_error_propagates() {
+    let mut engine = runtime_engine();
+    set_formula(&mut engine, 1, 17, "=1/0");
+    engine
+        .set_cell_value("Sheet1", 3, 17, LiteralValue::Int(9))
+        .expect("set Q3");
+    set_formula(&mut engine, 9, 3, "=INDEX(Q1:Q3,1)");
+    engine.evaluate_all().expect("evaluate");
+    assert!(
+        matches!(
+            engine.get_cell_value("Sheet1", 9, 3),
+            Some(LiteralValue::Error(error)) if error.kind == ExcelErrorKind::Div
+        ),
+        "INDEX must propagate the selected cell's DIV/0 error"
+    );
+}
+
+#[test]
+fn index_unselected_error_is_ignored() {
+    let mut engine = runtime_engine();
+    engine
+        .set_cell_value("Sheet1", 1, 17, LiteralValue::Int(7))
+        .expect("set Q1");
+    set_formula(&mut engine, 3, 17, "=NA()");
+    set_formula(&mut engine, 9, 3, "=INDEX(Q1:Q3,1)+1");
+    engine.evaluate_all().expect("evaluate");
+    assert!(
+        matches!(
+            engine.get_cell_value("Sheet1", 9, 3),
+            Some(LiteralValue::Number(8.0) | LiteralValue::Int(8))
+        ),
+        "an unselected error must not affect the INDEX result"
+    );
+}
+
+#[test]
+fn index_selected_error_phantom_cycle_stays_acyclic() {
+    let mut engine = runtime_engine();
+    set_formula(&mut engine, 1, 17, "=1/0");
+    set_formula(&mut engine, 3, 17, "=C9");
+    set_formula(&mut engine, 9, 3, "=INDEX(Q1:Q3,1)");
+    engine.evaluate_all().expect("evaluate");
+    for (row, col, label) in [(9, 3, "C9"), (3, 17, "Q3")] {
+        assert!(
+            matches!(
+                engine.get_cell_value("Sheet1", row, col),
+                Some(LiteralValue::Error(error)) if error.kind == ExcelErrorKind::Div
+            ),
+            "{label} must propagate DIV/0 without a circular error"
+        );
+    }
+}
+
+#[test]
+fn index_precise_path_applies_format_policy() {
+    let mut engine = runtime_engine();
+    engine
+        .set_cell_value(
+            "Sheet1",
+            1,
+            17,
+            LiteralValue::Date(NaiveDate::from_ymd_opt(2024, 12, 1).expect("valid date")),
+        )
+        .expect("set Q1");
+    let ast = parse("=INDEX(Q1:Q3,1)").expect("valid INDEX formula");
+    let value = crate::interpreter::Interpreter::new(&engine, "Sheet1")
+        .evaluate_ast(&ast)
+        .expect("evaluate INDEX");
+    assert_eq!(value.format_id(), None, "INDEX drops source annotations");
+}
+
+#[test]
+fn sum_over_rect_keeps_whole_rect_edges() {
+    let mut engine = build_guarded_chain("=SUM(Q1:Q100)");
+    engine.evaluate_all().expect("evaluate");
+    assert!(is_circ(&engine, 9, 3), "C9 must remain Circ");
+}
+
+#[test]
+fn index_unbounded_column_selection_measured() {
+    let mut engine = build_guarded_chain("=INDEX(Q:Q,24)");
+    engine.evaluate_all().expect("evaluate");
+    assert!(
+        is_circ(&engine, 9, 3),
+        "unbounded INDEX retains whole-column live edges while resolving bounds"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -187,6 +187,7 @@ mod iterate_corpus_numeric;
 mod iterate_corpus_scale;
 mod iterate_corpus_structural;
 mod iterate_corpus_text;
+mod live_edge_precision;
 mod live_edges;
 mod scalar_range_promotion;
 mod scc_iterate;

--- a/crates/formualizer-eval/src/function.rs
+++ b/crates/formualizer-eval/src/function.rs
@@ -9,6 +9,29 @@ use crate::{
     traits::ArgumentHandle,
 };
 use formualizer_common::{ExcelError, LiteralValue};
+use formualizer_parse::parser::ReferenceType;
+
+/// One-pass result for a function used where either a reference or a value is valid.
+#[doc(hidden)]
+#[derive(Clone)]
+pub enum FunctionResolution<'a> {
+    Reference(ReferenceType),
+    ReferenceError(ExcelError),
+    Value(crate::traits::CalcValue<'a>),
+}
+
+pub(crate) fn resolution_to_reference(
+    result: Result<FunctionResolution<'_>, ExcelError>,
+) -> Option<Result<ReferenceType, ExcelError>> {
+    match result {
+        Ok(FunctionResolution::Reference(reference)) => Some(Ok(reference)),
+        Ok(FunctionResolution::ReferenceError(error)) | Err(error) => Some(Err(error)),
+        Ok(FunctionResolution::Value(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+            error,
+        )))) => Some(Err(error)),
+        Ok(FunctionResolution::Value(_)) => None,
+    }
+}
 
 bitflags::bitflags! {
     /// Describes the capabilities and properties of a function.
@@ -187,6 +210,25 @@ pub trait Function: Send + Sync + 'static {
         _ctx: &dyn crate::traits::FunctionContext<'b>,
     ) -> Option<Result<formualizer_parse::parser::ReferenceType, ExcelError>> {
         None
+    }
+
+    /// Resolve a reference-capable function while preserving scalar-selector caching.
+    ///
+    /// The fallback deliberately re-enters the caller's ordinary value path. That
+    /// preserves dispatch validation and array lifting for existing functions whose
+    /// `eval_reference` declines a particular argument shape. Array-valued selectors
+    /// may be evaluated once by each path.
+    fn resolve_reference_or_value<'a, 'b, 'c>(
+        &self,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn crate::traits::FunctionContext<'b>,
+        value_fallback: &dyn Fn() -> Result<crate::traits::CalcValue<'b>, ExcelError>,
+    ) -> Result<FunctionResolution<'b>, ExcelError> {
+        match self.eval_reference(args, ctx) {
+            Some(Ok(reference)) => Ok(FunctionResolution::Reference(reference)),
+            Some(Err(error)) => Ok(FunctionResolution::ReferenceError(error)),
+            None => value_fallback().map(FunctionResolution::Value),
+        }
     }
 
     /// Dispatch to the unified evaluation path with automatic argument validation.

--- a/crates/formualizer-eval/src/tests/functions.rs
+++ b/crates/formualizer-eval/src/tests/functions.rs
@@ -789,6 +789,36 @@ fn if_family_selector_evaluation_count() {
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 1, "AST value arm");
 
+    calls.store(0, Ordering::SeqCst);
+    selected.store(true, Ordering::SeqCst);
+    let ast = formualizer_parse::parser::parse("=INDEX(IF(COUNTSELECTOR(),A1:A3,D1:D3),0,1)")
+        .expect("valid zero-index fallback formula");
+    assert!(matches!(
+        interpreter.evaluate_ast(&ast),
+        Ok(crate::traits::CalcValue::Range(_))
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "AST zero-index fallback");
+
+    for (formula, label) in [
+        (
+            "=INDEX(IF(COUNTSELECTOR(),5,A1:A3),1)",
+            "selected scalar fallback",
+        ),
+        (
+            "=INDEX(IF(COUNTSELECTOR(),A1:A3,D1:D3),99,1)",
+            "out-of-bounds fallback",
+        ),
+        (
+            "=INDEX(IF(COUNTSELECTOR(),A1:B3,D1:E3),2)",
+            "2-D omitted-column fallback",
+        ),
+    ] {
+        calls.store(0, Ordering::SeqCst);
+        let ast = formualizer_parse::parser::parse(formula).expect("valid INDEX fallback formula");
+        let _ = interpreter.evaluate_ast(&ast);
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "AST {label}");
+    }
+
     for (select_reference, expected) in [(true, 6.0), (false, 5.0)] {
         calls.store(0, Ordering::SeqCst);
         selected.store(select_reference, Ordering::SeqCst);
@@ -835,5 +865,42 @@ fn if_family_selector_evaluation_count() {
                 "value"
             }
         );
+    }
+
+    for path in ["AST", "Arena"] {
+        calls.store(0, Ordering::SeqCst);
+        array.store(true, Ordering::SeqCst);
+        let wb = workbook(
+            Arc::clone(&array),
+            Arc::clone(&calls),
+            Arc::clone(&selected),
+        );
+        if path == "AST" {
+            let interpreter = wb.interpreter();
+            let ast = formualizer_parse::parser::parse("=IF(COUNTSELECTOR(),{1,1},{2,2})")
+                .expect("valid AST array-selector formula");
+            let handle = ArgumentHandle::new(&ast, &interpreter);
+            let _ = handle.resolve_once();
+        } else {
+            let mut engine = crate::engine::Engine::new(
+                wb,
+                crate::engine::EvalConfig::default().with_cycle(crate::engine::CycleConfig {
+                    detection: crate::engine::CycleDetection::Runtime,
+                    policy: crate::engine::CyclePolicy::Error,
+                }),
+            );
+            engine
+                .set_cell_formula(
+                    "Sheet1",
+                    1,
+                    10,
+                    formualizer_parse::parser::parse("=SUM(IF(COUNTSELECTOR(),{1,1},{2,2}))")
+                        .expect("valid Arena array-selector formula"),
+                )
+                .expect("set Arena array-selector formula");
+            engine.evaluate_all().expect("evaluate array selector");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "{path} array selector");
+        array.store(false, Ordering::SeqCst);
     }
 }

--- a/crates/formualizer-eval/src/tests/functions.rs
+++ b/crates/formualizer-eval/src/tests/functions.rs
@@ -561,3 +561,279 @@ fn interpreter_incompatible_broadcast_is_value_error() {
         v => panic!("expected value error, got {v:?}"),
     }
 }
+
+fn reference_returning_engine(g1: i64) -> crate::engine::Engine<TestWorkbook> {
+    use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, EvalConfig};
+
+    let cfg = EvalConfig::default().with_cycle(CycleConfig {
+        detection: CycleDetection::Runtime,
+        policy: CyclePolicy::Error,
+    });
+    let mut engine = crate::engine::Engine::new(TestWorkbook::new(), cfg);
+    for row in 1..=20 {
+        for (col, value) in [
+            (1, row as i64),
+            (2, 100 + row as i64),
+            (3, 200 + row as i64),
+            (4, row as i64),
+            (5, 400 + row as i64),
+            (6, 500 + row as i64),
+        ] {
+            engine
+                .set_cell_value("Sheet1", row, col, LiteralValue::Int(value))
+                .expect("set reference fixture value");
+        }
+    }
+    engine
+        .set_cell_value("Sheet1", 1, 7, LiteralValue::Int(g1))
+        .expect("set selector");
+    engine
+}
+
+fn evaluate_reference_returning_formula(g1: i64, formula: &str) -> LiteralValue {
+    let mut engine = reference_returning_engine(g1);
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            10,
+            formualizer_parse::parser::parse(formula).expect("valid reference-returning formula"),
+        )
+        .expect("set reference-returning formula");
+    engine
+        .evaluate_all()
+        .expect("evaluate reference-returning formula");
+    engine
+        .get_cell_value("Sheet1", 1, 10)
+        .expect("formula result")
+}
+
+#[test]
+fn reference_returning_if_offset_index() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=OFFSET(INDEX(IF(G1=1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(0, "=OFFSET(INDEX(IF(G1=1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_if_offset_direct() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=OFFSET(IF(G1=1,A1:C20,D1:F20),1,1)"),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(0, "=OFFSET(IF(G1=1,A1:C20,D1:F20),1,1)"),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_ifs_offset_index() {
+    assert_eq!(
+        evaluate_reference_returning_formula(
+            1,
+            "=OFFSET(INDEX(IFS(G1=1,A1:C20,TRUE,D1:F20),2,1),0,1)",
+        ),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(
+            0,
+            "=OFFSET(INDEX(IFS(G1=1,A1:C20,TRUE,D1:F20),2,1),0,1)",
+        ),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_choose_offset_index() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=OFFSET(INDEX(CHOOSE(G1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(102.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(2, "=OFFSET(INDEX(CHOOSE(G1,A1:C20,D1:F20),2,1),0,1)",),
+        LiteralValue::Number(402.0)
+    );
+}
+
+#[test]
+fn reference_returning_if_family_value_paths() {
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=SUM(IF(G1=1,A1:A20,D1:D20))"),
+        LiteralValue::Number(210.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=VLOOKUP(5,CHOOSE(1,A1:B20,D1:E20),2,FALSE)",),
+        LiteralValue::Number(105.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=INDEX(IFERROR(1/0,A1:C20),3,3)"),
+        LiteralValue::Number(203.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(1, "=IF(G1=1,5,A1:A3)"),
+        LiteralValue::Number(5.0)
+    );
+    assert_eq!(
+        evaluate_reference_returning_formula(0, "=SUM(IF(G1=1,5,A1:A3))"),
+        LiteralValue::Number(6.0)
+    );
+}
+
+#[test]
+fn if_family_selector_evaluation_count() {
+    use crate::function::{FnCaps, Function};
+    use crate::traits::{FunctionContext, ResolvedArgument};
+    use formualizer_common::ExcelError;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    #[derive(Debug)]
+    struct CountSelectorFn {
+        array: Arc<AtomicBool>,
+        calls: Arc<AtomicUsize>,
+        selected: Arc<AtomicBool>,
+    }
+
+    impl Function for CountSelectorFn {
+        fn caps(&self) -> FnCaps {
+            FnCaps::empty()
+        }
+
+        fn name(&self) -> &'static str {
+            "COUNTSELECTOR"
+        }
+
+        fn arg_schema(&self) -> &'static [crate::args::ArgSchema] {
+            &[]
+        }
+
+        fn eval<'a, 'b, 'c>(
+            &self,
+            _args: &'c [ArgumentHandle<'a, 'b>],
+            _ctx: &dyn FunctionContext<'b>,
+        ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.array.load(Ordering::SeqCst) {
+                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Array(vec![
+                    vec![LiteralValue::Boolean(true), LiteralValue::Boolean(false)],
+                ])));
+            }
+            Ok(crate::traits::CalcValue::Scalar(LiteralValue::Boolean(
+                self.selected.load(Ordering::SeqCst),
+            )))
+        }
+    }
+
+    fn workbook(
+        array: Arc<AtomicBool>,
+        calls: Arc<AtomicUsize>,
+        selected: Arc<AtomicBool>,
+    ) -> TestWorkbook {
+        TestWorkbook::new()
+            .with_range(
+                "Sheet1",
+                1,
+                1,
+                vec![
+                    vec![LiteralValue::Int(1)],
+                    vec![LiteralValue::Int(2)],
+                    vec![LiteralValue::Int(3)],
+                ],
+            )
+            .with_function(Arc::new(CountSelectorFn {
+                array,
+                calls,
+                selected,
+            }))
+    }
+
+    crate::builtins::load_builtins();
+    let array = Arc::new(AtomicBool::new(false));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let selected = Arc::new(AtomicBool::new(true));
+
+    let wb = workbook(
+        Arc::clone(&array),
+        Arc::clone(&calls),
+        Arc::clone(&selected),
+    );
+    let interpreter = wb.interpreter();
+    let ast = formualizer_parse::parser::parse("=IF(COUNTSELECTOR(),A1:A3,5)")
+        .expect("valid AST selector formula");
+    let handle = ArgumentHandle::new(&ast, &interpreter);
+    assert!(matches!(
+        handle.resolve_once(),
+        Ok(ResolvedArgument::Range(_))
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "AST reference arm");
+
+    calls.store(0, Ordering::SeqCst);
+    selected.store(false, Ordering::SeqCst);
+    let ast = formualizer_parse::parser::parse("=IF(COUNTSELECTOR(),A1:A3,5)")
+        .expect("valid AST selector formula");
+    let handle = ArgumentHandle::new(&ast, &interpreter);
+    assert!(matches!(
+        handle.resolve_once(),
+        Ok(ResolvedArgument::Value(crate::traits::CalcValue::Scalar(
+            LiteralValue::Number(5.0)
+        )))
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "AST value arm");
+
+    for (select_reference, expected) in [(true, 6.0), (false, 5.0)] {
+        calls.store(0, Ordering::SeqCst);
+        selected.store(select_reference, Ordering::SeqCst);
+        let wb = workbook(
+            Arc::clone(&array),
+            Arc::clone(&calls),
+            Arc::clone(&selected),
+        );
+        let mut engine = crate::engine::Engine::new(
+            wb,
+            crate::engine::EvalConfig::default().with_cycle(crate::engine::CycleConfig {
+                detection: crate::engine::CycleDetection::Runtime,
+                policy: crate::engine::CyclePolicy::Error,
+            }),
+        );
+        for (row, value) in [(1, 1), (2, 2), (3, 3)] {
+            engine
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Int(value))
+                .expect("set arena reference value");
+        }
+        engine
+            .set_cell_formula(
+                "Sheet1",
+                1,
+                10,
+                formualizer_parse::parser::parse("=SUM(IF(COUNTSELECTOR(),A1:A3,5))")
+                    .expect("valid arena selector formula"),
+            )
+            .expect("set arena selector formula");
+        engine
+            .evaluate_all()
+            .expect("evaluate arena selector formula");
+        assert_eq!(
+            engine.get_cell_value("Sheet1", 1, 10),
+            Some(LiteralValue::Number(expected))
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "Arena {} arm",
+            if select_reference {
+                "reference"
+            } else {
+                "value"
+            }
+        );
+    }
+}

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -294,6 +294,8 @@ pub struct ArgumentHandle<'a, 'b> {
     interp: &'a Interpreter<'b>,
     cached_ast: std::cell::OnceCell<ASTNode>,
     cached_ref: std::cell::OnceCell<ReferenceType>,
+    cached_reference_or_value:
+        std::cell::OnceCell<Result<crate::function::FunctionResolution<'b>, ExcelError>>,
     cached_resolved: std::cell::OnceCell<Result<ResolvedArgument<'b>, ExcelError>>,
     /// Memoized result of [`Self::value`]. `Function::dispatch` evaluates
     /// every argument once during schema validation and the function's `eval`
@@ -313,6 +315,7 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
             interp,
             cached_ast: std::cell::OnceCell::new(),
             cached_ref: std::cell::OnceCell::new(),
+            cached_reference_or_value: std::cell::OnceCell::new(),
             cached_resolved: std::cell::OnceCell::new(),
             cached_value: std::cell::OnceCell::new(),
         }
@@ -333,6 +336,7 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
             interp,
             cached_ast: std::cell::OnceCell::new(),
             cached_ref: std::cell::OnceCell::new(),
+            cached_reference_or_value: std::cell::OnceCell::new(),
             cached_resolved: std::cell::OnceCell::new(),
             cached_value: std::cell::OnceCell::new(),
         }
@@ -532,6 +536,96 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         }
     }
 
+    fn function_resolution_attempt(
+        &self,
+    ) -> Option<Result<crate::function::FunctionResolution<'b>, ExcelError>> {
+        match &self.expr {
+            ArgumentExpr::Ast(node) => {
+                let ASTNodeType::Function { name, args } = &node.node_type else {
+                    return None;
+                };
+                if !self
+                    .interp
+                    .context
+                    .function_capabilities("", name)
+                    .is_some_and(|caps| caps.contains(crate::function::FnCaps::RETURNS_REFERENCE))
+                {
+                    return None;
+                }
+                let fun = match self.interp.context.get_function("", name) {
+                    Some(fun) => fun,
+                    None => {
+                        return Some(Err(ExcelError::new(ExcelErrorKind::Name)
+                            .with_message(format!("Unknown function: {name}"))));
+                    }
+                };
+                let handles: Vec<_> = args
+                    .iter()
+                    .map(|arg| ArgumentHandle::new(arg, self.interp))
+                    .collect();
+                let ctx = DefaultFunctionContext::new_with_sheet(
+                    self.interp.context,
+                    None,
+                    self.interp.current_sheet(),
+                );
+                Some(fun.resolve_reference_or_value(&handles, &ctx, &|| self.value()))
+            }
+            ArgumentExpr::Arena {
+                id,
+                data_store,
+                sheet_registry,
+            } => {
+                let node = match data_store.get_node(*id) {
+                    Some(node) => node,
+                    None => {
+                        return Some(Err(
+                            ExcelError::new(ExcelErrorKind::Value).with_message("Missing AST node")
+                        ));
+                    }
+                };
+                let crate::engine::arena::AstNodeData::Function { name_id, .. } = node else {
+                    return None;
+                };
+                let name = data_store.resolve_ast_string(*name_id);
+                if !self
+                    .interp
+                    .context
+                    .function_capabilities("", name)
+                    .is_some_and(|caps| caps.contains(crate::function::FnCaps::RETURNS_REFERENCE))
+                {
+                    return None;
+                }
+                let fun = match self.interp.context.get_function("", name) {
+                    Some(fun) => fun,
+                    None => {
+                        return Some(Err(ExcelError::new(ExcelErrorKind::Name)
+                            .with_message(format!("Unknown function: {name}"))));
+                    }
+                };
+                let args = match data_store.get_args(*id) {
+                    Some(args) => args,
+                    None => {
+                        return Some(Err(ExcelError::new(ExcelErrorKind::Value)
+                            .with_message("Missing function args")));
+                    }
+                };
+                let handles: Vec<_> = args
+                    .iter()
+                    .copied()
+                    .map(|arg_id| {
+                        ArgumentHandle::new_arena(arg_id, self.interp, data_store, sheet_registry)
+                    })
+                    .collect();
+                let ctx = DefaultFunctionContext::new_with_sheet(
+                    self.interp.context,
+                    None,
+                    self.interp.current_sheet(),
+                );
+                Some(fun.resolve_reference_or_value(&handles, &ctx, &|| self.value()))
+            }
+        }
+    }
+
     fn reference_attempt(&self) -> Option<Result<ReferenceType, ExcelError>> {
         match &self.expr {
             ArgumentExpr::Ast(node) => match &node.node_type {
@@ -607,6 +701,34 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         }
     }
 
+    pub(crate) fn resolve_reference_or_value(
+        &self,
+    ) -> Result<crate::function::FunctionResolution<'b>, ExcelError> {
+        let resolved = self
+            .cached_reference_or_value
+            .get_or_init(|| self.compute_reference_or_value())
+            .clone();
+        if let Ok(crate::function::FunctionResolution::Value(value)) = &resolved {
+            let _ = self.cached_value.set(Ok(value.clone()));
+        }
+        resolved
+    }
+
+    fn compute_reference_or_value(
+        &self,
+    ) -> Result<crate::function::FunctionResolution<'b>, ExcelError> {
+        if let Some(result) = self.function_resolution_attempt() {
+            return result;
+        }
+        if let Some(reference) = self.reference_attempt() {
+            return Ok(match reference {
+                Ok(reference) => crate::function::FunctionResolution::Reference(reference),
+                Err(error) => crate::function::FunctionResolution::ReferenceError(error),
+            });
+        }
+        self.value().map(crate::function::FunctionResolution::Value)
+    }
+
     /// Resolve this argument once without using a failed range conversion as type dispatch.
     ///
     /// Direct references and the `:` operator take the reference path. Functions
@@ -626,26 +748,32 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
     }
 
     fn compute_resolved_argument(&self) -> Result<ResolvedArgument<'b>, ExcelError> {
-        if let Some(attempt) = self.reference_attempt() {
-            let reference = match attempt {
-                Ok(reference) => reference,
-                Err(error) if error.kind == ExcelErrorKind::Cancelled => return Err(error),
-                Err(error) => return Ok(ResolvedArgument::ReferenceError(error)),
-            };
-            return match self
-                .interp
-                .context
-                .resolve_range_view(&reference, self.interp.current_sheet())
+        let value = match self.resolve_reference_or_value()? {
+            crate::function::FunctionResolution::Reference(reference) => {
+                return match self
+                    .interp
+                    .context
+                    .resolve_range_view(&reference, self.interp.current_sheet())
+                {
+                    Ok(view) => Ok(ResolvedArgument::Range(
+                        self.with_context_cancel_token(view),
+                    )),
+                    Err(error) if error.kind == ExcelErrorKind::Cancelled => Err(error),
+                    Err(error) => Ok(ResolvedArgument::ReferenceError(error)),
+                };
+            }
+            crate::function::FunctionResolution::ReferenceError(error)
+                if error.kind == ExcelErrorKind::Cancelled =>
             {
-                Ok(view) => Ok(ResolvedArgument::Range(
-                    self.with_context_cancel_token(view),
-                )),
-                Err(error) if error.kind == ExcelErrorKind::Cancelled => Err(error),
-                Err(error) => Ok(ResolvedArgument::ReferenceError(error)),
-            };
-        }
+                return Err(error);
+            }
+            crate::function::FunctionResolution::ReferenceError(error) => {
+                return Ok(ResolvedArgument::ReferenceError(error));
+            }
+            crate::function::FunctionResolution::Value(value) => value,
+        };
 
-        match self.value()? {
+        match value {
             CalcValue::Range(view) => Ok(ResolvedArgument::Range(
                 self.with_context_cancel_token(view),
             )),

--- a/crates/formualizer-eval/src/traits.rs
+++ b/crates/formualizer-eval/src/traits.rs
@@ -373,6 +373,46 @@ impl<'a, 'b> ArgumentHandle<'a, 'b> {
         self.reference_attempt().is_some()
     }
 
+    /// Return whether this argument's syntax may produce a spreadsheet reference.
+    ///
+    /// Unlike [`Self::has_reference_semantics`], this does not evaluate a
+    /// reference-returning function to discover which arm it selects.
+    pub(crate) fn may_return_reference(&self) -> bool {
+        match &self.expr {
+            ArgumentExpr::Ast(node) => match &node.node_type {
+                ASTNodeType::Reference { reference, .. } => {
+                    !matches!(reference, ReferenceType::NamedRange(name) if self.interp.resolve_local_name(name).is_some())
+                }
+                ASTNodeType::BinaryOp { op, .. } => op == ":",
+                ASTNodeType::Function { name, .. } => self
+                    .interp
+                    .context
+                    .function_capabilities("", name)
+                    .is_some_and(|caps| caps.contains(crate::function::FnCaps::RETURNS_REFERENCE)),
+                _ => false,
+            },
+            ArgumentExpr::Arena { id, data_store, .. } => match data_store.get_node(*id) {
+                Some(crate::engine::arena::AstNodeData::Reference { ref_type, .. }) => !matches!(
+                    ref_type,
+                    crate::engine::arena::CompactRefType::NamedRange(name_id)
+                        if self
+                            .interp
+                            .resolve_local_name(data_store.resolve_ast_string(*name_id))
+                            .is_some()
+                ),
+                Some(crate::engine::arena::AstNodeData::BinaryOp { op_id, .. }) => {
+                    data_store.resolve_ast_string(*op_id) == ":"
+                }
+                Some(crate::engine::arena::AstNodeData::Function { name_id, .. }) => self
+                    .interp
+                    .context
+                    .function_capabilities("", data_store.resolve_ast_string(*name_id))
+                    .is_some_and(|caps| caps.contains(crate::function::FnCaps::RETURNS_REFERENCE)),
+                _ => false,
+            },
+        }
+    }
+
     pub fn value(&self) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
         self.cached_value
             .get_or_init(|| self.compute_value())

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -8721,6 +8721,7 @@ pub fn formualizer_eval::function::Function::min_args(&self) -> usize
 pub fn formualizer_eval::function::Function::name(&self) -> &'static str
 pub fn formualizer_eval::function::Function::namespace(&self) -> &'static str
 pub fn formualizer_eval::function::Function::propagate_format(&self, &formualizer_eval::traits::CalcValue<'_>) -> core::option::Option<formualizer_eval::format::FormatId>
+pub fn formualizer_eval::function::Function::resolve_reference_or_value<'a, 'b, 'c>(&self, &'c [formualizer_eval::traits::ArgumentHandle<'a, 'b>], &dyn formualizer_eval::traits::FunctionContext<'b>, &dyn core::ops::function::Fn() -> core::result::Result<formualizer_eval::traits::CalcValue<'b>, formualizer_common::error::ExcelError>) -> core::result::Result<FunctionResolution<'b>, formualizer_common::error::ExcelError>
 pub fn formualizer_eval::function::Function::semantic_contract(&self, usize) -> core::option::Option<formualizer_eval::function_contract::FunctionSemanticContract>
 pub fn formualizer_eval::function::Function::variadic(&self) -> bool
 pub fn formualizer_eval::function::Function::volatile(&self) -> bool
@@ -9615,6 +9616,7 @@ pub fn formualizer_eval::traits::Function::min_args(&self) -> usize
 pub fn formualizer_eval::traits::Function::name(&self) -> &'static str
 pub fn formualizer_eval::traits::Function::namespace(&self) -> &'static str
 pub fn formualizer_eval::traits::Function::propagate_format(&self, &formualizer_eval::traits::CalcValue<'_>) -> core::option::Option<formualizer_eval::format::FormatId>
+pub fn formualizer_eval::traits::Function::resolve_reference_or_value<'a, 'b, 'c>(&self, &'c [formualizer_eval::traits::ArgumentHandle<'a, 'b>], &dyn formualizer_eval::traits::FunctionContext<'b>, &dyn core::ops::function::Fn() -> core::result::Result<formualizer_eval::traits::CalcValue<'b>, formualizer_common::error::ExcelError>) -> core::result::Result<FunctionResolution<'b>, formualizer_common::error::ExcelError>
 pub fn formualizer_eval::traits::Function::semantic_contract(&self, usize) -> core::option::Option<formualizer_eval::function_contract::FunctionSemanticContract>
 pub fn formualizer_eval::traits::Function::variadic(&self) -> bool
 pub fn formualizer_eval::traits::Function::volatile(&self) -> bool


### PR DESCRIPTION
> Stacked on #369; the first commit is that PR. Review only the final commit here.

## What was wrong

INDEX materialized an entire bounded rectangle before selecting one element. Runtime dependency tracking therefore recorded every member as read. If an unselected member depended on the INDEX result, the eager rectangle edge produced a circular result even though Excel consumed one cell.

## Excel behaviour vs engine, measured

> **Correction (2026-08-24):** rows K and L below were originally labelled "(control)", implying the pre-fix engine already matched Excel there. Measured on this PR's actual merge base (`ce93ff9e`, i.e. main with #369 merged), both return `#CIRC!` under runtime cycle detection with bulk ingest — the ranges `K1:K3` and `L1:L3` include the INDEX formula's own cell, so the eager rectangle read manufactured a self-edge. They are behavior changes fixed by this PR, not controls. Engine values for rows G, K, and L were measured by execution on 2026-08-24 at `ce93ff9e4dac44e74987ceff06ddd08c1a11ef1b` (base) and `06dad200fe87cb5bff9c17104c1487cdbf4b4eca` (current main) via a harness test in `crates/formualizer-eval` (`cargo test -p formualizer-eval --lib god187v -- --nocapture`, rustc 1.93.0, x86_64 Linux), under `CycleDetection::Runtime` + bulk ingest.

Excel column measured on Microsoft Excel 16.105.3, Microsoft 365 for Mac:

| Formula | Excel | base `ce93ff9e` | main `06dad200` |
| --- | --- | --- | --- |
| G1=7, G2=`=INDEX(G1:G3,1)+1`, G3=9 | 8, no circular flag | `#CIRC!` | 8 |
| K1=`=1/0`, K2=`=INDEX(K1:K3,1)`, K3=9 -> K2 | `#DIV/0!` | `#CIRC!` (behavior change, was mislabelled control) | `#DIV/0!` |
| L1=7, L2=`=INDEX(L1:L3,1)+1`, L3=`=NA()` -> L2 | 8 | `#CIRC!` (behavior change, was mislabelled control) | 8 |
| M1=`=NA()`, M2=`=INDEX(M1:M1,1)` -> M2 | `#N/A` | `#N/A` (control; original claim, not re-measured 2026-08-24) | `#N/A` |
| N1=`=1/0`, N2=`=INDEX(N1:N3,1)`, N3=`=N2` -> N2, N3 | `#DIV/0!`, `#DIV/0!` | circular result (original claim, not re-measured 2026-08-24) | `#DIV/0!` |

The selected error propagates, the unselected error is ignored, and the error-bearing phantom-cycle shape completes acyclically.

## Applicability

The behavior change is only reachable under `CycleDetection::Runtime` combined with the bulk-ingest path. Measured on current main (`06dad200`): with the default `CycleDetection::Static`, G2, K2, and L2 all still return `#CIRC!` — Static stamps every static SCC and no live-edge machinery runs, so default-configured engines are unaffected by this fix. On the incremental path, `set_cell_formula` rejects these self-inclusive INDEX formulas at set time with `#CIRC!` ("Self-reference detected") on both base and main, so the fix is not reachable there for these shapes either.

## The fix

For a bounded reference and one positive in-range selection, INDEX resolves the reference first, computes the selected cell, and materializes only that cell. Selected errors use the same path. Other shapes keep existing value dispatch.

The custom dispatch must reproduce the default dispatch wrapper because it bypasses that wrapper on precise-path success. It therefore applies INDEX's format policy after materialization. `index_precise_path_applies_format_policy` pins that behavior by proving a selected date's source annotation is dropped, matching ordinary INDEX evaluation.

## Scope

Builds on `fix/reference-returning-conditionals`; merge that first. Merge-alone is unsafe because this branch uses its reference-or-value contract.

Bounded cells and omitted dimensions on single vectors use the precise path. Arrays, zero indexes, rectangular omissions, and unbounded `INDEX(Q:Q,n)` keep their existing paths. Static dependencies are unchanged. This commit adds no public item, but inherits the first PR's additions.

## Verification

Six exact tests fail on the stacked base and pass here: four bounded-reference defects, the formula-produced phantom-cycle case, and selector-count fallback coverage. Six controls survive production revert: genuine cycle, selected error, unselected error, format policy, SUM rectangle, and unbounded column. Selector counts are one for zero-index and three fallback shapes, and two for the accepted AST/Arena array residual.

Executed with `rustc 1.97.1`:

```text
cargo fmt --all                                      exit 0; diff clean
cargo clippy --workspace --all-targets -- -D warnings exit 101; same 20 fingerprints as unmodified main
cargo test -p formualizer-eval                      2751 passed; the only failures are the IMEXP/IMSIN/IMCOS cases that fail identically on unmodified main
12 fully qualified exact-test commands              exit 0; one test selected each
```

## Deliberately not in this PR

No static-graph rewrite, unbounded-range precision, array-selector optimization, or public snapshot change is included.

## How this was found

A runtime trace showed INDEX manufacturing edges to unselected cells. Synthetic chains and formula-produced error cells isolate that behavior.

Drafted by Claude (agent), reviewed by a human before submission. Rows G, K, L and the Applicability section were re-measured by execution on 2026-08-24 as noted inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
