### PR TITLE
build: weak sheetport feature refs and a portable clock in the umya backend

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -23,7 +23,7 @@ js-sys = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 console_error_panic_hook = { version = "0.1", optional = true }
-formualizer = { path = "../../crates/formualizer", default-features = false, features = ["wasm-js"] }
+formualizer = { path = "../../crates/formualizer", default-features = false, features = ["wasm-js", "sheetport"] }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 

--- a/crates/formualizer-workbook/src/backends/umya.rs
+++ b/crates/formualizer-workbook/src/backends/umya.rs
@@ -5,6 +5,7 @@ use crate::traits::{
 };
 use formualizer_common::{ExcelError, ExcelErrorKind, LiteralValue, RangeAddress};
 use formualizer_eval::engine::{FormulaIngestBatch, FormulaIngestRecord};
+use formualizer_eval::instant::FzInstant as Instant;
 use formualizer_parse::parser::ReferenceType;
 use parking_lot::RwLock;
 use std::collections::BTreeMap;
@@ -13,7 +14,6 @@ use std::collections::HashSet;
 use std::io::{Cursor, Read, Seek};
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
 use umya_spreadsheet::{
     CellRawValue, CellValue, Spreadsheet,
     reader::xlsx,

--- a/crates/formualizer/Cargo.toml
+++ b/crates/formualizer/Cargo.toml
@@ -34,7 +34,7 @@ tracing_chrome = ["tracing", "formualizer-eval/tracing_chrome"]
 system-clock = [
   "formualizer-eval/system-clock",
   "formualizer-workbook/system-clock",
-  "formualizer-sheetport/system-clock",
+  "formualizer-sheetport?/system-clock",
 ]
 
 # js-runtime: browser/wasm-bindgen execution environment — activates web-time
@@ -42,7 +42,7 @@ system-clock = [
 js-runtime = [
   "formualizer-eval/js-runtime",
   "formualizer-workbook/js-runtime",
-  "formualizer-sheetport/js-runtime",
+  "formualizer-sheetport?/js-runtime",
 ]
 
 # --- Named top-level presets ---


### PR DESCRIPTION
## Summary

Two small fixes that agent-spreadsheet currently works around downstream, so both can be dropped there once this ships in a release.

**1. Weak sheetport feature references.** The `formualizer` facade's `system-clock` and `js-runtime` features reference `formualizer-sheetport/...` as strong feature references. A strong reference to an optional dependency implicitly enables it, so any consumer that turns on `js-runtime` (or `wasm-js`, which forwards to it) pulls in `formualizer-sheetport` and its whole tree even when it never asked for sheetport. Downstream that includes `clap`, `serde_yaml`, and `sheetport-spec`, which then land in browser wasm bundles. The references are now weak (`formualizer-sheetport?/...`). `bindings/wasm` does rely on sheetport, so it now requests the feature explicitly and its own build is unchanged.

**2. Portable clock in the umya backend.** `formualizer-workbook`'s umya backend imported `std::time::Instant` directly and calls `Instant::now()` on every xlsx open. That call panics on `wasm32-unknown-unknown`. `formualizer-eval` already exports `FzInstant` (web-time under `js-runtime`) and the calamine backend already guards its own timer, so the umya backend now uses `FzInstant` like the rest of the engine. agent-spreadsheet has been carrying a vendored copy of `formualizer-workbook` with exactly this change.

## Verification

- `cargo check -p formualizer --no-default-features --features wasm-js` compiles and its `cargo tree` no longer lists `formualizer-sheetport`, `clap`, `serde_yaml`, or `sheetport-spec`.
- `cargo check -p formualizer-wasm --target wasm32-unknown-unknown` compiles with `sheetport` requested explicitly.
- `cargo check -p formualizer --target wasm32-unknown-unknown --no-default-features --features js-runtime,eval,workbook,umya,common` compiles (the feature set agent-spreadsheet's wasm build uses).
- `cargo test -p formualizer-workbook --features umya --test umya`: 45 passed, 0 failed, 2 ignored.

## Notes

Weak feature references require Cargo 1.60 or newer, which the workspace already exceeds.
