### PR TITLE
fix(eval): invalidate retained schedules for logged topology edits

### DIFF
--- a/bindings/python/tests/test_inspection.py
+++ b/bindings/python/tests/test_inspection.py
@@ -254,7 +254,9 @@ def test_to_dict_full_nested_structure_for_every_report_kind() -> None:
     sheet.set_formula(1, 2, "=A1+SUM(A1:A2)")
     sheet.set_formula(1, 3, "=B1+1")
     wb.evaluate_all()
-    stamp = {"mutation_revision": 6, "recalc_epoch": 1}
+    # Logged formula topology edits now advance the mutation stamp as well.
+    # This exact fixture value checks serialization, not a one-tick-per-edit API.
+    stamp = {"mutation_revision": 8, "recalc_epoch": 1}
 
     assert wb.inspect_cell("S!B1").to_dict() == {
         "stamp": stamp,

--- a/crates/formualizer-eval/src/engine/eval.rs
+++ b/crates/formualizer-eval/src/engine/eval.rs
@@ -1708,7 +1708,6 @@ where
                 .clear_computed_overlay_after_row(sheet, before0 as usize);
             self.engine
                 .record_formula_plane_structural_change(StructuralScope::Region(affected_region));
-            self.engine.mark_topology_edited();
             if let Some(undo_ptr) = self.arrow_undo {
                 unsafe { &mut *undo_ptr }.record_insert_rows(sheet_id, before0, count);
             }
@@ -1784,7 +1783,6 @@ where
                 .clear_computed_overlay_after_col(sheet, before0 as usize);
             self.engine
                 .record_formula_plane_structural_change(StructuralScope::Region(affected_region));
-            self.engine.mark_topology_edited();
             if let Some(undo_ptr) = self.arrow_undo {
                 unsafe { &mut *undo_ptr }.record_insert_cols(sheet_id, before0, count);
             }
@@ -1867,6 +1865,26 @@ enum StructuralScope {
     RemovedSheet(SheetId),
     OpaqueGlobal,
     AllSheets,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum LoggedEditImpact {
+    NoOp,
+    DataOnly,
+    Topology,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LoggedEditDirection {
+    Original,
+    InverseReplay,
+    ForwardReplay,
+}
+
+#[derive(Clone, Copy)]
+struct InvalidationBaseline {
+    snapshot_id: u64,
+    topology_epoch: u64,
 }
 
 struct SourceCacheSession {
@@ -4981,6 +4999,7 @@ where
         name: String,
         f: impl FnOnce(&mut EngineAction<'_, R>) -> Result<T, crate::engine::EditorError>,
     ) -> Result<(T, crate::engine::ActionJournal), crate::engine::EditorError> {
+        let invalidation_baseline = self.invalidation_baseline();
         let mut arrow_undo = crate::engine::ArrowUndoBatch::default();
         let arrow_ptr: *mut crate::engine::ArrowUndoBatch = &mut arrow_undo;
 
@@ -5015,12 +5034,17 @@ where
                     for event in &journal.graph.events {
                         self.record_formula_plane_change_for_event(event);
                     }
-                    self.mark_data_edited();
+                    self.invalidate_for_action_journal(
+                        &journal,
+                        LoggedEditDirection::Original,
+                        invalidation_baseline,
+                    );
                 }
                 Ok((v, journal))
             }
             Err(e) => {
-                if let Err(rb) = self.rollback_from_action_journal(&journal) {
+                if let Err(rb) = self.rollback_from_action_journal(&journal, invalidation_baseline)
+                {
                     return Err(crate::engine::EditorError::TransactionFailed {
                         reason: format!(
                             "Engine::action_atomic rollback failed after error '{e}': {rb}"
@@ -5088,7 +5112,15 @@ where
     fn rollback_from_action_journal(
         &mut self,
         journal: &crate::engine::ActionJournal,
+        invalidation_baseline: InvalidationBaseline,
     ) -> Result<(), crate::engine::EditorError> {
+        // Invalidate first so a partial inverse failure cannot leave a changed
+        // graph behind an apparently current schedule or lookup cache.
+        self.invalidate_for_action_journal(
+            journal,
+            LoggedEditDirection::InverseReplay,
+            invalidation_baseline,
+        );
         // 1) Roll back the dependency graph structure.
         journal.graph.undo(&mut self.graph)?;
         // 2) Roll back engine row-visibility sidecar events.
@@ -5101,8 +5133,17 @@ where
     fn rollback_from_change_events(
         &mut self,
         events: &[crate::engine::ChangeEvent],
+        invalidation_baseline: InvalidationBaseline,
     ) -> Result<(), crate::engine::EditorError> {
         use crate::engine::ChangeEvent;
+
+        // Fail closed before applying inverses because replay can return after
+        // only part of the batch has been restored.
+        self.invalidate_for_change_events(
+            events,
+            LoggedEditDirection::InverseReplay,
+            invalidation_baseline,
+        );
 
         // 1) Roll back the dependency graph.
         {
@@ -5230,6 +5271,7 @@ where
         log: &mut crate::engine::ChangeLog,
         f: impl FnOnce(&mut crate::engine::VertexEditor) -> T,
     ) -> Result<T, crate::engine::EditorError> {
+        let invalidation_baseline = self.invalidation_baseline();
         // Record starting log length so we can mirror only newly-recorded events.
         let start_len = log.len();
 
@@ -5279,7 +5321,7 @@ where
                     | ChangeEvent::DeleteName { .. }
             )
         }) {
-            self.rollback_from_change_events(&new_events)?;
+            self.rollback_from_change_events(&new_events, invalidation_baseline)?;
             log.truncate(start_len);
             return Err(crate::engine::EditorError::TransactionUnsupported {
                 reason: "name mutations must use Engine's prepared logged-name APIs".to_string(),
@@ -5294,6 +5336,16 @@ where
         }
         for ev in &new_events {
             self.record_formula_plane_change_for_event(ev);
+        }
+
+        // Atomic EngineAction calls publish one invalidation for their complete
+        // journal at commit/rollback. Direct logged edits publish here.
+        if self.action_depth == 0 {
+            self.invalidate_for_change_events(
+                &new_events,
+                LoggedEditDirection::Original,
+                invalidation_baseline,
+            );
         }
 
         Ok(ret)
@@ -5412,10 +5464,18 @@ where
             .map(|index| log.events()[index].clone())
             .collect::<Vec<_>>();
         self.preflight_replay_admission(&pending_events, false)?;
+        let invalidation_baseline = self.invalidation_baseline();
         let names = Self::name_event_names(&pending_events);
         let prepared =
             self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str))?;
-        let demoted = self.commit_name_dependent_span_demotion(prepared)?;
+        self.commit_name_dependent_span_demotion(prepared)?;
+        // UndoEngine can fail after partially applying the batch, so publish
+        // invalidation before replay rather than only on the success path.
+        self.invalidate_for_change_events(
+            &pending_events,
+            LoggedEditDirection::InverseReplay,
+            invalidation_baseline,
+        );
         let batch = undo.undo(&mut self.graph, log)?;
         for item in batch.iter().rev() {
             self.apply_inverse_row_visibility_event(&item.event);
@@ -5433,9 +5493,6 @@ where
             for item in &batch {
                 self.record_formula_plane_change_for_event(&item.event);
             }
-            if !demoted && !names.is_empty() {
-                self.mark_topology_edited();
-            }
         }
         Ok(())
     }
@@ -5447,10 +5504,16 @@ where
     ) -> Result<(), crate::engine::EditorError> {
         let pending_events = undo.pending_redo_events();
         self.preflight_replay_admission(&pending_events, true)?;
+        let invalidation_baseline = self.invalidation_baseline();
         let names = Self::name_event_names(&pending_events);
         let prepared =
             self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str))?;
-        let demoted = self.commit_name_dependent_span_demotion(prepared)?;
+        self.commit_name_dependent_span_demotion(prepared)?;
+        self.invalidate_for_change_events(
+            &pending_events,
+            LoggedEditDirection::ForwardReplay,
+            invalidation_baseline,
+        );
         let batch = undo.redo(&mut self.graph, log)?;
         for item in &batch {
             self.apply_forward_row_visibility_event(&item.event);
@@ -5467,9 +5530,6 @@ where
         if !batch.is_empty() {
             for item in &batch {
                 self.record_formula_plane_change_for_event(&item.event);
-            }
-            if !demoted && !names.is_empty() {
-                self.mark_topology_edited();
             }
         }
         Ok(())
@@ -5489,6 +5549,7 @@ where
             undo.push_done_action(journal);
             return Err(error);
         }
+        let invalidation_baseline = self.invalidation_baseline();
         let names = Self::name_event_names(&journal.graph.events);
         let prepared =
             match self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str)) {
@@ -5498,25 +5559,22 @@ where
                     return Err(error);
                 }
             };
-        let demoted = match self.commit_name_dependent_span_demotion(prepared) {
-            Ok(demoted) => demoted,
-            Err(error) => {
-                undo.push_done_action(journal);
-                return Err(error);
-            }
-        };
+        if let Err(error) = self.commit_name_dependent_span_demotion(prepared) {
+            undo.push_done_action(journal);
+            return Err(error);
+        }
 
+        self.invalidate_for_action_journal(
+            &journal,
+            LoggedEditDirection::InverseReplay,
+            invalidation_baseline,
+        );
         journal.graph.undo(&mut self.graph)?;
         self.apply_inverse_row_visibility_events(&journal.graph.events);
         self.apply_arrow_undo_batch(&journal.arrow, /*undo=*/ true);
         if !journal.graph.is_empty() || !journal.arrow.is_empty() {
             for event in &journal.graph.events {
                 self.record_formula_plane_change_for_event(event);
-            }
-            if !demoted && !names.is_empty() {
-                self.mark_topology_edited();
-            } else {
-                self.mark_data_edited();
             }
         }
 
@@ -5538,6 +5596,7 @@ where
             undo.push_redo_action(journal);
             return Err(error);
         }
+        let invalidation_baseline = self.invalidation_baseline();
         let names = Self::name_event_names(&journal.graph.events);
         let prepared =
             match self.prepare_name_dependent_span_demotion(names.iter().map(String::as_str)) {
@@ -5547,25 +5606,22 @@ where
                     return Err(error);
                 }
             };
-        let demoted = match self.commit_name_dependent_span_demotion(prepared) {
-            Ok(demoted) => demoted,
-            Err(error) => {
-                undo.push_redo_action(journal);
-                return Err(error);
-            }
-        };
+        if let Err(error) = self.commit_name_dependent_span_demotion(prepared) {
+            undo.push_redo_action(journal);
+            return Err(error);
+        }
 
+        self.invalidate_for_action_journal(
+            &journal,
+            LoggedEditDirection::ForwardReplay,
+            invalidation_baseline,
+        );
         journal.graph.redo(&mut self.graph)?;
         self.apply_forward_row_visibility_events(&journal.graph.events);
         self.apply_arrow_undo_batch(&journal.arrow, /*undo=*/ false);
         if !journal.graph.is_empty() || !journal.arrow.is_empty() {
             for event in &journal.graph.events {
                 self.record_formula_plane_change_for_event(event);
-            }
-            if !demoted && !names.is_empty() {
-                self.mark_topology_edited();
-            } else {
-                self.mark_data_edited();
             }
         }
 
@@ -5728,6 +5784,122 @@ where
 
     fn clear_cached_static_schedule(&mut self) {
         self.cached_static_schedule = None;
+    }
+
+    fn invalidation_baseline(&self) -> InvalidationBaseline {
+        InvalidationBaseline {
+            snapshot_id: self.snapshot_id.load(std::sync::atomic::Ordering::Relaxed),
+            topology_epoch: self.topology_epoch,
+        }
+    }
+
+    fn classify_change_events(
+        events: &[crate::engine::ChangeEvent],
+        direction: LoggedEditDirection,
+    ) -> LoggedEditImpact {
+        use crate::engine::ChangeEvent;
+
+        events
+            .iter()
+            .map(|event| match event {
+                ChangeEvent::CompoundStart { .. } | ChangeEvent::CompoundEnd { .. } => {
+                    LoggedEditImpact::NoOp
+                }
+                ChangeEvent::SetRowVisibility { .. }
+                | ChangeEvent::SetValue {
+                    old_formula: None,
+                    old_value: Some(_),
+                    ..
+                } => LoggedEditImpact::DataOnly,
+                // Original canonical writes can lack an Arrow old value while
+                // updating an existing placeholder. Inverse replay actually
+                // removes that vertex; a later redo recreates it.
+                ChangeEvent::SetValue {
+                    old_formula: None,
+                    old_value: None,
+                    ..
+                } if direction == LoggedEditDirection::Original => LoggedEditImpact::DataOnly,
+                ChangeEvent::SetValue { .. }
+                | ChangeEvent::SetFormula { .. }
+                | ChangeEvent::AddVertex { .. }
+                | ChangeEvent::RemoveVertex { .. }
+                | ChangeEvent::VertexMoved { .. }
+                | ChangeEvent::FormulaAdjusted { .. }
+                | ChangeEvent::NamedRangeAdjusted { .. }
+                | ChangeEvent::EdgeAdded { .. }
+                | ChangeEvent::EdgeRemoved { .. }
+                | ChangeEvent::DefineName { .. }
+                | ChangeEvent::UpdateName { .. }
+                | ChangeEvent::DeleteName { .. }
+                | ChangeEvent::SpillCommitted { .. }
+                | ChangeEvent::SpillCleared { .. }
+                | ChangeEvent::StagedFormulaCellChanged { .. } => LoggedEditImpact::Topology,
+            })
+            .max()
+            .unwrap_or(LoggedEditImpact::NoOp)
+    }
+
+    fn classify_arrow_undo(arrow: &crate::engine::ArrowUndoBatch) -> LoggedEditImpact {
+        use crate::engine::ArrowOp;
+
+        arrow
+            .ops
+            .iter()
+            .map(|op| match op {
+                ArrowOp::SetDeltaCell { .. } | ArrowOp::SetComputedCell { .. } => {
+                    LoggedEditImpact::DataOnly
+                }
+                ArrowOp::RestoreComputedRect { .. }
+                | ArrowOp::InsertRows { .. }
+                | ArrowOp::InsertCols { .. } => LoggedEditImpact::Topology,
+            })
+            .max()
+            .unwrap_or(LoggedEditImpact::NoOp)
+    }
+
+    fn apply_logged_edit_impact(
+        &mut self,
+        impact: LoggedEditImpact,
+        baseline: InvalidationBaseline,
+    ) {
+        match impact {
+            LoggedEditImpact::NoOp => {}
+            LoggedEditImpact::DataOnly => {
+                if self.topology_epoch == baseline.topology_epoch
+                    && self.snapshot_id.load(std::sync::atomic::Ordering::Relaxed)
+                        == baseline.snapshot_id
+                {
+                    self.mark_data_edited();
+                }
+            }
+            LoggedEditImpact::Topology => {
+                // FormulaPlane demotion and some structural entry points already
+                // publish topology invalidation. Do not bump the same batch twice.
+                if self.topology_epoch == baseline.topology_epoch {
+                    self.mark_topology_edited();
+                }
+            }
+        }
+    }
+
+    fn invalidate_for_change_events(
+        &mut self,
+        events: &[crate::engine::ChangeEvent],
+        direction: LoggedEditDirection,
+        baseline: InvalidationBaseline,
+    ) {
+        self.apply_logged_edit_impact(Self::classify_change_events(events, direction), baseline);
+    }
+
+    fn invalidate_for_action_journal(
+        &mut self,
+        journal: &crate::engine::ActionJournal,
+        direction: LoggedEditDirection,
+        baseline: InvalidationBaseline,
+    ) {
+        let impact = Self::classify_change_events(&journal.graph.events, direction)
+            .max(Self::classify_arrow_undo(&journal.arrow));
+        self.apply_logged_edit_impact(impact, baseline);
     }
 
     /// Mark data edited: bump snapshot and set edited flag.

--- a/crates/formualizer-eval/src/engine/tests/issue_432_logged_invalidation.rs
+++ b/crates/formualizer-eval/src/engine/tests/issue_432_logged_invalidation.rs
@@ -1,0 +1,595 @@
+use crate::engine::addr::GridAddr;
+use crate::engine::graph::editor::undo_engine::UndoEngine;
+use crate::engine::{
+    ActionJournal, ArrowUndoBatch, ChangeEvent, ChangeLog, EditorError, Engine, EvalConfig,
+    FormulaIngestBatch, FormulaIngestRecord, FormulaPlaneMode, GraphUndoBatch, RowVisibilitySource,
+};
+use crate::reference::{CellRef, Coord};
+use crate::test_workbook::TestWorkbook;
+use formualizer_common::{ExcelErrorExtra, LiteralValue, PlanStaleReason};
+use formualizer_parse::parser::parse;
+use std::sync::Arc;
+
+type TestEngine = Engine<TestWorkbook>;
+
+#[derive(Clone, Copy)]
+enum ReplayOperation {
+    AtomicCommit,
+    UndoAction,
+    RedoAction,
+}
+
+fn config() -> EvalConfig {
+    EvalConfig {
+        formula_plane_mode: FormulaPlaneMode::Off,
+        enable_parallel: false,
+        enable_virtual_dep_telemetry: true,
+        ..EvalConfig::default()
+    }
+}
+
+fn setup(reversed: bool) -> TestEngine {
+    let mut engine = Engine::new(TestWorkbook::new(), config());
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        .unwrap();
+    let formulas = if reversed {
+        ["=C1+1", "=A1+10"]
+    } else {
+        ["=A1+1", "=B1+1"]
+    };
+    for (col, formula) in (2..=3).zip(formulas) {
+        engine
+            .set_cell_formula("Sheet1", 1, col, parse(formula).unwrap())
+            .unwrap();
+    }
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+fn setup_empty_precedent() -> TestEngine {
+    let mut engine = Engine::new(TestWorkbook::new(), config());
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=A1+1").unwrap())
+        .unwrap();
+    engine
+        .set_cell_formula("Sheet1", 1, 3, parse("=B1+1").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    engine
+}
+
+fn assert_graph_plan_stale(engine: &mut TestEngine, plan: &crate::engine::RecalcPlan) {
+    let error = engine.evaluate_recalc_plan(plan).unwrap_err();
+    assert!(matches!(
+        error.extra,
+        ExcelErrorExtra::PlanStale {
+            reason: PlanStaleReason::Graph
+        }
+    ));
+}
+
+fn reverse_with_action_logger(engine: &mut TestEngine, log: &mut ChangeLog) {
+    engine
+        .action_with_logger(log, "reverse dependencies", |action| {
+            action.set_cell_formula("Sheet1", 1, 2, parse("=C1+1").unwrap())?;
+            action.set_cell_formula("Sheet1", 1, 3, parse("=A1+10").unwrap())
+        })
+        .unwrap();
+}
+
+fn prepare_action_replay(operation: ReplayOperation) -> TestEngine {
+    let mut engine = setup(false);
+    let (_, journal) = engine
+        .action_atomic_journal("reverse dependencies", |action| {
+            action.set_cell_formula("Sheet1", 1, 2, parse("=C1+1").unwrap())?;
+            action.set_cell_formula("Sheet1", 1, 3, parse("=A1+10").unwrap())
+        })
+        .unwrap();
+    let mut undo = UndoEngine::new();
+    undo.push_action(journal);
+    if matches!(operation, ReplayOperation::AtomicCommit) {
+        return engine;
+    }
+
+    engine.mark_topology_edited();
+    engine.evaluate_all().unwrap();
+    engine.undo_action(&mut undo).unwrap();
+    if matches!(operation, ReplayOperation::UndoAction) {
+        return engine;
+    }
+
+    engine.mark_topology_edited();
+    engine.evaluate_all().unwrap();
+    engine.redo_action(&mut undo).unwrap();
+    engine
+}
+
+fn assert_b1_c1(engine: &mut TestEngine, expected: (f64, f64)) {
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(expected.0))
+    );
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 3),
+        Some(LiteralValue::Number(expected.1))
+    );
+}
+
+fn cell(engine: &TestEngine, row: u32, col: u32) -> CellRef {
+    CellRef::new(
+        engine.sheet_id("Sheet1").unwrap(),
+        Coord::from_excel(row, col, true, true),
+    )
+}
+
+fn reverse_with_direct_logger(engine: &mut TestEngine, log: &mut ChangeLog) {
+    let b1 = cell(engine, 1, 2);
+    let c1 = cell(engine, 1, 3);
+    engine
+        .edit_with_logger(log, |editor| {
+            editor.set_cell_formula(b1, parse("=C1+1").unwrap());
+            editor.set_cell_formula(c1, parse("=A1+10").unwrap());
+        })
+        .unwrap();
+}
+
+#[test]
+fn action_with_logger_formula_edits_invalidate_warm_schedule() {
+    let mut engine = setup(false);
+    reverse_with_action_logger(&mut engine, &mut ChangeLog::new());
+    assert_b1_c1(&mut engine, (12.0, 11.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 0);
+}
+
+#[test]
+fn atomic_commit_formula_edits_invalidate_warm_schedule() {
+    let mut engine = prepare_action_replay(ReplayOperation::AtomicCommit);
+    assert_b1_c1(&mut engine, (12.0, 11.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 0);
+}
+
+#[test]
+fn undo_action_formula_edits_invalidate_independently_warmed_schedule() {
+    let mut engine = prepare_action_replay(ReplayOperation::UndoAction);
+    assert_b1_c1(&mut engine, (2.0, 3.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 0);
+}
+
+#[test]
+fn redo_action_formula_edits_invalidate_independently_warmed_schedule() {
+    let mut engine = prepare_action_replay(ReplayOperation::RedoAction);
+    assert_b1_c1(&mut engine, (12.0, 11.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 0);
+}
+
+#[test]
+fn direct_edit_with_logger_formula_edits_invalidate_warm_schedule() {
+    let mut engine = setup(false);
+    reverse_with_direct_logger(&mut engine, &mut ChangeLog::new());
+    assert_b1_c1(&mut engine, (12.0, 11.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 0);
+}
+
+#[test]
+fn changelog_undo_formula_edits_invalidate_independently_warmed_schedule() {
+    let mut engine = setup(false);
+    let mut log = ChangeLog::new();
+    log.begin_compound("reverse dependencies".to_string());
+    reverse_with_direct_logger(&mut engine, &mut log);
+    log.end_compound();
+    engine.mark_topology_edited();
+    engine.evaluate_all().unwrap();
+
+    engine
+        .undo_logged(&mut UndoEngine::new(), &mut log)
+        .unwrap();
+    assert_b1_c1(&mut engine, (2.0, 3.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 0);
+}
+
+#[test]
+fn changelog_redo_formula_edits_invalidate_independently_warmed_schedule() {
+    let mut engine = setup(false);
+    let mut log = ChangeLog::new();
+    log.begin_compound("reverse dependencies".to_string());
+    reverse_with_direct_logger(&mut engine, &mut log);
+    log.end_compound();
+    engine.mark_topology_edited();
+    engine.evaluate_all().unwrap();
+    let mut undo = UndoEngine::new();
+    engine.undo_logged(&mut undo, &mut log).unwrap();
+    engine.mark_topology_edited();
+    engine.evaluate_all().unwrap();
+
+    engine.redo_logged(&mut undo, &mut log).unwrap();
+    assert_b1_c1(&mut engine, (12.0, 11.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 0);
+}
+
+#[test]
+fn logged_formula_value_transitions_are_topology_changes() {
+    let mut engine = setup(false);
+    let b1 = cell(&engine, 1, 2);
+    let mut log = ChangeLog::new();
+    let before_formula_to_value = engine.topology_epoch_for_test();
+    engine
+        .edit_with_logger(&mut log, |editor| {
+            editor.set_cell_value(b1, LiteralValue::Int(7));
+        })
+        .unwrap();
+    assert!(engine.topology_epoch_for_test() > before_formula_to_value);
+
+    let before_value_to_formula = engine.topology_epoch_for_test();
+    engine
+        .edit_with_logger(&mut log, |editor| {
+            editor.set_cell_formula(b1, parse("=A1+20").unwrap());
+        })
+        .unwrap();
+    assert!(engine.topology_epoch_for_test() > before_value_to_formula);
+    assert_b1_c1(&mut engine, (21.0, 22.0));
+}
+
+#[test]
+fn failed_action_rollback_invalidates_retained_plan_conservatively() {
+    let mut engine = setup(false);
+    let plan = engine.build_recalc_plan().unwrap();
+    let mut log = ChangeLog::new();
+    let result = engine.action_with_logger(
+        &mut log,
+        "failed reversal",
+        |action| -> Result<(), EditorError> {
+            action.set_cell_formula("Sheet1", 1, 2, parse("=C1+1").unwrap())?;
+            action.set_cell_formula("Sheet1", 1, 3, parse("=A1+10").unwrap())?;
+            Err(EditorError::TransactionFailed {
+                reason: "intentional".to_string(),
+            })
+        },
+    );
+    assert!(result.is_err());
+    assert!(log.is_empty());
+    let error = engine.evaluate_recalc_plan(&plan).unwrap_err();
+    assert!(matches!(
+        error.extra,
+        ExcelErrorExtra::PlanStale {
+            reason: PlanStaleReason::Graph
+        }
+    ));
+    assert_b1_c1(&mut engine, (2.0, 3.0));
+}
+
+#[test]
+fn undo_logged_empty_precedent_removal_invalidates_retained_plan() {
+    let mut engine = setup_empty_precedent();
+    let mut log = ChangeLog::new();
+    engine
+        .action_with_logger(&mut log, "fill empty precedent", |action| {
+            action.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        })
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    let plan = engine.build_recalc_plan().unwrap();
+    let topology_before = engine.topology_epoch_for_test();
+
+    engine
+        .undo_logged(&mut UndoEngine::new(), &mut log)
+        .unwrap();
+    assert_eq!(
+        engine.topology_epoch_for_test(),
+        topology_before.wrapping_add(1)
+    );
+    assert_graph_plan_stale(&mut engine, &plan);
+}
+
+#[test]
+fn undo_action_empty_precedent_removal_invalidates_retained_plan() {
+    let mut engine = setup_empty_precedent();
+    let (_, journal) = engine
+        .action_atomic_journal("fill empty precedent", |action| {
+            action.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        })
+        .unwrap();
+    let mut undo = UndoEngine::new();
+    undo.push_action(journal);
+    engine.evaluate_all().unwrap();
+    let plan = engine.build_recalc_plan().unwrap();
+    let topology_before = engine.topology_epoch_for_test();
+
+    engine.undo_action(&mut undo).unwrap();
+    assert_eq!(
+        engine.topology_epoch_for_test(),
+        topology_before.wrapping_add(1)
+    );
+    assert_graph_plan_stale(&mut engine, &plan);
+}
+
+#[test]
+fn redo_action_after_empty_precedent_removal_invalidates_retained_plan() {
+    let mut engine = setup_empty_precedent();
+    let (_, journal) = engine
+        .action_atomic_journal("fill empty precedent", |action| {
+            action.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))
+        })
+        .unwrap();
+    let mut undo = UndoEngine::new();
+    undo.push_action(journal);
+    engine.undo_action(&mut undo).unwrap();
+    let plan = engine.build_recalc_plan().unwrap();
+    let topology_before = engine.topology_epoch_for_test();
+
+    engine.redo_action(&mut undo).unwrap();
+    assert_eq!(
+        engine.topology_epoch_for_test(),
+        topology_before.wrapping_add(1)
+    );
+    assert_graph_plan_stale(&mut engine, &plan);
+}
+
+#[test]
+fn failed_empty_precedent_write_rollback_invalidates_retained_plan() {
+    let mut engine = setup_empty_precedent();
+    let plan = engine.build_recalc_plan().unwrap();
+    let topology_before = engine.topology_epoch_for_test();
+    let result = engine.action_with_logger(
+        &mut ChangeLog::new(),
+        "failed empty precedent write",
+        |action| -> Result<(), EditorError> {
+            action.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(1))?;
+            Err(EditorError::TransactionFailed {
+                reason: "intentional".to_string(),
+            })
+        },
+    );
+
+    assert!(result.is_err());
+    assert_eq!(
+        engine.topology_epoch_for_test(),
+        topology_before.wrapping_add(1)
+    );
+    assert_graph_plan_stale(&mut engine, &plan);
+}
+
+#[test]
+fn nonempty_value_undo_redo_reuses_warm_schedule() {
+    let mut engine = setup(false);
+    let (_, journal) = engine
+        .action_atomic_journal("value only", |action| {
+            action.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(5))
+        })
+        .unwrap();
+    let mut undo = UndoEngine::new();
+    undo.push_action(journal);
+    let topology_before = engine.topology_epoch_for_test();
+
+    assert_b1_c1(&mut engine, (6.0, 7.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 1);
+    engine.undo_action(&mut undo).unwrap();
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+    assert_b1_c1(&mut engine, (2.0, 3.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 1);
+    engine.redo_action(&mut undo).unwrap();
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+    assert_b1_c1(&mut engine, (6.0, 7.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 1);
+}
+
+#[test]
+fn retained_plan_rejects_direct_logged_topology_edit() {
+    let mut engine = setup(false);
+    let plan = engine.build_recalc_plan().unwrap();
+    reverse_with_direct_logger(&mut engine, &mut ChangeLog::new());
+    let error = engine.evaluate_recalc_plan(&plan).unwrap_err();
+    assert!(matches!(
+        error.extra,
+        ExcelErrorExtra::PlanStale {
+            reason: PlanStaleReason::Graph
+        }
+    ));
+}
+
+#[test]
+fn logged_existing_value_edit_keeps_warm_schedule() {
+    let mut engine = setup(false);
+    let a1 = cell(&engine, 1, 1);
+    let topology_before = engine.topology_epoch_for_test();
+    engine
+        .edit_with_logger(&mut ChangeLog::new(), |editor| {
+            editor.set_cell_value(a1, LiteralValue::Int(5));
+        })
+        .unwrap();
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+    assert_b1_c1(&mut engine, (6.0, 7.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 1);
+}
+
+#[test]
+fn action_logged_existing_value_edit_keeps_warm_schedule() {
+    let mut engine = setup(false);
+    let topology_before = engine.topology_epoch_for_test();
+    engine
+        .action_with_logger(&mut ChangeLog::new(), "value only", |action| {
+            action.set_cell_value("Sheet1", 1, 1, LiteralValue::Int(8))
+        })
+        .unwrap();
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+    assert_b1_c1(&mut engine, (9.0, 10.0));
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 1);
+}
+
+#[test]
+fn logged_visibility_edit_keeps_warm_topology() {
+    let mut engine = Engine::new(TestWorkbook::new(), config());
+    for row in 2..=5 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Int((row - 1) as i64))
+            .unwrap();
+    }
+    engine
+        .set_cell_formula("Sheet1", 1, 2, parse("=SUBTOTAL(109,A2:A5)").unwrap())
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    let topology_before = engine.topology_epoch_for_test();
+
+    engine
+        .action_with_logger(&mut ChangeLog::new(), "hide row", |action| {
+            action.set_row_hidden("Sheet1", 2, true, RowVisibilitySource::Manual)
+        })
+        .unwrap();
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+    engine.evaluate_all().unwrap();
+    assert_eq!(
+        engine.get_cell_value("Sheet1", 1, 2),
+        Some(LiteralValue::Number(9.0))
+    );
+    assert_eq!(engine.last_virtual_dep_telemetry().schedule_cache_hits, 1);
+}
+
+#[test]
+fn compound_markers_without_edits_do_not_invalidate() {
+    let mut engine = setup(false);
+    let topology_before = engine.topology_epoch_for_test();
+    engine
+        .action_with_logger(&mut ChangeLog::new(), "no edits", |_action| Ok(()))
+        .unwrap();
+    assert_eq!(engine.topology_epoch_for_test(), topology_before);
+}
+
+#[test]
+fn retained_plan_is_stale_before_partial_inverse_error_returns() {
+    let mut engine = setup(false);
+    engine
+        .set_cell_value("Sheet1", 1, 1, LiteralValue::Int(2))
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    let plan = engine.build_recalc_plan().unwrap();
+    let a1 = cell(&engine, 1, 1);
+    let b1 = cell(&engine, 1, 2);
+    let a1_vertex = engine.graph.get_vertex_for_cell(&a1).unwrap();
+    let b1_vertex = engine.graph.get_vertex_for_cell(&b1).unwrap();
+    let journal = ActionJournal {
+        name: "partial inverse failure".to_string(),
+        graph: GraphUndoBatch {
+            // Undo runs in reverse: move B1 to B2, then fail on EdgeAdded's
+            // intentionally unsupported inverse.
+            events: vec![
+                ChangeEvent::EdgeAdded {
+                    from: b1_vertex,
+                    to: a1_vertex,
+                },
+                ChangeEvent::VertexMoved {
+                    id: b1_vertex,
+                    sheet_id: a1.sheet_id,
+                    old_coord: GridAddr::new(1, 1),
+                    new_coord: GridAddr::new(0, 1),
+                },
+            ],
+        },
+        arrow: ArrowUndoBatch::default(),
+        affected_cells: 0,
+    };
+    let mut undo = UndoEngine::new();
+    undo.push_action(journal);
+
+    assert!(engine.undo_action(&mut undo).is_err());
+    assert_graph_plan_stale(&mut engine, &plan);
+}
+
+#[test]
+fn arrow_only_structural_journal_advances_topology_epoch_once() {
+    let mut engine = setup(false);
+    let mut arrow = ArrowUndoBatch::default();
+    arrow.record_insert_rows(engine.sheet_id("Sheet1").unwrap(), 0, 1);
+    let journal = ActionJournal {
+        name: "arrow-only insert".to_string(),
+        graph: GraphUndoBatch::default(),
+        arrow,
+        affected_cells: 1,
+    };
+    let mut undo = UndoEngine::new();
+    undo.push_action(journal);
+    let topology_before = engine.topology_epoch_for_test();
+
+    engine.undo_action(&mut undo).unwrap();
+    assert_eq!(
+        engine.topology_epoch_for_test(),
+        topology_before.wrapping_add(1)
+    );
+}
+
+#[test]
+fn formula_plane_demotion_and_later_logged_edit_bump_topology_once() {
+    let mut engine = Engine::new(
+        TestWorkbook::new(),
+        EvalConfig::default().with_formula_plane_mode(FormulaPlaneMode::AuthoritativeExperimental),
+    );
+    let mut formulas = Vec::new();
+    for row in 1..=200 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Number(row as f64))
+            .unwrap();
+        let formula = format!("=A{row}*2");
+        let ast_id = engine.intern_formula_ast(&parse(&formula).unwrap());
+        formulas.push(FormulaIngestRecord::new(
+            row,
+            2,
+            ast_id,
+            Some(Arc::<str>::from(formula)),
+        ));
+    }
+    engine
+        .ingest_formula_batches(vec![FormulaIngestBatch::new("Sheet1", formulas)])
+        .unwrap();
+    assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 1);
+    engine.evaluate_all().unwrap();
+    let topology_before = engine.topology_epoch_for_test();
+
+    engine
+        .action_atomic("demote then edit", |action| {
+            action.set_cell_formula("Sheet1", 8, 2, parse("=A8*3").unwrap())?;
+            action.set_cell_formula("Sheet1", 1, 3, parse("=A1+1").unwrap())
+        })
+        .unwrap();
+    assert_eq!(
+        engine.topology_epoch_for_test(),
+        topology_before.wrapping_add(1)
+    );
+}
+
+#[test]
+fn direct_logged_lookup_axis_value_edit_advances_snapshot() {
+    let mut engine = Engine::new(TestWorkbook::new(), config());
+    for row in 1..=100 {
+        engine
+            .set_cell_value("Sheet1", row, 1, LiteralValue::Int(row as i64))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 4, LiteralValue::Int(row as i64))
+            .unwrap();
+        engine
+            .set_cell_value("Sheet1", row, 5, LiteralValue::Int((row * 10) as i64))
+            .unwrap();
+        engine
+            .set_cell_formula(
+                "Sheet1",
+                row,
+                2,
+                parse(format!("=VLOOKUP(A{row}, $D$1:$E$100, 2, FALSE)")).unwrap(),
+            )
+            .unwrap();
+    }
+    engine.evaluate_all().unwrap();
+    assert!(engine.last_lookup_index_cache_report().hits > 0);
+
+    let d50 = cell(&engine, 50, 4);
+    engine
+        .edit_with_logger(&mut ChangeLog::new(), |editor| {
+            editor.set_cell_value(d50, LiteralValue::Int(500));
+        })
+        .unwrap();
+    engine.evaluate_all().unwrap();
+    assert!(matches!(
+        engine.get_cell_value("Sheet1", 50, 2),
+        Some(LiteralValue::Error(error)) if error.kind == formualizer_common::ExcelErrorKind::Na
+    ));
+}

