### PR TITLE
fix(eval): preserve derived formats across FormulaPlane span broadcasts

### DIFF
--- a/crates/formualizer-eval/src/engine/tests/formula_plane_format_broadcast.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_format_broadcast.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+
+use chrono::NaiveDate;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+use crate::engine::{
+    Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::test_workbook::TestWorkbook;
+
+const SHEET: &str = "Sheet1";
+const ROWS: u32 = 200;
+
+fn engine(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    Engine::new(
+        TestWorkbook::default(),
+        EvalConfig::default().with_formula_plane_mode(mode),
+    )
+}
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    let ast = parse(formula).unwrap_or_else(|err| panic!("parse {formula}: {err}"));
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn ingest(engine: &mut Engine<TestWorkbook>, formulas: Vec<FormulaIngestRecord>) {
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(SHEET, formulas)])
+        .expect("ingest formulas");
+    engine.evaluate_all().expect("evaluate formulas");
+}
+
+fn results(engine: &Engine<TestWorkbook>, col: u32) -> Vec<LiteralValue> {
+    (1..=ROWS)
+        .map(|row| {
+            engine
+                .get_cell_value(SHEET, row, col)
+                .unwrap_or_else(|| panic!("missing {SHEET}!R{row}C{col}"))
+        })
+        .collect()
+}
+
+fn constant_result_fixture(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    let mut engine = engine(mode);
+    engine
+        .set_cell_value(
+            SHEET,
+            10,
+            6,
+            LiteralValue::Date(NaiveDate::from_ymd_opt(2024, 12, 1).unwrap()),
+        )
+        .unwrap();
+    let formulas = (1..=ROWS)
+        .map(|row| record(&mut engine, row, 7, "=$F$10+0"))
+        .collect();
+    ingest(&mut engine, formulas);
+    engine
+}
+
+fn memoized_fixture(mode: FormulaPlaneMode, mixed_formats: bool) -> Engine<TestWorkbook> {
+    let mut engine = engine(mode);
+    let date = NaiveDate::from_ymd_opt(2024, 12, 1).unwrap();
+    let mut formulas = Vec::with_capacity(ROWS as usize);
+    for row in 1..=ROWS {
+        let value = if mixed_formats && row % 2 == 0 {
+            LiteralValue::Number(45_627.0)
+        } else {
+            LiteralValue::Date(date)
+        };
+        engine.set_cell_value(SHEET, row, 1, value).unwrap();
+        formulas.push(record(
+            &mut engine,
+            row,
+            2,
+            &format!("=A{row}+{}", if mixed_formats { 0 } else { 1 }),
+        ));
+    }
+    ingest(&mut engine, formulas);
+    engine
+}
+
+#[test]
+fn formula_plane_constant_result_broadcast_preserves_date_format_parity() {
+    let off = constant_result_fixture(FormulaPlaneMode::Off);
+    let authoritative = constant_result_fixture(FormulaPlaneMode::AuthoritativeExperimental);
+    let expected = LiteralValue::Date(NaiveDate::from_ymd_opt(2024, 12, 1).unwrap());
+
+    let off_results = results(&off, 7);
+    let authoritative_results = results(&authoritative, 7);
+    assert_eq!(authoritative_results, off_results);
+    assert!(off_results.iter().all(|value| value == &expected));
+    assert_eq!(
+        authoritative
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        ROWS as u64
+    );
+}
+
+#[test]
+fn formula_plane_memo_broadcast_preserves_equal_date_format_parity() {
+    let off = memoized_fixture(FormulaPlaneMode::Off, false);
+    let authoritative = memoized_fixture(FormulaPlaneMode::AuthoritativeExperimental, false);
+    let expected = LiteralValue::Date(NaiveDate::from_ymd_opt(2024, 12, 2).unwrap());
+
+    let off_results = results(&off, 2);
+    let authoritative_results = results(&authoritative, 2);
+    assert_eq!(authoritative_results, off_results);
+    assert!(off_results.iter().all(|value| value == &expected));
+    let report = authoritative.last_formula_plane_span_eval_report().unwrap();
+    assert_eq!(report.memo_eval_count, 1, "{report:?}");
+    assert_eq!(report.memo_broadcast_count, (ROWS - 1) as u64, "{report:?}");
+}
+
+#[test]
+fn formula_plane_memo_broadcast_preserves_mixed_format_parity() {
+    let off = memoized_fixture(FormulaPlaneMode::Off, true);
+    let authoritative = memoized_fixture(FormulaPlaneMode::AuthoritativeExperimental, true);
+
+    let off_results = results(&off, 2);
+    let authoritative_results = results(&authoritative, 2);
+    assert_eq!(authoritative_results, off_results);
+    for (index, value) in off_results.iter().enumerate() {
+        let expected = if index % 2 == 0 {
+            LiteralValue::Date(NaiveDate::from_ymd_opt(2024, 12, 1).unwrap())
+        } else {
+            LiteralValue::Number(45_627.0)
+        };
+        assert_eq!(*value, expected, "row {}", index + 1);
+    }
+    let report = authoritative.last_formula_plane_span_eval_report().unwrap();
+    assert_eq!(report.memo_eval_count, 2, "{report:?}");
+    assert_eq!(report.memo_broadcast_count, (ROWS - 2) as u64, "{report:?}");
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -128,6 +128,7 @@ mod formula_plane_coverage_pinning;
 mod formula_plane_cycle_member_exclusion;
 mod formula_plane_demotion_correctness;
 mod formula_plane_dirty_domain_preservation;
+mod formula_plane_format_broadcast;
 mod formula_plane_index_promotion;
 mod formula_plane_ingest_shadow;
 mod formula_plane_inspect_parity;

--- a/crates/formualizer-eval/src/formula_plane/span_eval.rs
+++ b/crates/formualizer-eval/src/formula_plane/span_eval.rs
@@ -16,6 +16,7 @@ use crate::engine::CancelToken;
 use crate::engine::arena::{AstNodeData, AstNodeId, CompactRefType, DataStore};
 use crate::engine::eval::ComputedWriteBuffer;
 use crate::engine::sheet_registry::SheetRegistry;
+use crate::format::FormatId;
 use crate::interpreter::{Interpreter, InterpreterParameterBindings};
 use crate::reference::CellRef;
 use crate::traits::EvaluationContext;
@@ -168,6 +169,11 @@ struct MemoGroup {
     placements: Vec<PlacementCoord>,
 }
 
+struct MemoGroupValue {
+    value: OverlayValue,
+    format_id: Option<FormatId>,
+}
+
 pub(crate) struct SpanEvaluator<'a> {
     plane: &'a FormulaPlane,
     context: &'a dyn EvaluationContext,
@@ -291,17 +297,15 @@ impl<'a> SpanEvaluator<'a> {
                 first_writable_placement.row,
                 first_writable_placement.col,
             ));
