### PR TITLE
fix(release): verify binding value-feature coverage

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/PSU3D0/formualizer"
 documentation = "https://pypi.org/project/formualizer/"
 keywords = ["spreadsheet", "excel", "formula", "python", "parser"]
 categories = ["api-bindings", "mathematics"]
+
+[package.metadata.formualizer-release.value-feature-opt-outs.python-pyodide]
+system-clock = "Pyodide/Emscripten deliberately uses a fixed or caller-injected clock instead of ambient wall-clock time."
+
 [lib]
 name = "formualizer_py"
 crate-type = ["cdylib", "rlib"]

--- a/crates/formualizer/Cargo.toml
+++ b/crates/formualizer/Cargo.toml
@@ -11,6 +11,12 @@ readme = "README.md"
 keywords = ["spreadsheet", "excel", "formula", "arrow", "wasm"]
 categories = ["data-structures", "mathematics", "parser-implementations"]
 
+[package.metadata.formualizer-release]
+# Features listed here can change computed cell values. Product preflight
+# requires every shipped binding profile to activate each one or carry an
+# independently approved exception with a substantive rationale.
+value-affecting-features = { system-clock = "Selects ambient wall-clock evaluation for TODAY() and NOW(); omitting it changes computed values to the fixed-clock fallback." }
+
 [features]
 # Default: preserve the pre-runtime-split user experience — full stack,
 # workbook JSON/CSV support, and ambient system clock behaviour.

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -107,6 +107,27 @@ Use only the track being released. `--allow-dirty` exists for development checks
 
 Every track first asserts the parser/SDK lockstep rule: `formualizer-common` and `formualizer-parse` must carry the same manifest version, and the product track additionally requires that version to already exist on crates.io. A product release that pins an unpublished parser-track version fails here rather than at `cargo publish`.
 
+A parser source change cannot reuse a published parser-track version. In particular, landing the parser hardening from #408 changes the payload already published as `formualizer-parse` 3.1.0. Before the next product release, bump both `formualizer-common` and `formualizer-parse` to 3.1.1, publish the paired `parse-v3.1.1` track, and only then run the final product preflight. The same-version source-drift and published-parser gates are intentional and must not be bypassed. Publication remains a separate, explicitly authorized operation.
+
+Product preflight also checks binding feature semantics before any registry query, tool installation, or package build. `crates/formualizer/Cargo.toml` declares value-affecting features in `[package.metadata.formualizer-release]`; adding a feature there immediately requires every shipped binding profile to activate it. Exceptions require an independently reviewed checker-policy update as well as a substantive manifest rationale; adding opt-out metadata cannot authorize a new exception by itself.
+
+The current policy has one value-affecting feature, `system-clock`, and four shipped profiles:
+
+| Profile | Dependency edge | Policy |
+| --- | --- | --- |
+| `cffi-native` | `formualizer-workbook`, workspace-inherited defaults | Required through the workbook `default` feature set. |
+| `python-native` | `formualizer`, `cfg(not(target_os = "emscripten"))` | Required explicitly. |
+| `python-pyodide` | `formualizer`, `cfg(target_os = "emscripten")` | Reviewed opt-out: the portable profile uses a fixed or caller-injected clock. |
+| `wasm-browser` | `formualizer`, ordinary dependency | Required transitively through `wasm-js`. |
+
+The four profile names, manifests, dependencies, and exact target keys are fixed independently in the checker; binding metadata cannot redefine or remove that inventory. Only the approved Pyodide `system-clock` exception is represented in binding metadata.
+
+This is deliberately not a Cargo resolver. It supports the current non-overlapping edges, dependency defaults, additive explicit features on the CFFI workspace-inherited edge, and small same-package alias closure. Binding forwarding remains supported for existing non-value features, but weak forwarding and any forwarded source alias that reaches a value-affecting feature are rejected. Generic-plus-target overlap, unknown target layouts, optional policy dependencies, member `default-features` overrides, unsupported workspace inheritance, and stale opt-outs also fail.
+
+The topology boundary is the dependency tables declared by the three binding crates plus their declared workspace inheritance. A binding may directly depend on the roll-up, eval, workbook, or sheetport semantic crates only at the fixed profile edges; alternate normal or target-qualified edges and direct or workspace-renamed aliases are rejected. This is a precise check of the current declared topology, not a universal claim about every future transitive Cargo graph. A richer topology must escalate to Cargo's actual resolved graph for concrete release targets rather than extending this checker into another resolver.
+
+Policy dependency paths and their `Cargo.toml` files must remain non-symlinked inside the checkout and resolve to the expected package.
+
 For multi-crate tracks, the script packages crates in dependency order, adds each prospective archive to a temporary local Cargo registry, and verifies downstream archives against those exact bytes. Workspace path dependencies therefore cannot hide an unpublished or incompatible registry package. The staging registry and Cargo home are temporary; inherited Cargo/GitHub token variables are removed and Git prompting is disabled. The exact `cargo-local-registry` helper and its isolated download cache live under `target/release-preflight-*` without replacing a global tool.
 
 For every package, the preflight queries crates.io. A version that does not yet exist is accepted. If the version exists, the shipped source/data/doc payload must match exactly; generated `Cargo.toml`, `Cargo.lock`, and `.cargo_vcs_info.json` are excluded because they vary with Cargo or the source commit, while `Cargo.toml.orig` remains compared so dependency requirements are covered. Any other difference means the source must be restored or the package version bumped.

