### PR TITLE
feat(eval): write plane derived formats to the Arrow computed-overlay lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ Formualizer combines broad Excel-compatible formula support with Arrow-backed st
 - **SaaS products** embedding spreadsheet logic — pricing calculators, planning tools, configurators — without shipping a full spreadsheet UI.
 - **Data engineers** extracting business logic trapped in spreadsheets into reproducible, testable pipelines.
 
+## Building an AI agent? Use agent-spreadsheet
+
+Formualizer is the **engine**. If you want an agent to *work with* workbooks — read, profile, edit, recalculate, diff, and verify them safely — use **[agent-spreadsheet](https://github.com/PSU3D0/agent-spreadsheet)**, the official agent tooling layer built on this engine:
+
+```
+your agent / app
+      │
+agent-spreadsheet     CLI (`agent-spreadsheet` / `asp`) · MCP server · JS SDK
+      │
+  formualizer         parsing · dependency graph · 400+ functions · recalc
+```
+
+- **CLI** — stateless one-shot reads, safe edits, recalc, and verifiable diffs for shell-native agents and CI (`npm i -g agent-spreadsheet` or `cargo install agent-spreadsheet`)
+- **MCP server** — stateful multi-turn sessions with workbook forks, checkpoints, staged edits, and native recalculation (no LibreOffice fallback)
+- **JS SDK** — typed API for app integrations, backed by the MCP server or an embedded in-process WASM engine
+
+Unlike screenshot-driven UI automation or MCP servers that can't compute a formula, agent-spreadsheet evaluates the actual workbook with this engine — every edit is recalculated, traceable, and diffable.
+
 ## Quick start
 
 ### Rust

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -2018,7 +2018,7 @@ impl Overlay {
     }
 
     #[inline]
-    fn has_formats(&self) -> bool {
+    pub(crate) fn has_formats(&self) -> bool {
         !self.format_points.is_empty()
     }
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -662,6 +662,7 @@ pub(crate) enum ComputedWrite {
         row0: u32,
         col0: u32,
         value: OverlayValue,
+        format_id: Option<crate::format::FormatId>,
     },
     Rect {
         seq: u64,
@@ -669,6 +670,7 @@ pub(crate) enum ComputedWrite {
         sr0: u32,
         sc0: u32,
         values: Vec<Vec<OverlayValue>>,
+        formats: Vec<Vec<Option<crate::format::FormatId>>>,
     },
 }
 
@@ -718,6 +720,17 @@ impl ComputedWriteBuffer {
         col0: u32,
         value: OverlayValue,
     ) {
+        self.push_cell_with_format(sheet_id, row0, col0, value, None);
+    }
+
+    pub(crate) fn push_cell_with_format(
+        &mut self,
+        sheet_id: SheetId,
+        row0: u32,
+        col0: u32,
+        value: OverlayValue,
+        format_id: Option<crate::format::FormatId>,
+    ) {
         let seq = self.next_sequence();
         self.estimated_bytes = self
             .estimated_bytes
@@ -728,6 +741,7 @@ impl ComputedWriteBuffer {
             row0,
             col0,
             value,
+            format_id,
         });
     }
 
@@ -745,12 +759,14 @@ impl ComputedWriteBuffer {
             .map(Self::estimate_value_bytes)
             .fold(0usize, usize::saturating_add);
         self.estimated_bytes = self.estimated_bytes.saturating_add(added);
+        let formats = values.iter().map(|row| vec![None; row.len()]).collect();
         self.writes.push(ComputedWrite::Rect {
             seq,
             sheet_id,
             sr0,
             sc0,
             values,
+            formats,
         });
     }
 
@@ -789,6 +805,7 @@ pub(crate) struct ComputedWriteChunkEntryPlan {
     pub(crate) row_in_chunk: usize,
     pub(crate) seq: u64,
     pub(crate) value: OverlayValue,
+    pub(crate) format_id: Option<crate::format::FormatId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16045,6 +16062,53 @@ where
             .retain(|cell, _| cell.sheet_id != sheet_id);
     }
 
+    #[cfg(test)]
+    pub(crate) fn debug_computed_overlay_format_0based(
+        &self,
+        sheet: &str,
+        row0: u32,
+        col0: u32,
+    ) -> Option<crate::format::FormatId> {
+        let sheet = self.arrow_sheets.sheet(sheet)?;
+        let (chunk_idx, row_in_chunk) = sheet.chunk_of_row(row0 as usize)?;
+        sheet
+            .columns
+            .get(col0 as usize)?
+            .chunk(chunk_idx)?
+            .computed_overlay
+            .get_format(row_in_chunk)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_computed_overlay_chunk_has_formats_0based(
+        &self,
+        sheet: &str,
+        row0: u32,
+        col0: u32,
+    ) -> bool {
+        let Some(sheet) = self.arrow_sheets.sheet(sheet) else {
+            return false;
+        };
+        let Some((chunk_idx, _)) = sheet.chunk_of_row(row0 as usize) else {
+            return false;
+        };
+        sheet
+            .columns
+            .get(col0 as usize)
+            .and_then(|column| column.chunk(chunk_idx))
+            .is_some_and(|chunk| chunk.computed_overlay.has_formats())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_clear_derived_format_0based(&mut self, sheet: &str, row0: u32, col0: u32) {
+        if let Some(sheet_id) = self.graph.sheet_id(sheet) {
+            self.derived_formats
+                .write()
+                .unwrap()
+                .remove(&CellRef::new_absolute(sheet_id, row0, col0));
+        }
+    }
+
     fn write_computed_overlay_format_0based(
         &mut self,
         sheet: &str,
@@ -16156,6 +16220,7 @@ where
                     row0,
                     col0,
                     value,
+                    format_id,
                 } => {
                     input_cells = input_cells.saturating_add(1);
                     self.push_computed_write_plan_entry(
@@ -16165,6 +16230,7 @@ where
                         row0,
                         col0,
                         value,
+                        format_id,
                     );
                 }
                 ComputedWrite::Rect {
@@ -16173,9 +16239,12 @@ where
                     sr0,
                     sc0,
                     values,
+                    formats,
                 } => {
-                    for (r_off, row) in values.into_iter().enumerate() {
-                        for (c_off, value) in row.into_iter().enumerate() {
+                    for (r_off, (row, format_row)) in values.into_iter().zip(formats).enumerate() {
+                        for (c_off, (value, format_id)) in
+                            row.into_iter().zip(format_row).enumerate()
+                        {
                             input_cells = input_cells.saturating_add(1);
                             self.push_computed_write_plan_entry(
                                 &mut groups,
@@ -16184,6 +16253,7 @@ where
                                 sr0.saturating_add(r_off as u32),
                                 sc0.saturating_add(c_off as u32),
                                 value,
+                                format_id,
                             );
                         }
                     }
@@ -16220,6 +16290,7 @@ where
         row0: u32,
         col0: u32,
         value: OverlayValue,
+        format_id: Option<crate::format::FormatId>,
     ) {
         let (chunk_idx, chunk_start_row0, row_in_chunk) =
             self.locate_computed_write_chunk(sheet_id, row0);
@@ -16236,6 +16307,7 @@ where
                 row_in_chunk,
                 seq,
                 value,
+                format_id,
             });
     }
 
@@ -16405,12 +16477,23 @@ where
 
     fn flush_computed_write_chunk_plan_as_points(&mut self, chunk: ComputedWriteChunkPlan) {
         let sheet_name = self.graph.sheet_name(chunk.sheet_id).to_string();
+        let formats: Vec<_> = chunk
+            .entries
+            .iter()
+            .map(|entry| (entry.row_in_chunk, entry.format_id))
+            .collect();
         for entry in chunk.entries {
             let row0 = chunk
                 .chunk_start_row0
                 .saturating_add(entry.row_in_chunk as u32);
             self.write_computed_overlay_value_0based(&sheet_name, row0, chunk.col0, entry.value);
         }
+        self.write_computed_overlay_formats_for_chunk(
+            chunk.sheet_id,
+            chunk.col0,
+            chunk.chunk_idx,
+            formats,
+        );
     }
 
     fn flush_computed_write_chunk_plan_as_sparse_fragment_or_points(
@@ -16422,6 +16505,11 @@ where
         let col0 = chunk.col0;
         let chunk_idx = chunk.chunk_idx;
         let chunk_start_row0 = chunk.chunk_start_row0;
+        let formats: Vec<_> = chunk
+            .entries
+            .iter()
+            .map(|entry| (entry.row_in_chunk, entry.format_id))
+            .collect();
         let items: Vec<(usize, OverlayValue)> = chunk
             .entries
             .into_iter()
@@ -16444,6 +16532,7 @@ where
             }
             None => {}
         }
+        self.write_computed_overlay_formats_for_chunk(sheet_id, col0, chunk_idx, formats);
     }
 
     #[inline]
@@ -16474,6 +16563,11 @@ where
             return;
         }
         let start = chunk.entries[0].row_in_chunk;
