### PR TITLE
fix(python): eliminate panicking unwraps in AST/Token/Sheet bindings

### DIFF
--- a/bindings/python/src/ast.rs
+++ b/bindings/python/src/ast.rs
@@ -96,7 +96,7 @@ impl PyASTNode {
     }
 
     /// Convert AST to a dictionary representation
-    fn to_dict(&self, py: Python<'_>) -> PyObject {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         self.node_to_dict(py, &self.inner)
     }
 
@@ -115,10 +115,10 @@ impl PyASTNode {
     }
 
     /// Get the value for literal nodes
-    fn get_literal_value(&self, py: Python<'_>) -> Option<PyObject> {
+    fn get_literal_value(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
         match &self.inner.node_type {
-            ASTNodeType::Literal(value) => Some(self.literal_value_to_py(py, value)),
-            _ => None,
+            ASTNodeType::Literal(value) => Ok(Some(self.literal_value_to_py(py, value)?)),
+            _ => Ok(None),
         }
     }
 
@@ -300,47 +300,42 @@ impl PyASTNode {
         }
     }
 
-    fn node_to_dict(&self, py: Python<'_>, node: &ASTNode) -> PyObject {
+    fn node_to_dict(&self, py: Python<'_>, node: &ASTNode) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("node_type", self.node_type()).unwrap();
+        dict.set_item("node_type", self.node_type())?;
 
         match &node.node_type {
             ASTNodeType::Literal(value) => {
-                dict.set_item("value", self.literal_value_to_py(py, value))
-                    .unwrap();
+                dict.set_item("value", self.literal_value_to_py(py, value)?)?;
             }
             ASTNodeType::Omitted => {}
             ASTNodeType::Reference { original, .. } => {
-                dict.set_item("reference", original).unwrap();
+                dict.set_item("reference", original)?;
             }
             ASTNodeType::UnaryOp { op, expr } => {
-                dict.set_item("operator", op).unwrap();
-                dict.set_item("operand", PyASTNode::new((**expr).clone()).to_dict(py))
-                    .unwrap();
+                dict.set_item("operator", op)?;
+                dict.set_item("operand", PyASTNode::new((**expr).clone()).to_dict(py)?)?;
             }
             ASTNodeType::BinaryOp { op, left, right } => {
-                dict.set_item("operator", op).unwrap();
-                dict.set_item("left", PyASTNode::new((**left).clone()).to_dict(py))
-                    .unwrap();
-                dict.set_item("right", PyASTNode::new((**right).clone()).to_dict(py))
-                    .unwrap();
+                dict.set_item("operator", op)?;
+                dict.set_item("left", PyASTNode::new((**left).clone()).to_dict(py)?)?;
+                dict.set_item("right", PyASTNode::new((**right).clone()).to_dict(py)?)?;
             }
             ASTNodeType::Function { name, args } => {
-                dict.set_item("name", name).unwrap();
+                dict.set_item("name", name)?;
                 let py_args: Vec<PyObject> = args
                     .iter()
                     .map(|arg| PyASTNode::new(arg.clone()).to_dict(py))
-                    .collect();
-                dict.set_item("args", py_args).unwrap();
+                    .collect::<PyResult<Vec<_>>>()?;
+                dict.set_item("args", py_args)?;
             }
             ASTNodeType::Call { callee, args } => {
-                dict.set_item("callee", PyASTNode::new((**callee).clone()).to_dict(py))
-                    .unwrap();
+                dict.set_item("callee", PyASTNode::new((**callee).clone()).to_dict(py)?)?;
                 let py_args: Vec<PyObject> = args
                     .iter()
                     .map(|arg| PyASTNode::new(arg.clone()).to_dict(py))
-                    .collect();
-                dict.set_item("args", py_args).unwrap();
+                    .collect::<PyResult<Vec<_>>>()?;
+                dict.set_item("args", py_args)?;
             }
             ASTNodeType::Array(rows) => {
                 let py_rows: Vec<Vec<PyObject>> = rows
@@ -348,68 +343,42 @@ impl PyASTNode {
                     .map(|row| {
                         row.iter()
                             .map(|cell| PyASTNode::new(cell.clone()).to_dict(py))
-                            .collect()
+                            .collect::<PyResult<Vec<_>>>()
                     })
-                    .collect();
-                dict.set_item("rows", py_rows).unwrap();
+                    .collect::<PyResult<Vec<_>>>()?;
+                dict.set_item("rows", py_rows)?;
             }
         }
 
-        dict.into()
+        Ok(dict.into())
     }
 
     #[allow(clippy::only_used_in_recursion)]
-    fn literal_value_to_py(&self, py: Python<'_>, value: &LiteralValue) -> PyObject {
-        match value {
-            LiteralValue::Int(i) => (*i)
-                .into_py_any(py)
-                .expect("integer conversion must succeed"),
-            LiteralValue::Number(n) => (*n)
-                .into_py_any(py)
-                .expect("number conversion must succeed"),
-            LiteralValue::Text(s) => s
-                .clone()
-                .into_py_any(py)
-                .expect("string conversion must succeed"),
-            LiteralValue::Boolean(b) => (*b)
-                .into_py_any(py)
-                .expect("boolean conversion must succeed"),
-            LiteralValue::Error(e) => e
-                .to_string()
-                .into_py_any(py)
-                .expect("error conversion must succeed"),
-            LiteralValue::Date(d) => d
-                .to_string()
-                .into_py_any(py)
-                .expect("date conversion must succeed"),
-            LiteralValue::DateTime(dt) => dt
-                .to_string()
-                .into_py_any(py)
-                .expect("datetime conversion must succeed"),
-            LiteralValue::Time(t) => t
-                .to_string()
-                .into_py_any(py)
-                .expect("time conversion must succeed"),
-            LiteralValue::Duration(dur) => dur
-                .to_string()
-                .into_py_any(py)
-                .expect("duration conversion must succeed"),
+    fn literal_value_to_py(&self, py: Python<'_>, value: &LiteralValue) -> PyResult<PyObject> {
+        Ok(match value {
+            LiteralValue::Int(i) => (*i).into_py_any(py)?,
+            LiteralValue::Number(n) => (*n).into_py_any(py)?,
+            LiteralValue::Text(s) => s.clone().into_py_any(py)?,
+            LiteralValue::Boolean(b) => (*b).into_py_any(py)?,
+            LiteralValue::Error(e) => e.to_string().into_py_any(py)?,
+            LiteralValue::Date(d) => d.to_string().into_py_any(py)?,
+            LiteralValue::DateTime(dt) => dt.to_string().into_py_any(py)?,
+            LiteralValue::Time(t) => t.to_string().into_py_any(py)?,
+            LiteralValue::Duration(dur) => dur.to_string().into_py_any(py)?,
             LiteralValue::Array(arr) => {
                 let py_arr: Vec<Vec<PyObject>> = arr
                     .iter()
                     .map(|row| {
                         row.iter()
                             .map(|cell| self.literal_value_to_py(py, cell))
-                            .collect()
+                            .collect::<PyResult<Vec<_>>>()
                     })
-                    .collect();
-                py_arr
-                    .into_py_any(py)
-                    .expect("array conversion must succeed")
+                    .collect::<PyResult<Vec<_>>>()?;
+                py_arr.into_py_any(py)?
             }
             LiteralValue::Empty => py.None(),
             LiteralValue::Pending => py.None(),
-        }
+        })
     }
 }
 
@@ -439,18 +408,14 @@ impl PyRefWalker {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<PyObject> {
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<PyObject>> {
         if slf.index < slf.refs.len() {
             let reference = slf.refs[slf.index].clone();
             slf.index += 1;
             let py = slf.py();
-            Some(
-                reference
-                    .into_py_any(py)
-                    .expect("ReferenceLike should convert to PyObject"),
-            )
+            Ok(Some(reference.into_py_any(py)?))
         } else {
-            None
+            Ok(None)
         }
     }
 }

--- a/bindings/python/src/sheet.rs
+++ b/bindings/python/src/sheet.rs
@@ -88,7 +88,9 @@ impl PySheet {
         self.workbook.check_reentrancy()?;
 
         let cached = {
-            let sheets = self.workbook.sheets.read().unwrap();
+            let sheets = self.workbook.sheets.read().map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("sheets cache lock: {e}"))
+            })?;
             sheets
                 .get(&self.name)
                 .and_then(|m| m.get(&(row, col)).cloned())

--- a/bindings/python/src/token.rs
+++ b/bindings/python/src/token.rs
@@ -80,14 +80,12 @@ impl PyToken {
         )
     }
 
-    fn to_dict(&self, py: Python<'_>) -> PyObject {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("value", self.value()).unwrap();
-        dict.set_item("token_type", self.token_type().to_string())
-            .unwrap();
-        dict.set_item("subtype", self.subtype().to_string())
-            .unwrap();
-        dict.into()
+        dict.set_item("value", self.value())?;
+        dict.set_item("token_type", self.token_type().to_string())?;
+        dict.set_item("subtype", self.subtype().to_string())?;
+        Ok(dict.into())
     }
 
     /// Check if this token is an operator


### PR DESCRIPTION
## Summary

Eliminates panicking `.unwrap()` calls in the Python AST/Token/Sheet bindings, propagating errors as Python exceptions instead of crashing the interpreter. This is the review-addressed successor to #344.

## What changed vs. #344 (addresses review)

- **F1 (blocking regression) resolved.** The three `check_reentrancy()` guards in `sheet.rs` (`get_cell`, `get_values`, `get_formulas`) are **restored**. They prevent a permanent deadlock when a Python custom-function callback re-enters Sheet methods during evaluation (the engine holds the workbook `RwLock` across the callback). The improved lock-error propagation is kept alongside them.
- **F2 (scope).** This PR is scoped to the AST/Token `PyResult` propagation plus the `sheet.rs` sheets-cache lock in `get_cell`. The remaining `workbook.rs` `.unwrap()` sites are left as a tracked follow-up rather than silently mixed in.

## Changes

- `bindings/python/src/ast.rs`, `token.rs`: `PyResult` error propagation instead of `.unwrap()`.
- `bindings/python/src/sheet.rs`: `sheets.read().unwrap()` -> `map_err(...)?`, guards retained.

## Testing

- `cargo check -p formualizer-python` — clean, no warnings

## Notes

- Rebased onto current `main`. Conventional commit style.