--- a/scripts/release-preflight.py
+++ b/scripts/release-preflight.py
@@ -76,6 +76,25 @@ BINDING_PACKAGE_POLICY: tuple[tuple[str, str], ...] = (
     ("bindings/wasm/Cargo.toml", "formualizer-wasm"),
 )
 
+VALUE_FEATURE_POLICY_MANIFEST = "crates/formualizer/Cargo.toml"
+RELEASE_METADATA_KEY = "formualizer-release"
+# Fixed release policy: (name, manifest, dependency, exact target, source manifest).
+BindingFeatureProfile = tuple[str, str, str, str | None, str]
+BINDING_FEATURE_PROFILES: tuple[BindingFeatureProfile, ...] = (
+    ("cffi-native", "crates/formualizer-cffi/Cargo.toml", "formualizer-workbook", None,
+     "crates/formualizer-workbook/Cargo.toml"),
+    ("python-native", "bindings/python/Cargo.toml", "formualizer",
+     'cfg(not(target_os = "emscripten"))', VALUE_FEATURE_POLICY_MANIFEST),
+    ("python-pyodide", "bindings/python/Cargo.toml", "formualizer",
+     'cfg(target_os = "emscripten")', VALUE_FEATURE_POLICY_MANIFEST),
+    ("wasm-browser", "bindings/wasm/Cargo.toml", "formualizer", None, VALUE_FEATURE_POLICY_MANIFEST),
+)
+APPROVED_VALUE_FEATURE_OPT_OUTS = {("python-pyodide", "system-clock")}
+SEMANTIC_PACKAGES = frozenset({
+    "formualizer", "formualizer-eval", "formualizer-workbook",
+    "formualizer-sheetport",
+})
+
 
 def validate_binding_package_policy(root: Path = ROOT) -> None:
     """Require exact identities and literal non-publishable binding manifests."""
@@ -111,6 +130,296 @@ def validate_binding_package_policy(root: Path = ROOT) -> None:
                 f"binding package policy {manifest}: package {expected_name!r} "
                 "must set literal publish = false"
             )