-            let value = match interpreter.evaluate_ast(&ast_tree) {
+            let (value, format_id) = match interpreter.evaluate_ast(&ast_tree) {
                 Ok(calc) => {
-                    self.context.record_cell_derived_format(
-                        self.current_sheet,
-                        first_writable_placement.row + 1,
-                        first_writable_placement.col + 1,
-                        calc.format_id(),
-                    );
-                    formula_result_to_overlay(calc.into_literal(), self.context.date_system())
+                    let format_id = calc.format_id();
+                    (
+                        formula_result_to_overlay(calc.into_literal(), self.context.date_system()),
+                        format_id,
+                    )
                 }
-                Err(err) => OverlayValue::Error(map_error_code(err.kind)),
+                Err(err) => (OverlayValue::Error(map_error_code(err.kind)), None),
             };
 
             for (index, placement) in placements.iter().enumerate() {
@@ -311,6 +315,12 @@ impl<'a> SpanEvaluator<'a> {
                         report.skipped_overlay_punchout_count.saturating_add(1);
                     continue;
                 }
+                self.context.record_cell_derived_format(
+                    self.current_sheet,
+                    placement.row + 1,
+                    placement.col + 1,
+                    format_id,
+                );
                 sink.push_cell(placement, value.clone());
                 report.span_eval_placement_count =
                     report.span_eval_placement_count.saturating_add(1);
@@ -695,7 +705,7 @@ impl<'a> SpanEvaluator<'a> {
         binding_set: &SpanBindingSet,
         group: &MemoGroup,
         base_interpreter: Option<&Interpreter<'a>>,
-    ) -> Result<OverlayValue, SpanEvalError> {
+    ) -> Result<MemoGroupValue, SpanEvalError> {
         let placement = group.representative;
         let row_delta = i64::from(placement.row) + 1 - i64::from(origin_row);
         let col_delta = i64::from(placement.col) + 1 - i64::from(origin_col);
@@ -732,15 +742,19 @@ impl<'a> SpanEvaluator<'a> {
             self.sheet_registry,
         ) {
             Ok(calc) => {
-                self.context.record_cell_derived_format(
-                    self.current_sheet,
-                    placement.row + 1,
-                    placement.col + 1,
-                    calc.format_id(),
-                );
-                formula_result_to_overlay(calc.into_literal(), self.context.date_system())
+                let format_id = calc.format_id();
+                MemoGroupValue {
+                    value: formula_result_to_overlay(
+                        calc.into_literal(),
+                        self.context.date_system(),
+                    ),
+                    format_id,
+                }
             }
-            Err(err) => OverlayValue::Error(map_error_code(err.kind)),
+            Err(err) => MemoGroupValue {
+                value: OverlayValue::Error(map_error_code(err.kind)),
+                format_id: None,
+            },
         };
         Ok(value)
     }
@@ -748,12 +762,18 @@ impl<'a> SpanEvaluator<'a> {
     fn push_memo_group_value(
         &self,
         group: &MemoGroup,
-        value: OverlayValue,
+        value: MemoGroupValue,
         sink: &mut SpanComputedWriteSink<'_>,
         report: &mut SpanEvalReport,
     ) {
         for placement in &group.placements {
-            sink.push_cell(*placement, value.clone());
+            self.context.record_cell_derived_format(
+                self.current_sheet,
+                placement.row + 1,
+                placement.col + 1,
+                value.format_id,
+            );
+            sink.push_cell(*placement, value.value.clone());
             report.span_eval_placement_count = report.span_eval_placement_count.saturating_add(1);
         }
         report.memo_broadcast_count = report


### PR DESCRIPTION
## Problem

Constant-result spans and memoized span groups recorded the derived number-format for only one representative placement before broadcasting the overlay value to every other cell. Under AuthoritativeExperimental this degraded temporal egress at get_cell_value: `=$F$10+0` over 200 rows below a date-formatted precedent returned Date(2024-12-01) for row 1 and bare Number(45627.0) for rows 2+, while Off mode returned dates everywhere. Mixed-format memo groups collapsed to a single format.

## Fix

Map-only parity change in span_eval.rs: the constant-result broadcast loop records the representative Option<FormatId> for every writable placement, and push_memo_group_value carries the format through a MemoGroupValue payload and records it per member. Egress policy and TemporalEgress untouched. This is the minimal remediation identified by the cutover audit; the Arrow computed-overlay format-lane writeback lands as a stacked follow-up.

## Tests

Three mode-parity oracles added in engine/tests/formula_plane_format_broadcast.rs covering constant-result broadcast, memoized equal-value runs, and mixed-format memo groups. All fail before the fix, pass after.

## Validation

cargo test -p formualizer-eval formula_plane: 646 passed. format_channel_t1: 12 passed. clippy -p formualizer-eval --all-targets -- -D warnings clean. fmt --check clean.