+        let formats: Vec<_> = chunk
+            .entries
+            .iter()
+            .map(|entry| (entry.row_in_chunk, entry.format_id))
+            .collect();
         let values: Vec<OverlayValue> =
             chunk.entries.into_iter().map(|entry| entry.value).collect();
         if let Some(fragment) = OverlayFragment::dense_range(start, values) {
@@ -16484,6 +16578,12 @@ where
                 fragment,
             );
         }
+        self.write_computed_overlay_formats_for_chunk(
+            chunk.sheet_id,
+            chunk.col0,
+            chunk.chunk_idx,
+            formats,
+        );
     }
 
     fn flush_computed_write_chunk_plan_as_run_fragment(&mut self, chunk: ComputedWriteChunkPlan) {
@@ -16491,6 +16591,11 @@ where
             return;
         }
         let start = chunk.entries[0].row_in_chunk;
+        let formats: Vec<_> = chunk
+            .entries
+            .iter()
+            .map(|entry| (entry.row_in_chunk, entry.format_id))
+            .collect();
         let values: Vec<OverlayValue> =
             chunk.entries.into_iter().map(|entry| entry.value).collect();
         if let Some(fragment) = OverlayFragment::run_range(start, values) {
@@ -16500,6 +16605,43 @@ where
                 chunk.chunk_idx,
                 fragment,
             );
