### PR TITLE
fix(eval): open ranges keep independent row and column bounds

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -21727,7 +21727,7 @@ where
                             format!(
                                 "{}!{}{}",
                                 sheet_name,
-                                Self::col_to_letters(cell_ref.coord.col()),
+                                Self::col_to_letters(cell_ref.coord.col() + 1),
                                 cell_ref.coord.row() + 1
                             )
                         })

--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -766,17 +766,20 @@ impl DependencyGraph {
                     let b = mk_axis(c0);
                     SharedRangeRef::from_parts(sheet_loc, None, Some(b), None, Some(b)).ok()
                 }
-                RK::OpenRect { start, end, .. } => {
-                    let (sr, sc) = match start {
-                        Some(p) => (Some(mk_axis(p.row())), Some(mk_axis(p.col()))),
-                        None => (None, None),
-                    };
-                    let (er, ec) = match end {
-                        Some(p) => (Some(mk_axis(p.row())), Some(mk_axis(p.col()))),
-                        None => (None, None),
-                    };
-                    SharedRangeRef::from_parts(sheet_loc, sr, sc, er, ec).ok()
-                }
+                RK::OpenRect {
+                    start_row,
+                    start_col,
+                    end_row,
+                    end_col,
+                    ..
+                } => SharedRangeRef::from_parts(
+                    sheet_loc,
+                    start_row.map(mk_axis),
+                    start_col.map(mk_axis),
+                    end_row.map(mk_axis),
+                    end_col.map(mk_axis),
+                )
+                .ok(),
             };
 
             if let Some(r) = built {

--- a/crates/formualizer-eval/src/engine/ingest_builder.rs
+++ b/crates/formualizer-eval/src/engine/ingest_builder.rs
@@ -106,14 +106,10 @@ fn range_key_from_shared(
         },
         _ => RangeKey::OpenRect {
             sheet,
-            start: range
-                .start_row
-                .zip(range.start_col)
-                .map(|(r, c)| AbsCoord::new(r.index, c.index)),
-            end: range
-                .end_row
-                .zip(range.end_col)
-                .map(|(r, c)| AbsCoord::new(r.index, c.index)),
+            start_row: range.start_row.map(|bound| bound.index),
+            start_col: range.start_col.map(|bound| bound.index),
+            end_row: range.end_row.map(|bound| bound.index),
+            end_col: range.end_col.map(|bound| bound.index),
         },
     }
 }

--- a/crates/formualizer-eval/src/engine/plan.rs
+++ b/crates/formualizer-eval/src/engine/plan.rs
@@ -27,8 +27,10 @@ pub enum RangeKey {
     /// Partially bounded rectangle; None means unbounded in that direction
     OpenRect {
         sheet: SheetId,
-        start: Option<AbsCoord>,
-        end: Option<AbsCoord>,
+        start_row: Option<u32>,
+        start_col: Option<u32>,
+        end_row: Option<u32>,
+        end_col: Option<u32>,
     },
 }
 
@@ -196,14 +198,10 @@ fn collect_plan_reference(
                 }
                 _ => context.per_ranges.push(RangeKey::OpenRect {
                     sheet: dep_sheet,
-                    start: range
-                        .start_row
-                        .zip(range.start_col)
-                        .map(|(row, col)| AbsCoord::from_excel(row, col)),
-                    end: range
-                        .end_row
-                        .zip(range.end_col)
-                        .map(|(row, col)| AbsCoord::from_excel(row, col)),
+                    start_row: range.start_row.map(|row| row.saturating_sub(1)),
+                    start_col: range.start_col.map(|col| col.saturating_sub(1)),
+                    end_row: range.end_row.map(|row| row.saturating_sub(1)),
+                    end_col: range.end_col.map(|col| col.saturating_sub(1)),
                 }),
             }
         }

