### PR TITLE
feat(formula-plane): admit cell/scalar-arm IF/IFS/CHOOSE as spans (reject-then-revoke)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Formualizer will be documented in this file.
 
 ### Changed
 
+- FormulaPlane now admits `IF`, `IFS`, and `CHOOSE` spans when every result arm is a single cell or a statically scalar expression. Range, open-range, named, volatile, and dynamic-reference arms remain on the legacy path.
 - Named-range definitions now track structural inserts and deletes like all other references; previously they stayed pinned to their original coordinates. Deleting a band containing a name target now invalidates the definition to `#REF!`. (#170)
 - Computed temporals are numeric during evaluation (`ISNUMBER`/`TYPE` now match Excel). Native scalar, range, table, Python, and SheetPort egress materializes date/time values from the cell's effective format; callers can opt into uniform raw serials. A known datetime class preserves midnight datetimes, while calamine's code-lossy date-ish signal can only classify pure fractions as time, day-plus-fraction serials as datetime, and integers as date.
 - Arrow dependencies upgraded 58.2 → 59.2 across `formualizer-eval` (`arrow`, `arrow-array`, `arrow-buffer`, `arrow-schema`, `arrow-select`, `arrow-cast`). No API or behaviour change; full suite green on the pinned surface, native and wasm32.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ Formualizer combines broad Excel-compatible formula support with Arrow-backed st
 - **SaaS products** embedding spreadsheet logic — pricing calculators, planning tools, configurators — without shipping a full spreadsheet UI.
 - **Data engineers** extracting business logic trapped in spreadsheets into reproducible, testable pipelines.
 
+## Building an AI agent? Use agent-spreadsheet
+
+Formualizer is the **engine**. If you want an agent to *work with* workbooks — read, profile, edit, recalculate, diff, and verify them safely — use **[agent-spreadsheet](https://github.com/PSU3D0/agent-spreadsheet)**, the official agent tooling layer built on this engine:
+
+```
+your agent / app
+      │
+agent-spreadsheet     CLI (`agent-spreadsheet` / `asp`) · MCP server · JS SDK
+      │
+  formualizer         parsing · dependency graph · 400+ functions · recalc
+```
+
+- **CLI** — stateless one-shot reads, safe edits, recalc, and verifiable diffs for shell-native agents and CI (`npm i -g agent-spreadsheet` or `cargo install agent-spreadsheet`)
+- **MCP server** — stateful multi-turn sessions with workbook forks, checkpoints, staged edits, and native recalculation (no LibreOffice fallback)
+- **JS SDK** — typed API for app integrations, backed by the MCP server or an embedded in-process WASM engine
+
+Unlike screenshot-driven UI automation or MCP servers that can't compute a formula, agent-spreadsheet evaluates the actual workbook with this engine — every edit is recalculated, traceable, and diffable.
+
 ## Quick start
 
 ### Rust

--- a/crates/formualizer-eval/src/engine/arena/ast.rs
+++ b/crates/formualizer-eval/src/engine/arena/ast.rs
@@ -156,6 +156,24 @@ pub(crate) struct AstNodeEntry {
 pub(crate) struct AstNodeMetadata {
     pub(crate) canonical_hash: u64,
     pub(crate) labels: CanonicalLabels,
+    pub(crate) reference_returning_admission: ReferenceReturningAdmission,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub(crate) struct ReferenceReturningAdmission(u8);
+
+impl ReferenceReturningAdmission {
+    pub(crate) const fn new(safe: bool, scalar: bool) -> Self {
+        Self((safe as u8) | ((scalar as u8) << 1))
+    }
+
+    pub(crate) const fn safe(self) -> bool {
+        self.0 & 1 != 0
+    }
+
+    pub(crate) const fn scalar(self) -> bool {
+        self.0 & 2 != 0
+    }
 }
 
 /// Compact bitset labels for arena-native canonicalization.

--- a/crates/formualizer-eval/src/engine/arena/canonical.rs
+++ b/crates/formualizer-eval/src/engine/arena/canonical.rs
@@ -25,7 +25,10 @@
 
 #![allow(dead_code)]
 
-use super::ast::{AstNodeData, AstNodeMetadata, CanonicalLabels, CompactRefType, SheetKey};
+use super::ast::{
+    AstNodeData, AstNodeMetadata, CanonicalLabels, CompactRefType, ReferenceReturningAdmission,
+    SheetKey,
+};
 use super::string_interner::StringInterner;
 use crate::traits::FunctionProvider;
 use formualizer_parse::parser::ExternalRefKind;
@@ -76,13 +79,18 @@ pub(crate) fn compute_node_metadata(
 
     let mut hasher = StableHasher::new();
     hasher.mix_bytes(b"fp8-arena-canonical:v1");
+    let mut admission = ReferenceReturningAdmission::default();
 
     match data {
         AstNodeData::Literal(value) => {
             hasher.mix_u8(KIND_LITERAL);
             hasher.mix_u32(value.as_raw());
+            admission = ReferenceReturningAdmission::new(true, true);
         }
-        AstNodeData::Omitted => hasher.mix_u8(KIND_OMITTED),
+        AstNodeData::Omitted => {
+            hasher.mix_u8(KIND_OMITTED);
+            admission = ReferenceReturningAdmission::new(true, true);
+        }
         AstNodeData::Reference {
             original_id,
             ref_type,
@@ -96,6 +104,7 @@ pub(crate) fn compute_node_metadata(
                 mix_string(&mut hasher, original);
             }
             mix_reference(&mut hasher, &mut labels, *ref_type, data_store_strings);
+            admission = reference_admission(*ref_type, labels.rejects == 0);
         }
         AstNodeData::UnaryOp { op_id, .. } => {
             hasher.mix_u8(KIND_UNARY);
@@ -106,12 +115,31 @@ pub(crate) fn compute_node_metadata(
                 "@" => labels.rejects |= CanonicalLabels::REJECT_IMPLICIT_INTERSECTION_OPERATOR,
                 _ => {}
             }
+            let child = children.first().copied().cloned().unwrap_or_default();
+            let supported = matches!(op, "+" | "-" | "%");
+            admission = ReferenceReturningAdmission::new(
+                supported && child.reference_returning_admission.safe(),
+                supported && child.reference_returning_admission.scalar(),
+            );
             mix_children(&mut hasher, children);
         }
         AstNodeData::BinaryOp { op_id, .. } => {
             hasher.mix_u8(KIND_BINARY);
             let op = data_store_strings.get(*op_id).unwrap_or("");
             mix_string(&mut hasher, op);
+            let supported = matches!(
+                op,
+                "+" | "-" | "*" | "/" | "^" | "&" | "=" | "<>" | "<" | "<=" | ">" | ">="
+            );
+            let safe = supported
+                && children
+                    .iter()
+                    .all(|child| child.reference_returning_admission.safe());
+            let scalar = supported
+                && children
+                    .iter()
+                    .all(|child| child.reference_returning_admission.scalar());
+            admission = ReferenceReturningAdmission::new(safe, scalar);
             mix_children(&mut hasher, children);
         }
         AstNodeData::Function {
@@ -123,7 +151,7 @@ pub(crate) fn compute_node_metadata(
             labels.flags |= CanonicalLabels::FLAG_CONTAINS_FUNCTION;
             let raw_name = data_store_strings.get(*name_id).unwrap_or("");
             hasher.mix_u16(*args_count);
-            classify_and_mix_function(
+            let classification = classify_and_mix_function(
                 raw_name,
                 usize::from(*args_count),
                 function_provider,
@@ -131,6 +159,32 @@ pub(crate) fn compute_node_metadata(
                 &mut hasher,
                 &mut labels,
             );
+            let all_safe = children
+                .iter()
+                .all(|child| child.reference_returning_admission.safe());
+            if matches!(
+                classification.canonical_name.as_str(),
+                "IF" | "IFS" | "CHOOSE"
+            ) {
+                let step = if classification.canonical_name == "IFS" {
+                    2
+                } else {
+                    1
+                };
+                let arms_scalar = (1..children.len())
+                    .step_by(step)
+                    .all(|index| children[index].reference_returning_admission.scalar());
+                let admitted = all_safe && arms_scalar;
+                if admitted {
+                    labels.rejects &= !(CanonicalLabels::REJECT_REFERENCE_RETURNING_FUNCTION
+                        | CanonicalLabels::REJECT_ARRAY_OR_SPILL_FUNCTION);
+                    labels.flags &= !CanonicalLabels::FLAG_CONTAINS_ARRAY;
+                }
+                admission = ReferenceReturningAdmission::new(admitted, admitted);
+            } else {
+                let safe = all_safe && classification.static_scalar;
+                admission = ReferenceReturningAdmission::new(safe, safe);
+            }
             mix_children(&mut hasher, children);
         }
         AstNodeData::Array { rows, cols, .. } => {
@@ -150,6 +204,31 @@ pub(crate) fn compute_node_metadata(
     AstNodeMetadata {
         canonical_hash: hasher.finish(),
         labels,
+        reference_returning_admission: admission,
+    }
+}
+
+fn reference_admission(reference: CompactRefType, no_rejects: bool) -> ReferenceReturningAdmission {
+    if !no_rejects {
+        return ReferenceReturningAdmission::default();
+    }
+    match reference {
+        CompactRefType::Cell { .. } => ReferenceReturningAdmission::new(true, true),
+        CompactRefType::Range {
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+            ..
+        } if start_row != 0 && start_col != 0 && end_row != u32::MAX && end_col != u32::MAX => {
+            ReferenceReturningAdmission::new(true, false)
+        }
+        CompactRefType::Range { .. }
+        | CompactRefType::External { .. }
+        | CompactRefType::NamedRange(_)
+        | CompactRefType::Table { .. }
+        | CompactRefType::Cell3D { .. }
+        | CompactRefType::Range3D { .. } => ReferenceReturningAdmission::default(),
     }
 }
 
@@ -367,6 +446,11 @@ fn finalize_anchor_flags(labels: &mut CanonicalLabels) {
     }
 }
 
+struct FunctionClassification {
+    canonical_name: String,
+    static_scalar: bool,
+}
+
 fn classify_and_mix_function(
     raw_name: &str,
     arity: usize,
@@ -374,7 +458,7 @@ fn classify_and_mix_function(
     allow_function_semantics: bool,
     hasher: &mut StableHasher,
     labels: &mut CanonicalLabels,
-) {
+) -> FunctionClassification {
     use crate::function::FnCaps;
     use crate::function_contract::{
         FunctionContextDependence, FunctionDependencySemantics, FunctionEnvironmentSemantics,
@@ -387,8 +471,12 @@ fn classify_and_mix_function(
         mix_string(hasher, &raw_name.trim().to_ascii_uppercase());
         hasher.mix_u64(0);
         labels.rejects |= CanonicalLabels::REJECT_UNKNOWN_OR_CUSTOM_FUNCTION;
-        return;
+        return FunctionClassification {
+            canonical_name: raw_name.trim().to_ascii_uppercase(),
+            static_scalar: false,
+        };
     };
+    let canonical_name = identity.canonical_name.clone();
     let encoded = identity.encode();
     hasher.mix_usize(encoded.len());
     hasher.mix_bytes(&encoded);
@@ -436,6 +524,24 @@ fn classify_and_mix_function(
     }
     if contract.context != FunctionContextDependence::None {
         labels.rejects |= CanonicalLabels::REJECT_UNKNOWN_OR_CUSTOM_FUNCTION;
+    }
+    let forbidden_caps = FnCaps::VOLATILE
+        | FnCaps::DYNAMIC_DEPENDENCY
+        | FnCaps::LOCAL_ENVIRONMENT
+        | FnCaps::RETURNS_REFERENCE
+        | FnCaps::MAY_SPILL;
+    let static_scalar = (caps & forbidden_caps).is_empty()
+        && matches!(
+            contract.dependency,
+            FunctionDependencySemantics::RecursiveSyntacticArgs
+        )
+        && contract.environment == FunctionEnvironmentSemantics::None
+        && !contract.result.may_return_reference()
+        && !contract.result.may_spill()
+        && contract.context == FunctionContextDependence::None;
+    FunctionClassification {
+        canonical_name,
+        static_scalar,
     }
 }
 

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -18601,7 +18601,9 @@ where
             } => {
                 let _source_cache = self.source_cache_session();
                 self.begin_evaluation_request();
-                if self.graph.formula_authority().active_span_count() > 0 {
+                if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+                    && self.graph.formula_authority().active_span_count() > 0
+                {
                     return self.evaluate_authoritative_formula_plane_all();
                 }
                 if *has_dynamic_refs {
@@ -21338,7 +21340,9 @@ where
         if self.config.defer_graph_building {
             self.build_graph_all()?;
         }
-        if self.graph.formula_authority().active_span_count() > 0 {
+        if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+            && self.graph.formula_authority().active_span_count() > 0
+        {
             return self.evaluate_authoritative_formula_plane(None, Some(delta));
         }
         self.reset_virtual_dep_telemetry_if_disabled();
@@ -22099,7 +22103,9 @@ where
         if self.config.defer_graph_building {
             self.build_graph_all()?;
         }
-        if self.graph.formula_authority().active_span_count() > 0 {
+        if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+            && self.graph.formula_authority().active_span_count() > 0
+        {
             if cancel_flag.load(Ordering::Relaxed) {
                 return Err(ExcelError::new(ExcelErrorKind::Cancelled).with_message(
                     "Evaluation cancelled before FormulaPlane scheduling".to_string(),
@@ -26655,7 +26661,9 @@ where
         if self.config.defer_graph_building {
             self.build_graph_all()?;
         }
-        if self.graph.formula_authority().active_span_count() > 0 {
+        if self.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental
+            && self.graph.formula_authority().active_span_count() > 0
+        {
             return self.evaluate_authoritative_formula_plane_all();
         }
         self.reset_virtual_dep_telemetry_if_disabled();

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -4231,12 +4231,6 @@ where
         // registry changes so their cells re-ingest and re-resolve through
         // the normal legacy path.
         self.graph.validate_define_name(name, scope)?;
-        let has_dependent_spans = !self.exact_name_dependent_span_refs([name]).is_empty();
-        if has_dependent_spans && matches!(definition, NamedDefinition::Formula { .. }) {
-            return Err(ExcelError::new(ExcelErrorKind::NImpl).with_message(
-                "formula-name shadowing with active FormulaPlane dependents is not supported",
-            ));
-        }
         let prepared = self
             .prepare_name_dependent_span_demotion([name])
             .map_err(Self::editor_error_to_excel)?;

--- a/crates/formualizer-eval/src/engine/graph/names.rs
+++ b/crates/formualizer-eval/src/engine/graph/names.rs
@@ -493,6 +493,11 @@ impl DependencyGraph {
                     affected.insert(*vertex_id);
                 }
             }
+            let formulas_to_rebuild = affected
+                .iter()
+                .filter(|&&vertex_id| self.get_cell_ref_for_vertex(vertex_id).is_some())
+                .filter_map(|&vertex_id| self.get_formula(vertex_id).map(|ast| (vertex_id, ast)))
+                .collect::<Vec<_>>();
             for vertex_id in affected {
                 self.mark_vertex_dirty(vertex_id);
                 if let Some(names) = self.vertex_to_names.get_mut(&vertex_id) {
@@ -503,6 +508,13 @@ impl DependencyGraph {
                 }
             }
             self.mark_named_vertex_deleted(&named_range);
+            // Re-extract cell-formula dependencies after the registry entry is gone. This
+            // preserves fallback-to-workbook resolution for a deleted sheet name and records
+            // an unresolved pending-name link otherwise, allowing a later define to heal the
+            // formula without requiring re-ingest.
+            for (vertex_id, ast) in formulas_to_rebuild {
+                self.rebuild_formula_dependencies(vertex_id, &ast);
+            }
             self.bump_symbol_revision();
             Ok(())
         } else {

--- a/crates/formualizer-eval/src/engine/ingest_pipeline.rs
+++ b/crates/formualizer-eval/src/engine/ingest_pipeline.rs
@@ -765,6 +765,121 @@ fn dedup_strings(values: &mut Vec<String>) {
     values.dedup();
 }
 
+#[derive(Clone, Copy)]
+struct ReferenceReturningProjectionShape {
+    safe: bool,
+    scalar: bool,
+}
+
+fn reference_returning_projection_shape(
+    ast: &ASTNode,
+    function_provider: Option<&dyn FunctionProvider>,
+) -> ReferenceReturningProjectionShape {
+    match &ast.node_type {
+        ASTNodeType::Literal(_) | ASTNodeType::Omitted => ReferenceReturningProjectionShape {
+            safe: true,
+            scalar: true,
+        },
+        ASTNodeType::Reference { reference, .. } => match reference {
+            ReferenceType::Cell { .. } => ReferenceReturningProjectionShape {
+                safe: true,
+                scalar: true,
+            },
+            ReferenceType::Range {
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                ..
+            } if start_row.is_some()
+                && start_col.is_some()
+                && end_row.is_some()
+                && end_col.is_some() =>
+            {
+                ReferenceReturningProjectionShape {
+                    safe: true,
+                    scalar: false,
+                }
+            }
+            _ => ReferenceReturningProjectionShape {
+                safe: false,
+                scalar: false,
+            },
+        },
+        ASTNodeType::UnaryOp { op, expr } => {
+            let child = reference_returning_projection_shape(expr, function_provider);
+            let supported = matches!(op.as_str(), "+" | "-" | "%");
+            ReferenceReturningProjectionShape {
+                safe: supported && child.safe,
+                scalar: supported && child.scalar,
+            }
+        }
+        ASTNodeType::BinaryOp { op, left, right } => {
+            let left = reference_returning_projection_shape(left, function_provider);
+            let right = reference_returning_projection_shape(right, function_provider);
+            let supported = matches!(
+                op.as_str(),
+                "+" | "-" | "*" | "/" | "^" | "&" | "=" | "<>" | "<" | "<=" | ">" | ">="
+            );
+            ReferenceReturningProjectionShape {
+                safe: supported && left.safe && right.safe,
+                scalar: supported && left.scalar && right.scalar,
+            }
+        }
+        ASTNodeType::Function { name, args } => {
+            let function =
+                crate::formula_plane::template_canonical::resolve_canonical_function_with_provider(
+                    function_provider,
+                    name,
+                    args.len(),
+                );
+            let children = args
+                .iter()
+                .map(|arg| reference_returning_projection_shape(arg, function_provider))
+                .collect::<Vec<_>>();
+            let all_safe = children.iter().all(|child| child.safe);
+            if matches!(function.canonical_name.as_str(), "IF" | "IFS" | "CHOOSE") {
+                let step = if function.canonical_name == "IFS" {
+                    2
+                } else {
+                    1
+                };
+                let admitted = all_safe
+                    && (1..children.len())
+                        .step_by(step)
+                        .all(|index| children[index].scalar);
+                ReferenceReturningProjectionShape {
+                    safe: admitted,
+                    scalar: admitted,
+                }
+            } else {
+                let caps = crate::function::FnCaps::from_bits_retain(function.semantic_flags);
+                let forbidden = crate::function::FnCaps::VOLATILE
+                    | crate::function::FnCaps::DYNAMIC_DEPENDENCY
+                    | crate::function::FnCaps::LOCAL_ENVIRONMENT
+                    | crate::function::FnCaps::RETURNS_REFERENCE
+                    | crate::function::FnCaps::MAY_SPILL;
+                let static_scalar = function.contract.is_some_and(|contract| {
+                    contract.dependency
+                        == crate::function_contract::FunctionDependencySemantics::RecursiveSyntacticArgs
+                        && contract.environment
+                            == crate::function_contract::FunctionEnvironmentSemantics::None
+                        && contract.context
+                            == crate::function_contract::FunctionContextDependence::None
+                        && !contract.result.may_return_reference()
+                        && !contract.result.may_spill()
+                }) && (caps & forbidden).is_empty();
+                let safe = all_safe && static_scalar;
+                ReferenceReturningProjectionShape { safe, scalar: safe }
+            }
+        }
+        ASTNodeType::Call { .. } | ASTNodeType::Array(_) => ReferenceReturningProjectionShape {
+            safe: false,
+            scalar: false,
+        },
+    }
+}
+
 fn compute_read_projections(
     ast: &ASTNode,
     placement: CellRef,
@@ -1062,13 +1177,16 @@ fn compute_read_projections(
                 let contract = function
                     .contract
                     .ok_or(ProjectionFallbackReason::UnsupportedDependencySummary)?;
+                let admitted_reference_returning =
+                    matches!(function.canonical_name.as_str(), "IF" | "IFS" | "CHOOSE")
+                        && reference_returning_projection_shape(ast, function_provider).safe;
                 if contract.dependency
                     != crate::function_contract::FunctionDependencySemantics::RecursiveSyntacticArgs
                     || contract.environment
                         != crate::function_contract::FunctionEnvironmentSemantics::None
                     || contract.context != crate::function_contract::FunctionContextDependence::None
-                    || contract.result.may_return_reference()
-                    || contract.result.may_spill()
+                    || (!admitted_reference_returning
+                        && (contract.result.may_return_reference() || contract.result.may_spill()))
                     || function.semantic_flags & crate::function::FnCaps::VOLATILE.bits() != 0
                 {
                     return Err(ProjectionFallbackReason::UnsupportedDependencySummary);

--- a/crates/formualizer-eval/src/engine/tests/active_span_gate_audit.rs
+++ b/crates/formualizer-eval/src/engine/tests/active_span_gate_audit.rs
@@ -1,16 +1,44 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::engine::graph::editor::change_log::ChangeEvent;
 use crate::engine::{
-    ChangeLog, Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode,
+    CancelToken, ChangeLog, Engine, EvalConfig, FormulaIngestBatch, FormulaIngestRecord,
+    FormulaPlaneMode,
 };
+use crate::function::Function;
 use crate::test_workbook::TestWorkbook;
-use formualizer_common::LiteralValue;
+use crate::traits::{ArgumentHandle, CalcValue, FunctionContext};
+use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
 use formualizer_parse::parser::parse;
 
 const TARGET_ROW: u32 = 100;
 const TARGET_COL: u32 = 2;
 const EDITED_INPUT: f64 = 500.0;
 const EXPECTED_TARGET: f64 = EDITED_INPUT * 2.0;
+
+#[derive(Debug)]
+struct MidEvaluationCanceller {
+    calls: Arc<AtomicUsize>,
+}
+
+impl Function for MidEvaluationCanceller {
+    fn name(&self) -> &'static str {
+        "MID_EVALUATION_CANCELLER"
+    }
+
+    fn eval<'a, 'b, 'c>(
+        &self,
+        _args: &'c [ArgumentHandle<'a, 'b>],
+        ctx: &dyn FunctionContext<'b>,
+    ) -> Result<CalcValue<'b>, ExcelError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        ctx.cancellation_token()
+            .expect("cancellable evaluation must expose its token")
+            .cancel();
+        Ok(CalcValue::Scalar(LiteralValue::Int(1)))
+    }
+}
 
 fn formula_record(
     engine: &mut Engine<TestWorkbook>,
@@ -23,10 +51,10 @@ fn formula_record(
     FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
 }
 
-pub(super) fn build_engine_with_active_spans() -> Engine<TestWorkbook> {
+fn build_engine_with_active_spans_in(workbook: TestWorkbook) -> Engine<TestWorkbook> {
     let cfg =
         EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental);
-    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+    let mut engine = Engine::new(workbook, cfg);
     let mut formulas = Vec::new();
     for row in 1..=200 {
         engine
@@ -47,6 +75,15 @@ pub(super) fn build_engine_with_active_spans() -> Engine<TestWorkbook> {
         .set_cell_value("Sheet1", TARGET_ROW, 1, LiteralValue::Number(EDITED_INPUT))
         .unwrap();
     engine
+}
+
+pub(super) fn build_engine_with_active_spans() -> Engine<TestWorkbook> {
+    build_engine_with_active_spans_in(TestWorkbook::default())
+}
+
+fn switch_to_off_with_spans(engine: &mut Engine<TestWorkbook>) {
+    assert_active_spans(engine);
+    engine.config.formula_plane_mode = FormulaPlaneMode::Off;
 }
 
 fn assert_active_spans(engine: &Engine<TestWorkbook>) {
@@ -71,36 +108,141 @@ fn evaluate_all_flushes_active_spans() {
 }
 
 #[test]
-fn evaluate_all_with_delta_flushes_active_spans() {
+fn authoritative_evaluate_all_with_delta_keeps_coordinator_delta_behavior() {
     let mut engine = build_engine_with_active_spans();
     assert_active_spans(&engine);
 
-    engine.evaluate_all_with_delta().unwrap();
+    let (_, delta) = engine.evaluate_all_with_delta().unwrap();
 
+    assert!(delta.changed_cells.iter().any(|cell| {
+        let (_, row, col) = cell.to_excel_1based();
+        (row, col) == (TARGET_ROW, TARGET_COL)
+    }));
     assert_target_fresh(&engine);
 }
 
 #[test]
-fn evaluate_all_cancellable_flushes_active_spans() {
+fn off_evaluate_all_with_delta_uses_legacy_collector_with_retained_spans() {
     let mut engine = build_engine_with_active_spans();
-    assert_active_spans(&engine);
-
     engine
-        .evaluate_all_cancellable(crate::engine::CancelToken::new())
+        .set_cell_formula("Sheet1", 1, 3, parse("=A100+1").unwrap())
         .unwrap();
+    switch_to_off_with_spans(&mut engine);
 
-    assert_target_fresh(&engine);
+    let (_, delta) = engine.evaluate_all_with_delta().unwrap();
+
+    assert!(!delta.changed_cells.is_empty());
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(EDITED_INPUT + 1.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
+}
+
+fn cancellation_engine() -> (Engine<TestWorkbook>, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let workbook = TestWorkbook::default().with_function(Arc::new(MidEvaluationCanceller {
+        calls: Arc::clone(&calls),
+    }));
+    let mut engine = build_engine_with_active_spans_in(workbook);
+    engine
+        .set_cell_formula(
+            "Sheet1",
+            1,
+            3,
+            parse("=MID_EVALUATION_CANCELLER()").unwrap(),
+        )
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 4, parse("=C1+1").unwrap())
+        .unwrap();
+    (engine, calls)
 }
 
 #[test]
-fn evaluate_all_logged_flushes_active_spans() {
+fn authoritative_evaluate_all_cancellable_keeps_late_cancellation_behavior() {
+    let (mut engine, calls) = cancellation_engine();
+    let token = CancelToken::new();
+    assert_active_spans(&engine);
+
+    let error = engine.evaluate_all_cancellable(token.clone()).unwrap_err();
+
+    assert_eq!(error.kind, ExcelErrorKind::Cancelled);
+    assert_eq!(
+        error.message.as_deref(),
+        Some("Evaluation cancelled during legacy island")
+    );
+    assert!(token.is_cancelled());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
+}
+
+#[test]
+fn off_evaluate_all_cancellable_observes_mid_evaluation_cancel_with_retained_spans() {
+    let (mut engine, calls) = cancellation_engine();
+    switch_to_off_with_spans(&mut engine);
+    let token = CancelToken::new();
+
+    let error = engine.evaluate_all_cancellable(token).unwrap_err();
+
+    assert_eq!(error.kind, ExcelErrorKind::Cancelled);
+    assert_eq!(
+        error.message.as_deref(),
+        Some("Evaluation cancelled between layers")
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn authoritative_evaluate_all_logged_keeps_coordinator_logging_behavior() {
     let mut engine = build_engine_with_active_spans();
     let mut log = ChangeLog::new();
     assert_active_spans(&engine);
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=SEQUENCE(2,1)").unwrap())
+        .unwrap();
 
     engine.evaluate_all_logged(&mut log).unwrap();
 
+    assert!(log.events().is_empty());
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 2, 3),
+        Some(LiteralValue::Number(2.0))
+    );
     assert_target_fresh(&engine);
+}
+
+#[test]
+fn off_evaluate_all_logged_writes_legacy_changelog_with_retained_spans() {
+    let mut engine = build_engine_with_active_spans();
+    let mut log = ChangeLog::new();
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=SEQUENCE(2,1)").unwrap())
+        .unwrap();
+    switch_to_off_with_spans(&mut engine);
+
+    engine.evaluate_all_logged(&mut log).unwrap();
+
+    assert!(
+        log.events()
+            .iter()
+            .any(|event| matches!(event, ChangeEvent::SpillCommitted { .. }))
+    );
+    assert!(
+        log.events()
+            .iter()
+            .any(|event| matches!(event, ChangeEvent::CompoundStart { .. }))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
 }
 
 #[test]
@@ -183,7 +325,7 @@ fn evaluate_until_cancellable_flushes_active_spans() {
 }
 
 #[test]
-fn evaluate_recalc_plan_flushes_active_spans() {
+fn authoritative_evaluate_recalc_plan_keeps_coordinator_behavior() {
     let mut engine = build_engine_with_active_spans();
     let plan = engine.build_recalc_plan().unwrap();
     assert_active_spans(&engine);
@@ -191,6 +333,21 @@ fn evaluate_recalc_plan_flushes_active_spans() {
     engine.evaluate_recalc_plan(&plan).unwrap();
 
     assert_target_fresh(&engine);
+}
+
+#[test]
+fn off_evaluate_recalc_plan_honors_legacy_plan_with_retained_spans() {
+    let mut engine = build_engine_with_active_spans();
+    switch_to_off_with_spans(&mut engine);
+    let plan = engine.build_recalc_plan().unwrap();
+
+    let result = engine.evaluate_recalc_plan(&plan).unwrap();
+
+    assert_eq!(result.computed_vertices, 0);
+    assert_eq!(
+        engine.get_cell_value("Sheet1", TARGET_ROW, TARGET_COL),
+        Some(LiteralValue::Number(TARGET_ROW as f64 * 2.0))
+    );
 }
 
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_coverage_pinning.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_coverage_pinning.rs
@@ -186,9 +186,8 @@ fn fp_coverage_corpus_pins_section_verdicts_and_values() {
             section.name
         );
 
-        let strict_result_shape_fallback = section.name == "nested_if_literals";
         match section.verdict {
-            SectionVerdict::Span if !strict_result_shape_fallback => {
+            SectionVerdict::Span => {
                 assert_eq!(
                     report.shadow_accepted_span_cells, n,
                     "section {}: expected all {n} cells span-accepted; fallback histogram: {:?}",
@@ -203,18 +202,6 @@ fn fp_coverage_corpus_pins_section_verdicts_and_values() {
                     report.shadow_spans_created >= 1,
                     "section {}: expected at least one span",
                     section.name
-                );
-            }
-            SectionVerdict::Span => {
-                assert_eq!(report.shadow_accepted_span_cells, 0);
-                assert_eq!(report.shadow_fallback_cells, n);
-                assert_eq!(
-                    report
-                        .fallback_reasons
-                        .get("UnsupportedCanonicalTemplate")
-                        .copied()
-                        .unwrap_or(0),
-                    n
                 );
             }
             SectionVerdict::Reject { placement_reason } => {
@@ -305,7 +292,7 @@ fn fp_coverage_corpus_combined_totals() {
     let expected_span_sections = corpus
         .sections
         .iter()
-        .filter(|s| s.verdict == SectionVerdict::Span && s.name != "nested_if_literals")
+        .filter(|s| s.verdict == SectionVerdict::Span)
         .count() as u64;
     let expected_reject_sections = corpus.sections.len() as u64 - expected_span_sections;
 
@@ -318,11 +305,7 @@ fn fp_coverage_corpus_combined_totals() {
 
     let mut expected_histogram: BTreeMap<&'static str, u64> = BTreeMap::new();
     for section in &corpus.sections {
-        if section.name == "nested_if_literals" {
-            *expected_histogram
-                .entry("UnsupportedCanonicalTemplate")
-                .or_default() += n;
-        } else if let SectionVerdict::Reject { placement_reason } = section.verdict {
+        if let SectionVerdict::Reject { placement_reason } = section.verdict {
             *expected_histogram.entry(placement_reason).or_default() += n;
         }
     }
@@ -358,16 +341,7 @@ fn fp_coverage_corpus_pins_canonical_reject_kinds() {
                 diag.reject_kinds
             );
         }
-        if section.name == "nested_if_literals" {
-            assert!(!diag.authority_supported);
-            assert!(
-                diag.reject_reasons
-                    .iter()
-                    .any(|reason| reason == "array_or_spill_function:IF"),
-                "nested IF must retain its conservative result-shape rejection: {:?}",
-                diag.reject_reasons
-            );
-        } else if section.expected_canonical_reject_kinds.is_empty()
+        if section.expected_canonical_reject_kinds.is_empty()
             && section.verdict == SectionVerdict::Span
         {
             assert!(

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_named_ranges.rs
@@ -328,6 +328,42 @@ fn sheet_scoped_define_after_ingest_invalidates_workbook_resolved_spans() {
     assert_column_parity("edit inside shadowed region", SHEET, 3, &auth, &off);
 }
 
+#[test]
+fn formula_name_define_demotes_active_dependent_span_and_succeeds() {
+    let mut engine = engine_with_mode(FormulaPlaneMode::AuthoritativeExperimental);
+    seed_named_workbook(&mut engine);
+    let report = ingest_column(&mut engine, SHEET, 3, |r| format!("=SUM(Data)+A{r}"));
+    assert_eq!(report.shadow_accepted_span_cells, u64::from(ROWS));
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+
+    engine
+        .set_cell_value(SHEET, 2, 4, LiteralValue::Number(50.0))
+        .unwrap();
+    let sheet_id = engine.graph.sheet_id_mut(SHEET);
+    engine
+        .define_name(
+            "Data",
+            NamedDefinition::Formula {
+                ast: parse("=D2").unwrap(),
+                dependencies: Vec::new(),
+                range_deps: Vec::new(),
+            },
+            NameScope::Sheet(sheet_id),
+        )
+        .expect("define_name must demote FormulaPlane dependents like update_name");
+
+    assert_eq!(
+        engine.baseline_stats().formula_plane_active_span_count,
+        0,
+        "formula-backed shadowing define must demote the dependent span"
+    );
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value(SHEET, FIRST_ROW, 3),
+        Some(LiteralValue::Number(70.0))
+    );
+}
+
 /// (e) delete_name: cells fall back to legacy and evaluate to #NAME? exactly
 /// like the Off-mode ground truth.
 #[test]

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_parallel_span_eval.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_parallel_span_eval.rs
@@ -234,7 +234,14 @@ fn parallel_short_circuit_correctness_under_parallelism() {
     ingest(&mut engine, formulas);
     engine.evaluate_all().unwrap();
 
-    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    assert_eq!(
+        engine
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .parallel_per_placement_invocations,
+        1
+    );
     for row in 1..=rows {
         assert_eq!(numeric_value(&engine, row, 2), 1.0);
     }

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_per_placement_literal_bindings.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_per_placement_literal_bindings.rs
@@ -211,7 +211,7 @@ fn per_placement_literal_in_nested_if_chain() {
                 "=IF({row}<10, IF({row}>0, A{row}+{row}, -1), IF({row}<100, IF(MOD({row}, 2)=0, A{row}+{row}*2, A{row}+{row}*3), IF({row}<150, A{row}-{row}, A{row}+{row}/2)))"
             )
         },
-        0,
+        1,
     );
 
     for row in SAMPLES {

--- a/crates/formualizer-eval/src/engine/tests/formula_plane_ref_returning_admission.rs
+++ b/crates/formualizer-eval/src/engine/tests/formula_plane_ref_returning_admission.rs
@@ -1,0 +1,546 @@
+use std::sync::Arc;
+
+use chrono::NaiveDate;
+use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue};
+use formualizer_parse::parser::parse;
+
+use crate::engine::{
+    CycleConfig, CycleDetection, CyclePolicy, Engine, EvalConfig, FormulaIngestBatch,
+    FormulaIngestRecord, FormulaPlaneMode,
+};
+use crate::test_workbook::TestWorkbook;
+
+const ROWS: u32 = 120;
+
+fn engine(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    Engine::new(
+        TestWorkbook::default(),
+        EvalConfig::default().with_formula_plane_mode(mode),
+    )
+}
+
+fn record(
+    engine: &mut Engine<TestWorkbook>,
+    sheet: &str,
+    row: u32,
+    col: u32,
+    formula: &str,
+) -> FormulaIngestRecord {
+    engine.add_sheet(sheet).ok();
+    let ast = parse(formula).unwrap_or_else(|err| panic!("parse {formula}: {err}"));
+    let ast_id = engine.intern_formula_ast(&ast);
+    FormulaIngestRecord::new(row, col, ast_id, Some(Arc::<str>::from(formula)))
+}
+
+fn ingest(
+    engine: &mut Engine<TestWorkbook>,
+    sheet: &str,
+    records: Vec<FormulaIngestRecord>,
+) -> crate::engine::FormulaIngestReport {
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new(sheet, records)])
+        .expect("ingest")
+}
+
+fn assert_cells_equal(
+    left: &Engine<TestWorkbook>,
+    right: &Engine<TestWorkbook>,
+    sheet: &str,
+    cells: impl IntoIterator<Item = (u32, u32)>,
+) {
+    for (row, col) in cells {
+        assert_eq!(
+            left.get_cell_value(sheet, row, col),
+            right.get_cell_value(sheet, row, col),
+            "{sheet}!R{row}C{col}"
+        );
+    }
+}
+
+fn fill_down_fixture(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    let mut engine = engine(mode);
+    engine.add_sheet("Aux").unwrap();
+    let mut formulas = Vec::new();
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Boolean(row % 2 == 0))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 3, LiteralValue::Number(1_000.0 + row as f64))
+            .unwrap();
+        engine
+            .set_cell_value("Aux", row, 4, LiteralValue::Number(10_000.0 + row as f64))
+            .unwrap();
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            5,
+            &format!("=IF(A{row},B{row},C{row})"),
+        ));
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            6,
+            &format!("=IF($A{row},Aux!D{row},C$1)"),
+        ));
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            7,
+            &format!("=IFS(A{row},B{row},TRUE,C{row})"),
+        ));
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            8,
+            &format!("=CHOOSE(IF(A{row},1,2),B{row},Aux!D{row})"),
+        ));
+    }
+    let report = ingest(&mut engine, "Sheet1", formulas);
+    if mode == FormulaPlaneMode::AuthoritativeExperimental {
+        assert_eq!(
+            report.shadow_accepted_span_cells,
+            u64::from(ROWS) * 4,
+            "{report:?}"
+        );
+        assert_eq!(report.shadow_fallback_cells, 0, "{report:?}");
+    }
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+#[test]
+fn reference_returning_fill_down_parity_covers_anchors_and_cross_sheet_arms() {
+    let off = fill_down_fixture(FormulaPlaneMode::Off);
+    let authoritative = fill_down_fixture(FormulaPlaneMode::AuthoritativeExperimental);
+    assert_cells_equal(
+        &off,
+        &authoritative,
+        "Sheet1",
+        (1..=ROWS).flat_map(|row| (5..=8).map(move |col| (row, col))),
+    );
+    assert_eq!(
+        authoritative
+            .baseline_stats()
+            .formula_plane_active_span_count,
+        4
+    );
+}
+
+fn semantic_fixture(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    let mut engine = engine(mode);
+    let values = [
+        (
+            1,
+            1,
+            LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div)),
+        ),
+        (1, 2, LiteralValue::Number(7.0)),
+        (
+            1,
+            3,
+            LiteralValue::Error(ExcelError::new(ExcelErrorKind::Ref)),
+        ),
+        (2, 1, LiteralValue::Boolean(true)),
+        (2, 2, LiteralValue::Number(11.0)),
+        (
+            2,
+            3,
+            LiteralValue::Error(ExcelError::new(ExcelErrorKind::Value)),
+        ),
+        (3, 1, LiteralValue::Text("not logical".into())),
+        (1, 4, LiteralValue::Number(1.0)),
+        (2, 4, LiteralValue::Number(2.0)),
+        (3, 4, LiteralValue::Number(3.0)),
+    ];
+    for (row, col, value) in values {
+        engine.set_cell_value("Sheet1", row, col, value).unwrap();
+    }
+    let cases = [
+        "=IF($A$1,$B$1,$C$1)",
+        "=IF($A$2,$B$2,$C$2)",
+        "=IF(FALSE,$B$2)",
+        "=IF(TRUE,,1)",
+        "=IF($A$3,$B$2,$C$2)",
+        "=IF($D$1:$D$3>0,$B$2,$C$2)",
+        "=IF(TRUE,IF(FALSE,$B$1,$B$2),$C$1)",
+        "=CHOOSE(4,$B$1,$B$2)",
+        "=CHOOSE(1.5,$B$1,$B$2)",
+        "=CHOOSE($A$1,$B$1,$B$2)",
+        "=IFS(FALSE,$B$1,FALSE,$B$2)",
+    ];
+    let mut formulas = Vec::new();
+    for (case_index, formula) in cases.iter().enumerate() {
+        let col = 10 + case_index as u32;
+        for row in 10..10 + ROWS {
+            formulas.push(record(&mut engine, "Sheet1", row, col, formula));
+        }
+    }
+    let report = ingest(&mut engine, "Sheet1", formulas);
+    if mode == FormulaPlaneMode::AuthoritativeExperimental {
+        assert_eq!(
+            report.shadow_accepted_span_cells,
+            cases.len() as u64 * u64::from(ROWS),
+            "{report:?}"
+        );
+        assert_eq!(report.shadow_fallback_cells, 0, "{report:?}");
+    }
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+#[test]
+fn reference_returning_error_empty_and_short_circuit_semantics_match_legacy() {
+    let off = semantic_fixture(FormulaPlaneMode::Off);
+    let authoritative = semantic_fixture(FormulaPlaneMode::AuthoritativeExperimental);
+    assert_cells_equal(
+        &off,
+        &authoritative,
+        "Sheet1",
+        (0..11).flat_map(|case| (10..10 + ROWS).map(move |row| (row, 10 + case))),
+    );
+    assert_eq!(
+        authoritative.get_cell_value("Sheet1", 10, 10),
+        Some(LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div)))
+    );
+    assert_eq!(
+        authoritative.get_cell_value("Sheet1", 10, 11),
+        Some(LiteralValue::Number(11.0)),
+        "untaken error arm must not propagate"
+    );
+    assert_eq!(
+        authoritative.get_cell_value("Sheet1", 10, 12),
+        Some(LiteralValue::Boolean(false))
+    );
+    assert_eq!(
+        authoritative.get_cell_value("Sheet1", 10, 13),
+        Some(LiteralValue::Number(0.0))
+    );
+    assert_eq!(
+        authoritative.get_cell_value("Sheet1", 10, 18),
+        Some(LiteralValue::Number(7.0)),
+        "CHOOSE truncates a non-integer numeric selector"
+    );
+    for (col, kind) in [
+        (14, ExcelErrorKind::Value),
+        (15, ExcelErrorKind::Value),
+        (17, ExcelErrorKind::Value),
+        (19, ExcelErrorKind::Div),
+        (20, ExcelErrorKind::Na),
+    ] {
+        assert!(
+            matches!(
+                authoritative.get_cell_value("Sheet1", 10, col),
+                Some(LiteralValue::Error(error)) if error.kind == kind
+            ),
+            "unexpected error at column {col}"
+        );
+    }
+}
+
+#[test]
+fn iferror_wrapped_if_remains_legacy_but_value_identical() {
+    let formula = "=IFERROR(IF(TRUE,$A$1,$B$1),99)";
+    let mut off = engine(FormulaPlaneMode::Off);
+    let mut authoritative = engine(FormulaPlaneMode::AuthoritativeExperimental);
+    for target in [&mut off, &mut authoritative] {
+        target
+            .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(42.0))
+            .unwrap();
+        let records = (10..10 + ROWS)
+            .map(|row| record(target, "Sheet1", row, 4, formula))
+            .collect();
+        let report = ingest(target, "Sheet1", records);
+        if target.config.formula_plane_mode == FormulaPlaneMode::AuthoritativeExperimental {
+            assert_eq!(report.shadow_accepted_span_cells, 0);
+            assert_eq!(report.shadow_fallback_cells, u64::from(ROWS));
+        }
+        target.evaluate_all().unwrap();
+    }
+    assert_cells_equal(
+        &off,
+        &authoritative,
+        "Sheet1",
+        (10..10 + ROWS).map(|row| (row, 4)),
+    );
+}
+
+fn spill_firewall_fixture(mode: FormulaPlaneMode) -> Engine<TestWorkbook> {
+    let mut engine = engine(mode);
+    for row in 1..=3 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64 * 10.0))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(row as f64 * 100.0))
+            .unwrap();
+    }
+    let formulas = [
+        (4, "=IF(TRUE,A1:A3,0)"),
+        (5, "=CHOOSE(2,A1,B1:B3)"),
+        (6, "=SQRT(IF(TRUE,A1:A3,B1:B3))"),
+        (7, "=SUM(IF(FALSE,A1:A3,B1:B3))"),
+    ];
+    let records = formulas
+        .iter()
+        .map(|(col, formula)| record(&mut engine, "Sheet1", 1, *col, formula))
+        .collect();
+    let report = ingest(&mut engine, "Sheet1", records);
+    if mode == FormulaPlaneMode::AuthoritativeExperimental {
+        assert_eq!(report.shadow_accepted_span_cells, 0, "{report:?}");
+        assert_eq!(report.shadow_fallback_cells, 4, "{report:?}");
+    }
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+#[test]
+fn range_arm_firewall_preserves_spills_and_scalar_consumption() {
+    let off = spill_firewall_fixture(FormulaPlaneMode::Off);
+    let authoritative = spill_firewall_fixture(FormulaPlaneMode::AuthoritativeExperimental);
+    assert_cells_equal(
+        &off,
+        &authoritative,
+        "Sheet1",
+        (4..=7).flat_map(|col| (1..=3).map(move |row| (row, col))),
+    );
+    assert_eq!(
+        authoritative.get_cell_value("Sheet1", 1, 7),
+        Some(LiteralValue::Number(600.0))
+    );
+    assert_eq!(
+        authoritative
+            .baseline_stats()
+            .formula_plane_active_span_count,
+        0
+    );
+}
+
+#[test]
+fn union_dependencies_dirty_taken_and_untaken_arms() {
+    let mut engine = engine(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut formulas = Vec::new();
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Boolean(true))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(row as f64))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 3, LiteralValue::Number(1_000.0))
+            .unwrap();
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            4,
+            &format!("=IF(A{row},B{row},C{row})"),
+        ));
+    }
+    ingest(&mut engine, "Sheet1", formulas);
+    engine.evaluate_all().unwrap();
+
+    engine
+        .set_cell_value("Sheet1", 10, 2, LiteralValue::Number(77.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 10, 4),
+        Some(LiteralValue::Number(77.0))
+    );
+    assert_eq!(
+        engine
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        1
+    );
+
+    engine
+        .set_cell_value("Sheet1", 10, 3, LiteralValue::Number(88.0))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 10, 4),
+        Some(LiteralValue::Number(77.0))
+    );
+    assert_eq!(
+        engine
+            .last_formula_plane_span_eval_report()
+            .unwrap()
+            .span_eval_placement_count,
+        1
+    );
+
+    engine
+        .set_cell_value("Sheet1", 10, 1, LiteralValue::Boolean(false))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 10, 4),
+        Some(LiteralValue::Number(88.0))
+    );
+}
+
+#[test]
+fn memo_groups_equal_branch_triples() {
+    let mut engine = engine(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut formulas = Vec::new();
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Boolean(true))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 2, LiteralValue::Number(9.0))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 3, LiteralValue::Number(5.0))
+            .unwrap();
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            4,
+            &format!("=IF(A{row},B{row},C{row})"),
+        ));
+    }
+    ingest(&mut engine, "Sheet1", formulas);
+    engine.evaluate_all().unwrap();
+    let report = engine.last_formula_plane_span_eval_report().unwrap();
+    assert_eq!(report.memo_eval_count, 1, "{report:?}");
+    assert_eq!(
+        report.memo_broadcast_count,
+        u64::from(ROWS - 1),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn memo_preserves_equal_values_with_different_selected_formats() {
+    let mut off = engine(FormulaPlaneMode::Off);
+    let mut authoritative = engine(FormulaPlaneMode::AuthoritativeExperimental);
+    let date = NaiveDate::from_ymd_opt(2024, 12, 1).unwrap();
+    for target in [&mut off, &mut authoritative] {
+        let mut formulas = Vec::new();
+        for row in 1..=ROWS {
+            target
+                .set_cell_value("Sheet1", row, 1, LiteralValue::Boolean(true))
+                .unwrap();
+            let selected = if row % 2 == 0 {
+                LiteralValue::Number(45_627.0)
+            } else {
+                LiteralValue::Date(date)
+            };
+            target.set_cell_value("Sheet1", row, 2, selected).unwrap();
+            target
+                .set_cell_value("Sheet1", row, 3, LiteralValue::Number(5.0))
+                .unwrap();
+            formulas.push(record(
+                target,
+                "Sheet1",
+                row,
+                4,
+                &format!("=IF(A{row},B{row},C{row})"),
+            ));
+        }
+        ingest(target, "Sheet1", formulas);
+        target.evaluate_all().unwrap();
+    }
+    assert_cells_equal(
+        &off,
+        &authoritative,
+        "Sheet1",
+        (1..=ROWS).map(|row| (row, 4)),
+    );
+    let report = authoritative.last_formula_plane_span_eval_report().unwrap();
+    assert_eq!(report.memo_eval_count, 2, "{report:?}");
+    assert_eq!(
+        report.memo_broadcast_count,
+        u64::from(ROWS - 2),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn guarded_self_reference_stays_legacy_via_internal_dependency() {
+    let mut engine = engine(FormulaPlaneMode::AuthoritativeExperimental);
+    let mut formulas = Vec::new();
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Boolean(false))
+            .unwrap();
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            2,
+            &format!("=IF(A{row},B{row},0)"),
+        ));
+    }
+    let report = ingest(&mut engine, "Sheet1", formulas);
+    assert_eq!(report.shadow_accepted_span_cells, 0, "{report:?}");
+    assert_eq!(
+        report.fallback_reasons.get("InternalDependency"),
+        Some(&u64::from(ROWS))
+    );
+    engine.evaluate_all().unwrap();
+    assert!(matches!(
+        engine.get_cell_value("Sheet1", 60, 2),
+        Some(LiteralValue::Error(error)) if error.kind == ExcelErrorKind::Circ
+    ));
+}
+
+#[test]
+fn conditional_cycle_demotes_and_runtime_witnessing_converges() {
+    let cfg = EvalConfig::default()
+        .with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental)
+        .with_cycle(CycleConfig {
+            detection: CycleDetection::Runtime,
+            policy: CyclePolicy::Error,
+        });
+    let mut engine = Engine::new(TestWorkbook::default(), cfg);
+    let mut formulas = Vec::new();
+    for row in 1..=ROWS {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Boolean(false))
+            .unwrap();
+        formulas.push(record(
+            &mut engine,
+            "Sheet1",
+            row,
+            2,
+            &format!("=IF(A{row},C{row},0)"),
+        ));
+    }
+    ingest(&mut engine, "Sheet1", formulas);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine
+        .set_cell_formula("Sheet1", 5, 3, parse("=B5").unwrap())
+        .unwrap();
+    let result = engine.evaluate_all().unwrap();
+    assert_eq!(result.cycle_errors, 0);
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+    assert_eq!(
+        engine
+            .formula_ingest_report_total()
+            .fallback_reasons
+            .get("CycleMember"),
+        Some(&1)
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 5, 2),
+        Some(LiteralValue::Number(0.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 5, 3),
+        Some(LiteralValue::Number(0.0))
+    );
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -141,6 +141,7 @@ mod formula_plane_named_ranges;
 mod formula_plane_parallel_span_eval;
 mod formula_plane_per_placement_literal_bindings;
 mod formula_plane_per_span_overhead;
+mod formula_plane_ref_returning_admission;
 mod formula_plane_structural;
 mod formula_plane_structural_affected_region;
 mod formula_plane_structural_split_acceptance;

--- a/crates/formualizer-eval/src/engine/tests/named_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/named_ranges.rs
@@ -1,7 +1,7 @@
 use crate::engine::graph::DependencyGraph;
 use crate::engine::named_range::{NameScope, NamedDefinition};
 use crate::engine::vertex::VertexKind;
-use crate::engine::{Engine, EvalConfig};
+use crate::engine::{Engine, EvalConfig, FormulaPlaneMode};
 use crate::reference::{CellRef, Coord, RangeRef};
 use crate::test_workbook::TestWorkbook;
 use formualizer_common::{ExcelErrorKind, LiteralValue};
@@ -59,6 +59,59 @@ fn workbook_named_literal_invalidation_updates_dependents() {
     match av.get_cell(0, 0) {
         LiteralValue::Number(n) => assert!((n - 3.0).abs() < 1e-9),
         other => panic!("expected Number(3.0) from Arrow overlay, got {other:?}"),
+    }
+}
+
+#[test]
+fn delete_then_redefine_name_heals_all_direct_readers_in_both_modes() {
+    for mode in [
+        FormulaPlaneMode::Off,
+        FormulaPlaneMode::AuthoritativeExperimental,
+    ] {
+        let mut engine = Engine::new(
+            TestWorkbook::new(),
+            EvalConfig::default().with_formula_plane_mode(mode),
+        );
+        engine
+            .define_name(
+                "X",
+                NamedDefinition::Literal(LiteralValue::Number(1.0)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        for col in 1..=3 {
+            engine
+                .set_cell_formula("Sheet1", 1, col, parse("=X").unwrap())
+                .unwrap();
+        }
+
+        engine.evaluate_all().unwrap();
+        engine.delete_name("X", NameScope::Workbook).unwrap();
+        engine.evaluate_all().unwrap();
+        for col in 1..=3 {
+            match engine.get_cell_value("Sheet1", 1, col) {
+                Some(LiteralValue::Error(error)) => {
+                    assert_eq!(error.kind, ExcelErrorKind::Name, "mode={mode:?}, col={col}")
+                }
+                other => panic!("mode={mode:?}, col={col}: expected #NAME?, got {other:?}"),
+            }
+        }
+
+        engine
+            .define_name(
+                "X",
+                NamedDefinition::Literal(LiteralValue::Number(2.0)),
+                NameScope::Workbook,
+            )
+            .unwrap();
+        engine.evaluate_all().unwrap();
+        for col in 1..=3 {
+            assert_eq!(
+                engine.get_cell_value("Sheet1", 1, col),
+                Some(LiteralValue::Number(2.0)),
+                "mode={mode:?}, col={col}"
+            );
+        }
     }
 }
 

--- a/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
+++ b/crates/formualizer-eval/src/formula_plane/dependency_summary.rs
@@ -2704,16 +2704,109 @@ mod tests {
     }
 
     #[test]
-    fn formula_plane_dependency_summary_rejects_reference_returning_functions() {
-        let choose = summary("=CHOOSE(1,A1,B1)", 1, 1);
+    fn formula_plane_dependency_summary_accepts_cell_armed_reference_returning_functions() {
+        for formula in ["=IF(A1,B1,C1)", "=IFS(A1,B1,A2,C1)", "=CHOOSE(A1,B1,C1)"] {
+            let summary = summary(formula, 1, 4);
+            assert_eq!(
+                summary.formula_class,
+                FormulaClass::StaticPointwise,
+                "{formula}"
+            );
+            assert!(summary.reject_reasons.is_empty(), "{formula}: {summary:?}");
+            assert!(
+                summary.precedent_patterns.len() >= 3,
+                "{formula}: {summary:?}"
+            );
+        }
+    }
 
-        assert_eq!(choose.formula_class, FormulaClass::Rejected);
-        assert!(has_reason(
-            &choose,
-            &DependencyRejectReason::ReferenceReturningUnsupported {
-                function: Some("CHOOSE".to_string())
+    #[test]
+    fn reference_returning_admission_firewall_preserves_reject_reason_strings() {
+        let cases: [(&str, &[&str]); 9] = [
+            (
+                "=IF(TRUE,A1:A3,0)",
+                &["reference_returning_unsupported:IF", "spill_unsupported"],
+            ),
+            (
+                "=CHOOSE(2,A1,B1:B3)",
+                &[
+                    "reference_returning_unsupported:CHOOSE",
+                    "spill_unsupported",
+                ],
+            ),
+            (
+                "=IF(TRUE,NOW(),0)",
+                &[
+                    "volatile_unsupported:NOW",
+                    "reference_returning_unsupported:IF",
+                    "spill_unsupported",
+                ],
+            ),
+            (
+                "=IF(TRUE,OFFSET(A1,1,0),0)",
+                &[
+                    "dynamic_dependency:OFFSET",
+                    "volatile_unsupported:OFFSET",
+                    "reference_returning_unsupported:IF",
+                    "reference_returning_unsupported:OFFSET",
+                    "spill_unsupported",
+                ],
+            ),
+            (
+                "=IF(TRUE,INDIRECT(\"A1\"),0)",
+                &[
+                    "dynamic_dependency:INDIRECT",
+                    "volatile_unsupported:INDIRECT",
+                    "reference_returning_unsupported:IF",
+                    "reference_returning_unsupported:INDIRECT",
+                    "spill_unsupported",
+                ],
+            ),
+            (
+                "=IF(TRUE,INDEX(A1:A3,1),0)",
+                &[
+                    "reference_returning_unsupported:IF",
+                    "reference_returning_unsupported:INDEX",
+                    "spill_unsupported",
+                ],
+            ),
+            (
+                "=IF(TRUE,MyName,0)",
+                &[
+                    "named_range_unsupported",
+                    "reference_returning_unsupported:IF",
+                    "spill_unsupported",
+                ],
+            ),
+            (
+                "=IF(TRUE,SUM($A$1:$A),0)",
+                &[
+                    "open_range_unsupported",
+                    "reference_returning_unsupported:IF",
+                    "spill_unsupported",
+                ],
+            ),
+            (
+                "=(IF(TRUE,A1,B1)):(C1)",
+                &["reference_returning_unsupported"],
+            ),
+        ];
+
+        for (formula, expected) in cases {
+            let summary = summary(formula, 4, 6);
+            assert_eq!(summary.formula_class, FormulaClass::Rejected, "{formula}");
+            let actual = summary
+                .reject_reasons
+                .iter()
+                .map(dependency_reject_reason_key)
+                .collect::<BTreeSet<_>>();
+            for reason in expected {
+                assert!(
+                    actual.contains(*reason),
+                    "{formula}: missing {reason}; {actual:?}"
+                );
             }
-        ));
+        }
     }
 
     #[test]
@@ -2739,14 +2832,11 @@ mod tests {
     }
 
     #[test]
-    fn formula_plane_dependency_summary_rejects_may_spill_short_circuit_function() {
+    fn formula_plane_dependency_summary_accepts_scalar_armed_short_circuit_function() {
         let summary = summary("=IF(ISNUMBER(A1), A1*2, 0)", 1, 2);
 
-        assert_eq!(summary.formula_class, FormulaClass::Rejected);
-        assert!(has_reason(
-            &summary,
-            &DependencyRejectReason::SpillUnsupported
-        ));
+        assert_eq!(summary.formula_class, FormulaClass::StaticPointwise);
+        assert!(summary.reject_reasons.is_empty());
         assert_eq!(summary.precedent_patterns.len(), 1);
     }
 

--- a/crates/formualizer-eval/src/formula_plane/template_canonical.rs
+++ b/crates/formualizer-eval/src/formula_plane/template_canonical.rs
@@ -11,7 +11,7 @@
 //! scope. Current-row structured references are classified explicitly here so a
 //! future ingest-side rewrite cannot silently give a different authority answer.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use formualizer_common::LiteralValue;
@@ -465,6 +465,9 @@ pub(crate) fn canonicalize_template_with_provider(
     }
 
     let expr = canonicalizer.canonicalize_expr(ast, CanonicalReferenceContext::Value);
+    canonicalizer
+        .labels
+        .revoke_admitted_reference_returning_rejects(&expr);
     if canonicalizer
         .labels
         .flags
@@ -492,6 +495,170 @@ pub(crate) fn canonicalize_template_with_provider(
         ),
         literal_bindings: canonicalizer.literal_bindings.into_boxed_slice(),
     }
+}
+
+impl CanonicalTemplateLabels {
+    fn revoke_admitted_reference_returning_rejects(&mut self, expr: &CanonicalExpr) {
+        let mut admissions = BTreeMap::<String, bool>::new();
+        classify_reference_returning_admission(expr, &mut admissions);
+        self.reject_reasons.retain(|reason| {
+            let name = match reason {
+                CanonicalRejectReason::ReferenceReturningFunction { name }
+                | CanonicalRejectReason::ArrayOrSpillFunction { name } => name,
+                _ => return true,
+            };
+            !admissions.get(name).copied().unwrap_or(false)
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ReferenceReturningAdmissionShape {
+    safe: bool,
+    scalar: bool,
+}
+
+fn classify_reference_returning_admission(
+    expr: &CanonicalExpr,
+    admissions: &mut BTreeMap<String, bool>,
+) -> ReferenceReturningAdmissionShape {
+    match expr {
+        CanonicalExpr::Literal(_) | CanonicalExpr::Omitted => ReferenceReturningAdmissionShape {
+            safe: true,
+            scalar: true,
+        },
+        CanonicalExpr::Reference { reference, .. } => match reference {
+            CanonicalReference::Cell { row, col, .. }
+                if admission_axis_is_cell(row) && admission_axis_is_cell(col) =>
+            {
+                ReferenceReturningAdmissionShape {
+                    safe: true,
+                    scalar: true,
+                }
+            }
+            CanonicalReference::Range {
+                start_row,
+                start_col,
+                end_row,
+                end_col,
+                ..
+            } if [start_row, start_col, end_row, end_col]
+                .into_iter()
+                .all(|axis| admission_axis_is_cell(axis)) =>
+            {
+                ReferenceReturningAdmissionShape {
+                    safe: true,
+                    scalar: false,
+                }
+            }
+            CanonicalReference::Cell { .. }
+            | CanonicalReference::Range { .. }
+            | CanonicalReference::Named { .. }
+            | CanonicalReference::Unsupported { .. } => ReferenceReturningAdmissionShape {
+                safe: false,
+                scalar: false,
+            },
+        },
+        CanonicalExpr::Unary { op, expr } => {
+            let child = classify_reference_returning_admission(expr, admissions);
+            let supported = matches!(op.as_str(), "+" | "-" | "%");
+            ReferenceReturningAdmissionShape {
+                safe: supported && child.safe,
+                scalar: supported && child.scalar,
+            }
+        }
+        CanonicalExpr::Binary { op, left, right } => {
+            let left = classify_reference_returning_admission(left, admissions);
+            let right = classify_reference_returning_admission(right, admissions);
+            let supported = matches!(
+                op.as_str(),
+                "+" | "-" | "*" | "/" | "^" | "&" | "=" | "<>" | "<" | "<=" | ">" | ">="
+            );
+            ReferenceReturningAdmissionShape {
+                safe: supported && left.safe && right.safe,
+                scalar: supported && left.scalar && right.scalar,
+            }
+        }
+        CanonicalExpr::Function { id, args } => {
+            let child_shapes = args
+                .iter()
+                .map(|arg| classify_reference_returning_admission(arg, admissions))
+                .collect::<Vec<_>>();
+            if admitted_reference_returning_function(&id.canonical_name) {
+                let admitted = child_shapes.iter().all(|shape| shape.safe)
+                    && reference_returning_arms(&id.canonical_name, args.len())
+                        .all(|index| child_shapes[index].scalar);
+                admissions
+                    .entry(id.canonical_name.clone())
+                    .and_modify(|all| *all &= admitted)
+                    .or_insert(admitted);
+                ReferenceReturningAdmissionShape {
+                    safe: admitted,
+                    scalar: admitted,
+                }
+            } else {
+                let safe =
+                    child_shapes.iter().all(|shape| shape.safe) && function_is_static_scalar(id);
+                ReferenceReturningAdmissionShape { safe, scalar: safe }
+            }
+        }
+        CanonicalExpr::CallUnsupported { callee, args } => {
+            classify_reference_returning_admission(callee, admissions);
+            for arg in args {
+                classify_reference_returning_admission(arg, admissions);
+            }
+            ReferenceReturningAdmissionShape {
+                safe: false,
+                scalar: false,
+            }
+        }
+        CanonicalExpr::ArrayUnsupported { rows } => {
+            for item in rows.iter().flatten() {
+                classify_reference_returning_admission(item, admissions);
+            }
+            ReferenceReturningAdmissionShape {
+                safe: false,
+                scalar: false,
+            }
+        }
+    }
+}
+
+fn admitted_reference_returning_function(name: &str) -> bool {
+    matches!(name, "IF" | "IFS" | "CHOOSE")
+}
+
+fn reference_returning_arms(name: &str, arity: usize) -> impl Iterator<Item = usize> {
+    let step = if name == "IFS" { 2 } else { 1 };
+    (1..arity).step_by(step)
+}
+
+fn admission_axis_is_cell(axis: &AxisRef) -> bool {
+    matches!(
+        axis,
+        AxisRef::RelativeToPlacement { .. } | AxisRef::AbsoluteVc { .. }
+    )
+}
+
+fn function_is_static_scalar(id: &CanonicalFunctionId) -> bool {
+    let forbidden_caps = FnCaps::VOLATILE
+        | FnCaps::DYNAMIC_DEPENDENCY
+        | FnCaps::LOCAL_ENVIRONMENT
+        | FnCaps::RETURNS_REFERENCE
+        | FnCaps::MAY_SPILL;
+    if !(FnCaps::from_bits_retain(id.semantic_flags) & forbidden_caps).is_empty() {
+        return false;
+    }
+    let Some(contract) = id.contract else {
+        return false;
+    };
+    matches!(
+        contract.dependency,
+        FunctionDependencySemantics::RecursiveSyntacticArgs
+    ) && contract.environment == FunctionEnvironmentSemantics::None
+        && !contract.result.may_return_reference()
+        && !contract.result.may_spill()
+        && contract.context == FunctionContextDependence::None
 }
 
 struct Canonicalizer<'a> {
@@ -2025,5 +2192,67 @@ mod tests {
                 name: "myname".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn reference_returning_cell_and_scalar_arms_revoke_both_shape_rejects() {
+        for formula in [
+            "=IF(A1,B1,C1)",
+            "=IF(A1,SUM(B1:B3),0)",
+            "=IFS(A1,B1,A2,2)",
+            "=CHOOSE(A1,B1,2,C1+1)",
+            "=IF(A1,IF(B1,C1,D1),E1)",
+            "=IF(A1:A3>0,B1,C1)",
+        ] {
+            let template = canonical(formula, 4, 6);
+            assert!(
+                template.labels.is_authority_supported(),
+                "{formula}: {:?}",
+                template.labels.reject_reasons
+            );
+        }
+    }
+
+    #[test]
+    fn reference_returning_revoke_invariant_preserves_rejects_for_every_other_shape() {
+        let cases = [
+            "=IF(TRUE,A1:A3,0)",
+            "=CHOOSE(2,A1,B1:B3)",
+            "=SQRT(IF(TRUE,A1:A3,B1:B3))",
+            "=IF(TRUE,NOW(),0)",
+            "=IF(TRUE,OFFSET(A1,1,0),0)",
+            "=IF(TRUE,INDIRECT(\"A1\"),0)",
+            "=IF(TRUE,INDEX(A1:A3,1),0)",
+            "=IF(TRUE,MyName,0)",
+            "=IF(TRUE,SUM($A$1:$A),0)",
+            "=IF(TRUE,A1:B2,IF(FALSE,C1,D1))",
+        ];
+        for formula in cases {
+            let template = canonical(formula, 4, 6);
+            let name = if formula.starts_with("=CHOOSE") {
+                "CHOOSE"
+            } else {
+                "IF"
+            };
+            assert!(
+                template.labels.reject_reasons.contains(
+                    &CanonicalRejectReason::ReferenceReturningFunction {
+                        name: name.to_string()
+                    }
+                ),
+                "{formula}: {:?}",
+                template.labels.reject_reasons
+            );
+            assert!(
+                template.labels.reject_reasons.contains(
+                    &CanonicalRejectReason::ArrayOrSpillFunction {
+                        name: name.to_string()
+                    }
+                ),
+                "{formula}: {:?}",
+                template.labels.reject_reasons
+            );
+            assert!(!template.labels.is_authority_supported(), "{formula}");
+        }
     }
 }

--- a/crates/formualizer-eval/src/formula_plane/template_canonical.rs
+++ b/crates/formualizer-eval/src/formula_plane/template_canonical.rs
@@ -544,7 +544,7 @@ fn classify_reference_returning_admission(
                 ..
             } if [start_row, start_col, end_row, end_col]
                 .into_iter()
-                .all(|axis| admission_axis_is_cell(axis)) =>
+                .all(&admission_axis_is_cell) =>
             {
                 ReferenceReturningAdmissionShape {
                     safe: true,


### PR DESCRIPTION
Stacked on #380 (format broadcast parity) — merge that first.

## What

IF, IFS, and CHOOSE become FormulaPlane span-admissible when every result/reference-role arm is a finite single-cell reference or a statically scalar expression. Relative, absolute, mixed-anchor, and cross-sheet arms; nested admitted calls; scalar aggregate arms such as SUM(A1:A3).

## How

The canonicalizer rejects these functions doubly today (ReferenceReturningFunction and ArrayOrSpillFunction caps). After argument canonicalization a bottom-up shape pass revokes both reasons per function only when every occurrence is proven safe and scalar-result-shaped; reject-then-revoke can never widen admission. The same rule is mirrored into the arena-native canonical-label path and the read-projection builder's duplicate gate, so production ingest matches tree canonicalization. Dependency summaries needed no changes: Value-context recursion already emits cond-union-then-union-else precedents per contract 8.6/9.4.

## Firewall (load-bearing)

Range arms stay legacy in v1 by construction: multi-cell range arms spill on legacy but would truncate to top-left through span publication. Pinned goldens with legacy-vs-authoritative equality: IF(TRUE,A1:A3,0), CHOOSE(2,A1,B1:B3), SQRT(IF(...)), SUM(IF(...)) = 600. Still-rejected sweep asserts unchanged reject strings for range, open-range, named, volatile, OFFSET/INDIRECT/INDEX, and colon-operator shapes.

## Tests

New formula_plane_ref_returning_admission.rs (546 lines): parity fill-downs, short-circuit untaken-error pin, error-code parity (#VALUE! conditions, IFS #N/A, CHOOSE selector errors), memo group-merge incl. format parity on equal-values-different-formats, taken/untaken arm dirty propagation, guarded self-reference InternalDependency fallback, conditional-cycle CycleMember demotion convergence. Coverage pins updated for the newly admitted population.

## Validation

cargo test -p formualizer-eval --lib: 2797 passed at commit, green post style fix. clippy -D warnings; fmt --check. CHANGELOG entry included. Contract section 9.2 amendment text drafted for the internal design bundle (reference_returning_static_unimplemented no longer describes admitted static shapes).