### PR TITLE
fix(eval): IF condition errors propagate unchanged

### DIFF
--- a/crates/formualizer-eval/src/builtins/logical.rs
+++ b/crates/formualizer-eval/src/builtins/logical.rs
@@ -479,6 +479,9 @@ impl Function for IfFn {
             LiteralValue::Number(n) => n != 0.0,
             LiteralValue::Int(i) => i != 0,
             LiteralValue::Empty => false,
+            LiteralValue::Error(error) => {
+                return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(error)));
+            }
             _ => {
                 return Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
                     ExcelError::new_value().with_message("IF condition must be boolean or number"),
@@ -511,9 +514,11 @@ pub fn register_builtins() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig};
     use crate::traits::ArgumentHandle;
     use crate::{interpreter::Interpreter, test_workbook::TestWorkbook};
-    use formualizer_parse::LiteralValue;
+    use formualizer_common::ExcelErrorKind;
+    use formualizer_parse::{LiteralValue, parser::Parser, parser::parse};
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -565,6 +570,22 @@ mod tests {
 
     fn interp(wb: &TestWorkbook) -> Interpreter<'_> {
         wb.interpreter()
+    }
+
+    fn evaluate_formula(formula: &str, wb: &TestWorkbook) -> LiteralValue {
+        let mut parser = Parser::new(formula).expect("parser");
+        let ast = parser.parse().expect("parse");
+        wb.interpreter()
+            .evaluate_ast(&ast)
+            .expect("evaluate")
+            .into_literal()
+    }
+
+    fn assert_error_kind(value: LiteralValue, kind: ExcelErrorKind) {
+        assert!(
+            matches!(value, LiteralValue::Error(ref error) if error.kind == kind),
+            "expected {kind:?}, got {value:?}"
+        );
     }
 
     #[test]
@@ -851,6 +872,60 @@ mod tests {
         assert_eq!(
             iff.eval(&args, &fctx).unwrap().into_literal(),
             LiteralValue::Int(20)
+        );
+    }
+
+    #[test]
+    fn if_propagates_condition_error_kind() {
+        let wb = TestWorkbook::new()
+            .with_function(Arc::new(IfFn))
+            .with_function(Arc::new(crate::builtins::info::NaFn));
+
+        assert_error_kind(evaluate_formula("=IF(NA()=0,0,1)", &wb), ExcelErrorKind::Na);
+        assert_error_kind(evaluate_formula("=IF(1/0>1,1,2)", &wb), ExcelErrorKind::Div);
+    }
+
+    #[test]
+    fn if_errored_condition_records_no_arm_edges() {
+        let config = EvalConfig::default().with_cycle(CycleConfig {
+            detection: CycleDetection::Runtime,
+            policy: CyclePolicy::Error,
+        });
+        let mut engine = Engine::new(TestWorkbook::new(), config);
+        engine
+            .set_cell_formula(
+                "Sheet1",
+                1,
+                1,
+                parse("=IF(NA()=0,INDEX(Q1:Q100,50),0)").expect("parse A1"),
+            )
+            .expect("set A1");
+        engine
+            .set_cell_formula("Sheet1", 50, 17, parse("=A1").expect("parse Q50"))
+            .expect("set Q50");
+
+        engine.evaluate_all().expect("evaluate");
+
+        assert_error_kind(
+            engine.get_cell_value("Sheet1", 1, 1).expect("A1 value"),
+            ExcelErrorKind::Na,
+        );
+        assert!(
+            !matches!(
+                engine.get_cell_value("Sheet1", 50, 17),
+                Some(LiteralValue::Error(error)) if error.kind == ExcelErrorKind::Circ
+            ),
+            "Q50 must not be circular when the IF condition errors"
+        );
+        assert_eq!(engine.last_cycle_telemetry().live_cycles_witnessed, 0);
+    }
+
+    #[test]
+    fn if_text_condition_is_value_error() {
+        let wb = TestWorkbook::new().with_function(Arc::new(IfFn));
+        assert_error_kind(
+            evaluate_formula("=IF(\"abc\",1,2)", &wb),
+            ExcelErrorKind::Value,
         );
     }
 }