--- a/crates/formualizer-eval/src/engine/plan_legacy_tests.rs
+++ b/crates/formualizer-eval/src/engine/plan_legacy_tests.rs
@@ -231,12 +231,10 @@ where
                         }
                         _ => per_ranges.push(RangeKey::OpenRect {
                             sheet: dep_sheet,
-                            start: start_row
-                                .zip(start_col)
-                                .map(|(r, c)| AbsCoord::from_excel(r, c)),
-                            end: end_row
-                                .zip(end_col)
-                                .map(|(r, c)| AbsCoord::from_excel(r, c)),
+                            start_row: start_row.map(|row| row.saturating_sub(1)),
+                            start_col: start_col.map(|col| col.saturating_sub(1)),
+                            end_row: end_row.map(|row| row.saturating_sub(1)),
+                            end_col: end_col.map(|col| col.saturating_sub(1)),
                         }),
                     }
                 }
@@ -394,12 +392,10 @@ where
                         }
                         _ => per_ranges.push(RangeKey::OpenRect {
                             sheet: dep_sheet,
-                            start: start_row
-                                .zip(start_col)
-                                .map(|(r, c)| AbsCoord::from_excel(r, c)),
-                            end: end_row
-                                .zip(end_col)
-                                .map(|(r, c)| AbsCoord::from_excel(r, c)),
+                            start_row: start_row.map(|row| row.saturating_sub(1)),
+                            start_col: start_col.map(|col| col.saturating_sub(1)),
+                            end_row: end_row.map(|row| row.saturating_sub(1)),
+                            end_col: end_col.map(|col| col.saturating_sub(1)),
                         }),
                     }
                 }

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -155,6 +155,7 @@ mod npv_variadic;
 mod offset_dynamic;
 mod omitted_arguments;
 mod open_ended_bounds_caps;
+mod open_rect_bounds;
 mod overlay_compaction;
 mod region_lock;
 mod spill_overlay_writeback;

