### PR TITLE
fix(eval): heal name readers across delete/redefine; align define_name span demotion with update_name

### DIFF
--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4231,12 +4231,6 @@ where
         // registry changes so their cells re-ingest and re-resolve through
         // the normal legacy path.
         self.graph.validate_define_name(name, scope)?;
-        let has_dependent_spans = !self.exact_name_dependent_span_refs([name]).is_empty();
-        if has_dependent_spans && matches!(definition, NamedDefinition::Formula { .. }) {
-            return Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(
-                "formula-name shadowing with active FormulaPlane dependents is not supported",
-            ));
-        }
         let prepared = self
             .prepare_name_dependent_span_demotion([name])
             .map_err(Self::editor_error_to_excel)?;

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -493,6 +493,11 @@ impl DependencyGraph {
                     affected.insert(*vertex_id);
                 }
             }
+            let formulas_to_rebuild = affected
+                .iter()
+                .filter(|&&vertex_id| self.get_cell_ref_for_vertex(vertex_id).is_some())
+                .filter_map(|&vertex_id| self.get_formula(vertex_id).map(|ast| (vertex_id, ast)))
+                .collect::<Vec<_>>();
             for vertex_id in affected {
                 self.mark_vertex_dirty(vertex_id);
                 if let Some(names) = self.vertex_to_names.get_mut(&vertex_id) {
@@ -503,6 +508,13 @@ impl DependencyGraph {
                 }
             }
             self.mark_named_vertex_deleted(&named_range);
+            // Re-extract cell-formula dependencies after the registry entry is gone. This
+            // preserves fallback-to-workbook resolution for a deleted sheet name and records
+            // an unresolved pending-name link otherwise, allowing a later define to heal the
+            // formula without requiring re-ingest.
+            for (vertex_id, ast) in formulas_to_rebuild {
+                self.rebuild_formula_dependencies(vertex_id, &ast);
+            }
             self.bump_symbol_revision();
             Ok(())
         } else {

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
@@ -328,6 +328,42 @@ fn sheet_scoped_define_after_ingest_invalidates_workbook_resolved_spans() {
     assert_column_parity("edit inside shadowed region", SHEET, 3, &auth, &off);
 }
 
+#[test]
+fn formula_name_define_demotes_active_dependent_span_and_succeeds() {
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    let report = ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(ROWS));
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+
+    engine
+        .set_cell_value(SHEET, 2, 4, LiteralValue::Number(50.0))
+        .unwrap();
+    let sheet_id = engine.graph.sheet_id_mut(SHEET);
+    engine
+        .define_name(
+            "Data",
+            NamedDefinition::Formula {
+                ast: parse("=D2").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            NameScope::Sheet(sheet_id),
+        )
+        .expect("define_name must demote FormulaPlane dependents like update_name");
+
+    assert_eq!(
+        engine.baseline_stats().formula_plane_active_span_count,
+        0,
+        "formula-backed shadowing define must demote the dependent span"
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value(SHEET, FIRST_ROW, 3),
+        Some(LiteralValue::Number(70.0))
+    );
+}
+
 /// (e) delete_name: cells fall back to legacy and evaluate to #NAME? exactly
 /// like the Off-mode ground truth.
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/named_ranges.rs
@@ -1,7 +1,7 @@
 use crate::engine::graph::DependencyGraph;
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::vertex::VertexKind;
-use crate::engine::{Engine, EvalConfig};
+use crate::engine::{Engine, EvalConfig, FormulaPlaneMode};
 use crate::reference::{CellRef, Coord, RangeRef};
 use crate::test_workbook::TestWorkbook;
 use formualizer_common::{ExcelErrorKind, LiteralValue};
@@ -59,6 +59,59 @@ fn workbook_named_literal_invalidation_updates_dependents() {
     match av.get_cell(0, 0) {
         LiteralValue::Number(n) => assert!((n - 3.0).abs() < 1e-9),
         other => panic!("expected Number(3.0) from Arrow overlay, got {other:?}"),
+    }
+}
+
+#[test]
+fn delete_then_redefine_name_heals_all_direct_readers_in_both_modes() {
+    for mode in [
+        FormulaPlaneMode::Off,
+        FormulaPlaneMode::AuthoritativeExperimental,
+    ] {
+        let mut engine = Engine::new(
+            TestWorkbook::new(),
+            EvalConfig::default().with_formula_plane_mode(mode),
+        );
+        engine
+            .define_name(
+                "X",
+                NamedDefinition::Literal(LiteralValue::Number(1.0)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        for col in 1..=3 {
+            engine
+                .set_cell_formula("Sheet1", 1, col, parse("=X").unwrap())
+                .unwrap();
+        }
+
+        engine.evaluate_all().unwrap();
+        engine.delete_name("X", NameScope::Workbook).unwrap();
+        engine.evaluate_all().unwrap();
+        for col in 1..=3 {
+            match engine.get_cell_value("Sheet1", 1, col) {
+                Some(LiteralValue::Error(error)) => {
+                    assert_eq!(error.kind, ExcelErrorKind::Name, "mode={mode:?}, col={col}")
+                }
+                other => panic!("mode={mode:?}, col={col}: expected #NAME?, got {other:?}"),
+            }
+        }
+
+        engine
+            .define_name(
+                "X",
+                NamedDefinition::Literal(LiteralValue::Number(2.0)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        for col in 1..=3 {
+            assert_eq!(
+                engine.get_cell_value("Sheet1", 1, col),
+                Some(LiteralValue::Number(2.0)),
+                "mode={mode:?}, col={col}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Fix A: delete/redefine healing (issue #365, wider than filed)

After delete_name followed by re-definition, all direct grid-formula readers of the name stayed stranded at #NAME? forever in both modes. Deletion pruned their dependency edges but re-definition never re-pended them; pending_name_links only healed unresolved-at-ingest cases.

delete_name now snapshots direct reader (vertex, AST) pairs before teardown and rebuilds their dependencies after the registry entry and symbol vertex are gone. Unresolved references land in the standard pending_name_links path, so a later define_name heals readers without re-ingest. Bonus: this also cleans up the dangling reader-to-dead-name-vertex edge the old code left behind.

Known limitation (pre-existing, follow-up material): indirect readers via another formula-backed name still do not heal; documented in review.

## Fix B: define/update alignment

define_name on a name with dependent plane spans hard-errored NImpl for formula definitions while update_name demoted-and-succeeded. The guard is removed; define_name now runs the same prepare/commit demotion sequence as update_name.

## Tests

Regression coverage for both fixes in named_ranges.rs and formula_plane_named_ranges.rs, both modes. Validation: named_ranges 100 passed, formula_plane_named_ranges 16 passed; clippy -D warnings; fmt --check.