--- a/crates/formualizer-eval/src/builtins/logical_ext.rs
+++ b/crates/formualizer-eval/src/builtins/logical_ext.rs
@@ -679,7 +679,7 @@ mod tests {
     use super::*;
     use crate::test_workbook::TestWorkbook;
     use crate::traits::ArgumentHandle;
-    use formualizer_common::LiteralValue;
+    use formualizer_common::{ExcelErrorKind, LiteralValue};
     use formualizer_parse::parser::{ASTNode, ASTNodeType};
 
     fn interp(wb: &TestWorkbook) -> crate::interpreter::Interpreter<'_> {
@@ -1049,6 +1049,53 @@ mod tests {
                 .unwrap()
                 .into_literal(),
             LiteralValue::Int(42)
+        );
+    }
+
+    #[test]
+    fn ifs_and_switch_propagate_condition_error() {
+        let wb = TestWorkbook::new()
+            .with_function(std::sync::Arc::new(IfsFn))
+            .with_function(std::sync::Arc::new(SwitchFn));
+        let ctx = interp(&wb);
+        let error = ASTNode::new(
+            ASTNodeType::Literal(LiteralValue::Error(ExcelError::new_na())),
+            None,
+        );
+        let one = ASTNode::new(ASTNodeType::Literal(LiteralValue::Int(1)), None);
+        let two = ASTNode::new(ASTNodeType::Literal(LiteralValue::Int(2)), None);
+
+        let ifs = ctx.context.get_function("", "IFS").unwrap();
+        let ifs_value = ifs
+            .dispatch(
+                &[
+                    ArgumentHandle::new(&error, &ctx),
+                    ArgumentHandle::new(&one, &ctx),
+                ],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(ifs_value, LiteralValue::Error(ref e) if e.kind == ExcelErrorKind::Na),
+            "IFS must preserve the condition error, got {ifs_value:?}"
+        );
+
+        let switch = ctx.context.get_function("", "SWITCH").unwrap();
+        let switch_value = switch
+            .dispatch(
+                &[
+                    ArgumentHandle::new(&error, &ctx),
+                    ArgumentHandle::new(&one, &ctx),
+                    ArgumentHandle::new(&two, &ctx),
+                ],
+                &ctx.function_context(None),
+            )
+            .unwrap()
+            .into_literal();
+        assert!(
+            matches!(switch_value, LiteralValue::Error(ref e) if e.kind == ExcelErrorKind::Na),
+            "SWITCH must preserve the expression error, got {switch_value:?}"
         );
     }
 }

--- a/crates/formualizer-eval/src/engine/tests/scc_runtime_property.rs
+++ b/crates/formualizer-eval/src/engine/tests/scc_runtime_property.rs
@@ -35,11 +35,9 @@
 //! The generated subset is intentionally narrow (numbers, `+ - *`,
 //! comparisons, `IF`, `NOT`, `SUM` over explicit ranges, boolean/number
 //! guards) so coercion is trivial and the oracle is auditable by eye. No
-//! division or text is generated, so the only errors that can ever surface are
-//! `#CIRC` (the cycle verdict) and the `#VALUE!` the engine's `IF`/`NOT`
-//! produce when an error reaches a *condition* — a documented, pre-#112 error
-//! rule the oracle reproduces faithfully (see the KNOWN ENGINE QUIRK notes) so
-//! the property stays sharp on cycle classification.
+//! division or text is generated, so the only error that can surface is
+//! `#CIRC` (the cycle verdict), including when it reaches an `IF`/`NOT`
+//! condition and propagates unchanged.
 
 use crate::engine::{CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig};
 use crate::test_workbook::TestWorkbook;