--- a/crates/formualizer-eval/src/engine/tests/open_rect_bounds.rs
+++ b/crates/formualizer-eval/src/engine/tests/open_rect_bounds.rs
@@ -1,0 +1,169 @@
+use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::{ASTNode, parse};
+
+fn runtime_engine() -> Engine<TestWorkbook> {
+    Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_cycle(CycleConfig {
+            detection: CycleDetection::Runtime,
+            policy: CyclePolicy::Error,
+        }),
+    )
+}
+
+fn formula(text: &str) -> ASTNode {
+    parse(text).expect("parse formula")
+}
+
+fn set_number(engine: &mut Engine<TestWorkbook>, row: u32, col: u32, value: f64) {
+    engine
+        .set_cell_value("Sheet1", row, col, LiteralValue::Number(value))
+        .expect("set number")
+}
+
+fn set_text(engine: &mut Engine<TestWorkbook>, row: u32, col: u32, value: &str) {
+    engine
+        .set_cell_value("Sheet1", row, col, LiteralValue::Text(value.to_string()))
+        .expect("set text")
+}
+
+fn number_at(engine: &Engine<TestWorkbook>, row: u32, col: u32) -> f64 {
+    match engine.get_cell_value("Sheet1", row, col) {
+        Some(LiteralValue::Number(value)) => value,
+        Some(LiteralValue::Int(value)) => value as f64,
+        other => panic!("expected number at Sheet1!R{row}C{col}, got {other:?}"),
+    }
+}
+
+fn seed_constants(engine: &mut Engine<TestWorkbook>, occupy_column_a: bool) {
+    set_number(engine, 1, 8, 2000.0);
+    set_number(engine, 3, 8, 2005.0);
+    if occupy_column_a {
+        set_text(engine, 2, 1, "tag");
+    }
+}
+
+fn d_to_f_formulas(consumer_row: u32, consumer: &str) -> Vec<(u32, u32, ASTNode)> {
+    let mut formulas = vec![(3, 4, formula("=$H$1"))];
+    for row in 4..=13 {
+        formulas.push((row, 4, formula(&format!("=D{}+1", row - 1))));
+    }
+    for row in 3..=13 {
+        formulas.push((row, 6, formula(&format!("=E{row}*10"))));
+    }
+    formulas.push((consumer_row, 14, formula(consumer)));
+    formulas
+}
+
+fn build_d_to_f_bulk(
+    occupy_column_a: bool,
+    consumer_row: u32,
+    consumer: &str,
+) -> Engine<TestWorkbook> {
+    let mut engine = runtime_engine();
+    seed_constants(&mut engine, occupy_column_a);
+    for row in 3..=13 {
+        set_number(&mut engine, row, 5, f64::from(row - 2) * 100.0);
+    }
+
+    let mut ingest = engine.begin_bulk_ingest();
+    let sheet = ingest.add_sheet("Sheet1");
+    ingest.add_formulas(sheet, d_to_f_formulas(consumer_row, consumer));
+    ingest.finish().expect("finish bulk ingest");
+    engine
+}
+
+fn assert_plan_has_precedents(engine: &Engine<TestWorkbook>, row: u32) {
+    let plan = engine
+        .get_eval_plan(&[("Sheet1", row, 14)])
+        .expect("get evaluation plan");
+    assert!(
+        plan.total_vertices_to_evaluate > 1,
+        "expected precedent chain in plan, got {plan:?}"
+    );
+}
+
+fn evaluate_and_expect(engine: &mut Engine<TestWorkbook>, row: u32, expected: f64) {
+    engine.evaluate_all().expect("evaluate all");
+    assert_eq!(number_at(engine, row, 14), expected);
+}
+
+#[test]
+fn open_rect_multi_column_a2_pinned_vlookup() {
+    let mut engine = build_d_to_f_bulk(true, 3, "=VLOOKUP(H3,$D:$F,3,FALSE)");
+    assert_plan_has_precedents(&engine, 3);
+    evaluate_and_expect(&mut engine, 3, 6000.0);
+}
+
+#[test]
+fn open_rect_multi_column_a2_pinned_countif() {
+    let mut engine = build_d_to_f_bulk(true, 5, "=COUNTIF($D:$F,2005)");
+    assert_plan_has_precedents(&engine, 5);
+    evaluate_and_expect(&mut engine, 5, 1.0);
+}
+
+#[test]
+fn open_rect_column_a_key_no_panic() {
+    let mut engine = runtime_engine();
+    seed_constants(&mut engine, true);
+    for row in 3..=13 {
+        set_number(&mut engine, row, 2, f64::from(row - 2) * 100.0);
+    }
+
+    let mut formulas = vec![(3, 1, formula("=$H$1"))];
+    for row in 4..=13 {
+        formulas.push((row, 1, formula(&format!("=A{}+1", row - 1))));
+    }
+    for row in 3..=13 {
+        formulas.push((row, 3, formula(&format!("=B{row}*10"))));
+    }
+    formulas.push((3, 14, formula("=VLOOKUP(H3,$A:$C,3,FALSE)")));
+
+    let mut ingest = engine.begin_bulk_ingest();
+    let sheet = ingest.add_sheet("Sheet1");
+    ingest.add_formulas(sheet, formulas);
+    ingest.finish().expect("finish bulk ingest");
+
+    assert_plan_has_precedents(&engine, 3);
+    evaluate_and_expect(&mut engine, 3, 6000.0);
+}
+
+#[test]
+fn open_rect_single_column_whole_col_unchanged() {
+    let mut engine = build_d_to_f_bulk(true, 3, "=VLOOKUP(H3,$D:$D,1,FALSE)");
+    assert_plan_has_precedents(&engine, 3);
+    evaluate_and_expect(&mut engine, 3, 2005.0);
+}
+
+#[test]
+fn open_rect_bounded_range_unchanged() {
+    let mut engine = build_d_to_f_bulk(true, 3, "=VLOOKUP(H3,$D$1:$F$50,3,FALSE)");
+    assert_plan_has_precedents(&engine, 3);
+    evaluate_and_expect(&mut engine, 3, 6000.0);
+}
+
+#[test]
+fn open_rect_column_a_empty_control() {
+    let mut engine = build_d_to_f_bulk(false, 3, "=VLOOKUP(H3,$D:$F,3,FALSE)");
+    assert_plan_has_precedents(&engine, 3);
+    evaluate_and_expect(&mut engine, 3, 6000.0);
+}
+
+#[test]
+fn open_rect_incremental_edit_path_unchanged() {
+    let mut engine = runtime_engine();
+    seed_constants(&mut engine, true);
+    for row in 3..=13 {
+        set_number(&mut engine, row, 5, f64::from(row - 2) * 100.0);
+    }
+    for (row, col, ast) in d_to_f_formulas(3, "=VLOOKUP(H3,$D:$F,3,FALSE)") {
+        engine
+            .set_cell_formula("Sheet1", row, col, ast)
+            .expect("set formula");
+    }
+
+    assert_plan_has_precedents(&engine, 3);
+    evaluate_and_expect(&mut engine, 3, 6000.0);
+}