+
+
+def read_manifest(root: Path, relative: str) -> dict[str, Any]:
+    try:
+        return tomllib.loads((root / relative).read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise RuntimeError(f"binding feature policy {relative}: {exc}") from exc
+
+
+def require_policy(ok: bool, context: str, message: str) -> None:
+    if not ok:
+        raise RuntimeError(f"binding feature policy {context}: {message}")
+
+
+def policy_table(value: Any, context: str, name: str) -> dict[str, Any]:
+    require_policy(isinstance(value, dict), context, f"{name} must be a table")
+    return value
+
+
+def string_list(value: Any, context: str, name: str) -> list[str]:
+    valid = isinstance(value, list) and all(isinstance(v, str) for v in value)
+    require_policy(valid, context, f"{name} must be a string list")
+    return value
+
+
+def feature_table(data: dict[str, Any], manifest: str) -> dict[str, list[str]]:
+    raw = policy_table(data.get("features", {}), manifest, "features")
+    return {name: string_list(value, manifest, f"feature {name!r}") for name, value in raw.items()}
+
+
+def dependency_edges(data: dict[str, Any], dependency: str, manifest: str) -> dict[str | None, dict[str, Any]]:
+    locations: list[tuple[str | None, Any]] = [(None, data.get("dependencies", {}))]
+    for target, value in policy_table(data.get("target", {}), manifest, "target").items():
+        target_table = policy_table(value, manifest, f"target {target!r}")
+        locations.append((target, target_table.get("dependencies", {})))
+    result = {}
+    for target, value in locations:
+        dependencies = policy_table(value, manifest, "dependencies")
+        aliases = [
+            name
+            for name, edge in dependencies.items()
+            if name != dependency and isinstance(edge, dict)
+            and edge.get("package") == dependency
+        ]
+        require_policy(
+            not aliases, manifest,
+            f"renamed policy dependency {dependency!r} is unsupported: {aliases}",
+        )
+        if dependency in dependencies:
+            result[target] = policy_table(
+                dependencies[dependency], manifest, f"dependency {dependency!r}"
+            )
+    return result
+
+
+def reject_alternate_semantic_edges(
+    root: Path, bindings: dict[str, dict[str, Any]]
+) -> None:
+    """Reject direct semantic-crate edges outside the fixed profile inventory."""
+    workspace = policy_table(
+        read_manifest(root, "Cargo.toml").get("workspace"), "Cargo.toml", "workspace"
+    )
+    workspace_dependencies = policy_table(
+        workspace.get("dependencies"), "Cargo.toml", "workspace.dependencies"
+    )
+    expected = {
+        (manifest, dependency, target)
+        for _, manifest, dependency, target, _ in BINDING_FEATURE_PROFILES
+    }
+    for manifest, binding in bindings.items():
+        locations: list[tuple[str | None, Any]] = [
+            (None, binding.get("dependencies", {}))
+        ]
+        targets = policy_table(binding.get("target", {}), manifest, "target")
+        for target, value in targets.items():
+            target_table = policy_table(value, manifest, f"target {target!r}")
+            locations.append((target, target_table.get("dependencies", {})))
+        for target, value in locations:
+            dependencies = policy_table(value, manifest, "dependencies")
+            for alias, edge in dependencies.items():
+                declaration = edge
+                if isinstance(edge, dict) and edge.get("workspace") is True:
+                    declaration = workspace_dependencies.get(alias)
+                package = (
+                    declaration.get("package", alias)
+                    if isinstance(declaration, dict)
+                    else alias
+                )
+                if package in SEMANTIC_PACKAGES:
+                    require_policy(
+                        (manifest, alias, target) in expected, manifest,
+                        f"alternate semantic dependency {alias!r} ({package!r}) "
+                        f"at target {target!r} is unsupported",
+                    )
+
+
+def effective_edge(root: Path, profile: BindingFeatureProfile, edge: dict[str, Any]) -> dict[str, Any]:
+    name, manifest, dependency, _, _ = profile
+    inherited: dict[str, Any] = {}
+    if name == "cffi-native":
+        require_policy(edge.get("workspace") is True, manifest, "expected workspace edge")
+        require_policy(
+            "default-features" not in edge, manifest,
+            "workspace member default-features override is unsupported",
+        )
+        require_policy(set(edge) <= {"workspace", "features"}, manifest, "unsupported workspace member inheritance")
+        workspace = policy_table(read_manifest(root, "Cargo.toml").get("workspace"), "Cargo.toml", "workspace")
+        dependencies = policy_table(workspace.get("dependencies"), "Cargo.toml", "workspace.dependencies")
+        inherited = policy_table(dependencies.get(dependency), "Cargo.toml", f"workspace dependency {dependency!r}")
+        supported = {"path", "version", "package", "features", "default-features"}
+        require_policy(set(inherited) <= supported, "Cargo.toml", "unsupported workspace dependency inheritance")
+    else:
+        require_policy("workspace" not in edge, manifest, "workspace edge is unsupported")
+        supported = {"path", "version", "package", "features", "default-features", "optional"}
+        require_policy(set(edge) <= supported, manifest, "unsupported policy dependency fields")
+    non_optional = inherited.get("optional") in (None, False) and edge.get(
+        "optional"
+    ) in (None, False)
+    require_policy(
+        non_optional, manifest,
+        f"optional policy dependency {dependency!r} is unsupported",
+    )
+    inherited_features = string_list(inherited.get("features", []), manifest, "inherited dependency features")
+    explicit_features = string_list(edge.get("features", []), manifest, "dependency features")
+    default_features = inherited.get("default-features", edge.get("default-features", True))
+    require_policy(isinstance(default_features, bool), manifest, "default-features must be boolean")
+    return {
+        **inherited, **edge,
+        "features": [*inherited_features, *explicit_features],
+        "default-features": default_features,
+    }
+
+
+def local_source(root: Path, profile: BindingFeatureProfile, edge: dict[str, Any]) -> dict[str, Any]:
+    _, manifest, dependency, _, source_manifest = profile
+    declared = edge.get("path")
+    require_policy(isinstance(declared, str), manifest, "local path is required")
+    checkout = Path(os.path.abspath(root))
+    base = checkout if edge.get("workspace") is True else (checkout / manifest).parent
+    source_dir = Path(os.path.abspath(base / declared))
+    require_policy(source_dir.is_relative_to(checkout), manifest, "source leaves checkout")
+    cursor = checkout
+    for part in source_dir.relative_to(checkout).parts:
+        cursor /= part
+        require_policy(not cursor.is_symlink(), manifest, "symlinked source path")
+    require_policy(source_dir.is_dir(), manifest, "source path must be a directory")
+    expected = (checkout / source_manifest).parent.resolve()
+    require_policy(
+        source_dir.resolve() == expected, manifest, f"source is not {source_manifest}"
+    )
+    source_file = source_dir / "Cargo.toml"
+    require_policy(not source_file.is_symlink(), manifest, "symlinked source Cargo.toml")
+    require_policy(source_file.is_file(), manifest, "source Cargo.toml must be a file")
+    require_policy(
+        source_file.resolve().is_relative_to(checkout.resolve()), manifest,
+        "source Cargo.toml leaves checkout",
+    )
+    source = read_manifest(root, source_manifest)
+    package = policy_table(source.get("package"), source_manifest, "package")
+    require_policy(
+        package.get("name") == edge.get("package", dependency), manifest,
+        "dependency package identity mismatch",
+    )
+    return source
+
+
+def alias_closure(source: dict[str, Any], initial: set[str], manifest: str) -> set[str]:
+    """Expand same-package aliases; external dependency forwarding stays opaque."""
+    features = feature_table(source, manifest)
+    active: set[str] = set()
+    pending = list(initial)
+    while pending:
+        feature = pending.pop()
+        if feature in active:
+            continue
+        require_policy(feature in features, manifest, f"unknown feature {feature!r}")
+        active.add(feature)
+        for member in features[feature]:
+            if member.startswith("dep:") or "/" in member:
+                continue
+            require_policy(member in features, manifest, f"unsupported same-package feature member {member!r}")
+            pending.append(member)
+    return active
+
+
+def validate_binding_value_feature_policy(root: Path = ROOT) -> dict[str, dict[str, str]]:
+    """Validate the fixed profiles without approximating general Cargo resolution."""
+    product = read_manifest(root, VALUE_FEATURE_POLICY_MANIFEST)
+    package = policy_table(product.get("package"), VALUE_FEATURE_POLICY_MANIFEST, "package")
+    metadata = policy_table(package.get("metadata"), VALUE_FEATURE_POLICY_MANIFEST, "package.metadata")
+    policy = policy_table(metadata.get(RELEASE_METADATA_KEY), VALUE_FEATURE_POLICY_MANIFEST, RELEASE_METADATA_KEY)
+    require_policy(set(policy) == {"value-affecting-features"}, VALUE_FEATURE_POLICY_MANIFEST, "metadata schema drift")
+    value_features = policy_table(
+        policy["value-affecting-features"], VALUE_FEATURE_POLICY_MANIFEST,
+        "value-affecting-features",
+    )
+    declared_features = feature_table(product, VALUE_FEATURE_POLICY_MANIFEST)
+    require_policy(bool(value_features), VALUE_FEATURE_POLICY_MANIFEST, "empty policy")
+    for feature, rationale in value_features.items():
+        valid = feature in declared_features and isinstance(rationale, str) and bool(rationale.strip())
+        require_policy(valid, VALUE_FEATURE_POLICY_MANIFEST, f"invalid value-affecting feature {feature!r}")
+
+    manifests = {profile[1] for profile in BINDING_FEATURE_PROFILES}
+    bindings = {manifest: read_manifest(root, manifest) for manifest in manifests}
+    reject_alternate_semantic_edges(root, bindings)
+    opt_outs: dict[str, dict[str, str]] = {}
+    for manifest, binding in bindings.items():
+        binding_package = policy_table(binding.get("package"), manifest, "package")
+        binding_metadata = policy_table(binding_package.get("metadata", {}), manifest, "package.metadata")
+        binding_policy = binding_metadata.get(RELEASE_METADATA_KEY)
+        if binding_policy is None:
+            continue
+        require_policy(manifest == "bindings/python/Cargo.toml", manifest, "binding release metadata is unsupported")
+        binding_policy = policy_table(binding_policy, manifest, RELEASE_METADATA_KEY)
+        require_policy(set(binding_policy) == {"value-feature-opt-outs"}, manifest, "metadata schema drift")
+        profile_values = policy_table(binding_policy["value-feature-opt-outs"], manifest, "value-feature-opt-outs")
+        for profile, values in profile_values.items():
+            require_policy(profile not in opt_outs, manifest, f"duplicate opt-out profile {profile!r}")
+            opt_outs[profile] = policy_table(values, manifest, f"opt-outs for {profile!r}")
+
+    profile_names = {profile[0] for profile in BINDING_FEATURE_PROFILES}
+    require_policy(set(opt_outs) <= profile_names, "metadata", "unknown opt-out profile")
+    for profile, values in opt_outs.items():
+        for feature, rationale in values.items():
+            require_policy(
+                (profile, feature) in APPROVED_VALUE_FEATURE_OPT_OUTS, profile,
+                f"unapproved opt-out for {feature!r}",
+            )
+            substantive = isinstance(rationale, str) and len(rationale.strip()) >= 40 and len(rationale.split()) >= 8
+            require_policy(substantive, profile, f"opt-out for {feature!r} needs a substantive rationale")
+
+    expected_edges: dict[tuple[str, str], set[str | None]] = {}
+    for _, manifest, dependency, target, _ in BINDING_FEATURE_PROFILES:
+        expected_edges.setdefault((manifest, dependency), set()).add(target)
+    for (manifest, dependency), expected in expected_edges.items():
+        actual = set(dependency_edges(bindings[manifest], dependency, manifest))
+        require_policy(
+            actual == expected, manifest,
+            f"dependency {dependency!r} edges {actual!r}, expected {expected!r}",
+        )
+        forwarded = [
+            item
+            for values in feature_table(bindings[manifest], manifest).values()
+            for item in values
+            if item.startswith((f"{dependency}/", f"{dependency}?/"))
+        ]
+        weak = [item for item in forwarded if item.startswith(f"{dependency}?/")]
+        require_policy(not weak, manifest, f"weak forwarding is unsupported: {weak}")
+        activated: set[str] = set()
+        if forwarded:
+            source_manifest = next(
+                profile[4]
+                for profile in BINDING_FEATURE_PROFILES
+                if profile[1:3] == (manifest, dependency)
+            )
+            source = read_manifest(root, source_manifest)
+            for item in forwarded:
+                activated.update(
+                    alias_closure(source, {item.split("/", 1)[1]}, source_manifest)
+                )
+        relevant = sorted(activated & set(value_features))
+        require_policy(
+            not relevant, manifest,
+            f"binding forwarding enables value-affecting features: {relevant}",
+        )
+
+    coverage: dict[str, dict[str, str]] = {}
+    for profile in BINDING_FEATURE_PROFILES:
+        name, manifest, dependency, target, source_manifest = profile
+        context = f"{manifest} profile {name}"
+        edge = dependency_edges(bindings[manifest], dependency, manifest)[target]
+        edge = effective_edge(root, profile, edge)
+        source = local_source(root, profile, edge)
+        initial = set(edge["features"])
+        if edge["default-features"]:
+            initial.add("default")
+        active = alias_closure(source, initial, source_manifest)
+        coverage[name] = {}
+        for feature in value_features:
+            rationale = opt_outs.get(name, {}).get(feature)
+            require_policy(
+                not (feature in active and rationale), context,
+                f"stale opt-out for enabled feature {feature!r}",
+            )
+            require_policy(
+                feature in active or rationale is not None, context,
+                f"value-affecting feature {feature!r} is uncovered",
+            )
+            coverage[name][feature] = "enabled" if feature in active else f"opt-out: {rationale}"
+    return coverage
 
 
 def validate_parser_track_lockstep(
@@ -596,6 +905,9 @@ def prepare_local_registry(
 
 def preflight(track: str, allow_dirty: bool) -> None:
     validate_binding_package_policy()
+    if track == "product":
+        coverage = validate_binding_value_feature_policy()
+        print(json.dumps({"binding_value_feature_policy": coverage}, indent=2))
     validate_parser_track_lockstep(track)
     ensure_clean(allow_dirty)
     packages = TRACKS[track]
@@ -650,6 +962,7 @@ def main() -> int:
     except (
         OSError,
         RuntimeError,
+        TypeError,
         ValueError,
         subprocess.CalledProcessError,
         tarfile.TarError,

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -19,6 +19,36 @@ sys.modules[SPEC.name] = release_preflight
 SPEC.loader.exec_module(release_preflight)
 
 
+POLICY_FIXTURE_FILES = (
+    "Cargo.toml",
+    "crates/formualizer/Cargo.toml",
+    "crates/formualizer-workbook/Cargo.toml",
+    "crates/formualizer-cffi/Cargo.toml",
+    "bindings/python/Cargo.toml",
+    "bindings/wasm/Cargo.toml",
+)
+
+
+def copy_policy_fixture(destination: Path) -> None:
+    for relative in POLICY_FIXTURE_FILES:
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            (release_preflight.ROOT / relative).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+
+def mutate_file(root: Path, relative: str, old: str, new: str) -> None:
+    path = root / relative
+    contents = path.read_text(encoding="utf-8")
+    if old not in contents:
+        raise AssertionError(
+            f"fixture mutation source not found in {relative}: {old!r}"
+        )
+    path.write_text(contents.replace(old, new, 1), encoding="utf-8")
+
+
 def crate_archive(
     path: Path, files: dict[str, bytes], *, symlink: str | None = None
 ) -> Path:
@@ -197,6 +227,406 @@ class ReleasePreflightTests(unittest.TestCase):
         for _, name in release_preflight.BINDING_PACKAGE_POLICY:
             self.assertNotIn(name, track_names)
         release_preflight.validate_binding_package_policy()
+
+    def assert_policy_mutations_fail(
+        self, pattern: str, *mutations: tuple[str, str, str]
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            copy_policy_fixture(root)
+            for mutation in mutations:
+                mutate_file(root, *mutation)
+            with self.assertRaisesRegex(RuntimeError, pattern):
+                release_preflight.validate_binding_value_feature_policy(root)
+
+    def test_binding_value_feature_policy_matches_fixed_inventory(self) -> None:
+        coverage = release_preflight.validate_binding_value_feature_policy()
+        self.assertEqual(
+            set(coverage),
+            {"cffi-native", "python-native", "python-pyodide", "wasm-browser"},
+        )
+        for profile in ("cffi-native", "python-native", "wasm-browser"):
+            self.assertEqual(coverage[profile], {"system-clock": "enabled"})
+        self.assertRegex(
+            coverage["python-pyodide"]["system-clock"], r"^opt-out: Pyodide"
+        )
+
+    def test_binding_value_feature_policy_rejects_native_python_omission(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"python-native.*system-clock.*uncovered",
+            (
+                "bindings/python/Cargo.toml",
+                ', "umya", "system-clock"] }',
+                ', "umya"] }',
+            ),
+        )
+
+    def test_binding_value_feature_policy_expands_only_source_aliases(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"wasm-browser.*system-clock.*uncovered",
+            (
+                "crates/formualizer/Cargo.toml",
+                'wasm-js = ["portable-wasm", "system-clock", "js-runtime"]',
+                'wasm-js = ["portable-wasm", "js-runtime"]',
+            ),
+        )
+
+    def test_binding_value_feature_policy_honors_dependency_defaults(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"cffi-native.*system-clock.*uncovered",
+            (
+                "crates/formualizer-workbook/Cargo.toml",
+                'default = ["json", "csv", "system-clock"]',
+                'default = ["json", "csv"]',
+            ),
+        )
+
+    def test_binding_value_feature_policy_honors_workspace_default_disable(
+        self,
+    ) -> None:
+        self.assert_policy_mutations_fail(
+            r"cffi-native.*system-clock.*uncovered",
+            (
+                "Cargo.toml",
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook", default-features = false }',
+            ),
+        )
+
+    def test_binding_value_feature_policy_unions_inherited_explicit_features(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            copy_policy_fixture(root)
+            mutate_file(
+                root,
+                "Cargo.toml",
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook", default-features = false, features = ["system-clock"] }',
+            )
+            release_preflight.validate_binding_value_feature_policy(root)
+
+    def test_binding_value_feature_policy_rejects_member_default_override(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"member default-features override",
+            (
+                "Cargo.toml",
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook", default-features = false }',
+            ),
+            (
+                "crates/formualizer-cffi/Cargo.toml",
+                'formualizer-workbook = { workspace = true, features = ["umya"] }',
+                'formualizer-workbook = { workspace = true, default-features = true, features = ["umya"] }',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_unsupported_workspace_inheritance(
+        self,
+    ) -> None:
+        self.assert_policy_mutations_fail(
+            r"unsupported workspace member inheritance",
+            (
+                "crates/formualizer-cffi/Cargo.toml",
+                'formualizer-workbook = { workspace = true, features = ["umya"] }',
+                'formualizer-workbook = { workspace = true, path = "../formualizer-workbook", features = ["umya"] }',
+            ),
+        )
+
+    def test_binding_value_feature_policy_requires_pyodide_opt_out(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"python-pyodide.*system-clock.*uncovered",
+            (
+                "bindings/python/Cargo.toml",
+                '[package.metadata.formualizer-release.value-feature-opt-outs.python-pyodide]\nsystem-clock = "Pyodide/Emscripten deliberately uses a fixed or caller-injected clock instead of ambient wall-clock time."\n\n',
+                "",
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_vacuous_review_claim(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"substantive rationale",
+            (
+                "bindings/python/Cargo.toml",
+                "Pyodide/Emscripten deliberately uses a fixed or caller-injected clock instead of ambient wall-clock time.",
+                "Reviewed ",
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_generic_target_overlap(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"alternate semantic dependency 'formualizer'|dependency 'formualizer' edges",
+            (
+                "bindings/python/Cargo.toml",
+                'formualizer = { path = "../../crates/formualizer", default-features = false, features = ["eval", "workbook", "sheetport", "parse", "calamine", "umya", "system-clock"] }',
+                "",
+            ),
+            (
+                "bindings/python/Cargo.toml",
+                "serde_json = { workspace = true }",
+                'serde_json = { workspace = true }\nformualizer = { path = "../../crates/formualizer", default-features = false, features = ["system-clock"] }',
+            ),
+        )
+
+    def test_binding_value_feature_policy_inventory_survives_profile_and_edge_removal(
+        self,
+    ) -> None:
+        self.assert_policy_mutations_fail(
+            r"edges.*emscripten",
+            (
+                "bindings/python/Cargo.toml",
+                '[package.metadata.formualizer-release.value-feature-opt-outs.python-pyodide]\nsystem-clock = "Pyodide/Emscripten deliberately uses a fixed or caller-injected clock instead of ambient wall-clock time."\n\n',
+                "",
+            ),
+            (
+                "bindings/python/Cargo.toml",
+                '[target.\'cfg(target_os = "emscripten")\'.dependencies]\nformualizer = { path = "../../crates/formualizer", default-features = false, features = ["eval", "workbook", "sheetport", "parse", "umya"] }',
+                "",
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_profile_and_target_rewrite(
+        self,
+    ) -> None:
+        self.assert_policy_mutations_fail(
+            r"unknown opt-out profile|alternate semantic dependency.*x86_64|edges.*x86_64",
+            (
+                "bindings/python/Cargo.toml",
+                "value-feature-opt-outs.python-pyodide",
+                "value-feature-opt-outs.python-other",
+            ),
+            (
+                "bindings/python/Cargo.toml",
+                "[target.'cfg(not(target_os = \"emscripten\"))'.dependencies]",
+                "[target.'cfg(target_arch = \"x86_64\")'.dependencies]",
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_optional_policy_edge(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"optional policy dependency",
+            (
+                "bindings/wasm/Cargo.toml",
+                'formualizer = { path = "../../crates/formualizer", default-features = false,',
+                'formualizer = { path = "../../crates/formualizer", optional = true, default-features = false,',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_optional_weak_activation_model(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"weak forwarding|optional policy dependency",
+            (
+                "bindings/wasm/Cargo.toml",
+                'formualizer = { path = "../../crates/formualizer", default-features = false, features = ["wasm-js", "sheetport"] }',
+                'formualizer = { path = "../../crates/formualizer", optional = true, default-features = false, features = ["portable-wasm", "sheetport"] }',
+            ),
+            (
+                "bindings/wasm/Cargo.toml",
+                'default = ["console_panic", "json", "calamine"]',
+                'default = ["console_panic", "json", "calamine", "clock"]\nclock = ["formualizer?/system-clock"]',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_binding_clock_forwarding(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"forwarding enables value-affecting features",
+            (
+                "bindings/wasm/Cargo.toml",
+                'default = ["console_panic", "json", "calamine"]',
+                'default = ["console_panic", "json", "calamine", "clock"]\nclock = ["formualizer/system-clock"]',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_forwarded_source_alias(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"forwarding enables value-affecting features.*system-clock",
+            (
+                "bindings/python/Cargo.toml",
+                'default = ["allocator-jemalloc"]',
+                'default = ["allocator-jemalloc", "formualizer/wasm-js"]',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_direct_semantic_dependency(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"alternate semantic dependency 'formualizer-workbook'",
+            (
+                "bindings/python/Cargo.toml",
+                "serde_json = { workspace = true }",
+                "serde_json = { workspace = true }\nformualizer-workbook = { workspace = true }",
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_renamed_target_semantic_dependency(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"alternate semantic dependency 'clock-workbook'.*formualizer-workbook",
+            (
+                "bindings/python/Cargo.toml",
+                '[target.\'cfg(target_os = "emscripten")\'.dependencies]',
+                '[target.\'cfg(target_os = "emscripten")\'.dependencies]\nclock-workbook = { package = "formualizer-workbook", path = "../../crates/formualizer-workbook" }',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_workspace_alias_semantic_dependency(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"alternate semantic dependency 'clock-workbook'.*formualizer-workbook",
+            (
+                "Cargo.toml",
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
+                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }\nclock-workbook = { package = "formualizer-workbook", version = "0.8.4", path = "crates/formualizer-workbook" }',
+            ),
+            (
+                "bindings/python/Cargo.toml",
+                "serde_json = { workspace = true }",
+                "serde_json = { workspace = true }\nclock-workbook = { workspace = true }",
+            ),
+        )
+
+    def test_new_value_affecting_feature_requires_real_activation(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"semantic-switch.*uncovered",
+            (
+                "crates/formualizer/Cargo.toml",
+                'value-affecting-features = { system-clock = "Selects ambient wall-clock evaluation for TODAY() and NOW(); omitting it changes computed values to the fixed-clock fallback." }',
+                'value-affecting-features = { system-clock = "Selects ambient wall-clock evaluation for TODAY() and NOW(); omitting it changes computed values to the fixed-clock fallback.", semantic-switch = "Test-only semantic switch." }',
+            ),
+            (
+                "crates/formualizer/Cargo.toml",
+                "[features]\n",
+                "[features]\nsemantic-switch = []\n",
+            ),
+        )
+
+    def test_new_value_affecting_feature_cannot_self_approve_opt_out(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"unapproved opt-out.*semantic-switch",
+            (
+                "crates/formualizer/Cargo.toml",
+                'value-affecting-features = { system-clock = "Selects ambient wall-clock evaluation for TODAY() and NOW(); omitting it changes computed values to the fixed-clock fallback." }',
+                'value-affecting-features = { system-clock = "Selects ambient wall-clock evaluation for TODAY() and NOW(); omitting it changes computed values to the fixed-clock fallback.", semantic-switch = "Test-only semantic switch." }',
+            ),
+            (
+                "crates/formualizer/Cargo.toml",
+                "[features]\n",
+                "[features]\nsemantic-switch = []\n",
+            ),
+            (
+                "bindings/python/Cargo.toml",
+                'system-clock = "Pyodide/Emscripten deliberately uses a fixed or caller-injected clock instead of ambient wall-clock time."',
+                'system-clock = "Pyodide/Emscripten deliberately uses a fixed or caller-injected clock instead of ambient wall-clock time."\nsemantic-switch = "A newly written rationale cannot authorize a policy exception without changing the independent checker allowlist."',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_stale_opt_out(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"python-pyodide.*stale opt-out",
+            (
+                "bindings/python/Cargo.toml",
+                'features = ["eval", "workbook", "sheetport", "parse", "umya"]',
+                'features = ["eval", "workbook", "sheetport", "parse", "umya", "system-clock"]',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_unknown_profile_metadata(
+        self,
+    ) -> None:
+        self.assert_policy_mutations_fail(
+            r"unknown opt-out profile",
+            (
+                "bindings/python/Cargo.toml",
+                "[lib]",
+                '[package.metadata.formualizer-release.value-feature-opt-outs.other]\nsystem-clock = "A long but unauthorized profile rationale that must never redefine the fixed release inventory."\n\n[lib]',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_metadata_schema_drift(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"unapproved opt-out.*approximate-cargo",
+            (
+                "bindings/python/Cargo.toml",
+                "[package.metadata.formualizer-release.value-feature-opt-outs.python-pyodide]",
+                "[package.metadata.formualizer-release.value-feature-opt-outs.python-pyodide]\napproximate-cargo = true",
+            ),
+        )
+
+    def test_binding_value_feature_policy_requires_directory_source_path(self) -> None:
+        self.assert_policy_mutations_fail(
+            r"source path must be a directory",
+            (
+                "bindings/wasm/Cargo.toml",
+                'path = "../../crates/formualizer"',
+                'path = "../../crates/formualizer/Cargo.toml"',
+            ),
+        )
+
+    def test_binding_value_feature_policy_rejects_source_outside_checkout(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            tempfile.TemporaryDirectory() as outside,
+        ):
+            root = Path(temp)
+            copy_policy_fixture(root)
+            mutate_file(
+                root,
+                "bindings/wasm/Cargo.toml",
+                'path = "../../crates/formualizer"',
+                f'path = "{outside}"',
+            )
+            with self.assertRaisesRegex(RuntimeError, r"source leaves checkout"):
+                release_preflight.validate_binding_value_feature_policy(root)
+
+    def test_binding_value_feature_policy_rejects_symlinked_source_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp, tempfile.TemporaryDirectory() as outside:
+            root = Path(temp)
+            copy_policy_fixture(root)
+            source = root / "crates/formualizer-workbook"
+            (source / "Cargo.toml").unlink()
+            source.rmdir()
+            source.symlink_to(Path(outside), target_is_directory=True)
+            with self.assertRaisesRegex(RuntimeError, r"symlinked source path"):
+                release_preflight.validate_binding_value_feature_policy(root)
+
+    def test_binding_value_feature_policy_rejects_symlinked_source_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp, tempfile.TemporaryDirectory() as outside:
+            root = Path(temp)
+            copy_policy_fixture(root)
+            source = root / "crates/formualizer-workbook/Cargo.toml"
+            external = Path(outside) / "Cargo.toml"
+            external.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+            source.unlink()
+            source.symlink_to(external)
+            with self.assertRaisesRegex(RuntimeError, r"symlinked source Cargo.toml"):
+                release_preflight.validate_binding_value_feature_policy(root)
+
+    def test_product_preflight_checks_features_before_registry_lookup(self) -> None:
+        calls: list[str] = []
+
+        def record(name: str):
+            def check(*_args, **_kwargs) -> None:
+                calls.append(name)
+                if name == "parser":
+                    raise RuntimeError("stop before registry lookup")
+
+            return check
+
+        with (
+            mock.patch.object(
+                release_preflight, "validate_binding_package_policy", record("package")
+            ),
+            mock.patch.object(
+                release_preflight,
+                "validate_binding_value_feature_policy",
+                record("features"),
+            ),
+            mock.patch.object(
+                release_preflight, "validate_parser_track_lockstep", record("parser")
+            ),
+            mock.patch("builtins.print"),
+            self.assertRaisesRegex(RuntimeError, "stop before registry lookup"),
+        ):
+            release_preflight.preflight("product", False)
+        self.assertEqual(calls, ["package", "features", "parser"])
 
     def test_parser_track_versions_are_in_lockstep_in_tree(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary

Closes #324. Product release preflight now checks value-affecting feature coverage for the fixed C ABI, native Python, Pyodide, and browser WASM profiles before registry access or package builds. The current `system-clock` policy is declared in the product manifest; only the independently approved Pyodide exception is allowed, with an explicit rationale.

The verifier is deliberately restricted to the declared workspace topology, not a general Cargo resolver. It rejects overlapping/unknown target layouts, unsupported inheritance and optional/weak forwarding, alternate direct semantic dependencies, stale opt-outs, and source-path/manifest symlinks. Strong forwarding is checked through same-package aliases so an indirect clock activation cannot hide behind an opt-out.

Documentation retains the parser publication gate: parser hardening requires lockstep common/parse 3.1.1, separately authorized parser-track publication, and then final product preflight. This PR does not bump, tag, or publish a release.

## Validation

- `uv run python3 -m unittest scripts/tests/test_release_preflight.py -v`: 44 passed on the committed source.
- Independent review reproduced rejection of indirect forwarding, direct/workspace/renamed alternate edges, and manifest-file symlinks; the four current profile results remain valid.
- `git diff --check`: passed.

These are verifier implementation checks, not evidence that a 0.9.0 candidate has completed packaging, installation, binding runtime, or publication-prerequisite validation. Those remain separate release gates.