@@ -280,13 +278,11 @@ fn gen_formula(rng: &mut Rng, i: usize, n_guards: usize, n: usize) -> String {
 ///     regardless of how the value is later consumed (an `IF` *guard* that
 ///     re-enters the cell still makes the cell a member — spec §7.3).
 ///   * `CircSettled` — a `#CIRC` value *read from an already-stamped member*
-///     by a cell that is itself **not** a member. It still propagates as
-///     `#CIRC` through arithmetic/comparison, but when fed into an `IF`/`NOT`
-///     *condition* the engine's coercion turns it into `#VALUE!` (see the
-///     KNOWN ENGINE QUIRK note on `eval_node`). Both map to the engine's
-///     `#CIRC` *only* when they survive to a cell's final value; the split
-///     exists purely to reproduce the IF-condition coercion faithfully.
-///   * `Value` — the `#VALUE!` produced by that coercion.
+///     by a cell that is itself **not** a member. It propagates unchanged
+///     through arithmetic, comparisons, and `IF`/`NOT` conditions. Both
+///     circular variants map to the same observable Excel value; the split
+///     records whether the cell is itself a live-cycle member.
+///   * `Value` — a `#VALUE!` result.
 ///
 /// Keeping this split is what lets the oracle stay a faithful mirror of the
 /// engine's *documented* error handling while remaining sharp on the cycle
@@ -441,14 +437,9 @@ impl Oracle {
                     self.walk_node(&args[0]);
                     match self.live_branch(&args[0]) {
                         Some(true) => self.walk_node(&args[1]),
-                        Some(false) => {
-                            if args.len() > 2 {
-                                self.walk_node(&args[2]);
-                            }
-                        }
-                        // Guard is itself circular/uncomputable: conservatively
-                        // descend neither arm — the guard read alone already
-                        // closes any live cycle that runs through the guard.
+                        Some(false) if args.len() > 2 => self.walk_node(&args[2]),
+                        Some(false) => {}
+                        // An errored guard selects no arm.
                         None => {}
                     }
                 }
@@ -495,8 +486,7 @@ impl Oracle {
     /// with `GuardEval` (the same arithmetic / short-circuit / error rules as
     /// the value phase, so arm selection is identical in both phases). A guard
     /// that resolves to a clean bool/number selects an arm; an error/circular
-    /// guard returns None ⇒ descend neither arm (the guard's own reads are
-    /// already walked, so any cycle through the guard is still detected).
+    /// guard returns None, so neither arm is live.
     fn live_branch(&mut self, guard: &ASTNode) -> Option<bool> {
         match self.eval_guard(guard) {
             OVal::Bool(b) => Some(b),
@@ -599,7 +589,7 @@ impl Oracle {
                         // TRUE short-circuit: only the taken arm is evaluated.
                         let cond = self.eval_node(&args[0]);
                         if let OVal::Err(e) = cond {
-                            return condition_error(e);
+                            return OVal::Err(e);
                         }
                         if as_bool(&cond) {
                             self.eval_node(&args[1])
@@ -612,7 +602,7 @@ impl Oracle {
                     "NOT" => {
                         let v = self.eval_node(&args[0]);
                         if let OVal::Err(e) = v {
-                            return condition_error(e);
+                            return OVal::Err(e);
                         }
                         OVal::Bool(!as_bool(&v))
                     }
@@ -696,9 +686,9 @@ impl Oracle {
 /// finalized yet). In the generated subset, guards only ever read leaf guard
 /// cells or *strictly earlier* cells (see the generator), so guards are always
 /// acyclic and this evaluator never actually recurses into a cycle; the
-/// re-entry guard is purely defensive. It applies the exact same arithmetic /
-/// short-circuit / error rules as the value phase (sharing `as_num`/`as_bool`/
-/// `condition_error`) so a guard's truth is identical in both phases.
+/// re-entry guard is purely defensive. It applies the exact same arithmetic,
+/// short-circuit, and error rules as the value phase (sharing `as_num` and
+/// `as_bool`) so a guard's truth is identical in both phases.
 struct GuardEval<'a> {
     asts: &'a [Option<ASTNode>],
     values: &'a [LiteralValue],
@@ -776,7 +766,7 @@ impl GuardEval<'_> {
                 "IF" => {
                     let cond = self.eval_node(&args[0]);
                     if let OVal::Err(e) = cond {
-                        return condition_error(e);
+                        return OVal::Err(e);
                     }
                     if as_bool(&cond) {
                         self.eval_node(&args[1])
@@ -789,7 +779,7 @@ impl GuardEval<'_> {
                 "NOT" => {
                     let v = self.eval_node(&args[0]);
                     if let OVal::Err(e) = v {
-                        return condition_error(e);
+                        return OVal::Err(e);
                     }
                     OVal::Bool(!as_bool(&v))
                 }
@@ -835,26 +825,6 @@ impl GuardEval<'_> {
                 v => Ok(as_num(&v)),
             }
         }
-    }
-}
-
-/// IF/NOT condition coercion of an error operand.
-///
-/// KNOWN ENGINE QUIRK (pre-#112, general error handling — NOT a cycle bug):
-/// `IfFn::eval`/`NotFn` coerce a *non*-bool/*non*-number condition to
-/// `#VALUE!` rather than propagating the condition's own error (the `IfFn`
-/// docs even state "non-numeric/non-boolean conditions return #VALUE!").
-///
-/// The one case the engine does NOT reach this coercion for is a cell that is
-/// itself a live-cycle member: such a cell is stamped `#CIRC` structurally
-/// during the SCC task, before any IF body runs. The oracle mirrors that by
-/// keeping an *active* re-entry (`Circ`) circular even when it flows through a
-/// guard (spec §7.3), and only coercing a `#CIRC` that was *read from another,
-/// already-stamped member* (`CircSettled`) — or any other error — to `#VALUE!`.
-fn condition_error(e: EKind) -> OVal {
-    match e {
-        EKind::Circ => OVal::Err(EKind::Circ), // member: stays #CIRC
-        EKind::CircSettled | EKind::Value => OVal::Err(EKind::Value),
     }
 }
 
@@ -907,10 +877,8 @@ fn engine_to_oval(v: &Option<LiteralValue>) -> Result<OVal, String> {
         Some(LiteralValue::Error(e)) if e.kind == ExcelErrorKind::Circ => {
             Ok(OVal::Err(EKind::Circ))
         }
-        // The only other error the generated subset can yield is the
-        // documented IF/NOT condition-coercion `#VALUE!` (see the KNOWN ENGINE
-        // QUIRK note). Any *other* error kind would be a genuine surprise and
-        // is surfaced as an un-modelable value (test failure).
+        // A Value error is modeled explicitly for clear diagnostics. Any
+        // other non-circular error kind is an un-modelable test failure.
         Some(LiteralValue::Error(e)) if e.kind == ExcelErrorKind::Value => {
             Ok(OVal::Err(EKind::Value))
         }
@@ -1100,8 +1068,8 @@ fn oracle_self_check_known_shapes() {
     let mut o = Oracle::new(&wb);
     assert_eq!(o.value_of(2), OVal::Num(5.0));
 
-    // Downstream non-member reading a member through an IF condition ⇒ #VALUE!
-    // (the documented IfFn coercion). A1↔A2 live cycle; A3 reads A1 via guard.
+    // A downstream non-member propagates a settled #CIRC through an IF guard.
+    // A1↔A2 is a live cycle; A3 reads A1 through its guard.
     let wb = Workbook {
         seed: 0,
         cells: vec![
@@ -1112,7 +1080,7 @@ fn oracle_self_check_known_shapes() {
     };
     let mut o = Oracle::new(&wb);
     assert!(!o.member[2], "A3 is a downstream reader, not a member");
-    assert_eq!(o.value_of(2), OVal::Err(EKind::Value));
+    assert_eq!(o.value_of(2), OVal::Err(EKind::CircSettled));
 }
 
 /// Self-check that the engine harness round-trips the same known shapes, so


### PR DESCRIPTION
## What was wrong

When IF's condition evaluated to an Excel error, the evaluator tried to coerce that error as a boolean. It replaced the original error with `#VALUE!`. That also obscured short-circuiting: an errored condition should return immediately without reading either arm.

## Excel behaviour

Measured on Microsoft Excel 16.105.3, Microsoft 365 for Mac:

| Formula | Excel | main @ 82a0b0d8 |
| --- | --- | --- |
| `=IF(NA()=0,0,1)` | `#N/A` | `#VALUE!` |
| `=IF(1/0>1,1,2)` | `#DIV/0!` | `#VALUE!` |
| `=IFS(1/0>1,1,TRUE,2)` (control) | `#DIV/0!` | `#DIV/0!` |
| `=SWITCH(1/0,1,2,3)` (control) | `#DIV/0!` | `#DIV/0!` |
| `=IF("x",1,2)` (control) | `#VALUE!` | `#VALUE!` |

A second probe used `H1=IF(NA()=0,H2,5)` and `H2=H1`. Excel returned `#N/A` from both without a circular condition. The errored condition makes neither arm live.

## The fix

IF now returns an error condition unchanged before boolean coercion. Boolean and numeric conditions keep current short-circuit behavior, while text still returns `#VALUE!`. IFS and SWITCH already propagate errors; their tests remain controls.

## Scope

This branch is standalone on main. The production change is one IF error arm. It does not add failed-arm tracking, change cycle detection, or modify IFS/SWITCH. No public item changes.

This is the companion to the reference-returning conditionals PR: that PR adds the reference path, while this one closes the ordinary value-path error seam.

## Verification

Two exact regressions fail on main because it returns `#VALUE!` instead of `#N/A`; both pass here. The text-condition and IFS/SWITCH controls pass before and after. Reverting the production arm fails both regressions. Other edits are tests and the property suite's reference model: it previously reproduced the old engine rule that coerces an errored `IF`/`NOT` condition to `#VALUE!`, and now expects the condition error to propagate unchanged with neither arm evaluated, matching the Excel rows above.

Executed with `rustc 1.97.1`:

```text
cargo fmt --all                                      exit 0; diff clean
cargo clippy --workspace --all-targets -- -D warnings exit 101; 19 fingerprints, an exact lower-count subset of main's 20
cargo test -p formualizer-eval                      2738 passed; the only failures are the IMEXP/IMSIN/IMCOS cases that fail identically on unmodified main
cargo test -p formualizer-eval --lib engine::tests::scc_runtime_cycles   39 passed
cargo test -p formualizer-eval --lib engine::tests::scc_runtime_property 4 passed, 2 ignored
```

## Deliberately not in this PR

No AND/OR behavior, cycle algorithm, documentation backlog, or unrelated evaluator cleanup is included.

## How this was found

An error-producing condition returned the wrong error kind. A second synthetic case proved the correction must preserve arm liveness.

Drafted by Claude (agent), verified by execution against a real Excel oracle, reviewed by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
