### PR TITLE
fix: bound parser recursion depth to prevent stack overflow on deeply nested formulas

### DIFF
--- a/crates/formualizer-parse/src/parser.rs
+++ b/crates/formualizer-parse/src/parser.rs
@@ -2324,7 +2324,17 @@ pub struct Parser {
     /// When > 0, treat a top-level `OpInfix(",")` as a terminator (call-arg
     /// separator) instead of the union/list operator. Used by `parse_call_arguments`.
     in_call_args_depth: usize,
+    /// Current recursion depth of `parse_bp`. Bounded by [`MAX_PARSE_DEPTH`] so a
+    /// deeply nested formula (e.g. `=((((...))))`) returns an error instead of
+    /// overflowing the stack.
+    depth: usize,
 }
+
+/// Maximum expression nesting depth accepted by the parser. Excel itself caps
+/// formula nesting at 64; matching that keeps every real formula well within
+/// bounds while preventing unbounded recursion (and stack overflow) on hostile
+/// input.
+const MAX_PARSE_DEPTH: usize = 64;
 
 impl Parser {
     /// Tokenize a formula using the default Excel dialect and prepare it for parsing.
@@ -2372,6 +2382,7 @@ impl Parser {
             volatility_classifier: None,
             dialect,
             in_call_args_depth: 0,
+            depth: 0,
         }
     }
 
@@ -2508,6 +2519,22 @@ impl Parser {
     }
 
     fn parse_bp(&mut self, min_precedence: u8) -> Result<ASTNode, ParserError> {
+        // Bound recursion so deeply nested input (e.g. `=((((...))))`) returns
+        // an error instead of overflowing the stack.
+        self.depth += 1;
+        if self.depth > MAX_PARSE_DEPTH {
+            self.depth -= 1;
+            return Err(ParserError {
+                message: format!("Formula nesting too deep (max {MAX_PARSE_DEPTH})"),
+                position: Some(self.position),
+            });
+        }
+        let result = self.parse_bp_inner(min_precedence);
+        self.depth -= 1;
+        result
+    }
+
+    fn parse_bp_inner(&mut self, min_precedence: u8) -> Result<ASTNode, ParserError> {
         let mut left = self.parse_prefix()?;
 
         loop {

--- a/crates/formualizer-parse/src/tests/parser.rs
+++ b/crates/formualizer-parse/src/tests/parser.rs
@@ -4141,4 +4141,36 @@ mod r1c1_disambiguation {
             assert_not_table(formula, &spanned);
         }
     }
+
+    #[test]
+    fn deeply_nested_formula_errors_instead_of_overflowing_stack() {
+        // A hostile formula string of deeply nested parentheses / unary ops /
+        // calls must return a ParserError, not overflow the stack. Run on a
+        // small (1 MiB) thread stack so an unbounded recursion would abort the
+        // process rather than silently succeed on the generous test-runner stack.
+        for formula in [
+            format!("={}1{}", "(".repeat(5000), ")".repeat(5000)),
+            format!("={}1", "-".repeat(5000)),
+            format!("={}1{}", "SUM(".repeat(5000), ")".repeat(5000)),
+        ] {
+            let handle = std::thread::Builder::new()
+                .stack_size(1024 * 1024)
+                .spawn(move || crate::parser::parse(&formula).is_err())
+                .expect("spawn parse thread");
+            let is_err = handle
+                .join()
+                .expect("parser must not overflow the stack on deep input");
+            assert!(
+                is_err,
+                "deeply nested formula should be rejected with an error"
+            );
+        }
+
+        // A modestly nested formula (well under the limit) must still parse.
+        let ok = format!("={}1{}", "(".repeat(40), ")".repeat(40));
+        assert!(
+            crate::parser::parse(&ok).is_ok(),
+            "normal nesting must still parse"
+        );
+    }
 }


### PR DESCRIPTION
## What

The recursive-descent expression parser (`parse_bp`) has no depth limit. A formula string with deep nesting recurses one stack frame per level until the thread stack overflows and the **process aborts** (`fatal runtime error: stack overflow, aborting`).

`parse()` takes an untrusted formula string — an embeddable spreadsheet engine ingests formulas from arbitrary workbooks / user input — so this is a denial of service. A ~1 KB string reliably crashes the host process.

Reproduced (before this change) on an 8 MB main-thread stack:

```rust
let f = format!("={}1{}", "(".repeat(1000), ")".repeat(1000)); // =((((...1...))))
let _ = formualizer_parse::parser::parse(&f); // -> stack overflow, aborts the process
```

Same for a long unary-minus chain (`=-----…1`) and nested calls (`=SUM(SUM(SUM(…)))`).

## Fix

Track recursion depth on the `Parser` and return a `ParserError` once it exceeds `MAX_PARSE_DEPTH` (64, matching Excel's own formula-nesting limit) instead of recursing further. `parse_bp` becomes a thin wrapper that increments/decrements the counter around the existing logic (renamed `parse_bp_inner`), so the guard covers every nesting path (parens, unary, infix, calls).

Normal formulas are unaffected — 40-deep nesting still parses, and all 321 existing parser tests pass.

## Test

Adds a regression test that parses hostile deeply nested input (parens / unary / calls, 5000 deep) on a small **1 MiB** thread stack and asserts an `Err` is returned rather than the process aborting. On `main` this test aborts; with the fix it passes.

`cargo test -p formualizer-parse` (322 pass), `cargo clippy --workspace`, and `cargo fmt --all --check` are all clean.

---
*Disclosure: prepared with AI assistance; the crash was reproduced and the fix compiled/tested locally before submitting.*