--- a/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
+++ b/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
@@ -343,8 +343,10 @@ enum NormalizedRangeDependency {
     },
     OpenRect {
         sheet: String,
-        start: Option<(u32, u32)>,
-        end: Option<(u32, u32)>,
+        start_row: Option<u32>,
+        start_col: Option<u32>,
+        end_row: Option<u32>,
+        end_col: Option<u32>,
     },
 }
 
@@ -430,10 +432,18 @@ fn normalize_planner_range(graph: &DependencyGraph, range: &RangeKey) -> Normali
             sheet: graph.sheet_name(*sheet).to_string(),
             col: *col,
         },
-        RangeKey::OpenRect { sheet, start, end } => NormalizedRangeDependency::OpenRect {
+        RangeKey::OpenRect {
+            sheet,
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+        } => NormalizedRangeDependency::OpenRect {
             sheet: graph.sheet_name(*sheet).to_string(),
-            start: start.map(planner_coord_to_vc),
-            end: end.map(planner_coord_to_vc),
+            start_row: start_row.map(|axis| axis.saturating_add(1)),
+            start_col: start_col.map(|axis| axis.saturating_add(1)),
+            end_row: end_row.map(|axis| axis.saturating_add(1)),
+            end_col: end_col.map(|axis| axis.saturating_add(1)),
         },
     }
 }

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -3626,9 +3626,11 @@ pub fn formualizer_eval::engine::plan::DependencyPlanAst<'a>::fmt(&self, &mut co
 impl<'a> core::marker::Copy for formualizer_eval::engine::plan::DependencyPlanAst<'a>
 pub enum formualizer_eval::engine::plan::RangeKey
 pub formualizer_eval::engine::plan::RangeKey::OpenRect
-pub formualizer_eval::engine::plan::RangeKey::OpenRect::end: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::plan::RangeKey::OpenRect::end_col: core::option::Option<u32>
+pub formualizer_eval::engine::plan::RangeKey::OpenRect::end_row: core::option::Option<u32>
 pub formualizer_eval::engine::plan::RangeKey::OpenRect::sheet: formualizer_eval::reference::SheetId
-pub formualizer_eval::engine::plan::RangeKey::OpenRect::start: core::option::Option<formualizer_common::coord::Coord>
+pub formualizer_eval::engine::plan::RangeKey::OpenRect::start_col: core::option::Option<u32>
+pub formualizer_eval::engine::plan::RangeKey::OpenRect::start_row: core::option::Option<u32>
 pub formualizer_eval::engine::plan::RangeKey::Rect
 pub formualizer_eval::engine::plan::RangeKey::Rect::end: formualizer_common::coord::Coord
 pub formualizer_eval::engine::plan::RangeKey::Rect::sheet: formualizer_eval::reference::SheetId


### PR DESCRIPTION
## What was wrong

Open rectangles used optional start and end coordinates. That coupled row and column bounds: if one axis was open, constructing the coordinate discarded the other axis's bound. Planning, bulk ingest, and dependency summaries could lose valid precedents. A plan-label path also passed a zero-based column to a one-based API and produced `ColumnOutOfRange(0)`.

On the bulk-ingest path the lost precedents are not just a thinner plan: the consumer schedules before its precedents and commits a stale read, producing silently wrong values.

## Measured reproduction

> **Correction (2026-08-24):** the table originally published here (constant `k1..k3`/`100..300` values with `D:E` and `D:D` ranges) did **not** reproduce the defect, as the maintainers demonstrated after merge. Constant-valued precedents never become plan vertices (nothing to lose), and a single-column `D:D` normalizes to `WholeCol` before `OpenRect` construction — the exact shape this PR's own `open_rect_single_column_whole_col_unchanged` control pins as unaffected. That table was assembled from the expected mechanism rather than executed as posted, contrary to the "verified by execution" claim it sat under. The table below replaces it and every engine value in it was measured by executing a harness on both commits.

