### PR TITLE
test(eval): fast-follow for the #369/#370/#371 review asks; close the all-unbounded OpenRect trap (#376)

### DIFF
--- a/crates/formualizer-eval/src/builtins/lookup/choose.rs
+++ b/crates/formualizer-eval/src/builtins/lookup/choose.rs
@@ -651,6 +651,44 @@ mod tests {
     }
 
     #[test]
+    fn choose_len_boundary_value_path() {
+        let wb = TestWorkbook::new().with_function(Arc::new(ChooseFn));
+        let ctx = wb.interpreter();
+        let f = ctx.context.get_function("", "CHOOSE").unwrap();
+
+        let a = lit(LiteralValue::Text("A".into()));
+        let b = lit(LiteralValue::Text("B".into()));
+
+        // CHOOSE(len, ...): the last choice is the highest valid index.
+        let two = lit(LiteralValue::Int(2));
+        let args = vec![
+            ArgumentHandle::new(&two, &ctx),
+            ArgumentHandle::new(&a, &ctx),
+            ArgumentHandle::new(&b, &ctx),
+        ];
+        let result = f
+            .dispatch(&args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert_eq!(result, LiteralValue::Text("B".into()));
+
+        // CHOOSE(len + 1, ...): exactly one past the last choice must be
+        // #VALUE!, not an out-of-bounds argument access. A bound widened by
+        // one panics here while every wider overflow still errors.
+        let three = lit(LiteralValue::Int(3));
+        let args = vec![
+            ArgumentHandle::new(&three, &ctx),
+            ArgumentHandle::new(&a, &ctx),
+            ArgumentHandle::new(&b, &ctx),
+        ];
+        let result = f
+            .dispatch(&args, &ctx.function_context(None))
+            .unwrap()
+            .into_literal();
+        assert!(matches!(result, LiteralValue::Error(e) if e.kind == ExcelErrorKind::Value));
+    }
+
+    #[test]
     fn choose_decimal_index() {
         let wb = TestWorkbook::new().with_function(Arc::new(ChooseFn));
         let ctx = wb.interpreter();

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -165,7 +165,7 @@ impl IndexFn {
         }
     }
 
-    fn precise_single_cell_selection<'a, 'b>(
+    pub(crate) fn precise_single_cell_selection<'a, 'b>(
         args: &[ArgumentHandle<'a, 'b>],
         rows: u32,
         cols: u32,

--- a/crates/formualizer-eval/src/builtins/reference_fns.rs
+++ b/crates/formualizer-eval/src/builtins/reference_fns.rs
@@ -290,6 +290,38 @@ impl IndexFn {
         }
     }
 
+    /// Attempt the precise single-cell fast path.
+    ///
+    /// Returns `None` when any gate declines, in which case the caller falls
+    /// back to `validated_dispatch`. Factored out of `dispatch` (and
+    /// parameterized over the dispatching function) so tests can assert which
+    /// path a given argument shape takes and observe the format policy being
+    /// applied to the precise result.
+    pub(crate) fn precise_dispatch<'a, 'b, 'c>(
+        function: &dyn Function,
+        args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Option<crate::traits::CalcValue<'b>> {
+        let argument = args.first()?;
+        if !argument.may_return_reference() {
+            return None;
+        }
+        let Ok(FunctionResolution::Reference(base)) = argument.resolve_reference_or_value() else {
+            return None;
+        };
+        let (rows, cols) = Self::bounded_dimensions(&base)?;
+        if !Self::precise_single_cell_selection(args, rows, cols) {
+            return None;
+        }
+        let Some(Ok(reference @ ReferenceType::Cell { .. })) =
+            Self::reference_from_base(args, ctx, base)
+        else {
+            return None;
+        };
+        let value = Self::materialize_reference(ctx, &reference).ok()?;
+        Some(function.apply_format_propagation(value))
+    }
+
     fn validated_dispatch<'a, 'b>(
         &self,
         args: &[ArgumentHandle<'a, 'b>],
@@ -393,16 +425,8 @@ impl Function for IndexFn {
         args: &'c [ArgumentHandle<'a, 'b>],
         ctx: &dyn FunctionContext<'b>,
     ) -> Result<crate::traits::CalcValue<'b>, ExcelError> {
-        if let Some(argument) = args.first()
-            && argument.may_return_reference()
-            && let Ok(FunctionResolution::Reference(base)) = argument.resolve_reference_or_value()
-            && let Some((rows, cols)) = Self::bounded_dimensions(&base)
-            && Self::precise_single_cell_selection(args, rows, cols)
-            && let Some(Ok(reference @ ReferenceType::Cell { .. })) =
-                Self::reference_from_base(args, ctx, base)
-            && let Ok(value) = Self::materialize_reference(ctx, &reference)
-        {
-            return Ok(self.apply_format_propagation(value));
+        if let Some(value) = Self::precise_dispatch(self, args, ctx) {
+            return Ok(value);
         }
         self.validated_dispatch(args, ctx)
     }

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -21727,7 +21727,7 @@ where
                             format!(
                                 "{}!{}{}",
                                 sheet_name,
-                                Self::col_to_letters(cell_ref.coord.col() + 1),
+                                Self::col_to_letters(cell_ref.coord.col().saturating_add(1)),
                                 cell_ref.coord.row() + 1
                             )
                         })