+        }
+        self.write_computed_overlay_formats_for_chunk(
+            chunk.sheet_id,
+            chunk.col0,
+            chunk.chunk_idx,
+            formats,
+        );
+    }
+
+    fn write_computed_overlay_formats_for_chunk(
+        &mut self,
+        sheet_id: SheetId,
+        col0: u32,
+        chunk_idx: usize,
+        formats: Vec<(usize, Option<crate::format::FormatId>)>,
+    ) {
+        if !(self.config.arrow_storage_enabled
+            && self.config.delta_overlay_enabled
+            && self.config.write_formula_overlay_enabled)
+            || self.computed_overlay_mirroring_disabled
+        {
+            return;
+        }
+
+        let sheet_name = self.graph.sheet_name(sheet_id);
+        let Some(sheet) = self.arrow_sheets.sheet_mut(sheet_name) else {
+            return;
+        };
+        let Some(chunk) = sheet
+            .columns
+            .get_mut(col0 as usize)
+            .and_then(|column| column.chunk_mut(chunk_idx))
+        else {
+            return;
+        };
+        for (row_in_chunk, format_id) in formats {
+            chunk.computed_overlay.set_format(row_in_chunk, format_id);
         }
     }
 
@@ -16657,7 +16799,14 @@ where
         let date_system = self.arrow_sheet_date_system(&sheet_name);
         let ov = Self::literal_to_overlay_value(value, date_system);
         if let Some(buffer) = computed_writes {
-            buffer.push_cell(cell.sheet_id, cell.coord.row(), cell.coord.col(), ov);
+            let format_id = self.derived_formats.read().unwrap().get(&cell).copied();
+            buffer.push_cell_with_format(
+                cell.sheet_id,
+                cell.coord.row(),
+                cell.coord.col(),
+                ov,
+                format_id,
+            );
             if self.should_flush_computed_write_buffer(buffer) {
                 self.flush_computed_write_buffer(buffer)?;
             }

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -18601,7 +18601,9 @@ where
             } => {
                 let _source_cache = self.source_cache_session();
                 self.begin_evaluation_request();
-                if self.graph.formula_authority().active_span_count() > 0 {
+                if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+                    && self.graph.formula_authority().active_span_count() > 0
+                {
                     return self.evaluate_authoritative_formula_plane_all();
                 }
                 if *has_dynamic_refs {
@@ -21338,7 +21340,9 @@ where
         if self.config.defer_graph_building {
             self.build_graph_all()?;
         }
-        if self.graph.formula_authority().active_span_count() > 0 {
+        if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+            && self.graph.formula_authority().active_span_count() > 0
+        {
             return self.evaluate_authoritative_formula_plane(None, Some(delta));
         }
         self.reset_virtual_dep_telemetry_if_disabled();
@@ -22099,7 +22103,9 @@ where
         if self.config.defer_graph_building {
             self.build_graph_all()?;
         }
-        if self.graph.formula_authority().active_span_count() > 0 {
+        if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+            && self.graph.formula_authority().active_span_count() > 0
+        {
             if cancel_flag.load(Ordering::Relaxed) {
                 return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
                     "Evaluation cancelled before FormulaPlane scheduling".to_string(),
@@ -26655,7 +26661,9 @@ where
         if self.config.defer_graph_building {
             self.build_graph_all()?;
         }
-        if self.graph.formula_authority().active_span_count() > 0 {
+        if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+            && self.graph.formula_authority().active_span_count() > 0
+        {
             return self.evaluate_authoritative_formula_plane_all();
         }
         self.reset_virtual_dep_telemetry_if_disabled();

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4231,12 +4231,6 @@ where
         // registry changes so their cells re-ingest and re-resolve through
         // the normal legacy path.
         self.graph.validate_define_name(name, scope)?;
-        let has_dependent_spans = !self.exact_name_dependent_span_refs([name]).is_empty();
-        if has_dependent_spans && matches!(definition, NamedDefinition::Formula { .. }) {
-            return Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(
-                "formula-name shadowing with active FormulaPlane dependents is not supported",
-            ));
-        }
         let prepared = self
             .prepare_name_dependent_span_demotion([name])
             .map_err(Self::editor_error_to_excel)?;

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -493,6 +493,11 @@ impl DependencyGraph {
                     affected.insert(*vertex_id);
                 }
             }
+            let formulas_to_rebuild = affected
+                .iter()
+                .filter(|&&vertex_id| self.get_cell_ref_for_vertex(vertex_id).is_some())
+                .filter_map(|&vertex_id| self.get_formula(vertex_id).map(|ast| (vertex_id, ast)))
+                .collect::<Vec<_>>();
             for vertex_id in affected {
                 self.mark_vertex_dirty(vertex_id);
                 if let Some(names) = self.vertex_to_names.get_mut(&vertex_id) {
@@ -503,6 +508,13 @@ impl DependencyGraph {
                 }
             }
             self.mark_named_vertex_deleted(&named_range);
+            // Re-extract cell-formula dependencies after the registry entry is gone. This
+            // preserves fallback-to-workbook resolution for a deleted sheet name and records
+            // an unresolved pending-name link otherwise, allowing a later define to heal the
+            // formula without requiring re-ingest.
+            for (vertex_id, ast) in formulas_to_rebuild {
+                self.rebuild_formula_dependencies(vertex_id, &ast);
+            }
             self.bump_symbol_revision();
             Ok(())
         } else {

--- a/crates/formualizer-eval/src/engine/tests/active_span_gate_audit.rs
+++ b/crates/formualizer-eval/src/engine/tests/active_span_gate_audit.rs
@@ -1,16 +1,44 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::engine::graph::editor::change_log::ChangeEvent;
 use crate::engine::{
-    ChangeLog, Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+    CancelToken, ChangeLog, Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord,
+    FormulaPlaneMode,
 };
+use crate::function::Function;
 use crate::test_workbook::TestWorkbook;
-use formualizer_common::LiteralValue;
+use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
+use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
 
 const TARGET_ROW: u32 = 100;
 const TARGET_COL: u32 = 2;
 const EDITED_INPUT: f64 = 500.0;
 const EXPECTED_TARGET: f64 = EDITED_INPUT * 2.0;
+
+#[derive(Debug)]
+struct MidEvaluationCanceller {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Function for MidEvaluationCanceller {
+    fn name(&self) -> &'static str {
+        "MID_EVALUATION_CANCELLER"
+    }
+
+    fn eval<'a, 'b, 'c>(
+        &self,
+        _args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Result<CalcValue<'b>, ExcelError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        ctx.cancellation_token()
+            .expect("cancellable evaluation must expose its token")
+            .cancel();
+        Ok(CalcValue::Scalar(LiteralValue::Int(1)))
+    }
+}
 
 fn formula_record(
     engine: &mut Engine<TestWorkbook>,
@@ -23,10 +51,10 @@ fn formula_record(
     FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
 }
 
-pub(super) fn build_engine_with_active_spans() -> Engine<TestWorkbook> {
+fn build_engine_with_active_spans_in(workbook: TestWorkbook) -> Engine<TestWorkbook> {
     let cfg =
         EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
-    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+    let mut engine = Engine::new(workbook, cfg);
     let mut formulas = Vec::new();
     for row in 1..=200 {
         engine
@@ -47,6 +75,15 @@ pub(super) fn build_engine_with_active_spans() -> Engine<TestWorkbook> {
         .set_cell_value("Sheet1", TARGET_ROW, 1, LiteralValue::Number(EDITED_INPUT))
         .unwrap();
     engine
+}
+
+pub(super) fn build_engine_with_active_spans() -> Engine<TestWorkbook> {
+    build_engine_with_active_spans_in(TestWorkbook::default())
+}
+
+fn switch_to_off_with_spans(engine: &mut Engine<TestWorkbook>) {
+    assert_active_spans(engine);
+    engine.config.formula_plane_mode = FormulaPlaneMode::Off;
 }
 
 fn assert_active_spans(engine: &Engine<TestWorkbook>) {
@@ -71,36 +108,141 @@ fn evaluate_all_flushes_active_spans() {
 }
 
 #[test]
-fn evaluate_all_with_delta_flushes_active_spans() {
+fn authoritative_evaluate_all_with_delta_keeps_coordinator_delta_behavior() {
     let mut engine = build_engine_with_active_spans();
     assert_active_spans(&engine);
 
-    engine.evaluate_all_with_delta().unwrap();
+    let (_, delta) = engine.evaluate_all_with_delta().unwrap();
 
+    assert!(delta.changed_cells.iter().any(|cell| {
+        let (_, row, col) = cell.to_excel_1based();
+        (row, col) == (TARGET_ROW, TARGET_COL)
+    }));
     assert_target_fresh(&engine);
 }
 
 #[test]
-fn evaluate_all_cancellable_flushes_active_spans() {
+fn off_evaluate_all_with_delta_uses_legacy_collector_with_retained_spans() {
     let mut engine = build_engine_with_active_spans();
-    assert_active_spans(&engine);
-
     engine
-        .evaluate_all_cancellable(crate::engine::CancelToken::new())
+        .set_cell_formula("Sheet1", 1, 3, parse("=A100+1").unwrap())
         .unwrap();
+    switch_to_off_with_spans(&mut engine);
 
-    assert_target_fresh(&engine);
+    let (_, delta) = engine.evaluate_all_with_delta().unwrap();
+
+    assert!(!delta.changed_cells.is_empty());
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(EDITED_INPUT + 1.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
+}
+
+fn cancellation_engine() -> (Engine<TestWorkbook>, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let workbook = TestWorkbook::default().with_function(Arc::new(MidEvaluationCanceller {
+        calls: Arc::clone(&calls),
+    }));
+    let mut engine = build_engine_with_active_spans_in(workbook);
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            3,
+            parse("=MID_EVALUATION_CANCELLER()").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 4, parse("=C1+1").unwrap())
+        .unwrap();
+    (engine, calls)
 }
 
 #[test]
-fn evaluate_all_logged_flushes_active_spans() {
+fn authoritative_evaluate_all_cancellable_keeps_late_cancellation_behavior() {
+    let (mut engine, calls) = cancellation_engine();
+    let token = CancelToken::new();
+    assert_active_spans(&engine);
+
+    let error = engine.evaluate_all_cancellable(token.clone()).unwrap_err();
+
+    assert_eq!(error.kind, ExcelErrorKind::Cancelled);
+    assert_eq!(
+        error.message.as_deref(),
+        Some("Evaluation cancelled during legacy island")
+    );
+    assert!(token.is_cancelled());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
+}
+
+#[test]
+fn off_evaluate_all_cancellable_observes_mid_evaluation_cancel_with_retained_spans() {
+    let (mut engine, calls) = cancellation_engine();
+    switch_to_off_with_spans(&mut engine);
+    let token = CancelToken::new();
+
+    let error = engine.evaluate_all_cancellable(token).unwrap_err();
+
+    assert_eq!(error.kind, ExcelErrorKind::Cancelled);
+    assert_eq!(
+        error.message.as_deref(),
+        Some("Evaluation cancelled between layers")
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn authoritative_evaluate_all_logged_keeps_coordinator_logging_behavior() {
     let mut engine = build_engine_with_active_spans();
     let mut log = ChangeLog::new();
     assert_active_spans(&engine);
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=SEQUENCE(2,1)").unwrap())
+        .unwrap();
 
     engine.evaluate_all_logged(&mut log).unwrap();
 
+    assert!(log.events().is_empty());
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 3),
+        Some(LiteralValue::Number(2.0))
+    );
     assert_target_fresh(&engine);
+}
+
+#[test]
+fn off_evaluate_all_logged_writes_legacy_changelog_with_retained_spans() {
+    let mut engine = build_engine_with_active_spans();
+    let mut log = ChangeLog::new();
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=SEQUENCE(2,1)").unwrap())
+        .unwrap();
+    switch_to_off_with_spans(&mut engine);
+
+    engine.evaluate_all_logged(&mut log).unwrap();
+
+    assert!(
+        log.events()
+            .iter()
+            .any(|event| matches!(event, ChangeEvent::SpillCommitted { .. }))
+    );
+    assert!(
+        log.events()
+            .iter()
+            .any(|event| matches!(event, ChangeEvent::CompoundStart { .. }))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
 }
 
 #[test]
@@ -183,7 +325,7 @@ fn evaluate_until_cancellable_flushes_active_spans() {
 }
 
 #[test]
-fn evaluate_recalc_plan_flushes_active_spans() {
+fn authoritative_evaluate_recalc_plan_keeps_coordinator_behavior() {
     let mut engine = build_engine_with_active_spans();
     let plan = engine.build_recalc_plan().unwrap();
     assert_active_spans(&engine);
@@ -191,6 +333,21 @@ fn evaluate_recalc_plan_flushes_active_spans() {
     engine.evaluate_recalc_plan(&plan).unwrap();
 
     assert_target_fresh(&engine);
+}
+
+#[test]
+fn off_evaluate_recalc_plan_honors_legacy_plan_with_retained_spans() {
+    let mut engine = build_engine_with_active_spans();
+    switch_to_off_with_spans(&mut engine);
+    let plan = engine.build_recalc_plan().unwrap();
+
+    let result = engine.evaluate_recalc_plan(&plan).unwrap();
+
+    assert_eq!(result.computed_vertices, 0);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_format_broadcast.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_format_broadcast.rs
@@ -7,6 +7,7 @@ use formualizer_parse::parser::parse;
 use crate::engine::{
     Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
 };
+use crate::format::FormatId;
 use crate::test_workbook::TestWorkbook;
 
 const SHEET: &str = "Sheet1";
@@ -45,6 +46,20 @@ fn results(engine: &Engine<TestWorkbook>, col: u32) -> Vec<LiteralValue> {
                 .unwrap_or_else(|| panic!("missing {SHEET}!R{row}C{col}"))
         })
         .collect()
+}
+
+fn assert_computed_overlay_formats(
+    engine: &Engine<TestWorkbook>,
+    col: u32,
+    expected: impl Fn(u32) -> Option<FormatId>,
+) {
+    for row in 1..=ROWS {
+        assert_eq!(
+            engine.debug_computed_overlay_format_0based(SHEET, row - 1, col - 1),
+            expected(row),
+            "overlay format at {SHEET}!R{row}C{col}"
+        );
+    }
 }
 
 fn constant_result_fixture(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
@@ -96,6 +111,7 @@ fn formula_plane_constant_result_broadcast_preserves_date_format_parity() {
     let authoritative_results = results(&authoritative, 7);
     assert_eq!(authoritative_results, off_results);
     assert!(off_results.iter().all(|value| value == &expected));
+    assert_computed_overlay_formats(&authoritative, 7, |_| Some(FormatId::DATE));
     assert_eq!(
         authoritative
             .last_formula_plane_span_eval_report()
@@ -115,6 +131,7 @@ fn formula_plane_memo_broadcast_preserves_equal_date_format_parity() {
     let authoritative_results = results(&authoritative, 2);
     assert_eq!(authoritative_results, off_results);
     assert!(off_results.iter().all(|value| value == &expected));
+    assert_computed_overlay_formats(&authoritative, 2, |_| Some(FormatId::DATE));
     let report = authoritative.last_formula_plane_span_eval_report().unwrap();
     assert_eq!(report.memo_eval_count, 1, "{report:?}");
     assert_eq!(report.memo_broadcast_count, (ROWS - 1) as u64, "{report:?}");
@@ -136,7 +153,28 @@ fn formula_plane_memo_broadcast_preserves_mixed_format_parity() {
         };
         assert_eq!(*value, expected, "row {}", index + 1);
     }
+    assert_computed_overlay_formats(&authoritative, 2, |row| {
+        (row % 2 == 1).then_some(FormatId::DATE)
+    });
     let report = authoritative.last_formula_plane_span_eval_report().unwrap();
     assert_eq!(report.memo_eval_count, 2, "{report:?}");
     assert_eq!(report.memo_broadcast_count, (ROWS - 2) as u64, "{report:?}");
+}
+
+#[test]
+fn formula_plane_date_output_resolves_from_overlay_lane_without_side_band() {
+    let mut engine = constant_result_fixture(FormulaPlaneMode::AuthoritativeExperimental);
+    assert!(engine.debug_computed_overlay_chunk_has_formats_0based(SHEET, 0, 6));
+    assert_eq!(
+        engine.debug_computed_overlay_format_0based(SHEET, 0, 6),
+        Some(FormatId::DATE)
+    );
+
+    engine.debug_clear_derived_format_0based(SHEET, 0, 6);
+    assert_eq!(
+        engine.get_cell_value(SHEET, 1, 7),
+        Some(LiteralValue::Date(
+            NaiveDate::from_ymd_opt(2024, 12, 1).unwrap()
+        ))
+    );
 }

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
@@ -328,6 +328,42 @@ fn sheet_scoped_define_after_ingest_invalidates_workbook_resolved_spans() {
     assert_column_parity("edit inside shadowed region", SHEET, 3, &auth, &off);
 }
 
+#[test]
+fn formula_name_define_demotes_active_dependent_span_and_succeeds() {
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    let report = ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(ROWS));
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+
+    engine
+        .set_cell_value(SHEET, 2, 4, LiteralValue::Number(50.0))
+        .unwrap();
+    let sheet_id = engine.graph.sheet_id_mut(SHEET);
+    engine
+        .define_name(
+            "Data",
+            NamedDefinition::Formula {
+                ast: parse("=D2").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            NameScope::Sheet(sheet_id),
+        )
+        .expect("define_name must demote FormulaPlane dependents like update_name");
+
+    assert_eq!(
+        engine.baseline_stats().formula_plane_active_span_count,
+        0,
+        "formula-backed shadowing define must demote the dependent span"
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value(SHEET, FIRST_ROW, 3),
+        Some(LiteralValue::Number(70.0))
+    );
+}
+
 /// (e) delete_name: cells fall back to legacy and evaluate to #NAME? exactly
 /// like the Off-mode ground truth.
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/named_ranges.rs
@@ -1,7 +1,7 @@
 use crate::engine::graph::DependencyGraph;
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::vertex::VertexKind;
-use crate::engine::{Engine, EvalConfig};
+use crate::engine::{Engine, EvalConfig, FormulaPlaneMode};
 use crate::reference::{CellRef, Coord, RangeRef};
 use crate::test_workbook::TestWorkbook;
 use formualizer_common::{ExcelErrorKind, LiteralValue};
@@ -59,6 +59,59 @@ fn workbook_named_literal_invalidation_updates_dependents() {
     match av.get_cell(0, 0) {
         LiteralValue::Number(n) => assert!((n - 3.0).abs() < 1e-9),
         other => panic!("expected Number(3.0) from Arrow overlay, got {other:?}"),
+    }
+}
+
+#[test]
+fn delete_then_redefine_name_heals_all_direct_readers_in_both_modes() {
+    for mode in [
+        FormulaPlaneMode::Off,
+        FormulaPlaneMode::AuthoritativeExperimental,
+    ] {
+        let mut engine = Engine::new(
+            TestWorkbook::new(),
+            EvalConfig::default().with_formula_plane_mode(mode),
+        );
+        engine
+            .define_name(
+                "X",
+                NamedDefinition::Literal(LiteralValue::Number(1.0)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        for col in 1..=3 {
+            engine
+                .set_cell_formula("Sheet1", 1, col, parse("=X").unwrap())
+                .unwrap();
+        }
+
+        engine.evaluate_all().unwrap();
+        engine.delete_name("X", NameScope::Workbook).unwrap();
+        engine.evaluate_all().unwrap();
+        for col in 1..=3 {
+            match engine.get_cell_value("Sheet1", 1, col) {
+                Some(LiteralValue::Error(error)) => {
+                    assert_eq!(error.kind, ExcelErrorKind::Name, "mode={mode:?}, col={col}")
+                }
+                other => panic!("mode={mode:?}, col={col}: expected #NAME?, got {other:?}"),
+            }
+        }
+
+        engine
+            .define_name(
+                "X",
+                NamedDefinition::Literal(LiteralValue::Number(2.0)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        for col in 1..=3 {
+            assert_eq!(
+                engine.get_cell_value("Sheet1", 1, col),
+                Some(LiteralValue::Number(2.0)),
+                "mode={mode:?}, col={col}"
+            );
+        }
     }
 }
 

--- a/crates/formualizer-eval/src/formula_plane/span_eval.rs
+++ b/crates/formualizer-eval/src/formula_plane/span_eval.rs
@@ -80,9 +80,19 @@ impl<'a> SpanComputedWriteSink<'a> {
         }
     }
 
-    pub(crate) fn push_cell(&mut self, placement: PlacementCoord, value: OverlayValue) {
-        self.buffer
-            .push_cell(placement.sheet_id, placement.row, placement.col, value);
+    pub(crate) fn push_cell(
+        &mut self,
+        placement: PlacementCoord,
+        value: OverlayValue,
+        format_id: Option<FormatId>,
+    ) {
+        self.buffer.push_cell_with_format(
+            placement.sheet_id,
+            placement.row,
+            placement.col,
+            value,
+            format_id,
+        );
         self.push_count = self.push_count.saturating_add(1);
     }
 
@@ -321,7 +331,7 @@ impl<'a> SpanEvaluator<'a> {
                     placement.col + 1,
                     format_id,
                 );
-                sink.push_cell(placement, value.clone());
+                sink.push_cell(placement, value.clone(), format_id);
                 report.span_eval_placement_count =
                     report.span_eval_placement_count.saturating_add(1);
             }
@@ -420,7 +430,7 @@ impl<'a> SpanEvaluator<'a> {
         origin_col: u32,
         binding_set: Option<&SpanBindingSet>,
         placement: PlacementCoord,
-    ) -> Result<OverlayValue, SpanEvalError> {
+    ) -> Result<MemoGroupValue, SpanEvalError> {
         let row_delta = i64::from(placement.row) + 1 - i64::from(origin_row);
         let col_delta = i64::from(placement.col) + 1 - i64::from(origin_col);
         let interpreter = Interpreter::new(self.context, self.current_sheet).with_current_cell(
@@ -442,15 +452,25 @@ impl<'a> SpanEvaluator<'a> {
                 self.sheet_registry,
             ) {
                 Ok(calc) => {
+                    let format_id = calc.format_id();
                     self.context.record_cell_derived_format(
                         self.current_sheet,
                         placement.row + 1,
                         placement.col + 1,
-                        calc.format_id(),
+                        format_id,
                     );
-                    formula_result_to_overlay(calc.into_literal(), self.context.date_system())
+                    MemoGroupValue {
+                        value: formula_result_to_overlay(
+                            calc.into_literal(),
+                            self.context.date_system(),
+                        ),
+                        format_id,
+                    }
                 }
-                Err(err) => OverlayValue::Error(map_error_code(err.kind)),
+                Err(err) => MemoGroupValue {
+                    value: OverlayValue::Error(map_error_code(err.kind)),
+                    format_id: None,
+                },
             }
         } else {
             match interpreter.evaluate_arena_ast_with_offset(
@@ -461,15 +481,25 @@ impl<'a> SpanEvaluator<'a> {
                 self.sheet_registry,
             ) {
                 Ok(calc) => {
+                    let format_id = calc.format_id();
                     self.context.record_cell_derived_format(
                         self.current_sheet,
                         placement.row + 1,
                         placement.col + 1,
-                        calc.format_id(),
+                        format_id,
                     );
-                    formula_result_to_overlay(calc.into_literal(), self.context.date_system())
+                    MemoGroupValue {
+                        value: formula_result_to_overlay(
+                            calc.into_literal(),
+                            self.context.date_system(),
+                        ),
+                        format_id,
+                    }
                 }
-                Err(err) => OverlayValue::Error(map_error_code(err.kind)),
+                Err(err) => MemoGroupValue {
+                    value: OverlayValue::Error(map_error_code(err.kind)),
+                    format_id: None,
+                },
             }
         };
         Ok(value)
@@ -500,7 +530,7 @@ impl<'a> SpanEvaluator<'a> {
                 binding_set,
                 placement,
             )?;
-            sink.push_cell(placement, value);
+            sink.push_cell(placement, value.value, value.format_id);
         }
         let count = writable_placements.len() as u64;
         report.transient_ast_relocation_count =
@@ -545,7 +575,7 @@ impl<'a> SpanEvaluator<'a> {
                 .collect::<Result<Vec<_>, _>>()
         })?;
         for (placement, value) in values {
-            sink.push_cell(placement, value);
+            sink.push_cell(placement, value.value, value.format_id);
         }
         let count = writable_placements.len() as u64;
         report.transient_ast_relocation_count =
@@ -773,7 +803,7 @@ impl<'a> SpanEvaluator<'a> {
                 placement.col + 1,
                 value.format_id,
             );
-            sink.push_cell(*placement, value.value.clone());
+            sink.push_cell(*placement, value.value.clone(), value.format_id);
             report.span_eval_placement_count = report.span_eval_placement_count.saturating_add(1);
         }
         report.memo_broadcast_count = report


### PR DESCRIPTION
Stacked on #380 (format broadcast parity) — merge that first.

## Problem

Derived number-formats lived in two stores: the engine side-band map and the Arrow computed-overlay format lane. Legacy vertex evaluation dual-writes both, but plane flushes only recorded the side-band, so the plane structurally diverged from legacy and cutover could not rely on lane-first egress for span output.

## Fix

Option<FormatId> now threads through ComputedWriteBuffer / SpanComputedWriteSink entries and survives last-write-wins coalescing as part of the winning entry. Every flush shape (point, sparse, dense, run) applies formats in one chunk-local batched pass after value application; rect writes carry a parallel format matrix. Side-band recording is retained (intentional dual-write during transition). Unformatted results write None, clearing stale lane entries. No public API changes.

## Tests

The three broadcast oracles now also assert overlay-lane FormatIds after flush, plus a proof test that a plane-flushed date cell egresses Date with its side-band entry manually cleared (lane-first resolution).

## Validation

cargo test -p formualizer-eval --lib: 2787 passed. computed_flush 24 passed. clippy -D warnings; fmt --check.