Setup, mirroring this PR's shipped tests (`open_rect_bounds.rs`): bulk-ingest path, `CycleDetection::Runtime`; constants `H1=2000`, `H3=2005`, `A2="tag"`, `E3:E13 = 100..1100`; formulas `D3 = =$H$1`, `D4:D13 = =D{r-1}+1` (values 2000..2010), `F3:F13 = =E{r}*10`; the consumer formula in column N (row 3 or 5; row 20 for the row-mirror case so the consumer sits outside `$3:$13`).

| Formula | Expected (Excel semantics) | merge base `b5bae5a4` | merged `main` `06dad200` |
| --- | --- | --- | --- |
| `=VLOOKUP(H3,$D:$F,3,FALSE)` | 6000 | `#N/A` | 6000 |
| `=COUNTIF($D:$F,2005)` | 1 | 0 | 1 |
| `=SUM($D:$F)` | 94655 | 74600 (short by 20,055) | 94655 |
| `=SUM($3:$13)` — axis mirror | 96660 | 76605 | 96660 |
| `=VLOOKUP(H3,$D:$F,3,FALSE)` via incremental `set_cell_formula` (control) | 6000 | 6000 | 6000 |

Provenance: each engine value printed by a test harness added as `crates/formualizer-eval/src/engine/tests/god187v_repro.rs` and run with `cargo test -p formualizer-eval --lib god187v -- --nocapture` at `b5bae5a491477d75a1c088ddfd51226438785ece` (merge base, first parent of the merge) and `06dad200fe87cb5bff9c17104c1487cdbf4b4eca` (merge commit of this PR), rustc 1.93.0, x86_64 Linux. The expected column is the fixture's arithmetic under Excel semantics (D sums to 22,055; E to 6,600; F to 66,000; the row mirror adds H3=2005) and matches the maintainers' independent measurements of the same shapes.

## The fix

`RangeKey::OpenRect` now carries start row, start column, end row, and end column independently. Producers and consumers preserve all four through graph construction, ingest, legacy planning, and formula-plane summaries. Plan-label conversion adds one before constructing a visible cell coordinate.

This replaces the public enum variant's two optional coordinates with four optional axis values, a suspected source-breaking API change. The public-API snapshot was regenerated with `scripts/public-api.sh` on x86_64 Linux under the pinned toolchains and is included as a separate `chore(api)` commit; `scripts/public-api.sh check` exits clean at this tip. The field change is source-breaking for code that constructs or matches `RangeKey::OpenRect` directly.

## Scope

This branch is standalone on main. It preserves axis bounds and fixes the zero-column panic. Proposed `into_iter` and sorting cleanups were removed as unrelated.

## Verification

On main, VLOOKUP and COUNTIF each build a one-vertex plan instead of the precedent chain. The column-A case panics with `ColumnOutOfRange(0)`. Those three exact RED tests pass here. Four controls cover a single-column open range, bounded range, empty column A, and incremental edits. Reverting the axis-field hunks fails the lookup/count controls; reverting the label conversion restores the panic.

Executed with `rustc 1.97.1`:

```text
cargo fmt --all                                      exit 0; diff clean
cargo clippy --workspace --all-targets -- -D warnings exit 101; same 20 (file, full-message) pairs as main
cargo test -p formualizer-eval                      2741 passed; only base-identical IMEXP/IMSIN/IMCOS strings failed
```

Six clippy spans move with unchanged messages/counts. `ingest_builder.rs` moves 465:30 to 461:30 because the axis-field hunk removes four lines. Five `dependency_summary.rs` spans move by +10 because the enum and normalization hunks add two and eight lines. The multiset of clippy messages is unchanged from unmodified main; only line numbers move.

## Deliberately not in this PR

No sorting cleanup, iterator cleanup, general range redesign, or macOS-generated public snapshot is included.

## How this was found

An open-range schedule omitted cells that produce a lookup result. Tracing the normalized key exposed the coupled-axis representation and one-based label bug.

Drafted by Claude (agent), reviewed by a human before submission. The reproduction table above was measured by execution on 2026-08-24, replacing an earlier table that had not been.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
