### PR TITLE
perf(eval): fix criteria, registry, and lookup-cache overhead

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@ docs-site/content/docs/reference/functions/** linguist-generated=true
 
 # Generated metadata consumed by docs components
 docs-site/src/generated/functions-meta.json linguist-generated=true
+
+# Unified diffs encode empty context lines as one space.
+benchmarks/*-baseline.patch whitespace=-blank-at-eol

--- a/benchmarks/perf-tranche-419-421-baseline.patch
+++ b/benchmarks/perf-tranche-419-421-baseline.patch
@@ -1,0 +1,42 @@
+--- a/crates/formualizer-eval/src/engine/eval.rs
++++ b/crates/formualizer-eval/src/engine/eval.rs
+@@ -2448,8 +2448,20 @@
+     use std::cell::Cell;
+ 
+     thread_local! {
++        static MASK_CALLS_ROWS: Cell<(usize, usize)> = const { Cell::new((0, 0)) };
+         static TEXT_SEGMENTS_TOTAL: Cell<usize> = const { Cell::new(0) };
+         static TEXT_SEGMENTS_ALL_NULL: Cell<usize> = const { Cell::new(0) };
++    }
++
++    pub(crate) fn take_mask_work() -> (usize, usize) {
++        MASK_CALLS_ROWS.with(|c| c.replace((0, 0)))
++    }
++
++    pub(crate) fn note_mask(rows: usize) {
++        MASK_CALLS_ROWS.with(|c| {
++            let (calls, work) = c.get();
++            c.set((calls + 1, work + rows));
++        });
+     }
+ 
+     pub fn reset_text_segment_counters() {
+@@ -25831,6 +25843,8 @@
+         col_in_view: usize,
+         pred: &crate::args::CriteriaPredicate,
+     ) -> Option<std::sync::Arc<arrow_array::BooleanArray>> {
++        #[cfg(test)]
++        criteria_mask_test_hooks::note_mask(view.dims().0);
+         if view.dims().1 == 0 {
+             return None;
+         }
+--- a/crates/formualizer-eval/src/engine/tests/mod.rs
++++ b/crates/formualizer-eval/src/engine/tests/mod.rs
+@@ -30,6 +30,7 @@
+ mod mark_dirty_multi_source;
+ mod mixed_target_coordinator;
+ mod parallel;
++mod perf_tranche;
+ mod range_dependencies;
+ mod range_property_tests;
+ mod recalc_plan;

--- a/benchmarks/perf-tranche-419-421.md
+++ b/benchmarks/perf-tranche-419-421.md
@@ -1,0 +1,92 @@
+# Criteria, registry, and exact-lookup lifecycle measurements
+
+Baseline: `2a8303d95acf2881c539e3700f7b8effc2e7bd35`. This tranche addresses #419, #420, and #421 without changing lookup matching rules or introducing a global predicate cache.
+
+## Changes
+
+- Criteria masks are lazily memoized per invocation/predicate/column, including unsupported results. Admission is limited to a 1 MiB conservative charge: array and backing buffers plus 512 bytes for Arc/buffer owners, allocation overhead and hash buckets. Over-budget masks retain the previous rebuild behavior; one current mask can exceed this additional-retention bound. Reduction order and mask padding stay unchanged. Unused text fallback lanes disappear; numeric fallback lanes are lazy.
+- Ordinary registry hits use a read lock and clone only the current function Arc. Prefix misses retain write-locked alias insertion with a registration/ownership recheck. Normalization still allocates.
+- Exact indexes and admission state are cleared at exclusive Engine snapshot mutation boundaries, covering data, topology and direct value edits. Concurrent admission checks the actual estimated size under the insertion lock, after duplicate detection. Text values, folded keys, hash capacity and spilled duplicate vectors are charged. Actual-size rejection is remembered until the next snapshot. Unrelated edits still invalidate conservatively; axis-local reuse is deferred.
+
+## Method
+
+The ignored `engine::tests::perf_tranche::release_probe` is a **cfg(test) release probe**, not a production executable or Criterion benchmark. It uses actual Engine Arrow storage and the Engine criteria/index paths, with an empty TestWorkbook as resolver. The thread-local allocation counter measures requested allocation/reallocation bytes, not peak/live memory. Parallel Engine allocation counts cover only the calling thread; the standalone registry probe sums its worker counters. Instrumentation overhead is present in both builds.
+
+Rust 1.93.0, default eval features (`system-clock`), release optimization with repository `lto=true`, `codegen-units=1`; no profile/RUSTFLAGS overrides. Linux x86_64, Ryzen 9 3900XT, 12 cores/24 threads. These are shared-host observations, with unrelated rendering workloads and no CPU pinning. No benchmarks overlap our builds. Final order was baseline/fixed/fixed/baseline, seven samples per run. Warm criteria/Engine distributions exclude sample zero (12 samples); registry uses 14 samples. Lookup distributions use medians of late cycles 4-15 per run/sample/needle position, then summarize those 14 medians. IQRs below are descriptive, not confidence intervals. Cold/setup/edit-only criteria distributions have only two observations.
+
+Fixtures are deterministic: criteria N=32768, 1/8/32 chunks, P=1/4, numeric alternating 0/1 or text alpha/beta, sums of 2, one/16 formulas. Tiny/sparse controls use eight rows, two populated criteria cells and four chunks. Registry uses 2048 independent nested ABS/ROUND formulas or arithmetic controls, one/four workers. Lookup uses 512 unique keys, numeric or 106-byte text, a 512000-byte cap, 24 MATCH/VLOOKUP/XLOOKUP formulas, 16 edit/recalc cycles and an additional no-edit dirty/recalc per cycle. Axis edits swap the queried key between first and last rows with different returns; unrelated edits touch F1. All output cells are checked outside timing.
+
+Timing fixtures assert **zero active FormulaPlane spans**, including AuthoritativeExperimental-configured cases: these are configured-legacy measurements, not active-span speedups. Separate batch-ingested correctness coverage asserts three active spans (MATCH, VLOOKUP, nested ABS/ROUND), changed numeric/text answers and warm reuse. XLOOKUP retains its existing unsupported-canonical-template fallback.
+
+## Results
+
+Warm single-formula SUMIFS, P=4, microseconds, median [p25, p75]:
+
+| Chunks | Numeric baseline | Numeric fixed | Text baseline | Text fixed |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 129 [129,130] | 127 [126,128] | 491 [487,494] | 490 [489,494] |
+| 8 | 1040 [1025,1055] | 155 [155,160] | 3948 [3944,4176] | 525 [520,535] |
+| 32 | 6248 [6180,6273] | 250 [249,258] | 18512 [18318,18589] | 624 [619,644] |
+
+At 32 chunks/P=4, mask calls fall from 128 to 4; requested logical rows from 4194304 to 131072. Requested allocation bytes fall from 5761147 to 365019 (numeric) and 6316891 to 382479 (text). P=1 follows the same structural reduction, 32 to 1 calls. With 16 report formulas, calls fall 2048 to 64; numeric/text warm medians are 101.12/298.08 ms baseline versus 4.05/10.16 ms fixed. Setup remains approximately 3.0/3.6 ms. The edited-overlay recalc is 101.77/301.69 ms versus 4.19/10.35 ms (only two observations).
+
+Tiny finite warm medians: 21.68 [21.45,24.16] to 10.83 [10.51,11.56] us; sparse whole-column: 23.00 [22.83,24.11] to 11.54 [11.44,12.88] us. Allocation bytes: 29256 to 13680 and 29841 to 14265. These are narrow four-chunk controls, not a general sparse-floor guarantee. Single-chunk dense text P=1 is essentially unchanged (137.59 to 139.00 us). `mask_logical_rows` counts requested view dimensions per mask call, not actual processed/allocated rows; the sparse fixture trims to eight rows. No separate physical-row counter or peak allocator measurement is claimed.
+
+Registry, milliseconds, median [p25,p75]:
+
+| Case | Baseline | Fixed |
+| --- | ---: | ---: |
+| Direct get, 1 worker, 200000 calls | 24.08 [23.95,24.36] | 12.48 [12.19,12.53] |
+| Direct get, 4 workers, 800000 calls | 260.06 [249.91,268.11] | 104.87 [101.62,106.77] |
+| Engine nested calls, Off, 1 worker | 4.44 [4.39,4.49] | 3.89 [3.88,4.01] |
+| Engine nested calls, Off, 4 workers | 3.51 [3.07,3.57] | 2.40 [2.30,2.47] |
+| Engine arithmetic, Off, 1 worker | 1.65 [1.61,1.68] | 1.61 [1.60,1.74] |
+| Engine arithmetic, Off, 4 workers | 1.34 [1.31,1.43] | 1.31 [1.21,1.42] |
+
+Direct get allocations fall from three to one per call (12 to 4 requested bytes/call averaged over ABS/ROUND). Structural tests show no resolution write path on registered/alias hits, including concurrent readers. Lock wait time is not separately profiled. Authoritative-configured legacy nested medians are 4.39 to 3.72 ms (one worker), 3.54 to 2.51 ms (four workers); do not extrapolate these to active-span execution or arbitrary providers.
+
+Late unrelated-edit lookup recalc, Off, microseconds:
+
+| Keys | Baseline median [p25,p75] | Fixed median [p25,p75] | Fixed no-edit warm |
+| --- | ---: | ---: | ---: |
+| Numeric | 1214 [1201,1228] | 195 [193,197] | 54 [53,54] |
+| Text | 1936 [1911,1942] | 265 [264,266] | 58 [57,58] |
+
+Baseline retains four obsolete entries/427008 estimated bytes, then reports zero builds/hits and 18 skipped-cap calls per edited evaluation (24 skipped on no-edit retries). Fixed retains two entries, 240128 numeric or 457216 text bytes: each edited evaluation has two builds/16 hits/six threshold skips/zero cap skips; no-edit evaluation has zero builds/24 hits. Changed-axis first/last medians are 191/226 us numeric and 266/321 us text; all changed answers pass. Cleanup intentionally moves work into edits: unrelated numeric edit median rises 2.00 to 6.35 us, text 2.05 to 35.72 us. Retained byte figures are estimated index charges, not total cache-map capacity or process RSS; index construction and externally held Arcs are outside admission accounting.
+
+## Reproduction
+
+Raw captures and compiled probe executables are local-only artifacts, not repository contents. This reviewable report, fixture source, baseline instrumentation patch, and summarizer provide the reproduction path below. Inspect and sanitize locally generated output before sharing it; do not commit binary archives or machine/environment dumps.
+
+The baseline instrumentation patch SHA-256 is `a8fbf4f93b8e2edd29a54a6bf37a8a671f902e20aefcc5350de4693ac864a8b7`.
+
+From the fixed checkout, build/copy each executable before rebuilding the other source. The emitted executable filename can vary with features/toolchain.
+
+```bash
+fix=$PWD
+out=/tmp/formualizer-perf-reproduce
+mkdir -p "$out"
+export CARGO_TARGET_DIR="$out/target"
+cargo +1.93.0 test -p formualizer-eval --lib --release --no-run -j 4
+# Copy the executable path printed by Cargo to "$out/fixed-probe".
+git worktree add --detach "$out/baseline-source" 2a8303d95acf2881c539e3700f7b8effc2e7bd35
+git -C "$out/baseline-source" apply "$fix/benchmarks/perf-tranche-419-421-baseline.patch"
+sed '/^\/\/ Regression tests/,$d' "$fix/crates/formualizer-eval/src/engine/tests/perf_tranche.rs" \
+  > "$out/baseline-source/crates/formualizer-eval/src/engine/tests/perf_tranche.rs"
+(cd "$out/baseline-source" && cargo +1.93.0 test -p formualizer-eval --lib --release --no-run -j 4)
+# Copy the newly emitted executable to "$out/baseline-probe".
+for run in baseline:1 fixed:1 fixed:2 baseline:2; do
+  variant=${run%:*}; repeat=${run#*:}
+  FZ_PERF_SAMPLES=7 "$out/$variant-probe" release_probe --ignored --nocapture --test-threads=1 \
+    > "$out/paired-$variant-$repeat.txt" || exit 1
+done
+uv run python3 benchmarks/summarize-perf-tranche.py "$out"/paired-*.txt > "$out/summary.json"
+```
+
+Optional `FZ_PERF_CASE=criteria|registry|lookup` selects one family. The common measured-harness SHA-256 is `0589298ab9223a8b8842202d2b83ada610eb41038cff04c366f6a26d91f9fe0f` (source before the regression-test marker). Baseline instrumentation only adds cfg(test) mask counters and the probe module. Initial baseline measurements preceded production changes; final paired baselines rebuild that same base with the expanded common fixture.
+
+## Correctness and gates
+
+Eight new regressions cover mask scaling/laziness/bounded distinct masks, current registry handles/read-only hits, concurrent cap/duplicate races, payload accounting, all snapshot mutation boundaries and warm reuse, active-span moved-key parity, and one rejected oversized text build per snapshot. Existing criteria blank/null/error/wildcard/cross-sheet/padding/overlay, cancellation, lookup duplicate first/last/temporal/error/volatile, registry ownership/replacement/provider and workbook UDF suites remain unchanged.
+
+`cargo +1.93.0 test -p formualizer-eval -p formualizer-workbook --tests -j 4 -- --test-threads=4`: 3057 passed, 16 ignored across 45 binaries (eval library: 2907 passed, 15 ignored). Format and `clippy` for these crates with `--tests -- -D warnings` pass. Full release eval library: 2906 passed, 15 ignored, one baseline-reproduced failure, `engine::arena::scalar::tests::test_scalar_arena_float_overflow` (expects a debug overflow panic absent in release). It passes in debug; no unrelated fix is included. No whole-workspace/optional-backend build or cross-platform claim is made.

--- a/benchmarks/summarize-perf-tranche.py
+++ b/benchmarks/summarize-perf-tranche.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Summarize standalone probe logs: uv run python3 benchmarks/summarize-perf-tranche.py LOG..."""
+import json
+import re
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+FIELDS = (
+    "chunks", "p", "text", "formulas", "threads", "mode", "calls", "axis_edit",
+    "whole_column", "active_spans", "execution",
+)
+METRICS = (
+    "ns", "edit_ns", "recalc_ns", "allocs", "allocated_bytes",
+    "allocs_main_thread", "allocated_bytes_main_thread", "lookups",
+    "mask_calls", "mask_logical_rows", "builds", "hits", "misses",
+    "skipped_cap", "skipped_below_threshold", "bytes_in_cache", "entries_count",
+)
+# First collapse lookup cycles within each run/sample/position to medians;
+# the resulting distribution does not treat correlated cycles as independent samples.
+groups = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+for filename in sys.argv[1:]:
+    path = Path(filename)
+    variant = "baseline" if "baseline" in path.name else "fixed"
+    for line in path.read_text().splitlines():
+        line = re.sub(r"^test .*? \.\.\. ", "", line)
+        if not line.startswith(("criteria", "registry", "lookup")):
+            continue
+        event = line.split()[0]
+        fields = dict(re.findall(r"(\w+)=(\S+)", line))
+        fields.update(re.findall(r"(\w+): (\d+)", line))
+        params = [f"{key}={fields[key]}" for key in FIELDS if key in fields]
+        if "cycle" in fields:
+            cycle = int(fields["cycle"])
+            phase = "initial" if cycle == 0 else "early" if cycle < 4 else "late"
+            position = "first" if fields["axis_edit"] == "true" and cycle % 2 else "last"
+            params.extend((f"phase={phase}", f"position={position}"))
+        elif event in ("criteria", "criteria_floor", "registry_engine"):
+            params.append("phase=cold" if fields["sample"] == "0" else "phase=warm")
+        sample = (filename, fields.get("sample", "setup"))
+        group = groups[(variant, event, " ".join(params))]
+        for metric in METRICS:
+            if metric in fields:
+                group[metric][sample].append(int(fields[metric]))
+
+output = []
+for (variant, event, params), metrics in sorted(groups.items()):
+    summary = {}
+    for metric, samples in metrics.items():
+        values = sorted(statistics.median(v) for v in samples.values())
+        if len(values) > 1:
+            p25, _, p75 = statistics.quantiles(values, n=4, method="inclusive")
+        else:
+            p25 = p75 = values[0]
+        summary[metric] = dict(n=len(values), median=statistics.median(values),
+                               p25=p25, p75=p75, min=values[0], max=values[-1])
+    output.append(dict(variant=variant, event=event, params=params, metrics=summary))
+json.dump(output, sys.stdout, indent=2)
+print()

--- a/crates/formualizer-eval/src/builtins/math/criteria_aggregates.rs
+++ b/crates/formualizer-eval/src/builtins/math/criteria_aggregates.rs
@@ -85,6 +85,43 @@ fn range_or_scalar<'a, 'b>(
     })
 }
 
+// Bound additional retained masks per invocation; an over-budget mask is still
+// used for the current chunk, but is not retained. Keep the row-major reduction
+// order unchanged (including floating-point summation order).
+const CRITERIA_MASK_MEMO_BYTES: usize = 1024 * 1024;
+
+#[derive(Default)]
+struct CriteriaMaskMemo {
+    masks: rustc_hash::FxHashMap<(usize, usize), Option<std::sync::Arc<BooleanArray>>>,
+    bytes: usize,
+}
+
+impl CriteriaMaskMemo {
+    fn get_or_build(
+        &mut self,
+        key: (usize, usize),
+        build: impl FnOnce() -> Option<std::sync::Arc<BooleanArray>>,
+    ) -> Option<std::sync::Arc<BooleanArray>> {
+        if let Some(mask) = self.masks.get(&key) {
+            return mask.clone();
+        }
+        let mask = build();
+        // Include the BooleanArray allocation and full backing buffers. The extra
+        // 512 bytes conservatively cover its Arc header, two Arrow buffer owners,
+        // allocator overhead, and hash buckets (including growth slack). Charge
+        // unsupported predicates too, so memo metadata remains bounded.
+        let bytes = mask
+            .as_ref()
+            .map_or(0, |m| m.get_array_memory_size())
+            .saturating_add(512);
+        if bytes <= CRITERIA_MASK_MEMO_BYTES.saturating_sub(self.bytes) {
+            self.bytes += bytes;
+            self.masks.insert(key, mask.clone());
+        }
+        mask
+    }
+}
+
 fn eval_if_family<'a, 'b>(
     args: &[ArgumentHandle<'a, 'b>],
     ctx: &dyn FunctionContext<'b>,
@@ -226,6 +263,7 @@ fn eval_if_family<'a, 'b>(
             drv
         };
 
+        let mut criteria_masks = CriteriaMaskMemo::default();
         for res in driver.iter_row_chunks() {
             let cs = res?;
             let row_start = cs.row_start;
@@ -234,18 +272,9 @@ fn eval_if_family<'a, 'b>(
                 continue;
             }
 
-            // Get slices for all criteria and sum range
-            let mut crit_num_slices = Vec::with_capacity(crit_specs.len());
-            let mut crit_text_slices = Vec::with_capacity(crit_specs.len());
-            for (rv, _, _) in &crit_specs {
-                if let Some(v) = rv {
-                    crit_num_slices.push(Some(v.slice_numbers(row_start, row_len)));
-                    crit_text_slices.push(Some(v.slice_lowered_text(row_start, row_len)));
-                } else {
-                    crit_num_slices.push(None);
-                    crit_text_slices.push(None);
-                }
-            }
+            // Numeric fallback lanes are materialized only if a mask is unsupported.
+            // Text fallback uses get_cell, not lowered-text lanes.
+            let mut crit_num_slices = vec![None; crit_specs.len()];
 
             let sum_slices = sum_view
                 .as_ref()
@@ -273,45 +302,47 @@ fn eval_if_family<'a, 'b>(
 
                     // Try cache
                     let cur_cached = if let Some(ref view) = crit_specs[j].0 {
-                        ctx.get_criteria_mask(view, c, pred).map(|m| {
-                            let fill = criteria_match(pred, &LiteralValue::Empty);
-                            let m_len = m.len();
+                        criteria_masks
+                            .get_or_build((j, c), || ctx.get_criteria_mask(view, c, pred))
+                            .map(|m| {
+                                let fill = criteria_match(pred, &LiteralValue::Empty);
+                                let m_len = m.len();
 
-                            // The cached mask may be shorter than the current driver's chunk
-                            // (e.g., whole-column references trimmed to different used-regions).
-                            // Treat out-of-bounds rows as Empty cells.
-                            if row_start + row_len <= m_len {
-                                #[cfg(test)]
-                                test_hooks::inc_slice_fast();
-                                let sl = m.slice(row_start, row_len);
-                                return sl
-                                    .as_any()
-                                    .downcast_ref::<arrow_array::BooleanArray>()
-                                    .expect("cached criteria mask slice downcast")
-                                    .clone();
-                            }
+                                // The cached mask may be shorter than the current driver's chunk
+                                // (e.g., whole-column references trimmed to different used-regions).
+                                // Treat out-of-bounds rows as Empty cells.
+                                if row_start + row_len <= m_len {
+                                    #[cfg(test)]
+                                    test_hooks::inc_slice_fast();
+                                    let sl = m.slice(row_start, row_len);
+                                    return sl
+                                        .as_any()
+                                        .downcast_ref::<arrow_array::BooleanArray>()
+                                        .expect("cached criteria mask slice downcast")
+                                        .clone();
+                                }
 
-                            let mut bb =
-                                arrow_array::builder::BooleanBuilder::with_capacity(row_len);
-                            if row_start < m_len {
-                                #[cfg(test)]
-                                test_hooks::inc_pad_partial();
-                                let take_len = row_len.min(m_len - row_start);
-                                let sl = m.slice(row_start, take_len);
-                                let ba = sl
-                                    .as_any()
-                                    .downcast_ref::<arrow_array::BooleanArray>()
-                                    .expect("cached criteria mask slice downcast");
-                                bb.append_array(ba);
-                                bb.append_n(row_len - take_len, fill);
-                            } else {
-                                #[cfg(test)]
-                                test_hooks::inc_pad_all_fill();
-                                bb.append_n(row_len, fill);
-                            }
+                                let mut bb =
+                                    arrow_array::builder::BooleanBuilder::with_capacity(row_len);
+                                if row_start < m_len {
+                                    #[cfg(test)]
+                                    test_hooks::inc_pad_partial();
+                                    let take_len = row_len.min(m_len - row_start);
+                                    let sl = m.slice(row_start, take_len);
+                                    let ba = sl
+                                        .as_any()
+                                        .downcast_ref::<arrow_array::BooleanArray>()
+                                        .expect("cached criteria mask slice downcast");
+                                    bb.append_array(ba);
+                                    bb.append_n(row_len - take_len, fill);
+                                } else {
+                                    #[cfg(test)]
+                                    test_hooks::inc_pad_all_fill();
+                                    bb.append_n(row_len, fill);
+                                }
 
-                            bb.finish()
-                        })
+                                bb.finish()
+                            })
                     } else {
                         None
                     };
@@ -324,28 +355,44 @@ fn eval_if_family<'a, 'b>(
                         continue;
                     }
 
-                    // Compute mask for this chunk
+                    // Compute mask for this chunk.
+                    use crate::args::CriteriaPredicate;
+                    if matches!(
+                        pred,
+                        CriteriaPredicate::Gt(_)
+                            | CriteriaPredicate::Ge(_)
+                            | CriteriaPredicate::Lt(_)
+                            | CriteriaPredicate::Le(_)
+                            | CriteriaPredicate::Eq(LiteralValue::Number(_) | LiteralValue::Int(_))
+                            | CriteriaPredicate::Ne(LiteralValue::Number(_) | LiteralValue::Int(_))
+                    ) && crit_num_slices[j].is_none()
+                    {
+                        crit_num_slices[j] = Some(
+                            crit_specs[j]
+                                .0
+                                .as_ref()
+                                .unwrap()
+                                .slice_numbers(row_start, row_len),
+                        );
+                    }
                     let num_col = crit_num_slices[j]
                         .as_ref()
                         .and_then(|cols| cols.get(c).and_then(|a| a.as_ref()));
-                    let text_col = crit_text_slices[j]
-                        .as_ref()
-                        .and_then(|cols| cols.get(c).and_then(|a| a.as_ref()));
 
-                    let m = match (pred, num_col, text_col) {
-                        (crate::args::CriteriaPredicate::Gt(n), Some(nc), _) => {
+                    let m = match (pred, num_col) {
+                        (crate::args::CriteriaPredicate::Gt(n), Some(nc)) => {
                             cmp::gt(nc.as_ref(), &Float64Array::new_scalar(*n)).unwrap()
                         }
-                        (crate::args::CriteriaPredicate::Ge(n), Some(nc), _) => {
+                        (crate::args::CriteriaPredicate::Ge(n), Some(nc)) => {
                             cmp::gt_eq(nc.as_ref(), &Float64Array::new_scalar(*n)).unwrap()
                         }
-                        (crate::args::CriteriaPredicate::Lt(n), Some(nc), _) => {
+                        (crate::args::CriteriaPredicate::Lt(n), Some(nc)) => {
                             cmp::lt(nc.as_ref(), &Float64Array::new_scalar(*n)).unwrap()
                         }
-                        (crate::args::CriteriaPredicate::Le(n), Some(nc), _) => {
+                        (crate::args::CriteriaPredicate::Le(n), Some(nc)) => {
                             cmp::lt_eq(nc.as_ref(), &Float64Array::new_scalar(*n)).unwrap()
                         }
-                        (crate::args::CriteriaPredicate::Eq(v), nc, tc) => {
+                        (crate::args::CriteriaPredicate::Eq(v), nc) => {
                             match v {
                                 LiteralValue::Number(x) => {
                                     let nx = *x;
@@ -451,7 +498,7 @@ fn eval_if_family<'a, 'b>(
                                 }
                             }
                         }
-                        (crate::args::CriteriaPredicate::Ne(v), nc, tc) => match v {
+                        (crate::args::CriteriaPredicate::Ne(v), nc) => match v {
                             LiteralValue::Number(x) => {
                                 let nx = *x;
                                 if let Some(nc) = nc {
@@ -545,7 +592,7 @@ fn eval_if_family<'a, 'b>(
                                 bb.finish()
                             }
                         },
-                        (crate::args::CriteriaPredicate::TextLike { .. }, _, _) => {
+                        (crate::args::CriteriaPredicate::TextLike { .. }, _) => {
                             let mut bb =
                                 arrow_array::builder::BooleanBuilder::with_capacity(row_len);
                             let view = crit_specs[j].0.as_ref().unwrap();
@@ -1559,6 +1606,45 @@ mod tests {
     }
     fn lit(v: LiteralValue) -> ASTNode {
         ASTNode::new(ASTNodeType::Literal(v), None)
+    }
+
+    #[test]
+    fn criteria_mask_memo_is_lazy_and_bounded() {
+        let mut memo = CriteriaMaskMemo::default();
+        let small = std::sync::Arc::new(BooleanArray::from(vec![true; 1024]));
+        assert!(memo.get_or_build((0, 0), || Some(small.clone())).is_some());
+        assert!(
+            memo.get_or_build((0, 0), || panic!("rebuilt mask"))
+                .is_some()
+        );
+        assert!(memo.get_or_build((1, 0), || None).is_none());
+        assert!(
+            memo.get_or_build((1, 0), || panic!("retried unsupported mask"))
+                .is_none()
+        );
+        let oversized =
+            std::sync::Arc::new(BooleanArray::from(vec![true; CRITERIA_MASK_MEMO_BYTES * 8]));
+        assert!(memo.get_or_build((2, 0), || Some(oversized)).is_some());
+        assert!(!memo.masks.contains_key(&(2, 0)));
+        // COUNTIF on a one-row wide range builds distinct tiny masks, not shared
+        // buffers. Include both mask allocations and the backing table in the gate.
+        for col in 1..16_384 {
+            memo.get_or_build((0, col), || {
+                Some(std::sync::Arc::new(BooleanArray::from(vec![true])))
+            });
+        }
+        let arrays_and_owners: usize = memo
+            .masks
+            .values()
+            .flatten()
+            .map(|m| m.get_array_memory_size() + 16 + 2 * 128)
+            .sum();
+        let buckets = (memo.masks.capacity() + 1).next_power_of_two();
+        let table_bytes = buckets
+            * (std::mem::size_of::<((usize, usize), Option<std::sync::Arc<BooleanArray>>)>() + 1);
+        assert!(arrays_and_owners + table_bytes <= CRITERIA_MASK_MEMO_BYTES);
+        assert!(memo.bytes <= CRITERIA_MASK_MEMO_BYTES);
+        assert!(memo.masks.len() < 16_384);
     }
 
     #[test]

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -2448,8 +2448,20 @@ pub(crate) mod criteria_mask_test_hooks {
     use std::cell::Cell;
 
     thread_local! {
+        static MASK_CALLS_ROWS: Cell<(usize, usize)> = const { Cell::new((0, 0)) };
         static TEXT_SEGMENTS_TOTAL: Cell<usize> = const { Cell::new(0) };
         static TEXT_SEGMENTS_ALL_NULL: Cell<usize> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn take_mask_work() -> (usize, usize) {
+        MASK_CALLS_ROWS.with(|c| c.replace((0, 0)))
+    }
+
+    pub(crate) fn note_mask(rows: usize) {
+        MASK_CALLS_ROWS.with(|c| {
+            let (calls, work) = c.get();
+            c.set((calls + 1, work + rows));
+        });
     }
 
     pub fn reset_text_segment_counters() {
@@ -5721,6 +5733,7 @@ where
     /// Mark data edited: bump snapshot and set edited flag.
     /// Value-only edits keep the stable-topology schedule cache alive.
     pub fn mark_data_edited(&mut self) {
+        self.lookup_index_cache.clear();
         self.snapshot_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.has_edited = true;
@@ -5728,6 +5741,7 @@ where
 
     /// Mark a topology-changing edit: bump snapshot + topology epoch and invalidate cached schedules.
     pub fn mark_topology_edited(&mut self) {
+        self.lookup_index_cache.clear();
         self.snapshot_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.topology_epoch = self.topology_epoch.wrapping_add(1);
@@ -17599,10 +17613,8 @@ where
         }
         // Mirror into Arrow overlay when enabled
         self.mirror_value_to_overlay(sheet, row, col, &value);
-        // Advance snapshot to reflect external mutation
-        self.snapshot_id
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.has_edited = true;
+        // Advance snapshot to reflect external mutation.
+        self.mark_data_edited();
         Ok(())
     }
 
@@ -25831,6 +25843,8 @@ where
         col_in_view: usize,
         pred: &crate::args::CriteriaPredicate,
     ) -> Option<std::sync::Arc<arrow_array::BooleanArray>> {
+        #[cfg(test)]
+        criteria_mask_test_hooks::note_mask(view.dims().0);
         if view.dims().1 == 0 {
             return None;
         }

--- a/crates/formualizer-eval/src/engine/lookup_index_cache.rs
+++ b/crates/formualizer-eval/src/engine/lookup_index_cache.rs
@@ -106,12 +106,24 @@ pub struct LookupIndex {
     pub(crate) first_empty: Option<usize>,
 }
 
+#[cfg(test)]
+thread_local! {
+    static BUILD_ATTEMPTS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn take_build_attempts() -> usize {
+    BUILD_ATTEMPTS.with(|c| c.replace(0))
+}
+
 impl LookupIndex {
     pub(crate) fn build(
         view: &RangeView<'_>,
         axis: LookupAxis,
         date_system: DateSystem,
     ) -> Result<BuildOutcome, ExcelError> {
+        #[cfg(test)]
+        BUILD_ATTEMPTS.with(|c| c.set(c.get() + 1));
         let (rows, cols) = view.dims();
         let len = match axis {
             LookupAxis::ColumnInView(col) => {
@@ -166,7 +178,7 @@ impl LookupIndex {
             return Ok(BuildOutcome::ErrorInLookupAxis);
         }
 
-        let bytes = estimate_bytes(len, entries.len());
+        let bytes = retained_bytes(&cell_values, &entries);
         Ok(BuildOutcome::Built(Self {
             len,
             date_system,
@@ -220,6 +232,63 @@ fn numeric_zero_candidate(needle: &LiteralValue) -> Option<f64> {
     }
 }
 
+fn retained_bytes(
+    values: &[LiteralValue],
+    entries: &FxHashMap<LookupHashKey, DuplicateIndices>,
+) -> usize {
+    // HashMap capacity excludes control bytes and vacant buckets. Round up to
+    // the backing power-of-two bucket count; allocator bookkeeping is estimated.
+    let buckets = if entries.capacity() == 0 {
+        0
+    } else {
+        entries.capacity().saturating_add(1).next_power_of_two()
+    };
+    let mut bytes = values
+        .len()
+        .saturating_mul(std::mem::size_of::<LiteralValue>())
+        .saturating_add(
+            buckets.saturating_mul(std::mem::size_of::<(LookupHashKey, DuplicateIndices)>() + 1),
+        )
+        .saturating_add(256);
+    for value in values {
+        bytes = bytes.saturating_add(literal_payload_bytes(value));
+    }
+    for (key, indices) in entries {
+        if let LookupHashKey::Text(text) = key {
+            bytes = bytes.saturating_add(text.len());
+        }
+        if indices.all.spilled() {
+            bytes = bytes.saturating_add(
+                indices
+                    .all
+                    .capacity()
+                    .saturating_mul(std::mem::size_of::<usize>()),
+            );
+        }
+    }
+    bytes
+}
+
+fn literal_payload_bytes(value: &LiteralValue) -> usize {
+    match value {
+        LiteralValue::Text(text) => text.capacity(),
+        LiteralValue::Array(rows) => rows.iter().fold(
+            rows.capacity()
+                .saturating_mul(std::mem::size_of::<Vec<LiteralValue>>()),
+            |bytes, row| {
+                row.iter().fold(
+                    bytes.saturating_add(
+                        row.capacity()
+                            .saturating_mul(std::mem::size_of::<LiteralValue>()),
+                    ),
+                    |bytes, value| bytes.saturating_add(literal_payload_bytes(value)),
+                )
+            },
+        ),
+        _ => 0,
+    }
+}
+
 pub(crate) fn estimate_bytes(len: usize, entries: usize) -> usize {
     len.saturating_mul(std::mem::size_of::<LiteralValue>().saturating_add(8))
         .saturating_add(entries.saturating_mul(96))
@@ -233,6 +302,7 @@ pub(crate) enum BuildOutcome {
 }
 
 const LOOKUP_INDEX_BUILD_THRESHOLD: u32 = 3;
+const CAP_REJECTED: u32 = u32::MAX;
 const CALL_COUNT_PRUNE_LIMIT: usize = 4096;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -291,6 +361,24 @@ impl LookupIndexCache {
         }
     }
 
+    // Called only at an exclusive Engine mutation boundary, after all evaluation
+    // workers have joined. No old-generation builder can race this reclamation.
+    pub(crate) fn clear(&mut self) {
+        self.inner
+            .get_mut()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
+        self.call_counts
+            .get_mut()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
+        self.volatile_keys
+            .get_mut()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
+        self.bytes_in_use.store(0, Ordering::Relaxed);
+    }
+
     pub(crate) fn get(&self, key: &LookupIndexKey) -> Option<Arc<LookupIndex>> {
         let found = self
             .inner
@@ -314,7 +402,11 @@ impl LookupIndexCache {
             guard.retain(|existing_key, _| existing_key.snapshot_id == key.snapshot_id);
         }
         let count = guard.entry(key).or_insert(0);
-        *count = count.saturating_add(1);
+        if *count == CAP_REJECTED {
+            self.skipped_cap.fetch_add(1, Ordering::Relaxed);
+            return false;
+        }
+        *count = count.saturating_add(1).min(CAP_REJECTED - 1);
         if *count <= self.build_threshold {
             self.skipped_below_threshold.fetch_add(1, Ordering::Relaxed);
             return false;
@@ -352,17 +444,24 @@ impl LookupIndexCache {
         index: LookupIndex,
     ) -> Option<Arc<LookupIndex>> {
         let bytes = index.bytes;
-        let current = self.bytes_in_use.load(Ordering::Relaxed);
-        if current.saturating_add(bytes) > self.max_bytes {
-            self.skipped_cap.fetch_add(1, Ordering::Relaxed);
-            return None;
-        }
-        let index = Arc::new(index);
         if let Ok(mut guard) = self.inner.write() {
             if let Some(existing) = guard.get(&key) {
                 self.hits.fetch_add(1, Ordering::Relaxed);
                 return Some(existing.clone());
             }
+            // Serialize duplicate detection, admission and accounting. The earlier
+            // preflight estimate is only a hint and cannot reserve concurrent space.
+            let current = self.bytes_in_use.load(Ordering::Relaxed);
+            if bytes > self.max_bytes.saturating_sub(current) {
+                self.skipped_cap.fetch_add(1, Ordering::Relaxed);
+                // Actual payloads (especially text) can exceed the preflight
+                // estimate. Do not rebuild and discard them on every later call.
+                if let Ok(mut counts) = self.call_counts.write() {
+                    counts.insert(key, CAP_REJECTED);
+                }
+                return None;
+            }
+            let index = Arc::new(index);
             guard.insert(key, index.clone());
             self.bytes_in_use.fetch_add(bytes, Ordering::Relaxed);
             self.builds.fetch_add(1, Ordering::Relaxed);
@@ -400,11 +499,8 @@ impl LookupIndexCache {
     }
 
     pub(crate) fn report(&self) -> LookupIndexCacheReport {
-        let entries_count = self
-            .inner
-            .read()
-            .map(|guard| guard.len())
-            .unwrap_or_default();
+        let guard = self.inner.read().ok();
+        let entries_count = guard.as_ref().map_or(0, |guard| guard.len());
         LookupIndexCacheReport {
             builds: self.builds.load(Ordering::Relaxed),
             hits: self.hits.load(Ordering::Relaxed),
@@ -417,5 +513,95 @@ impl LookupIndexCache {
             bytes_in_cache: self.bytes_in_use.load(Ordering::Relaxed),
             entries_count,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(col: u32) -> LookupIndexKey {
+        LookupIndexKey {
+            sheet_id: 0,
+            start_row: 0,
+            start_col: col,
+            end_row: 128,
+            end_col: col,
+            axis: LookupAxis::ColumnInView(0),
+            snapshot_id: 1,
+        }
+    }
+    fn index(bytes: usize) -> LookupIndex {
+        LookupIndex {
+            len: 0,
+            date_system: DateSystem::Excel1900,
+            bytes,
+            entries: FxHashMap::default(),
+            cell_values: Box::new([]),
+            first_empty: None,
+        }
+    }
+
+    #[test]
+    fn concurrent_admission_and_duplicate_races_obey_cap() {
+        for duplicate in [false, true] {
+            let mut cache = LookupIndexCache::new(if duplicate { 1024 } else { 4096 });
+            let barrier = std::sync::Barrier::new(16);
+            std::thread::scope(|scope| {
+                let handles: Vec<_> = (0..16)
+                    .map(|i| {
+                        let cache = &cache;
+                        let barrier = &barrier;
+                        scope.spawn(move || {
+                            barrier.wait();
+                            cache.insert_if_room(key(if duplicate { 0 } else { i }), index(1024))
+                        })
+                    })
+                    .collect();
+                let admitted: Vec<_> = handles
+                    .into_iter()
+                    .filter_map(|h| h.join().unwrap())
+                    .collect();
+                assert_eq!(admitted.len(), if duplicate { 16 } else { 4 });
+                if duplicate {
+                    assert!(admitted.iter().all(|item| Arc::ptr_eq(item, &admitted[0])));
+                }
+            });
+            let report = cache.report();
+            assert_eq!(report.bytes_in_cache, cache.max_bytes);
+            assert_eq!(report.builds, if duplicate { 1 } else { 4 });
+            assert_eq!(report.entries_count, report.builds);
+            assert_eq!(report.skipped_cap, if duplicate { 0 } else { 12 });
+            cache.clear();
+            assert_eq!(cache.report().bytes_in_cache, 0);
+            assert_eq!(cache.report().entries_count, 0);
+            assert!(cache.insert_if_room(key(0), index(1024)).is_some());
+        }
+    }
+
+    #[test]
+    fn retained_text_and_duplicate_heap_payloads_are_charged() {
+        let mut entries = FxHashMap::default();
+        let mut text = String::with_capacity(4096);
+        text.push_str("LONG KEY");
+        let values = [LiteralValue::Text(text)];
+        let empty_bytes = retained_bytes(&[], &entries);
+        assert_eq!(
+            retained_bytes(&values, &entries) - empty_bytes,
+            std::mem::size_of::<LiteralValue>() + 4096
+        );
+        let mut dups = DuplicateIndices::default();
+        dups.all.extend(0..100);
+        let heap_bytes = dups.all.capacity() * std::mem::size_of::<usize>();
+        entries.insert(LookupHashKey::Text("long key".into()), dups);
+        let charged = retained_bytes(&values, &entries);
+        assert!(charged >= empty_bytes + 4096 + 8 + heap_bytes);
+        entries
+            .get_mut(&LookupHashKey::Text("long key".into()))
+            .unwrap()
+            .all = SmallVec::new();
+        assert_eq!(charged - retained_bytes(&values, &entries), heap_bytes);
+        let cache = LookupIndexCache::new(charged - 1);
+        assert!(cache.insert_if_room(key(0), index(charged)).is_none());
     }
 }

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -26,6 +26,7 @@ mod graph_internal_helpers;
 mod issue_326_error_skip_oracle;
 mod layer_evaluation;
 mod load_fast_mappings;
+mod perf_tranche;
 //mod mark_dirty_benchmarks;
 mod mark_dirty_multi_source;
 mod mixed_target_coordinator;

--- a/crates/formualizer-eval/src/engine/tests/perf_tranche.rs
+++ b/crates/formualizer-eval/src/engine/tests/perf_tranche.rs
@@ -1,0 +1,638 @@
+//! Standalone release probe: see benchmarks/perf-tranche-419-421.md.
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::hint::black_box;
+use std::time::Instant;
+
+use crate::engine::{Engine, EvalConfig, FormulaPlaneMode};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::LiteralValue;
+use formualizer_parse::parser::parse;
+
+thread_local! {
+    static ALLOCATIONS: Cell<Option<(usize, usize)>> = const { Cell::new(None) };
+}
+struct ProbeAllocator;
+#[global_allocator]
+static ALLOCATOR: ProbeAllocator = ProbeAllocator;
+
+fn allocation(bytes: usize) {
+    let _ = ALLOCATIONS.try_with(|c| {
+        if let Some((calls, total)) = c.get() {
+            c.set(Some((calls + 1, total + bytes)));
+        }
+    });
+}
+unsafe impl GlobalAlloc for ProbeAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        allocation(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        allocation(layout.size());
+        unsafe { System.alloc_zeroed(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        allocation(size);
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+fn measure(f: impl FnOnce()) -> (u128, usize, usize) {
+    ALLOCATIONS.with(|c| c.set(Some((0, 0))));
+    let start = Instant::now();
+    f();
+    let ns = start.elapsed().as_nanos();
+    let (calls, bytes) = ALLOCATIONS.with(|c| c.replace(None).unwrap());
+    (ns, calls, bytes)
+}
+fn config(mode: FormulaPlaneMode, threads: usize) -> EvalConfig {
+    EvalConfig {
+        enable_parallel: threads > 1,
+        max_threads: Some(threads),
+        formula_plane_mode: mode,
+        arrow_storage_enabled: true,
+        delta_overlay_enabled: true,
+        write_formula_overlay_enabled: true,
+        ..EvalConfig::default()
+    }
+}
+fn formula(e: &mut Engine<TestWorkbook>, row: u32, col: u32, text: &str) {
+    e.set_cell_formula("Sheet1", row, col, parse(text).unwrap())
+        .unwrap();
+}
+fn dirty(e: &mut Engine<TestWorkbook>) {
+    let ids: Vec<_> = e.graph.vertices_with_formulas().collect();
+    for id in ids {
+        e.graph.mark_vertex_dirty(id);
+    }
+    e.graph.mark_all_formula_spans_dirty(
+        crate::engine::graph::WholeSpanDirtyReason::GlobalInvalidation,
+    );
+}
+fn assert_number(e: &Engine<TestWorkbook>, row: u32, col: u32, expected: f64) {
+    let v = e.get_cell_value("Sheet1", row, col).unwrap();
+    let n = match v {
+        LiteralValue::Number(n) => n,
+        LiteralValue::Int(n) => n as f64,
+        _ => panic!("{v:?}"),
+    };
+    assert_eq!(n, expected);
+}
+fn samples() -> usize {
+    std::env::var("FZ_PERF_SAMPLES")
+        .ok()
+        .map(|s| s.parse().unwrap())
+        .unwrap_or(7)
+}
+
+fn criteria() {
+    const N: usize = 32768;
+    for chunks in [1, 8, 32] {
+        for predicates in [1, 4] {
+            for text in [false, true] {
+                for formulas in [1, 16] {
+                    let mut e = Engine::new(TestWorkbook::new(), config(FormulaPlaneMode::Off, 1));
+                    let setup = measure(|| {
+                        let mut ingest = e.begin_bulk_ingest_arrow();
+                        ingest.add_sheet("Sheet1", 2, N / chunks);
+                        for i in 0..N {
+                            let key = if text {
+                                LiteralValue::Text(if i % 2 == 0 { "alpha" } else { "beta" }.into())
+                            } else {
+                                LiteralValue::Number((i % 2) as f64)
+                            };
+                            ingest
+                                .append_row("Sheet1", &[key, LiteralValue::Number(2.0)])
+                                .unwrap();
+                        }
+                        ingest.finish().unwrap();
+                        let pred = if text { "\"alpha\"" } else { "\">0\"" };
+                        let pairs = std::iter::repeat_n(format!("A1:A{N},{pred}"), predicates)
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        for row in 1..=formulas {
+                            formula(&mut e, row, 4, &format!("=SUMIFS(B1:B{N},{pairs})"));
+                        }
+                    });
+                    println!(
+                        "criteria_setup chunks={chunks} p={predicates} text={text} formulas={formulas} ns={} allocs={} allocated_bytes={}",
+                        setup.0, setup.1, setup.2
+                    );
+                    for sample in 0..samples() {
+                        dirty(&mut e);
+                        super::super::eval::criteria_mask_test_hooks::take_mask_work();
+                        let m = measure(|| {
+                            e.evaluate_all().unwrap();
+                        });
+                        let work = super::super::eval::criteria_mask_test_hooks::take_mask_work();
+                        for row in 1..=formulas {
+                            assert_number(&e, row, 4, N as f64);
+                        }
+                        println!(
+                            "criteria chunks={chunks} p={predicates} text={text} formulas={formulas} sample={sample} ns={} allocs={} allocated_bytes={} mask_calls={} mask_logical_rows={}",
+                            m.0, m.1, m.2, work.0, work.1
+                        );
+                    }
+                    let edit = measure(|| {
+                        e.set_cell_value("Sheet1", 1, 2, LiteralValue::Number(4.0))
+                            .unwrap();
+                    });
+                    let recalc = measure(|| {
+                        e.evaluate_all().unwrap();
+                    });
+                    for row in 1..=formulas {
+                        assert_number(&e, row, 4, N as f64 + if text { 2.0 } else { 0.0 });
+                    }
+                    println!(
+                        "criteria_edit chunks={chunks} p={predicates} text={text} formulas={formulas} edit_ns={} recalc_ns={} allocated_bytes={}",
+                        edit.0, recalc.0, recalc.2
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn criteria_floors() {
+    for whole_column in [false, true] {
+        let mut e = Engine::new(TestWorkbook::new(), config(FormulaPlaneMode::Off, 1));
+        let setup = measure(|| {
+            let mut ingest = e.begin_bulk_ingest_arrow();
+            ingest.add_sheet("Sheet1", 2, 2);
+            for i in 0..8 {
+                let value = if i == 0 || i == 7 {
+                    LiteralValue::Number(1.0)
+                } else {
+                    LiteralValue::Empty
+                };
+                ingest
+                    .append_row("Sheet1", &[value, LiteralValue::Number(2.0)])
+                    .unwrap();
+            }
+            ingest.finish().unwrap();
+            formula(
+                &mut e,
+                1,
+                4,
+                if whole_column {
+                    "=SUMIFS(B:B,A:A,\">0\")"
+                } else {
+                    "=SUMIFS(B1:B8,A1:A8,\">0\")"
+                },
+            );
+        });
+        println!(
+            "criteria_floor_setup whole_column={whole_column} ns={} allocated_bytes={}",
+            setup.0, setup.2
+        );
+        for sample in 0..samples() {
+            dirty(&mut e);
+            super::super::eval::criteria_mask_test_hooks::take_mask_work();
+            let m = measure(|| {
+                e.evaluate_all().unwrap();
+            });
+            let work = super::super::eval::criteria_mask_test_hooks::take_mask_work();
+            assert_number(&e, 1, 4, 4.0);
+            println!(
+                "criteria_floor whole_column={whole_column} sample={sample} ns={} allocs={} allocated_bytes={} mask_calls={} mask_logical_rows={}",
+                m.0, m.1, m.2, work.0, work.1
+            );
+        }
+    }
+}
+
+fn registry() {
+    crate::builtins::load_builtins();
+    for threads in [1, 4] {
+        for sample in 0..samples() {
+            let start = Instant::now();
+            let counts: Vec<_> = std::thread::scope(|s| {
+                (0..threads)
+                    .map(|_| {
+                        s.spawn(|| {
+                            measure(|| {
+                                for _ in 0..100_000 {
+                                    black_box(crate::function_registry::get("", "ABS").unwrap());
+                                    black_box(crate::function_registry::get("", "ROUND").unwrap());
+                                }
+                            })
+                        })
+                    })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .map(|h| h.join().unwrap())
+                    .collect()
+            });
+            println!(
+                "registry threads={threads} sample={sample} ns={} lookups={} allocs={} allocated_bytes={}",
+                start.elapsed().as_nanos(),
+                threads * 200_000,
+                counts.iter().map(|x| x.1).sum::<usize>(),
+                counts.iter().map(|x| x.2).sum::<usize>()
+            );
+        }
+        for mode in [
+            FormulaPlaneMode::Off,
+            FormulaPlaneMode::AuthoritativeExperimental,
+        ] {
+            for calls in [false, true] {
+                let mut e = Engine::new(TestWorkbook::new(), config(mode, threads));
+                let setup = measure(|| {
+                    for row in 1..=2048 {
+                        e.set_cell_value("Sheet1", row, 1, LiteralValue::Number(-2.0))
+                            .unwrap();
+                        let expr = if calls {
+                            format!("=ABS(ROUND(ABS(ROUND(A{row},2)),2))")
+                        } else {
+                            format!("=((A{row}+2)*3-4)/2")
+                        };
+                        formula(&mut e, row, 2, &expr);
+                    }
+                });
+                let spans = e.baseline_stats().formula_plane_active_span_count;
+                assert_eq!(spans, 0);
+                println!(
+                    "registry_engine_setup threads={threads} mode={mode:?} calls={calls} ns={} active_spans={spans} execution=legacy",
+                    setup.0
+                );
+                for sample in 0..samples() {
+                    dirty(&mut e);
+                    let m = measure(|| {
+                        e.evaluate_all().unwrap();
+                    });
+                    for row in 1..=2048 {
+                        assert_number(&e, row, 2, if calls { 2.0 } else { -2.0 });
+                    }
+                    println!(
+                        "registry_engine threads={threads} mode={mode:?} calls={calls} formulas=2048 sample={sample} ns={} allocs_main_thread={} allocated_bytes_main_thread={}",
+                        m.0, m.1, m.2
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn lookup() {
+    const N: usize = 512;
+    for mode in [
+        FormulaPlaneMode::Off,
+        FormulaPlaneMode::AuthoritativeExperimental,
+    ] {
+        for text in [false, true] {
+            for axis_edit in [false, true] {
+                for sample in 0..samples() {
+                    let mut cfg = config(mode, 1);
+                    cfg.lookup_index_cache_max_bytes = 512_000;
+                    let mut e = Engine::new(TestWorkbook::new(), cfg);
+                    let key = |i: usize| {
+                        if text {
+                            LiteralValue::Text(format!("key-{i:05}-{}", "x".repeat(96)))
+                        } else {
+                            LiteralValue::Number(i as f64)
+                        }
+                    };
+                    let setup = measure(|| {
+                        let mut ingest = e.begin_bulk_ingest_arrow();
+                        ingest.add_sheet("Sheet1", 2, 64);
+                        for i in 0..N {
+                            ingest
+                                .append_row("Sheet1", &[key(i), LiteralValue::Number(i as f64)])
+                                .unwrap();
+                        }
+                        ingest.finish().unwrap();
+                        e.set_cell_value("Sheet1", 1, 3, key(N - 1)).unwrap();
+                        for row in 1..=24 {
+                            let expr = match row % 3 {
+                                0 => format!("=VLOOKUP($C$1,$A$1:$B${N},2,FALSE)"),
+                                1 => format!("=MATCH($C$1,$A$1:$A${N},0)-1"),
+                                _ => format!("=XLOOKUP($C$1,$A$1:$A${N},$B$1:$B${N})"),
+                            };
+                            formula(&mut e, row, 4, &expr);
+                        }
+                    });
+                    let spans = e.baseline_stats().formula_plane_active_span_count;
+                    assert_eq!(spans, 0);
+                    println!(
+                        "lookup_setup mode={mode:?} text={text} axis_edit={axis_edit} sample={sample} ns={} active_spans={spans} execution=legacy",
+                        setup.0
+                    );
+                    for cycle in 0..16 {
+                        let edit = measure(|| {
+                            if cycle > 0 {
+                                if axis_edit {
+                                    let moved = cycle % 2 == 1;
+                                    e.set_cell_value(
+                                        "Sheet1",
+                                        1,
+                                        1,
+                                        key(if moved { N - 1 } else { 0 }),
+                                    )
+                                    .unwrap();
+                                    e.set_cell_value(
+                                        "Sheet1",
+                                        N as u32,
+                                        1,
+                                        key(if moved { 0 } else { N - 1 }),
+                                    )
+                                    .unwrap();
+                                } else {
+                                    e.set_cell_value(
+                                        "Sheet1",
+                                        1,
+                                        6,
+                                        LiteralValue::Number(cycle as f64),
+                                    )
+                                    .unwrap();
+                                }
+                            }
+                        });
+                        dirty(&mut e);
+                        let m = measure(|| {
+                            e.evaluate_all().unwrap();
+                        });
+                        let expected = if axis_edit && cycle % 2 == 1 {
+                            0.0
+                        } else {
+                            (N - 1) as f64
+                        };
+                        for row in 1..=24 {
+                            assert_number(&e, row, 4, expected);
+                        }
+                        println!(
+                            "lookup mode={mode:?} text={text} axis_edit={axis_edit} sample={sample} cycle={cycle} edit_ns={} ns={} allocs={} allocated_bytes={} report={:?}",
+                            edit.0,
+                            m.0,
+                            m.1,
+                            m.2,
+                            e.last_lookup_index_cache_report()
+                        );
+                        dirty(&mut e);
+                        let warm = measure(|| {
+                            e.evaluate_all().unwrap();
+                        });
+                        for row in 1..=24 {
+                            assert_number(&e, row, 4, expected);
+                        }
+                        println!(
+                            "lookup_warm mode={mode:?} text={text} axis_edit={axis_edit} sample={sample} cycle={cycle} ns={} allocs={} allocated_bytes={} report={:?}",
+                            warm.0,
+                            warm.1,
+                            warm.2,
+                            e.last_lookup_index_cache_report()
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore = "release measurement; run alone with --nocapture --test-threads=1"]
+fn release_probe() {
+    match std::env::var("FZ_PERF_CASE").as_deref() {
+        Ok("criteria") => {
+            criteria();
+            criteria_floors();
+        }
+        Ok("registry") => registry(),
+        Ok("lookup") => lookup(),
+        _ => {
+            criteria();
+            criteria_floors();
+            registry();
+            lookup();
+        }
+    }
+}
+
+// Regression tests (not part of the baseline measurement harness).
+#[test]
+fn criteria_whole_mask_work_is_independent_of_driver_chunks() {
+    for mode in [
+        FormulaPlaneMode::Off,
+        FormulaPlaneMode::AuthoritativeExperimental,
+    ] {
+        for chunks in [1, 8, 32] {
+            for text in [false, true] {
+                let mut e = Engine::new(TestWorkbook::new(), config(mode, 1));
+                let mut ingest = e.begin_bulk_ingest_arrow();
+                ingest.add_sheet("Sheet1", 2, 256 / chunks);
+                for _ in 0..256 {
+                    let key = if text {
+                        LiteralValue::Text("alpha".into())
+                    } else {
+                        LiteralValue::Number(1.0)
+                    };
+                    ingest
+                        .append_row("Sheet1", &[key, LiteralValue::Number(2.0)])
+                        .unwrap();
+                }
+                ingest.finish().unwrap();
+                let pred = if text { "\"a*\"" } else { "\">0\"" };
+                for p in [1, 4] {
+                    let pairs = std::iter::repeat_n(format!("A1:A256,{pred}"), p)
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    for (expression, expected, calls) in [
+                        (format!("=SUMIFS(B1:B256,{pairs})"), 512.0, p),
+                        (format!("=COUNTIFS({pairs})"), 256.0, p),
+                        (format!("=AVERAGEIFS(B1:B256,{pairs})"), 2.0, p),
+                        (format!("=SUMIF(A1:A256,{pred},B1:B256)"), 512.0, 1),
+                        (format!("=SUMIFS(B1:B256,FALSE,TRUE,{pairs})"), 0.0, 0),
+                    ] {
+                        formula(&mut e, 1, 4, &expression);
+                        super::super::eval::criteria_mask_test_hooks::take_mask_work();
+                        e.evaluate_all().unwrap();
+                        assert_number(&e, 1, 4, expected);
+                        assert_eq!(
+                            super::super::eval::criteria_mask_test_hooks::take_mask_work(),
+                            (calls, calls * 256),
+                            "{mode:?} chunks={chunks} {expression}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn lookup_mutation_boundaries_reclaim_and_readmit() {
+    for mode in [
+        FormulaPlaneMode::Off,
+        FormulaPlaneMode::AuthoritativeExperimental,
+    ] {
+        for mutation in 0..4 {
+            let mut cfg = config(mode, 1);
+            cfg.lookup_index_cache_max_bytes = 512_000;
+            let mut e = Engine::new(TestWorkbook::new(), cfg);
+            for row in 1..=128 {
+                e.set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+                    .unwrap();
+            }
+            for row in 1..=12 {
+                formula(&mut e, row, 3, "=MATCH(128,$A$1:$A$128,0)");
+            }
+            for cycle in 0..8 {
+                dirty(&mut e);
+                e.evaluate_all().unwrap();
+                let report = e.last_lookup_index_cache_report();
+                assert_eq!(report.builds, 1, "{mode:?} {mutation} {cycle} {report:?}");
+                assert!(report.hits >= 8, "{report:?}");
+                assert_eq!(report.entries_count, 1);
+                assert_eq!(report.skipped_cap, 0);
+                assert_number(&e, 1, 3, 128.0);
+                dirty(&mut e);
+                e.evaluate_all().unwrap();
+                let warm = e.last_lookup_index_cache_report();
+                assert_eq!(warm.builds, 0);
+                assert_eq!(warm.hits, 12);
+                assert_eq!(warm.bytes_in_cache, report.bytes_in_cache);
+                assert_eq!(warm.entries_count, report.entries_count);
+                match mutation {
+                    0 => e.mark_data_edited(),
+                    1 => e.mark_topology_edited(),
+                    2 => e
+                        .set_cell_value("Sheet1", 1, 6, LiteralValue::Number(cycle as f64))
+                        .unwrap(),
+                    _ => e
+                        .set_cell_value("Sheet1", 1, 1, LiteralValue::Number(-(cycle as f64)))
+                        .unwrap(),
+                }
+                let report = e.last_lookup_index_cache_report();
+                assert_eq!(report.entries_count, 0);
+                assert_eq!(report.bytes_in_cache, 0);
+            }
+        }
+    }
+}
+
+#[test]
+fn lookup_axis_edits_change_answers_with_active_spans() {
+    use crate::engine::{FormulaIngestBatch, FormulaIngestRecord};
+    for mode in [
+        FormulaPlaneMode::Off,
+        FormulaPlaneMode::AuthoritativeExperimental,
+    ] {
+        for text in [false, true] {
+            let mut e = Engine::new(TestWorkbook::new(), config(mode, 1));
+            let key = |i: u32| {
+                if text {
+                    LiteralValue::Text(format!("key-{i}"))
+                } else {
+                    LiteralValue::Number(i as f64)
+                }
+            };
+            for row in 1..=128 {
+                e.set_cell_value("Sheet1", row, 1, key(row)).unwrap();
+                e.set_cell_value("Sheet1", row, 2, LiteralValue::Number(row as f64 * 10.0))
+                    .unwrap();
+            }
+            e.set_cell_value("Sheet1", 1, 6, key(128)).unwrap();
+            let mut records = Vec::new();
+            for row in 1..=24 {
+                for (col, expr) in [
+                    (3, "=MATCH($F$1,$A$1:$A$128,0)"),
+                    (4, "=VLOOKUP($F$1,$A$1:$B$128,2,FALSE)"),
+                    (5, "=XLOOKUP($F$1,$A$1:$A$128,$B$1:$B$128)"),
+                    (7, "=ABS(ROUND(ABS(ROUND($B$1,2)),2))"),
+                ] {
+                    let ast = e.intern_formula_ast(&parse(expr).unwrap());
+                    records.push(FormulaIngestRecord::new(
+                        row,
+                        col,
+                        ast,
+                        Some(std::sync::Arc::<str>::from(expr)),
+                    ));
+                }
+            }
+            e.ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", records)])
+                .unwrap();
+            let spans = e.baseline_stats().formula_plane_active_span_count;
+            if mode == FormulaPlaneMode::AuthoritativeExperimental {
+                assert_eq!(spans, 3);
+                // MATCH, VLOOKUP and nested ABS/ROUND promote. XLOOKUP currently
+                // retains its existing UnsupportedCanonicalTemplate fallback.
+                assert_eq!(
+                    e.last_formula_ingest_report()
+                        .unwrap()
+                        .graph_formula_cells_materialized,
+                    24
+                );
+            } else {
+                assert_eq!(spans, 0);
+            }
+            for cycle in 0..4 {
+                if cycle > 0 {
+                    e.set_cell_value("Sheet1", 1, 1, key(if cycle % 2 == 1 { 128 } else { 1 }))
+                        .unwrap();
+                    e.set_cell_value("Sheet1", 128, 1, key(if cycle % 2 == 1 { 1 } else { 128 }))
+                        .unwrap();
+                }
+                dirty(&mut e);
+                e.evaluate_all().unwrap();
+                for row in 1..=24 {
+                    assert_number(&e, row, 3, if cycle % 2 == 1 { 1.0 } else { 128.0 });
+                    for col in [4, 5] {
+                        assert_number(&e, row, col, if cycle % 2 == 1 { 10.0 } else { 1280.0 });
+                    }
+                    assert_number(&e, row, 7, 10.0);
+                }
+                let report = e.last_lookup_index_cache_report();
+                assert_eq!(
+                    report.builds,
+                    if mode == FormulaPlaneMode::Off { 2 } else { 1 },
+                    "{mode:?} {report:?}"
+                );
+                dirty(&mut e);
+                e.evaluate_all().unwrap();
+                let warm = e.last_lookup_index_cache_report();
+                assert_eq!(warm.builds, 0);
+                assert!(warm.hits > 0);
+                assert_eq!(warm.bytes_in_cache, report.bytes_in_cache);
+            }
+        }
+    }
+}
+
+#[test]
+fn oversized_text_index_is_built_once_per_snapshot() {
+    use crate::engine::lookup_index_cache::take_build_attempts;
+    let mut cfg = config(FormulaPlaneMode::Off, 1);
+    cfg.lookup_index_cache_max_bytes = 512_000;
+    let mut e = Engine::new(TestWorkbook::new(), cfg);
+    for row in 1..=128 {
+        e.set_cell_value(
+            "Sheet1",
+            row,
+            1,
+            LiteralValue::Text(format!("{row}-{}", "X".repeat(4096))),
+        )
+        .unwrap();
+    }
+    for row in 1..=16 {
+        formula(&mut e, row, 3, "=MATCH($A$1,$A$1:$A$128,0)");
+    }
+    for _ in 0..3 {
+        take_build_attempts();
+        dirty(&mut e);
+        e.evaluate_all().unwrap();
+        assert_eq!(take_build_attempts(), 1);
+        for row in 1..=16 {
+            assert_number(&e, row, 3, 1.0);
+        }
+        let report = e.last_lookup_index_cache_report();
+        assert_eq!(report.skipped_cap, 13);
+        assert_eq!(report.bytes_in_cache, 0);
+        dirty(&mut e);
+        e.evaluate_all().unwrap();
+        assert_eq!(take_build_attempts(), 0);
+        assert_eq!(e.last_lookup_index_cache_report().skipped_cap, 16);
+        e.mark_data_edited();
+    }
+}

--- a/crates/formualizer-eval/src/function_registry.rs
+++ b/crates/formualizer-eval/src/function_registry.rs
@@ -571,7 +571,14 @@ fn resolve_registered(
         .map(|entry| (alias.target.clone(), entry.clone()))
 }
 
+#[cfg(test)]
+thread_local! {
+    static RESOLUTION_WRITES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 fn resolve_entry(ns: &str, name: &str) -> Option<(RegistryKey, RegistryEntry)> {
+    #[cfg(test)]
+    RESOLUTION_WRITES.with(|c| c.set(c.get() + 1));
     let ns = norm(ns);
     let normalized_name = norm(name);
     let key = (ns.clone(), normalized_name.clone());
@@ -637,7 +644,28 @@ fn resolve_entry_read_only(ns: &str, name: &str) -> Option<(RegistryKey, Registr
 }
 
 pub fn get(ns: &str, name: &str) -> Option<Arc<dyn Function>> {
-    resolve_entry(ns, name).map(|(_, entry)| entry.function)
+    let key = (norm(ns), norm(name));
+    {
+        let state = REGISTRY
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = state.registrations.get(&key).or_else(|| {
+            let alias = state.aliases.get(&key)?;
+            state.registrations.get(&alias.target)
+        });
+        if let Some(entry) = entry {
+            return Some(Arc::clone(&entry.function));
+        }
+        if !EXCEL_PREFIXES
+            .iter()
+            .any(|prefix| key.1.starts_with(prefix))
+        {
+            return None;
+        }
+    }
+    // Prefix misses may publish an alias. Recheck under the write lock, since a
+    // registration or alias owner could have changed after releasing the read lock.
+    resolve_entry(&key.0, &key.1).map(|(_, entry)| entry.function)
 }
 
 /// Read-only registry lookup for planning providers. Unlike [`get`], this does
@@ -1172,6 +1200,38 @@ mod tests {
             aliases,
             caps,
         })
+    }
+
+    #[test]
+    fn runtime_hits_only_clone_current_function_without_resolution_writes() {
+        let ns = "__RUNTIME_READ_FAST_PATH__";
+        let first = planning_fn(ns, "TARGET", &["ALIAS"], FnCaps::empty());
+        register_function(first.clone());
+        assert!(Arc::ptr_eq(&get(ns, "_xlfn._xlws.alias").unwrap(), &first));
+        RESOLUTION_WRITES.with(|c| c.set(0));
+        for name in ["target", "ALIAS", "_XLFN._XLWS.ALIAS"] {
+            assert!(Arc::ptr_eq(&get(ns, name).unwrap(), &first));
+        }
+        assert!(get(ns, "MISSING").is_none());
+        assert_eq!(RESOLUTION_WRITES.with(|c| c.get()), 0);
+        let second = planning_fn(ns, "TARGET", &["ALIAS"], FnCaps::empty());
+        register_function(second.clone());
+        for name in ["target", "ALIAS", "_XLFN._XLWS.ALIAS"] {
+            assert!(Arc::ptr_eq(&get(ns, name).unwrap(), &second));
+        }
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let second = &second;
+                scope.spawn(move || {
+                    RESOLUTION_WRITES.with(|c| c.set(0));
+                    for _ in 0..1000 {
+                        assert!(Arc::ptr_eq(&get(ns, "TARGET").unwrap(), second));
+                        assert!(Arc::ptr_eq(&get(ns, "_XLFN._XLWS.ALIAS").unwrap(), second));
+                    }
+                    assert_eq!(RESOLUTION_WRITES.with(|c| c.get()), 0);
+                });
+            }
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the first measurement-and-fix tranche from #418: bounded per-invocation criteria-mask reuse, read-only ordinary builtin registry hits, and lookup-index reclamation at exclusive snapshot mutation boundaries. Includes eight new regressions, paired release measurements, a baseline instrumentation patch, and a summarizer. Raw captures and compiled artifacts remain local-only.

Closes #419.
Closes #420.
Closes #421.

## Changes

- Memoize criteria masks lazily per predicate/column with a conservative 1 MiB retained charge; preserve reduction/padding order and prior rebuild behavior above the limit. Remove unused text fallback materialization and make numeric fallback lazy.
- Resolve registered/alias hits under a read lock, cloning only the current function Arc; keep prefix-alias write/recheck and registration ownership semantics.
- Reclaim obsolete index/admission state on data/topology/direct-value mutation; serialize duplicate detection, actual-size admission and accounting. Charge text/hash/duplicate payloads and remember oversized-index rejection until the next snapshot.
- Preserve conservative global invalidation. No FormulaPlane default changes, global predicate cache, axis-local indexing, or JIT work.

## Measured results

Baseline `2a8303d95acf2881c539e3700f7b8effc2e7bd35`; Rust 1.93.0 release with LTO/codegen-units=1; Ryzen 9 3900XT shared host. Final order baseline/fixed/fixed/baseline, seven samples per run. These are instrumented `cfg(test)` Engine probes, not universal workbook throughput claims.

| Case | Baseline median | Fixed median | Structural evidence |
| --- | ---: | ---: | --- |
| SUMIFS, 32768 rows, 32 chunks, 4 numeric predicates | 6.248 ms | 0.250 ms | 128 → 4 mask calls |
| Same, text predicates | 18.512 ms | 0.624 ms | 128 → 4 mask calls |
| Direct registry, 200000 calls, 1 worker | 24.08 ms | 12.48 ms | 3 → 1 allocations/call |
| Direct registry, 800000 calls, 4 workers | 260.06 ms | 104.87 ms | registered hits avoid exclusive resolution |
| Late numeric lookup recalc after unrelated edits, 512000-byte cap | 1.214 ms | 0.195 ms | obsolete-cache cliff removed |
| Same, text keys | 1.936 ms | 0.265 ms | 2 builds/16 hits/0 cap skips each edited generation |

Unchanged-snapshot lookup reevaluation retains 24 hits/zero builds. Reclamation has an edit cost: unrelated numeric/text edits rise approximately 2.00/2.05 → 6.35/35.72 us. Tiny finite and sparse whole-column criteria controls improve, while single-chunk dense text P=1 is essentially unchanged. Full Engine function-heavy gains are smaller than the direct registry microbenchmark; arithmetic controls remain similar.

The report includes distributions, requested allocation bytes, cleanup costs, and limitations. Timing fixtures explicitly assert zero active spans, even when authoritative mode is configured; separate batch-ingested correctness tests prove three active spans and changed-key parity. No active-span timing speedup is claimed.

## Validation

- `cargo +1.93.0 test -p formualizer-eval -p formualizer-workbook --tests -j 4 -- --test-threads=4`: **3057 passed, 0 failed, 16 ignored** across 45 binaries.
- Final release eval library: 2906 passed, 15 ignored, one failure in `engine::arena::scalar::tests::test_scalar_arena_float_overflow`; independently reproduced on the baseline executable. It expects a debug overflow panic and passes in debug. No unrelated change included.
- `cargo +1.93.0 clippy -p formualizer-eval -p formualizer-workbook --tests -j 4 -- -D warnings`, formatting and diff whitespace checks pass.
- Parent independently reran all eight new release regressions and reproduced the summary from local paired logs byte-for-byte.
- Fresh read-only production and measurement reviews completed; both production findings (small-mask metadata accounting and repeated oversized-index builds) were fixed and re-reviewed with no remaining concrete blockers.

## Evidence and limits

- [Report and reproduction recipe](https://github.com/PSU3D0/formualizer/blob/4c56f655cc669ea7b7cb6282cc141bd86feed645/benchmarks/perf-tranche-419-421.md)
- Allocator counters measure cumulative requested bytes, not peak memory/RSS; parallel Engine counts are main-thread-only. Index byte charges exclude outer-map capacity, in-flight construction and externally held Arcs.
- No own builds overlap final measurements; unrelated host workloads remain a timing caveat. Cold/setup/criteria-edit-only figures have two observations; warm distributions and lookup aggregation methodology are documented.
- No whole-workspace optional-backend build, cross-platform validation, separate lock-wait profile, or production allocator profile is claimed.