--- a/crates/formualizer-eval/src/engine/tests/mod.rs
+++ b/crates/formualizer-eval/src/engine/tests/mod.rs
@@ -24,6 +24,7 @@ mod evaluation_resource_observability;
 mod graph_basic;
 mod graph_internal_helpers;
 mod issue_326_error_skip_oracle;
+mod issue_432_logged_invalidation;
 mod layer_evaluation;
 mod load_fast_mappings;
 mod perf_tranche;


### PR DESCRIPTION
## Summary

Closes #432. Logged formula edits, atomic actions, and undo/redo could reuse a static schedule after its dependency ordering changed, returning stale intermediate values. An exhaustive event classifier now publishes topology or data invalidation at the existing mutation boundaries, preserving legitimate value-only schedule hits and clearing snapshot-bound lookup indexes.

Replay and rollback invalidate before applying mutations, so a partial replay error cannot leave a changed graph behind a valid retained plan. Classification is direction-aware: undoing a value write with no old value/formula removes a vertex, and replaying it can recreate one. FormulaPlane demotion and structural boundaries retain one-batch epoch deduplication.

No schedule eligibility, cache key, ownership, default FormulaPlane mode, or general undo semantics are changed.

## Validation

- 23 focused regressions pass, including independently warmed forward/undo/redo numerical oracles, value-only cache-hit controls, retained-plan rejection, empty-precedent removal/recreation, partial inverse failure, Arrow-only structural changes, FormulaPlane epoch deduplication, and lookup snapshot invalidation.
- Full eval library suite: 2,930 passed (existing ignored tests remain ignored).
- Independent final review: clean scoped disposition; 23 focused tests and two schedule-cache controls re-run successfully.
- Parent re-ran all 23 focused tests on the committed source; formatting, Clippy and diff checks pass.

## Explicit limits

Correctness here requires complete event capture. Disabled/capped external `ChangeLog` retention can currently lose the very events needed for internal mirroring, rollback, and invalidation; that separate capture defect is tracked in #434. This PR does not repair general inverse semantics (#301) or make partially failed replay transactionally recoverable.