--- a/crates/formualizer-eval/src/engine/graph/range_deps.rs
+++ b/crates/formualizer-eval/src/engine/graph/range_deps.rs
@@ -590,6 +590,18 @@ impl DependencyGraph {
                 self.record_self_loop(dependent);
             }
 
+            // #376: an all-unbounded range means "the whole sheet". The stripe
+            // classification below would treat it as both column- and
+            // row-striped, fall through both branches, and collapse it to a
+            // single row-0 stripe, hiding edits anywhere else from this
+            // dependent. Register full column coverage instead; the precision
+            // check against `formula_to_range_deps` already treats the missing
+            // bounds as unbounded.
+            if s_row.is_none() && e_row.is_none() && s_col.is_none() && e_col.is_none() {
+                self.register_whole_sheet_stripes(dependent, sheet_id);
+                continue;
+            }
+
             let col_stripes = (s_row.is_none() && e_row.is_none())
                 || (s_col.is_some() && e_col.is_some() && (s_row.is_none() || e_row.is_none()));
             let row_stripes = (s_col.is_none() && e_col.is_none())
@@ -724,6 +736,26 @@ impl DependencyGraph {
         }
     }
 
+    /// Register stripes covering every cell of a sheet, for a dependent whose
+    /// range is unbounded on both axes (#376). Dirty-propagation lookups probe
+    /// the column stripe of every edited cell, so covering all columns
+    /// guarantees any edit on the sheet reaches the precision check.
+    fn register_whole_sheet_stripes(&mut self, dependent: VertexId, sheet_id: SheetId) {
+        /// Excel sheet column capacity (column XFD), as a 0-based exclusive bound.
+        const SHEET_MAX_COLS: u32 = 16_384;
+        for col in 0..SHEET_MAX_COLS {
+            let key = StripeKey {
+                sheet_id,
+                stripe_type: StripeType::Column,
+                index: col,
+            };
+            self.stripe_to_dependents
+                .entry(key)
+                .or_default()
+                .insert(dependent);
+        }
+    }
+
     /// Fast-path: add range dependencies using compact RangeKey.
     pub fn add_range_deps_from_keys(
         &mut self,
@@ -813,6 +845,18 @@ impl DependencyGraph {
                     != RangeSelfUse::Excluded
             {
                 self.record_self_loop(dependent);
+            }
+
+            // #376: an all-unbounded range means "the whole sheet". The stripe
+            // classification below would treat it as both column- and
+            // row-striped, fall through both branches, and collapse it to a
+            // single row-0 stripe, hiding edits anywhere else from this
+            // dependent. Register full column coverage instead; the precision
+            // check against `formula_to_range_deps` already treats the missing
+            // bounds as unbounded.
+            if s_row.is_none() && e_row.is_none() && s_col.is_none() && e_col.is_none() {
+                self.register_whole_sheet_stripes(dependent, sheet_id);
+                continue;
             }
 
             let col_stripes = (s_row.is_none() && e_row.is_none())

--- a/crates/formualizer-eval/src/engine/tests/live_edge_precision.rs
+++ b/crates/formualizer-eval/src/engine/tests/live_edge_precision.rs
@@ -354,3 +354,46 @@ fn index_unbounded_column_selection_measured() {
         "unbounded INDEX retains whole-column live edges while resolving bounds"
     );
 }
+
+/// Direct bound assertions on `precise_single_cell_selection`. The dispatch
+/// path re-rejects out-of-range selections in `reference_from_base`, so a
+/// widened bound in this filter is invisible to the taken/not-taken matrix
+/// above; only predicate-level assertions catch such an off-by-one.
+#[test]
+fn index_precise_selection_predicate_bounds() {
+    use formualizer_parse::parser::ASTNodeType;
+
+    let engine = runtime_engine();
+    let checks: &[(&str, u32, u32, bool)] = &[
+        ("=INDEX(A1:B3,2,1)", 3, 2, true),
+        ("=INDEX(A1:B3,3,2)", 3, 2, true), // inclusive upper corner
+        ("=INDEX(A1:B3,4,1)", 3, 2, false), // row one past the rect
+        ("=INDEX(A1:B3,2,3)", 3, 2, false), // column one past the rect
+        ("=INDEX(A1:B3,0,1)", 3, 2, false), // zero row selects a whole column
+        ("=INDEX(A1:B3,1,0)", 3, 2, false), // zero column selects a whole row
+        ("=INDEX(A1:B3,2)", 3, 2, false),  // 2-arg over a 2D rect
+        ("=INDEX(A1:A3,3)", 3, 1, true),   // column-vector boundary
+        ("=INDEX(A1:A3,4)", 3, 1, false),
+        ("=INDEX(A1:B1,2)", 1, 2, true), // row-vector boundary
+        ("=INDEX(A1:B1,3)", 1, 2, false),
+    ];
+
+    for (formula, rows, cols, expected) in checks {
+        let interpreter = crate::interpreter::Interpreter::new(&engine, "Sheet1");
+        let ast = parse(formula).expect("valid INDEX formula");
+        let ASTNodeType::Function { args, .. } = &ast.node_type else {
+            panic!("expected a function call: {formula}");
+        };
+        let handles: Vec<crate::traits::ArgumentHandle<'_, '_>> = args
+            .iter()
+            .map(|arg| crate::traits::ArgumentHandle::new(arg, &interpreter))
+            .collect();
+        assert_eq!(
+            crate::builtins::reference_fns::IndexFn::precise_single_cell_selection(
+                &handles, *rows, *cols
+            ),
+            *expected,
+            "{formula} with dims {rows}x{cols}"
+        );
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/live_edge_precision.rs
+++ b/crates/formualizer-eval/src/engine/tests/live_edge_precision.rs
@@ -184,22 +184,158 @@ fn index_selected_error_phantom_cycle_stays_acyclic() {
     }
 }
 
+/// Test-only INDEX stand-in with a non-None format policy. The precise path
+/// must route its result through `apply_format_propagation`; with the real
+/// IndexFn the policy is `None`, which makes the application unobservable, so
+/// this marker function is what makes deleting that call falsifiable.
+#[derive(Debug)]
+struct MarkedIndexFn;
+
+impl crate::function::Function for MarkedIndexFn {
+    fn name(&self) -> &'static str {
+        "INDEX.MARKED"
+    }
+
+    fn min_args(&self) -> usize {
+        2
+    }
+
+    fn arg_schema(&self) -> &'static [crate::args::ArgSchema] {
+        &[]
+    }
+
+    fn propagate_format(
+        &self,
+        _result: &crate::traits::CalcValue<'_>,
+    ) -> Option<crate::format::FormatId> {
+        Some(MARKER_FORMAT)
+    }
+
+    fn eval<'a, 'b, 'c>(
+        &self,
+        _args: &'c [crate::traits::ArgumentHandle<'a, 'b>],
+        _ctx: &dyn crate::traits::FunctionContext<'b>,
+    ) -> Result<crate::traits::CalcValue<'b>, formualizer_common::ExcelError> {
+        Ok(crate::traits::CalcValue::Scalar(LiteralValue::Error(
+            formualizer_common::ExcelError::new(ExcelErrorKind::NImpl),
+        )))
+    }
+}
+
+const MARKER_FORMAT: crate::format::FormatId = crate::format::FormatId(30);
+
+type PreciseDispatchResult = Option<(Option<crate::format::FormatId>, LiteralValue)>;
+
+fn precise_dispatch_on(
+    engine: &Engine<TestWorkbook>,
+    function: &dyn crate::function::Function,
+    formula: &str,
+) -> PreciseDispatchResult {
+    use formualizer_parse::parser::ASTNodeType;
+
+    let interpreter = crate::interpreter::Interpreter::new(engine, "Sheet1");
+    let ast = parse(formula).expect("valid INDEX formula");
+    let ASTNodeType::Function { args, .. } = &ast.node_type else {
+        panic!("expected a function call: {formula}");
+    };
+    let handles: Vec<crate::traits::ArgumentHandle<'_, '_>> = args
+        .iter()
+        .map(|arg| crate::traits::ArgumentHandle::new(arg, &interpreter))
+        .collect();
+    let ctx = interpreter.function_context(None);
+    crate::builtins::reference_fns::IndexFn::precise_dispatch(function, &handles, &ctx)
+        .map(|value| (value.format_id(), value.into_literal()))
+}
+
 #[test]
 fn index_precise_path_applies_format_policy() {
     let mut engine = runtime_engine();
     engine
+        .set_cell_value("Sheet1", 1, 17, LiteralValue::Int(7))
+        .expect("set Q1");
+
+    // Marker policy: the precise path must apply the dispatching function's
+    // format policy to the materialized value.
+    let (marked_format, _) = precise_dispatch_on(&engine, &MarkedIndexFn, "=INDEX(Q1:Q3,1)")
+        .expect("precise path taken");
+    assert_eq!(
+        marked_format,
+        Some(MARKER_FORMAT),
+        "the precise path must route through apply_format_propagation"
+    );
+
+    // Control: INDEX itself declares no policy, so the same dispatch clears
+    // any annotation.
+    engine
         .set_cell_value(
             "Sheet1",
-            1,
+            2,
             17,
             LiteralValue::Date(NaiveDate::from_ymd_opt(2024, 12, 1).expect("valid date")),
         )
-        .expect("set Q1");
-    let ast = parse("=INDEX(Q1:Q3,1)").expect("valid INDEX formula");
-    let value = crate::interpreter::Interpreter::new(&engine, "Sheet1")
-        .evaluate_ast(&ast)
-        .expect("evaluate INDEX");
-    assert_eq!(value.format_id(), None, "INDEX drops source annotations");
+        .expect("set Q2");
+    let (unmarked_format, _) = precise_dispatch_on(
+        &engine,
+        &crate::builtins::reference_fns::IndexFn,
+        "=INDEX(Q1:Q3,2)",
+    )
+    .expect("precise path taken");
+    assert_eq!(unmarked_format, None, "INDEX drops source annotations");
+}
+
+/// Path-taken matrix for `precise_single_cell_selection`: the filter is a
+/// perf gate whose rejections are re-rejected downstream, so only direct
+/// taken/not-taken assertions can catch an off-by-one in its bounds.
+#[test]
+fn index_precise_path_taken_matrix() {
+    let mut engine = runtime_engine();
+    for (row, col, value) in [
+        (1, 1, 1),
+        (2, 1, 2),
+        (3, 1, 3),
+        (1, 2, 10),
+        (2, 2, 20),
+        (3, 2, 30),
+    ] {
+        engine
+            .set_cell_value("Sheet1", row, col, LiteralValue::Int(value))
+            .expect("set fixture cell");
+    }
+
+    let cases: &[(&str, Option<f64>)] = &[
+        ("=INDEX(A1:B3,2,1)", Some(2.0)),
+        ("=INDEX(A1:B3,3,2)", Some(30.0)), // both upper bounds inclusive
+        ("=INDEX(A1:B3,1,1)", Some(1.0)),
+        ("=INDEX(A1:B3,4,1)", None),    // row just past the rect
+        ("=INDEX(A1:B3,2,3)", None),    // column just past the rect
+        ("=INDEX(A1:B3,0,1)", None),    // zero selects a whole row/column
+        ("=INDEX(A1:B3,2)", None),      // 2-arg over a 2D rect is not single-cell
+        ("=INDEX(A1:A3,3)", Some(3.0)), // single-column vector boundary
+        ("=INDEX(A1:A3,4)", None),
+        ("=INDEX(A1:B1,2)", Some(10.0)), // single-row vector boundary
+        ("=INDEX(A1:B1,3)", None),
+    ];
+
+    for (formula, expected) in cases {
+        let result =
+            precise_dispatch_on(&engine, &crate::builtins::reference_fns::IndexFn, formula);
+        match (result, expected) {
+            (Some((_, literal)), Some(expected)) => {
+                let number = match literal {
+                    LiteralValue::Int(int) => int as f64,
+                    LiteralValue::Number(number) => number,
+                    other => panic!("{formula}: expected a number, got {other:?}"),
+                };
+                assert_eq!(number, *expected, "{formula}");
+            }
+            (None, None) => {}
+            (taken, _) => panic!(
+                "{formula}: precise path taken = {}, expected {}",
+                taken.is_some(),
+                expected.is_some()
+            ),
+        }
+    }
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/open_rect_bounds.rs
+++ b/crates/formualizer-eval/src/engine/tests/open_rect_bounds.rs
@@ -167,3 +167,54 @@ fn open_rect_incremental_edit_path_unchanged() {
     assert_plan_has_precedents(&engine, 3);
     evaluate_and_expect(&mut engine, 3, 6000.0);
 }
+
+#[test]
+fn open_rect_row_mirror_sum_pinned() {
+    // Axis mirror of the multi-column shapes above: an open row band with
+    // formula-valued precedents through the bulk-ingest path. Before the
+    // open-rect bounds fix the collapsed row bounds lost scheduling edges and
+    // the consumer committed a stale 76605 instead of 96660.
+    let mut engine = build_d_to_f_bulk(true, 20, "=SUM($3:$13)");
+    assert_plan_has_precedents(&engine, 20);
+    evaluate_and_expect(&mut engine, 20, 96660.0);
+}
+
+#[test]
+fn open_rect_stripe_set_preserves_start_col() {
+    // Precision pin for the stripe index: an open range that does not start at
+    // column A must register exactly its own column stripes. Dropping
+    // `start_col` on either the key-producer or the stripe-consumer side
+    // degrades into a "safe" over-widening to column A that value-level tests
+    // cannot observe.
+    use crate::engine::graph::StripeType;
+
+    let engine = build_d_to_f_bulk(true, 3, "=VLOOKUP(H3,$D:$F,3,FALSE)");
+    let consumer = *engine
+        .graph
+        .get_vertex_id_for_address(&engine.graph.make_cell_ref("Sheet1", 3, 14))
+        .expect("consumer vertex");
+    let sheet_id = engine.graph.sheet_id("Sheet1").expect("sheet id");
+
+    let mut column_stripes: Vec<u32> = Vec::new();
+    let mut other_stripes: Vec<(StripeType, u32)> = Vec::new();
+    for (key, dependents) in engine.graph.stripe_to_dependents() {
+        if key.sheet_id != sheet_id || !dependents.contains(&consumer) {
+            continue;
+        }
+        match key.stripe_type {
+            StripeType::Column => column_stripes.push(key.index),
+            ref other => other_stripes.push((other.clone(), key.index)),
+        }
+    }
+    column_stripes.sort_unstable();
+
+    assert_eq!(
+        column_stripes,
+        vec![3, 4, 5],
+        "=VLOOKUP over $D:$F must register exactly the D..F column stripes (0-based 3..5)"
+    );
+    assert!(
+        other_stripes.is_empty(),
+        "no row or block stripes expected for an open multi-column range, got {other_stripes:?}"
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/range_dependencies.rs
+++ b/crates/formualizer-eval/src/engine/tests/range_dependencies.rs
@@ -1164,3 +1164,63 @@ fn test_heal_one_of_multiple_missing_sheets_does_not_double_bind() {
         "Healing S2 first must not rewrite S3 references"
     );
 }
+
+/// #376: an `OpenRect` key with no bounds on either axis means "the whole
+/// sheet". Before the whole-sheet branch the stripe classifier treated it as
+/// both column- and row-striped, fell through both stripe arms, and collapsed
+/// it to a single row-0 stripe — edits anywhere else never reached the
+/// dependent.
+#[test]
+fn all_unbounded_open_rect_key_covers_whole_sheet() {
+    use crate::engine::graph::{StripeKey, StripeType};
+    use crate::engine::plan::RangeKey;
+
+    let mut graph = DependencyGraph::new();
+    graph
+        .set_cell_formula("Sheet1", 1, 20, parse("=1").unwrap())
+        .unwrap();
+    let dependent = *graph
+        .get_vertex_id_for_address(&abs_cell_ref(0, 1, 20))
+        .unwrap();
+    let sheet = graph.sheet_id("Sheet1").unwrap();
+
+    graph.add_range_deps_from_keys(
+        dependent,
+        &[RangeKey::OpenRect {
+            sheet,
+            start_row: None,
+            start_col: None,
+            end_row: None,
+            end_col: None,
+        }],
+        sheet,
+    );
+
+    // Structural: every edited cell probes its own column stripe, so full
+    // column coverage is what makes the dependent reachable from anywhere.
+    for col0 in [0u32, 7, 16_383] {
+        let key = StripeKey {
+            sheet_id: sheet,
+            stripe_type: StripeType::Column,
+            index: col0,
+        };
+        assert!(
+            graph
+                .stripe_to_dependents()
+                .get(&key)
+                .is_some_and(|deps| deps.contains(&dependent)),
+            "column stripe {col0} must include the whole-sheet dependent"
+        );
+    }
+
+    // Behavioral: an edit far from row 1 must dirty the dependent.
+    graph.clear_dirty_flags(&[dependent]);
+    assert!(!graph.is_dirty(dependent), "dependent starts clean");
+    graph
+        .set_cell_value("Sheet1", 500, 8, LiteralValue::Int(5))
+        .unwrap();
+    assert!(
+        graph.is_dirty(dependent),
+        "an edit anywhere on the sheet must dirty the all-unbounded dependent"
+    );
+}

--- a/crates/formualizer-eval/src/tests/functions.rs
+++ b/crates/formualizer-eval/src/tests/functions.rs
@@ -904,3 +904,96 @@ fn if_family_selector_evaluation_count() {
         array.store(false, Ordering::SeqCst);
     }
 }
+
+fn assert_reference_formula_number(formula: &str, expected: f64) {
+    match evaluate_reference_returning_formula(1, formula) {
+        LiteralValue::Int(value) => assert_eq!(value as f64, expected, "{formula}"),
+        LiteralValue::Number(value) => assert_eq!(value, expected, "{formula}"),
+        other => panic!("expected {expected} from {formula}, got {other:?}"),
+    }
+}
+
+fn assert_reference_formula_value_error(formula: &str) {
+    match evaluate_reference_returning_formula(1, formula) {
+        LiteralValue::Error(error) => assert_eq!(
+            error.kind,
+            formualizer_common::ExcelErrorKind::Value,
+            "{formula}"
+        ),
+        other => panic!("expected #VALUE! from {formula}, got {other:?}"),
+    }
+}
+
+/// CHOOSE selector bounds on the value path. `CHOOSE(len, ...)` is the last
+/// valid index and `CHOOSE(len + 1, ...)` must be #VALUE! rather than an
+/// out-of-bounds argument access: a selector bound widened by one panics on
+/// the len + 1 case while every wider overflow still errors.
+#[test]
+fn choose_selector_bounds_value_path() {
+    assert_reference_formula_number("=CHOOSE(2,A1,B1)", 101.0);
+    assert_reference_formula_value_error("=CHOOSE(0,A1,B1)");
+    assert_reference_formula_value_error("=CHOOSE(3,A1,B1)");
+}
+
+/// The same bounds through `resolve_choose_reference_or_value`: OFFSET forces
+/// CHOOSE down the reference path, which carries its own selector check.
+#[test]
+fn choose_selector_bounds_reference_path() {
+    assert_reference_formula_number("=OFFSET(CHOOSE(2,A1,B1),0,0)", 101.0);
+    assert_reference_formula_number("=OFFSET(CHOOSE(2,A1,B1),1,0)", 102.0);
+    assert_reference_formula_value_error("=OFFSET(CHOOSE(0,A1,B1),0,0)");
+    assert_reference_formula_value_error("=OFFSET(CHOOSE(3,A1,B1),0,0)");
+}
+
+/// Pin every syntax arm of `ArgumentHandle::may_return_reference` so the
+/// guard is falsifiable: it exists to keep arguments that cannot produce a
+/// reference off the reference-resolution path, and the downstream let-chain
+/// re-rejects them, so only direct assertions can catch a broken arm.
+#[test]
+fn may_return_reference_syntax_arms() {
+    crate::builtins::load_builtins();
+    let wb = TestWorkbook::new();
+    let interpreter = wb.interpreter();
+    let arm = |formula: &str| {
+        let ast = formualizer_parse::parser::parse(formula).expect("parse arm formula");
+        ArgumentHandle::new(&ast, &interpreter).may_return_reference()
+    };
+
+    assert!(arm("=A1"), "cell reference");
+    assert!(arm("=A1:B3"), "range reference");
+    assert!(arm("=INDEX(A1:B3,1,1)"), "RETURNS_REFERENCE function");
+    assert!(
+        arm("=UNBOUNDNAME"),
+        "an unbound name may be a workbook named range"
+    );
+    assert!(!arm("=SUM(A1:B3)"), "value-returning function");
+    assert!(!arm("=1+2"), "arithmetic expression");
+    assert!(!arm("=\"text\""), "literal");
+}
+
+/// The LET/LAMBDA exclusion: a local binding shadows any workbook name of the
+/// same spelling and locals resolve only on the value path, so a bound name
+/// must report itself as not reference-capable.
+#[test]
+fn may_return_reference_excludes_let_lambda_locals() {
+    use crate::interpreter::{LocalBinding, LocalEnv};
+
+    crate::builtins::load_builtins();
+    let wb = TestWorkbook::new();
+    let interpreter = wb.interpreter();
+    let ast = formualizer_parse::parser::parse("=X").expect("parse local name");
+
+    let unbound = ArgumentHandle::new(&ast, &interpreter);
+    assert!(
+        unbound.may_return_reference(),
+        "without a local binding the name may be a workbook named range"
+    );
+
+    let env = LocalEnv::default().with_binding("X", LocalBinding::Value(LiteralValue::Int(7)));
+    let scoped = interpreter.with_local_env(env);
+    let bound = ArgumentHandle::new(&ast, &scoped);
+    assert!(
+        !bound.may_return_reference(),
+        "a LET/LAMBDA local must not be sent down the named-range route"
+    );
+}


### PR DESCRIPTION
# Fast-follow: test and hardening asks from the #369/#370/#371 reviews, plus #376

Closes #376.

One PR bundling every follow-up the reviews asked for. Each item quotes the ask (short), names the commit, and links to a measured row in the evidence table. Every value in that table was observed by executing the named test at the named commit — nothing is reconstructed.

## Items

### From the #371 review

**1. Axis-mirror test** — "add the mirror-shape test — `=SUM($3:$13)` with formula precedents"
`open_rect_row_mirror_sum_pinned` (commit `7dc8ccb3`): the row-band mirror of the shipped column shapes, formula-valued precedents through bulk ingest. Measured failing on the #371 merge base with the exact stale value your review reported (76605 vs 96660) and passing on this branch. Rows E1/E2.

**2. Stripe-precision test** — "a test asserting the exact stripe set ... would pin the precision, not just the presence"
`open_rect_stripe_set_preserves_start_col` (commit `7dc8ccb3`): asserts the consumer of `=VLOOKUP(H3,$D:$F,3,FALSE)` registers exactly column stripes {3,4,5} (0-based) and nothing else. Both safe-over-widening mutants were applied and are killed — dropping `start_col` in the producer (`ingest_builder.rs` `range_key_from_shared`) and in the consumer (`add_range_deps_from_keys`) each widen the observed set to [0..5] and fail the assertion. Rows E3/E4/E5.
One scoping note from verifying the kills: `plan.rs` also builds `RangeKey::OpenRect` values, but that producer feeds only the formula-plane dependency-summary comparison oracle (`dependency_summary.rs`), never stripe registration, so a `start_col` drop there is not observable through scheduling and is outside this test's reach — measured as row E6.

**3. Saturation nit** — "`col + 1` is the one non-saturating conversion in a hunk that saturates everywhere else"
Commit `ef6df6e3`: `cell_ref.coord.col() + 1` → `cell_ref.coord.col().saturating_add(1)` in the eval-plan sample-cell labels.

### From the #369 review

**4. CHOOSE bound regressions** — "please add `CHOOSE(0,...)` / `CHOOSE(len,...)` / `OFFSET(CHOOSE(len,...),0,0)` regressions covering both the value and reference paths"
Commit `d03fd3a4`: `choose_len_boundary_value_path` (direct dispatch, exact `len` and `len+1` boundaries), plus engine-level `choose_selector_bounds_value_path` and `choose_selector_bounds_reference_path` (OFFSET forcing `resolve_choose_reference_or_value`). Your measured mutant — the selector bound widened by one — was applied separately to each path's check: the value-path mutant panics `choose_len_boundary_value_path` with an out-of-bounds argument access, and the reference-path mutant panics `choose_selector_bounds_reference_path` the same way. Rows E7/E8.

**5. `may_return_reference` falsifiability** — "a path-taken assertion (your CountSelectorFn pattern fits) would make it falsifiable"
Commit `d03fd3a4`: we ended up pinning the predicate directly rather than counting calls — `ArgumentHandle` caches its reference resolution, so a CountSelectorFn-style count cannot distinguish the guard from the downstream re-rejection (the same masking that made it untestable end to end). `may_return_reference_syntax_arms` asserts every syntax arm (cell reference, range, RETURNS_REFERENCE function, unbound name, value function, arithmetic, literal), and `may_return_reference_excludes_let_lambda_locals` pins the LET/LAMBDA exclusion both ways via `Interpreter::with_local_env`. Removing the exclusion arm is killed (row E9). Residual: the arena-side arm mirrors the AST arm and is not separately constructible from a unit test; its mutants remain uncovered.

### From the #370 review

**6. Vacuous format-policy test** — "either make the policy observable in the test or soften the claim"
Commit `c75c2fa9`: the precise single-cell fast path is factored out of `IndexFn::dispatch` into `IndexFn::precise_dispatch`, parameterized over the dispatching function. `index_precise_path_applies_format_policy` now drives the same dispatch through a test-only `MarkedIndexFn` whose `propagate_format` is `Some(FormatId(30))` and asserts the marker lands on the result — deleting `apply_format_propagation` from the precise path now fails the test (row E10) instead of holding vacuously. The original INDEX-clears-annotations assertion is kept as a control.

**7. Path-taken test for `precise_single_cell_selection`** — "a path-taken test would keep future off-by-ones catchable"
Commits `c75c2fa9` + `d3120c23`, two layers because we measured the first alone to be insufficient: `index_precise_path_taken_matrix` asserts taken/not-taken through `precise_dispatch` across 11 shapes, but the column bound widened by one *survives* it — `reference_from_base` re-rejects the widened selection, exactly the downstream masking your review described (row E11). `index_precise_selection_predicate_bounds` therefore asserts the filter directly (exposed `pub(crate)`) across the same boundary shapes, and that kills the mutant on the exact widened case (row E12).

### From issue #376

**8. All-unbounded OpenRect key** — "an explicit branch mapping the all-unbounded key to whole-sheet dependency semantics"
Commit `5ff7f933`: both stripe-registration sites (`add_range_deps_from_keys`, and `add_range_dependent_edges`, which accepts arbitrary `SharedRangeRef`s through the public `add_range_edges` and carries the same fall-through) now route a no-bounds-on-either-axis range to `register_whole_sheet_stripes`, registering all 16,384 column stripes. Dirty lookups probe the edited cell's column stripe, so full column coverage reaches the existing precision check, which already treats missing bounds as unbounded. We chose the branch over the `debug_assert!` since it removes the trap rather than documenting it. `all_unbounded_open_rect_key_covers_whole_sheet` constructs the degenerate key directly and asserts both stripe coverage and behavior (an edit at R500C8 dirties the dependent); measured failing with the fix reverted (row E13).

## Measured evidence

Provenance: all runs via `cargo test -p formualizer-eval --lib -- <test>` on the same Linux x86_64 host, rustc 1.93.0. Branch = `fastfollow/review-asks`, tip `d3120c23964a9fd34f9af480ad9f61d51b71088f` (from upstream main `06dad200fe87cb5bff9c17104c1487cdbf4b4eca`); base = #371 merge base `b5bae5a491477d75a1c088ddfd51226438785ece` (mirror test ported to a worktree of that commit as `open_rect_mirror_red.rs`, fixture identical). Mutants were applied to the branch working tree one at a time, the named test executed, output recorded, and the tree restored (verified clean after each run).

| Row | What ran | Where | Observed |
|---|---|---|---|
| E1 | `open_rect_row_mirror_sum_pinned` | base `b5bae5a4` | FAILED — `left: 76605.0, right: 96660.0` |
| E2 | `open_rect_row_mirror_sum_pinned` | branch | ok |
| E3 | `open_rect_stripe_set_preserves_start_col` | branch | ok — set = [3, 4, 5] |
| E4 | same, consumer mutant (`add_range_deps_from_keys`: `sc = 0`) | branch + mutant | FAILED — `left: [0, 1, 2, 3, 4, 5], right: [3, 4, 5]` |
| E5 | same, producer mutant (`ingest_builder.rs`: `start_col: None`) | branch + mutant | FAILED — `left: [0, 1, 2, 3, 4, 5], right: [3, 4, 5]` |
| E6 | same, `plan.rs` OpenRect `start_col: None` probe | branch + mutant | ok — survives; that producer feeds the dependency-summary oracle only (item 2 note) |
| E7 | `choose_len_boundary_value_path`, eval bound `> args.len() - 1` → `> args.len()` | branch + mutant | FAILED — panicked at `choose.rs:173` (out-of-bounds arg access) |
| E8 | `choose_selector_bounds_reference_path`, resolver bound widened the same way | branch + mutant | FAILED — panicked at `choose.rs:204` (out-of-bounds arg access) |
| E9 | `may_return_reference_excludes_let_lambda_locals`, exclusion arm removed | branch + mutant | FAILED — panicked at `functions.rs:995` (local not excluded) |
| E10 | `index_precise_path_applies_format_policy`, `apply_format_propagation` dropped from precise path | branch + mutant | FAILED — `left: None, right: Some(FormatId(30))` |
| E11 | `index_precise_path_taken_matrix`, column bound `col <= cols` → `col <= cols + 1` | branch + mutant | ok — survives; `reference_from_base` re-rejects (motivates E12) |
| E12 | `index_precise_selection_predicate_bounds`, same mutant | branch + mutant | FAILED — `=INDEX(A1:B3,2,3) with dims 3x2: left: true, right: false` |
| E13 | `all_unbounded_open_rect_key_covers_whole_sheet` with `range_deps.rs` reverted to `06dad200` | branch, fix reverted | FAILED — panicked at first stripe assertion (`range_dependencies.rs:1207`) |
| E14 | full `cargo test -p formualizer-eval` (includes the 10 new tests and the rewritten format-policy test) | branch | ok — lib 2775 passed; 0 failed; 14 ignored (main baseline: 2765 passed; 0 failed) |

## Gates

- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, zero warnings or errors on rustc/clippy 1.93.0; the pre-existing clippy fingerprints known from other environments did not reproduce on this toolchain, so nothing was suppressed.
- `cargo test -p formualizer-eval` — branch: lib 2775 passed / 0 failed / 14 ignored, all other suites 0 failed. Unmodified main `06dad200` on the same machine: lib 2765 passed / 0 failed, all other suites 0 failed. The IMEXP/IMSIN/IMCOS failures we have seen on other hosts did not occur on this machine on either commit, so no known-base failure list applies to these runs.

drafted by Claude (agent), approved by Tommy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
