### PR TITLE
perf(eval): bound range traversal and project numeric/error lanes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@ docs-site/src/generated/functions-meta.json linguist-generated=true
 
 # Unified diffs encode empty context lines as one space.
 benchmarks/*-baseline.patch whitespace=-blank-at-eol
+# This experimental diff also ends on an encoded empty context line.
+benchmarks/perf-ranges-422-a-only.patch whitespace=-blank-at-eol,-blank-at-eof

--- a/benchmarks/perf-ranges-422-a-only.patch
+++ b/benchmarks/perf-ranges-422-a-only.patch
@@ -1,0 +1,272 @@
+--- a/crates/formualizer-eval/src/engine/range_view.rs
++++ b/crates/formualizer-eval/src/engine/range_view.rs
+@@ -102,13 +102,20 @@
+     pub cols: Vec<ChunkCol>,
+ }
+ 
+-pub struct RowChunkIterator<'a> {
++struct RowSegment {
++    chunk_idx: usize,
++    chunk_offset: usize,
++    row_start: usize,
++    row_len: usize,
++}
++
++struct RowSegmentIterator<'a> {
+     view: &'a RangeView<'a>,
+-    current_chunk_idx: usize,
++    chunks: Option<core::ops::Range<usize>>,
+ }
+ 
+-impl<'a> Iterator for RowChunkIterator<'a> {
+-    type Item = Result<ChunkSlice, ExcelError>;
++impl Iterator for RowSegmentIterator<'_> {
++    type Item = Result<RowSegment, ExcelError>;
+ 
+     fn next(&mut self) -> Option<Self::Item> {
+         if self
+@@ -121,42 +128,107 @@
+                 formualizer_common::ExcelErrorKind::Cancelled,
+             )));
+         }
+-
+         let sheet = self.view.sheet();
+-        let chunk_starts = &sheet.chunk_starts;
++        let starts = &sheet.chunk_starts;
+         let sheet_rows = sheet.nrows as usize;
+         let row_end = self.view.er.min(sheet_rows.saturating_sub(1));
+-
+-        while self.current_chunk_idx < chunk_starts.len() {
++        let chunks = self.chunks.get_or_insert_with(|| {
++            // Match row coverage independently of logical column/zero-sized subview dimensions.
++            if sheet_rows == 0 || starts.is_empty() || self.view.sr > row_end {
++                return 0..0;
++            }
++            let first = starts
++                .partition_point(|&start| {
++                    #[cfg(test)]
++                    range_work::record(|w| w.search_probes += 1);
++                    start <= self.view.sr
++                })
++                .saturating_sub(1);
++            let end = starts.partition_point(|&start| {
++                #[cfg(test)]
++                range_work::record(|w| w.search_probes += 1);
++                start <= row_end
++            });
++            first..end
++        });
++        for ci in chunks.by_ref() {
+             #[cfg(test)]
+             range_work::record(|w| w.candidates += 1);
+-            let ci = self.current_chunk_idx;
+-            let start = chunk_starts[ci];
+-            self.current_chunk_idx += 1;
+-
+-            let end = if ci + 1 < chunk_starts.len() {
+-                chunk_starts[ci + 1]
+-            } else {
+-                sheet_rows
+-            };
++            let start = starts[ci];
++            let end = starts.get(ci + 1).copied().unwrap_or(sheet_rows);
+             let len = end.saturating_sub(start);
+             if len == 0 {
+                 continue;
+             }
+-            let chunk_end_abs = start + len - 1;
+-            let is = start.max(self.view.sr);
+-            let ie = chunk_end_abs.min(row_end);
+-            if is > ie {
++            let lo = start.max(self.view.sr);
++            let hi = (start + len - 1).min(row_end);
++            if lo > hi {
+                 continue;
+             }
+-            let seg_len = ie - is + 1;
+-            let rel_off = is - start;
++            let row_len = hi - lo + 1;
++            #[cfg(test)]
++            range_work::record(|w| {
++                w.segments += 1;
++                w.segment_rows += row_len;
++            });
++            return Some(Ok(RowSegment {
++                chunk_idx: ci,
++                chunk_offset: lo - start,
++                row_start: lo - self.view.sr,
++                row_len,
++            }));
++        }
++        None
++    }
++}
++
++pub struct RowChunkIterator<'a> {
++    segments: RowSegmentIterator<'a>,
++}
++
++impl Iterator for RowChunkIterator<'_> {
++    type Item = Result<ChunkSlice, ExcelError>;
+ 
+-            let mut cols = Vec::with_capacity(self.view.cols);
+-            for col_idx in self.view.sc..=self.view.ec {
++    fn next(&mut self) -> Option<Self::Item> {
++        let segment = match self.segments.next()? {
++            Ok(segment) => segment,
++            Err(error) => return Some(Err(error)),
++        };
++        let view = self.segments.view;
++        let sheet = view.sheet();
++        let ci = segment.chunk_idx;
++        let rel_off = segment.chunk_offset;
++        let seg_len = segment.row_len;
++        let mut cols = Vec::with_capacity(view.cols);
++        for col_idx in view.sc..=view.ec {
++            #[cfg(test)]
++            range_work::record(|w| w.generic_columns += 1);
++            if col_idx >= sheet.columns.len() {
+                 #[cfg(test)]
+-                range_work::record(|w| w.generic_columns += 1);
+-                if col_idx >= sheet.columns.len() {
++                range_work::record(|w| {
++                    w.null_arrays += 4;
++                    w.null_slots += 4 * seg_len;
++                });
++                let numbers = Some(arrow_array::new_null_array(&DataType::Float64, seg_len));
++                let booleans = Some(arrow_array::new_null_array(&DataType::Boolean, seg_len));
++                let text = Some(arrow_array::new_null_array(&DataType::Utf8, seg_len));
++                let errors = Some(arrow_array::new_null_array(&DataType::UInt8, seg_len));
++                let type_tag: arrow_array::ArrayRef =
++                    Arc::new(arrow_array::UInt8Array::from(vec![
++                        arrow_store::TypeTag::Empty
++                            as u8;
++                        seg_len
++                    ]));
++                cols.push(ChunkCol {
++                    numbers,
++                    booleans,
++                    text,
++                    errors,
++                    type_tag,
++                });
++            } else {
++                let col = &sheet.columns[col_idx];
++                let Some(ch) = col.chunk(ci) else {
+                     #[cfg(test)]
+                     range_work::record(|w| {
+                         w.null_arrays += 4;
+@@ -179,68 +251,33 @@
+                         errors,
+                         type_tag,
+                     });
+-                } else {
+-                    let col = &sheet.columns[col_idx];
+-                    let Some(ch) = col.chunk(ci) else {
+-                        #[cfg(test)]
+-                        range_work::record(|w| {
+-                            w.null_arrays += 4;
+-                            w.null_slots += 4 * seg_len;
+-                        });
+-                        let numbers =
+-                            Some(arrow_array::new_null_array(&DataType::Float64, seg_len));
+-                        let booleans =
+-                            Some(arrow_array::new_null_array(&DataType::Boolean, seg_len));
+-                        let text = Some(arrow_array::new_null_array(&DataType::Utf8, seg_len));
+-                        let errors = Some(arrow_array::new_null_array(&DataType::UInt8, seg_len));
+-                        let type_tag: arrow_array::ArrayRef =
+-                            Arc::new(arrow_array::UInt8Array::from(vec![
+-                                arrow_store::TypeTag::Empty
+-                                    as u8;
+-                                seg_len
+-                            ]));
+-                        cols.push(ChunkCol {
+-                            numbers,
+-                            booleans,
+-                            text,
+-                            errors,
+-                            type_tag,
+-                        });
+-                        continue;
+-                    };
+-
+-                    let numbers_base: arrow_array::ArrayRef = ch.numbers_or_null();
+-                    let booleans_base: arrow_array::ArrayRef = ch.booleans_or_null();
+-                    let text_base: arrow_array::ArrayRef = ch.text_or_null();
+-                    let errors_base: arrow_array::ArrayRef = ch.errors_or_null();
+-
+-                    let numbers = Some(numbers_base.slice(rel_off, seg_len));
+-                    let booleans = Some(booleans_base.slice(rel_off, seg_len));
+-                    let text = Some(text_base.slice(rel_off, seg_len));
+-                    let errors = Some(errors_base.slice(rel_off, seg_len));
+-                    let type_tag: arrow_array::ArrayRef =
+-                        Arc::new(ch.type_tag.slice(rel_off, seg_len));
+-                    cols.push(ChunkCol {
+-                        numbers,
+-                        booleans,
+-                        text,
+-                        errors,
+-                        type_tag,
+-                    });
+-                }
++                    continue;
++                };
++
++                let numbers_base: arrow_array::ArrayRef = ch.numbers_or_null();
++                let booleans_base: arrow_array::ArrayRef = ch.booleans_or_null();
++                let text_base: arrow_array::ArrayRef = ch.text_or_null();
++                let errors_base: arrow_array::ArrayRef = ch.errors_or_null();
++
++                let numbers = Some(numbers_base.slice(rel_off, seg_len));
++                let booleans = Some(booleans_base.slice(rel_off, seg_len));
++                let text = Some(text_base.slice(rel_off, seg_len));
++                let errors = Some(errors_base.slice(rel_off, seg_len));
++                let type_tag: arrow_array::ArrayRef = Arc::new(ch.type_tag.slice(rel_off, seg_len));
++                cols.push(ChunkCol {
++                    numbers,
++                    booleans,
++                    text,
++                    errors,
++                    type_tag,
++                });
+             }
+-            #[cfg(test)]
+-            range_work::record(|w| {
+-                w.segments += 1;
+-                w.segment_rows += seg_len;
+-            });
+-            return Some(Ok(ChunkSlice {
+-                row_start: is - self.view.sr,
+-                row_len: seg_len,
+-                cols,
+-            }));
+         }
+-        None
++        Some(Ok(ChunkSlice {
++            row_start: segment.row_start,
++            row_len: seg_len,
++            cols,
++        }))
+     }
+ }
+ 
+@@ -547,11 +584,17 @@
+ 
+     /// Iterate overlapping chunks by row segment.
+     pub fn iter_row_chunks(&self) -> RowChunkIterator<'_> {
++        RowChunkIterator {
++            segments: self.iter_row_segments(),
++        }
++    }
++
++    fn iter_row_segments(&self) -> RowSegmentIterator<'_> {
+         #[cfg(test)]
+         range_work::record(|w| w.iterators += 1);
+-        RowChunkIterator {
++        RowSegmentIterator {
+             view: self,
+-            current_chunk_idx: 0,
++            chunks: None,
+         }
+     }
+ 

--- a/benchmarks/perf-ranges-422-baseline.patch
+++ b/benchmarks/perf-ranges-422-baseline.patch
@@ -1,0 +1,223 @@
+diff --git a/crates/formualizer-eval/src/arrow_store/mod.rs b/crates/formualizer-eval/src/arrow_store/mod.rs
+index 085782a5..920e27e3 100644
+--- a/crates/formualizer-eval/src/arrow_store/mod.rs
++++ b/crates/formualizer-eval/src/arrow_store/mod.rs
+@@ -158,11 +158,18 @@ impl ColumnChunk {
+     }
+     #[inline]
+     pub fn numbers_or_null(&self) -> Arc<Float64Array> {
++        #[cfg(test)]
++        crate::engine::range_view::range_work::record(|w| w.provider_requests[0] += 1);
+         if let Some(a) = &self.numbers {
+             return a.clone();
+         }
+         self.lazy_null_numbers
+             .get_or_init(|| {
++                #[cfg(test)]
++                crate::engine::range_view::range_work::record(|w| {
++                    w.provider_builds[0] += 1;
++                    w.provider_slots[0] += self.len();
++                });
+                 let arr = new_null_array(&DataType::Float64, self.len());
+                 Arc::new(arr.as_any().downcast_ref::<Float64Array>().unwrap().clone())
+             })
+@@ -170,11 +177,18 @@ impl ColumnChunk {
+     }
+     #[inline]
+     pub fn booleans_or_null(&self) -> Arc<BooleanArray> {
++        #[cfg(test)]
++        crate::engine::range_view::range_work::record(|w| w.provider_requests[1] += 1);
+         if let Some(a) = &self.booleans {
+             return a.clone();
+         }
+         self.lazy_null_booleans
+             .get_or_init(|| {
++                #[cfg(test)]
++                crate::engine::range_view::range_work::record(|w| {
++                    w.provider_builds[1] += 1;
++                    w.provider_slots[1] += self.len();
++                });
+                 let arr = new_null_array(&DataType::Boolean, self.len());
+                 Arc::new(arr.as_any().downcast_ref::<BooleanArray>().unwrap().clone())
+             })
+@@ -182,11 +196,18 @@ impl ColumnChunk {
+     }
+     #[inline]
+     pub fn errors_or_null(&self) -> Arc<UInt8Array> {
++        #[cfg(test)]
++        crate::engine::range_view::range_work::record(|w| w.provider_requests[2] += 1);
+         if let Some(a) = &self.errors {
+             return a.clone();
+         }
+         self.lazy_null_errors
+             .get_or_init(|| {
++                #[cfg(test)]
++                crate::engine::range_view::range_work::record(|w| {
++                    w.provider_builds[2] += 1;
++                    w.provider_slots[2] += self.len();
++                });
+                 let arr = new_null_array(&DataType::UInt8, self.len());
+                 Arc::new(arr.as_any().downcast_ref::<UInt8Array>().unwrap().clone())
+             })
+@@ -194,11 +215,20 @@ impl ColumnChunk {
+     }
+     #[inline]
+     pub fn text_or_null(&self) -> ArrayRef {
++        #[cfg(test)]
++        crate::engine::range_view::range_work::record(|w| w.provider_requests[3] += 1);
+         if let Some(a) = &self.text {
+             return a.clone();
+         }
+         self.lazy_null_text
+-            .get_or_init(|| new_null_array(&DataType::Utf8, self.len()))
++            .get_or_init(|| {
++                #[cfg(test)]
++                crate::engine::range_view::range_work::record(|w| {
++                    w.provider_builds[3] += 1;
++                    w.provider_slots[3] += self.len();
++                });
++                new_null_array(&DataType::Utf8, self.len())
++            })
+             .clone()
+     }
+ 
+diff --git a/crates/formualizer-eval/src/engine/range_view.rs b/crates/formualizer-eval/src/engine/range_view.rs
+index 46d5bab0..dfbc52db 100644
+--- a/crates/formualizer-eval/src/engine/range_view.rs
++++ b/crates/formualizer-eval/src/engine/range_view.rs
+@@ -7,6 +7,49 @@ use arrow_schema::DataType;
+ use formualizer_common::{CoercionPolicy, DateSystem, ExcelError, LiteralValue};
+ use std::sync::Arc;
+ 
++#[cfg(test)]
++pub(crate) mod range_work {
++    use std::cell::Cell;
++
++    #[derive(Clone, Copy, Debug, Default, serde::Serialize)]
++    pub(crate) struct Work {
++        pub iterators: usize,
++        pub search_probes: usize,
++        pub candidates: usize,
++        pub segments: usize,
++        pub segment_rows: usize,
++        pub generic_columns: usize,
++        pub selector_searches: usize,
++        pub null_arrays: usize,
++        pub null_slots: usize,
++        pub provider_requests: [usize; 4],
++        pub provider_builds: [usize; 4],
++        pub provider_slots: [usize; 4],
++    }
++
++    thread_local! {
++        static WORK: Cell<Option<Work>> = const { Cell::new(None) };
++    }
++
++    pub(crate) fn begin() {
++        WORK.with(|work| work.set(Some(Work::default())));
++    }
++
++    pub(crate) fn take() -> Work {
++        WORK.with(|work| work.replace(None).unwrap_or_default())
++    }
++
++    #[inline]
++    pub(crate) fn record(f: impl FnOnce(&mut Work)) {
++        WORK.with(|work| {
++            if let Some(mut value) = work.get() {
++                f(&mut value);
++                work.set(Some(value));
++            }
++        });
++    }
++}
++
+ #[derive(Clone)]
+ pub enum RangeBacking<'a> {
+     Borrowed(&'a arrow_store::ArrowSheet),
+@@ -85,6 +128,8 @@ impl<'a> Iterator for RowChunkIterator<'a> {
+         let row_end = self.view.er.min(sheet_rows.saturating_sub(1));
+ 
+         while self.current_chunk_idx < chunk_starts.len() {
++            #[cfg(test)]
++            range_work::record(|w| w.candidates += 1);
+             let ci = self.current_chunk_idx;
+             let start = chunk_starts[ci];
+             self.current_chunk_idx += 1;
+@@ -109,7 +154,14 @@ impl<'a> Iterator for RowChunkIterator<'a> {
+ 
+             let mut cols = Vec::with_capacity(self.view.cols);
+             for col_idx in self.view.sc..=self.view.ec {
++                #[cfg(test)]
++                range_work::record(|w| w.generic_columns += 1);
+                 if col_idx >= sheet.columns.len() {
++                    #[cfg(test)]
++                    range_work::record(|w| {
++                        w.null_arrays += 4;
++                        w.null_slots += 4 * seg_len;
++                    });
+                     let numbers = Some(arrow_array::new_null_array(&DataType::Float64, seg_len));
+                     let booleans = Some(arrow_array::new_null_array(&DataType::Boolean, seg_len));
+                     let text = Some(arrow_array::new_null_array(&DataType::Utf8, seg_len));
+@@ -130,6 +182,11 @@ impl<'a> Iterator for RowChunkIterator<'a> {
+                 } else {
+                     let col = &sheet.columns[col_idx];
+                     let Some(ch) = col.chunk(ci) else {
++                        #[cfg(test)]
++                        range_work::record(|w| {
++                            w.null_arrays += 4;
++                            w.null_slots += 4 * seg_len;
++                        });
+                         let numbers =
+                             Some(arrow_array::new_null_array(&DataType::Float64, seg_len));
+                         let booleans =
+@@ -172,6 +229,11 @@ impl<'a> Iterator for RowChunkIterator<'a> {
+                     });
+                 }
+             }
++            #[cfg(test)]
++            range_work::record(|w| {
++                w.segments += 1;
++                w.segment_rows += seg_len;
++            });
+             return Some(Ok(ChunkSlice {
+                 row_start: is - self.view.sr,
+                 row_len: seg_len,
+@@ -485,6 +547,8 @@ impl<'a> RangeView<'a> {
+ 
+     /// Iterate overlapping chunks by row segment.
+     pub fn iter_row_chunks(&self) -> RowChunkIterator<'_> {
++        #[cfg(test)]
++        range_work::record(|w| w.iterators += 1);
+         RowChunkIterator {
+             view: self,
+             current_chunk_idx: 0,
+@@ -661,6 +725,8 @@ impl<'a> RangeView<'a> {
+ 
+                 // Identify chunk and overlay segment
+                 let abs_seg_start = self.sr + cs.row_start;
++                #[cfg(test)]
++                range_work::record(|w| w.selector_searches += 1);
+                 let ch_idx = match chunk_starts.binary_search(&abs_seg_start) {
+                     Ok(i) => i,
+                     Err(0) => 0,
+@@ -873,6 +939,8 @@ impl<'a> RangeView<'a> {
+                     .clone();
+                 let base_arc: Arc<arrow_array::UInt8Array> = Arc::new(base_e);
+                 let abs_seg_start = self.sr + cs.row_start;
++                #[cfg(test)]
++                range_work::record(|w| w.selector_searches += 1);
+                 let ch_idx = match chunk_starts.binary_search(&abs_seg_start) {
+                     Ok(i) => i,
+                     Err(0) => 0,
+diff --git a/crates/formualizer-eval/src/engine/tests/perf_tranche.rs b/crates/formualizer-eval/src/engine/tests/perf_tranche.rs
+index 0ef0f663..f99ad786 100644
+--- a/crates/formualizer-eval/src/engine/tests/perf_tranche.rs
++++ b/crates/formualizer-eval/src/engine/tests/perf_tranche.rs
+@@ -1,4 +1,6 @@
+ //! Standalone release probe: see benchmarks/perf-tranche-419-421.md.
++#[path = "perf_ranges.rs"]
++mod perf_ranges;
+ use std::alloc::{GlobalAlloc, Layout, System};
+ use std::cell::Cell;
+ use std::hint::black_box;

--- a/benchmarks/perf-ranges-422.md
+++ b/benchmarks/perf-ranges-422.md
@@ -1,0 +1,113 @@
+# Bounded range discovery and numeric/error projection (#422 subset)
+
+Baseline: `8a912b50a086a8cdb0001ea10b6468073aa446ca` (after #431). A bounds chunk discovery with a private metadata cursor; B projects only numbers/errors instead of constructing all generic lanes and searching for the same chunk again per column. The public chunk shape, row/column order, physical overlap, cancellation checkpoints, and existing overlay cascade remain unchanged. Production logic changes only in `range_view.rs`.
+
+This is a subset of #422, not a general range/workbook throughput claim. Other typed lanes still use the generic adapter. Missing chunks inside the view remain represented; requested-lane null caches may still allocate whole-chunk buffers. No lookup semantics, used-extent policy, default FormulaPlane mode, or global cache changes are included. #414's approximate-lookup scalar materialization remains open and unchanged.
+
+## Method
+
+Shared Linux x86_64 host, AMD Ryzen 9 3900XT (12 cores). Rust 1.93.0, native release, repository `lto=true`/`codegen-units=1`, empty rustflags. The normal example uses default eval features plus `test-support`, **library cfg(test) OFF**, and no test allocator/counter hooks. Engine fixtures use TestWorkbook, one worker, FormulaPlane Off, and Arrow/delta/computed overlays; outputs are on a separate sheet. This is not interactive/ephemeral workbook-mode or active-span performance coverage.
+
+The exclusive window was 2026-09-05 14:50:02Z-14:50:41Z. No program builds or other tests overlapped it. Instrumented order: baseline/A/AB/AB/A/baseline; normal-example order: baseline/fixed/fixed/baseline. Each process uses seven samples. These are short shared-host observations, without CPU pinning; external activity, allocator/cache state and process-global initialization remain possible noise. Quartiles describe dispersion, not confidence intervals.
+
+Direct samples build a fresh fixture, validate it through scalar reads, then measure one cold lane read and a warm batch. Construction, ingestion, range creation and scalar validation are excluded. Cold means cold lane providers, not cold CPU/process/OS state. Warm batches use 128 operations for tiny ranges, eight for dense ranges and four for sparse spans. Each reported direct distribution has **14 fixture batches from two process runs**, not 14 process launches or hundreds of independent timings.
+
+Direct `Sum` is **SUM-like**, counting non-null errors before Arrow numeric summation, not implementing builtin SUM error propagation. Quoted numeric/sparse fixtures contain no errors. `Numbers` reads numeric slices and sums them; `Count` reads numeric null counts rather than scanning every value. Actual Engine SUM/COUNT is separate below. All results are checked outside timing; normal captures emit checksums, while instrumented captures assert answers but do not emit a checksum field.
+
+## Counter-free results
+
+Warm direct microseconds per operation, median [p25,p75], n=14 per variant. Default chunks contain 32768 rows; fragmented layouts are explicit stress controls.
+
+| Fixture | Baseline | A+B |
+| --- | ---: | ---: |
+| Eight-row numeric head, one default chunk | 0.426 [0.424,0.433] | 0.088 [0.087,0.088] |
+| Eight-row numeric tail, 32 default chunks | 1.613 [1.603,1.673] | 1.188 [1.151,1.224] |
+| Eight-row numeric tail, 4096 x 256-row chunks | 5.186 [5.163,5.260] | 1.122 [1.062,1.151] |
+| Dense 32768 x 8, one default chunk, Sum-like | 68.030 [66.934,68.785] | 51.445 [51.257,52.275] |
+| Dense 32768 x 8, 32 x 1024-row chunks, Sum-like | 270.096 [266.855,272.079] | 89.705 [88.688,91.292] |
+| Dense 32768 x 8, one default chunk, Count | 9.390 [9.321,10.072] | 0.480 [0.465,0.485] |
+| Million-row sparse gap span, one column, 4096 chunks, Sum-like | 12054 [11986,12149] | 1469 [1409,1865] |
+
+The sparse fixture has 1,048,576 rows, populated top/tail and missing intervening column chunks. **Both variants still yield 8192 segments and 2097152 presented row-segment rows across the two passes.** Its improvement is lane/null-array/owner work, not occupied-cell-only traversal. It excludes whole-column resolution and must not be described as an Engine `SUM(A:A)` result. Fixed p90 is 1984 us and per-run medians are 1509/1414 us, showing appreciable dispersion.
+
+For the default 32-chunk numeric tail, cold medians are 22.843 [22.262,31.342] us baseline versus 7.108 [6.836,9.741] us fixed; p90 is 89.615/16.153 us. Do not generalize these dispersed cold observations.
+
+Actual Engine **fresh first evaluation**, microseconds, n=14 fresh fixtures per variant:
+
+| SUM+COUNT source layout | Baseline median [p25,p75] | A+B median [p25,p75] | Baseline / A+B p90 |
+| --- | ---: | ---: | ---: |
+| 32768 rows, one default chunk | 19.106 [17.761,21.906] | 15.425 [14.487,16.514] | 62.586 / 56.201 |
+| 32768 rows, 128 x 256-row chunks | 16.251 [15.870,18.139] | 13.515 [13.247,13.960] | 19.569 / 17.542 |
+
+The formulas read `A32761:A32768`; SUM=262116 and COUNT=8, with two computed vertices and zero active spans. Global registry initialization can affect the first Engine sample in each process. These are **not** the instrumented warm-dirty phase: that probe explicitly dirties formulas on the same Engine outside timing, while the public example rebuilds the Engine for each sample. Neither phase is no-op recalculation.
+
+## Mechanism and trade-off
+
+The instrumented probe is cfg(test), with thread-local work/requested-allocation counters; its timing ratios are not production-style ratios. A-only captures separate discovery from projection:
+
+- Tiny tail candidates change 32/4096 -> 1, plus 12/26 search predicates, with one eight-row segment unchanged. At default chunk counts A alone is a small effect; projection supplies much of the improvement.
+- Dense 32-chunk, eight-column Sum-like traversal: A retains baseline's 512 generic columns, 512 numeric/error re-searches and 3200 requested allocations. A+B removes generic/re-search work and records 576 allocations; requested bytes change 397312 -> 61440. Presented shape is unchanged.
+- Sparse one-column span: fresh missing-lane arrays change 32752 -> 8188; requested bytes change 42625376 -> 11606384. Gaps and segment counts remain unchanged. These are cumulative allocation requests, not live/peak memory; presented rows are not exact Arrow kernel row visits.
+- Instrumented exact VLOOKUP first/last/miss controls use 64-row axes. Zero cache cap forces typed fallback; warmed normal-cap queries assert cache hits and zero range segments. Fragmented warm-dirty medians (n=12) are 9.258 -> 7.319 us for fallback and 6.808 -> 6.823 us for indexed queries. The latter is a negative control, not an indexed-lookup improvement.
+
+There is an accepted small regression: generic head-only `First` now computes both boundaries before yielding. Counter-free warm microseconds, n=14:
+
+| Generic First | Baseline [p25,p75] | A+B [p25,p75] |
+| --- | ---: | ---: |
+| One default chunk | 0.365 [0.362,0.369] | 0.374 [0.372,0.375] |
+| 32 default chunks, head | 0.365 [0.363,0.389] | 0.383 [0.381,0.388] |
+| 4096 fragmented chunks, head | 0.365 [0.362,0.378] | 0.399 [0.398,0.400] |
+
+The fragmented pooled increase is about 34 ns/9%, with the direction repeated in both runs. The default 32-chunk distributions overlap and its run medians reverse direction, so that percentage is not a stable effect. No first-chunk shortcut was added after measurement; not every generic reader improves.
+
+Coverage is smaller than the investigation plan. There is no timed Engine A:A/used-bounds resolution, criteria/SUMIFS, MEDIAN, approximate lookup, edit-triggered recalculation, width-64 sweep, parallel scaling or active-FormulaPlane case. Mixed/sparse/wide and overlay instrumented controls are not all repeated in the normal example. The seven new independent segmentation/projection, sparse/structural/lifetime, cancellation, overlay, lane-locality and bit/error-order regressions pass in debug and release. Recorded full validation: debug eval/workbook 3065 passed, 17 ignored; release eval 2914 passed, 16 ignored, excluding only the separately baseline-reproduced `test_scalar_arena_float_overflow` release-only missing-panic failure. Targeted Clippy and formatting pass. These are recorded implementation checks, not a new CI claim.
+
+## Source identity
+
+The measured candidate was uncommitted; source hashes pin it instead of a fictitious fixed commit. SHA-256:
+
+- `crates/formualizer-eval/src/engine/range_view.rs`: `ac2f72a1be9a07c91aeb36a780a5ac12632ad0038b227f213e07fa4ee5261761`.
+- Instrumented `crates/formualizer-eval/src/engine/tests/perf_ranges.rs`: `37324a4206555f5d1dc1ff16be44bcfda51991d9d8cbeb6bc2efb1bce8272c66`.
+- Counter-free `crates/formualizer-eval/examples/range_projection_probe.rs`: `cde1bbeee4d11bf6fd8e03d2d12b00367bbe963b154ac57cc7cd1abca707df07`.
+- `benchmarks/perf-ranges-422-baseline.patch`: `148bcbef2267bcb7fd6afe2bb6342dc5c9ba763dfd31d1948b679a9efaaaae93`.
+- `benchmarks/perf-ranges-422-a-only.patch`: `a3e2013cc6ecc6664904fd0e17bed34831677bbb66270b727122c2b2919401f7`.
+
+Exact exclusions: baseline/A instrumented builds lack the appended `bounded_projection_tests` module; the measured A+B binary includes all seven tests. A pre-test A+B source snapshot is not the full source used to build that binary. Counter-free builds exclude all cfg(test) modules, including those tests, provider counters and the allocator probe. This report, minimal reproduction patches and summarizer were added after measurement; the production/harness sources were not changed. The public baseline patch omits the duplicate common probe body: copy the hash-identified source as instructed below.
+
+## Reproduction
+
+Build first, then measure without overlapping builds. Raw captures and binaries stay local; inspect any text before sharing it. From the candidate checkout, this creates a fresh baseline with only the example/stanza and uses **distinct target directories**; never trust cross-worktree artifact reuse based on source mtimes.
+
+```bash
+set -eu
+fixed=$PWD
+out=$(mktemp -d)
+base="$out/program-ranges-baseline"
+git worktree add --detach "$base" 8a912b50a086a8cdb0001ea10b6468073aa446ca
+cp crates/formualizer-eval/examples/range_projection_probe.rs "$base/crates/formualizer-eval/examples/"
+cat >> "$base/crates/formualizer-eval/Cargo.toml" <<'TOML'
+
+[[example]]
+name = "range_projection_probe"
+path = "examples/range_projection_probe.rs"
+required-features = ["test-support"]
+TOML
+(cd "$base" && CARGO_TARGET_DIR="$out/target-baseline" cargo +1.93.0 build \
+  -p formualizer-eval --example range_projection_probe --features test-support --release -j4)
+CARGO_TARGET_DIR="$out/target-fixed" cargo +1.93.0 build \
+  -p formualizer-eval --example range_projection_probe --features test-support --release -j4
+cp "$out/target-baseline/release/examples/range_projection_probe" "$out/production-baseline"
+cp "$out/target-fixed/release/examples/range_projection_probe" "$out/production-fixed"
+"$out/production-baseline" --validate
+"$out/production-fixed" --validate
+# Run only in a quiet measurement window, after all builds finish.
+for run in baseline:1 fixed:1 fixed:2 baseline:2; do
+  variant=${run%:*}; repeat=${run#*:}
+  FZ_RANGES_SAMPLES=7 "$out/production-$variant" > "$out/production-$variant-$repeat.txt" || exit 1
+done
+uv run --no-project python3 benchmarks/summarize-perf-ranges.py "$out"/production-*.txt
+```
+
+For mechanism reproduction, apply `perf-ranges-422-baseline.patch` to that baseline and copy `crates/formualizer-eval/src/engine/tests/perf_ranges.rs` from the candidate into its matching path. The patch adds only test counters and the child-module declaration, reusing the existing allocator. Build/copy its eval lib test executable with `cargo +1.93.0 test -p formualizer-eval --lib --release --no-run -j4`. Then apply `perf-ranges-422-a-only.patch` on top for **A only** (bounded discovery, not projection), build/copy into a distinct A target. Build/copy the candidate for A+B in another target. The A-only patch intentionally changes the experimental variant's cursor; it is not an instrumentation-only patch or a second proposed production fix.
+
+Validate each executable with `range_probe_fixtures_validate --test-threads=1`. After all builds finish, use `FZ_RANGES_SAMPLES=7 <executable> range_release_probe --ignored --nocapture --test-threads=1` in baseline/A/AB/AB/A/baseline order, saving names `instrumented-baseline-1.txt`, `instrumented-a-1.txt`, `instrumented-ab-1.txt`, etc. The summarizer accepts those files and `--work` emits per-iteration median allocation/work counts. It handles the libtest-prefixed first record. Neither patches nor report contain raw captures, binaries, archives or environment dumps.

--- a/benchmarks/summarize-perf-ranges.py
+++ b/benchmarks/summarize-perf-ranges.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Print TSV summaries of local range probe captures; never run a benchmark."""
+import argparse
+import collections
+import json
+from pathlib import Path
+import re
+import statistics
+
+
+def quantile(values, fraction):
+    values = sorted(values)
+    position = (len(values) - 1) * fraction
+    lo = int(position)
+    hi = min(lo + 1, len(values) - 1)
+    return values[lo] + (values[hi] - values[lo]) * (position - lo)
+
+
+def load(paths):
+    groups = collections.defaultdict(list)
+    for path in paths:
+        match = re.fullmatch(r"(instrumented|production)-(baseline|a|ab|fixed)-(\d+)\.txt", path.name)
+        if match is None:
+            raise ValueError("unexpected capture filename: " + path.name)
+        kind, variant, _run = match.groups()
+        count = 0
+        for line in path.read_text().splitlines():
+            brace = line.find("{")
+            if brace < 0:
+                continue
+            # Libtest can prefix the first complete JSON record with the test name.
+            record = json.loads(line[brace:])
+            if record["family"] == "direct":
+                case = record["case"] + "/" + record["mode"]
+                phase = record["phase"]
+            else:
+                case = record["case"] + "/" + str(record["chunk_rows"])
+                if kind == "instrumented":
+                    case += "/index=" + str(record["index_enabled"])
+                    phase = "cold" if record["sample"] == 0 else "warm-dirty"
+                else:
+                    phase = record["phase"]
+            groups[(kind, variant, record["family"], case, phase)].append(record)
+            count += 1
+        if count == 0:
+            raise ValueError("no JSON records: " + path.name)
+    return groups
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--work", action="store_true", help="emit median instrumented work per iteration")
+    parser.add_argument("captures", nargs="+", type=Path)
+    args = parser.parse_args()
+    groups = load(args.captures)
+    keys = ["kind", "variant", "family", "case", "phase", "samples"]
+    work_fields = ["candidates", "search_probes", "segments", "segment_rows",
+                   "generic_columns", "selector_searches", "null_arrays"]
+    fields = (["allocations", "allocated_bytes"] + work_fields if args.work
+              else ["median_us", "p25_us", "p75_us", "p90_us"])
+    print("\t".join(keys + fields))
+    for key, records in sorted(groups.items()):
+        if args.work:
+            if key[0] != "instrumented":
+                continue
+            values = []
+            for field in fields:
+                values.append(statistics.median([
+                    (r[field] if field in r else r["work"][field]) / r.get("iterations", 1)
+                    for r in records
+                ]))
+        else:
+            timings = [r["ns"] / r.get("iterations", 1) / 1000 for r in records]
+            values = [statistics.median(timings)] + [quantile(timings, q) for q in (0.25, 0.75, 0.9)]
+        print("\t".join(list(key) + [str(len(records))] + [format(v, ".6f") for v in values]))
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -123,6 +123,11 @@ benchmark_internal = []
 test-support = []
 
 [[example]]
+name = "range_projection_probe"
+path = "examples/range_projection_probe.rs"
+required-features = ["test-support"]
+
+[[example]]
 name = "recalc_quadratic"
 path = "examples/recalc_quadratic.rs"
 required-features = ["test-support"]

--- a/crates/formualizer-eval/examples/range_projection_probe.rs
+++ b/crates/formualizer-eval/examples/range_projection_probe.rs
@@ -1,0 +1,309 @@
+//! Counter-free counterparts of selected perf_ranges fixtures (library cfg(test) is off).
+//! Build with --release --features test-support; --validate never calls Instant.
+//! Raw timing output stays local. An exclusive measurement window is required.
+use arrow_array::Array;
+use formualizer_common::{DateSystem, LiteralValue};
+use formualizer_eval::arrow_store::{ArrowSheet, IngestBuilder, OverlayValue};
+use formualizer_eval::engine::range_view::RangeView;
+use formualizer_eval::engine::{Engine, EvalConfig, FormulaPlaneMode};
+use formualizer_eval::test_workbook::TestWorkbook;
+use formualizer_parse::parser::parse;
+use std::hint::black_box;
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug)]
+enum Read {
+    Numbers,
+    First,
+    Sum,
+    Count,
+}
+
+fn read(view: &RangeView<'_>, mode: Read) -> f64 {
+    if matches!(mode, Read::First) {
+        return view
+            .iter_row_chunks()
+            .next()
+            .map(|r| {
+                let segment = r.unwrap();
+                black_box(&segment.cols);
+                segment.row_len as f64
+            })
+            .unwrap_or(0.0);
+    }
+    let mut total = 0.0;
+    if matches!(mode, Read::Sum) {
+        for segment in view.errors_slices() {
+            for col in segment.unwrap().2 {
+                total += (col.len() - col.null_count()) as f64;
+            }
+        }
+    }
+    for segment in view.numbers_slices() {
+        for col in segment.unwrap().2 {
+            total += if matches!(mode, Read::Count) {
+                (col.len() - col.null_count()) as f64
+            } else {
+                arrow::compute::kernels::aggregate::sum(col.as_ref()).unwrap_or(0.0)
+            };
+        }
+    }
+    black_box(total)
+}
+
+fn sparse(chunk_rows: usize, chunks: usize) -> ArrowSheet {
+    let mut ingest = IngestBuilder::new("Source", 2, chunk_rows, DateSystem::Excel1900);
+    for _ in 0..chunk_rows {
+        ingest
+            .append_row(&[LiteralValue::Number(2.0), LiteralValue::Empty])
+            .unwrap();
+    }
+    let mut sheet = ingest.finish();
+    sheet.ensure_row_capacity(chunk_rows * chunks);
+    let tail = sheet.nrows as usize - 8;
+    for row in tail..tail + 8 {
+        let (ci, off) = sheet.chunk_of_row(row).unwrap();
+        sheet
+            .ensure_column_chunk_mut(0, ci)
+            .unwrap()
+            .overlay
+            .set(off, OverlayValue::Number(3.0));
+    }
+    sheet
+}
+
+fn dense(chunk_rows: usize) -> ArrowSheet {
+    let mut ingest = IngestBuilder::new("Source", 8, chunk_rows, DateSystem::Excel1900);
+    for _ in 0..32768 {
+        ingest
+            .append_row(&vec![LiteralValue::Number(2.0); 8])
+            .unwrap();
+    }
+    ingest.finish()
+}
+
+fn oracle(view: &RangeView<'_>, mode: Read) -> f64 {
+    let sheet = view.sheet();
+    let mut total = 0.0;
+    for (ci, &start) in sheet.chunk_starts.iter().enumerate() {
+        let end = sheet
+            .chunk_starts
+            .get(ci + 1)
+            .copied()
+            .unwrap_or(sheet.nrows as usize);
+        let lo = start.max(view.start_row());
+        let hi = end.min(view.end_row().saturating_add(1));
+        if lo >= hi {
+            continue;
+        }
+        if matches!(mode, Read::First) {
+            return (hi - lo) as f64;
+        }
+        for r in lo..hi {
+            for c in 0..view.dims().1 {
+                match view.get_cell(r - view.start_row(), c) {
+                    LiteralValue::Number(_) if matches!(mode, Read::Count) => total += 1.0,
+                    LiteralValue::Number(n) => total += n,
+                    LiteralValue::Error(_) if matches!(mode, Read::Sum) => total += 1.0,
+                    _ => {}
+                }
+            }
+        }
+    }
+    total
+}
+
+fn observe(validate: bool, f: impl FnOnce()) -> u128 {
+    if validate {
+        f();
+        0
+    } else {
+        let start = Instant::now();
+        f();
+        start.elapsed().as_nanos()
+    }
+}
+
+fn direct_case(
+    name: &str,
+    make: impl Fn() -> ArrowSheet,
+    bounds: impl Fn(&ArrowSheet) -> (usize, usize, usize, usize),
+    mode: Read,
+    expected: f64,
+    validate: bool,
+    samples: usize,
+    repeats: usize,
+) {
+    for sample in 0..samples {
+        let sheet = make();
+        let (sr, sc, er, ec) = bounds(&sheet);
+        let view = sheet.range_view(sr, sc, er, ec);
+        assert_eq!(oracle(&view, mode), expected);
+        for phase in ["cold", "warm"] {
+            let iterations = if phase == "cold" || validate {
+                1
+            } else {
+                repeats
+            };
+            let mut checksum = 0.0;
+            let ns = observe(validate, || {
+                for _ in 0..iterations {
+                    checksum += read(black_box(&view), mode);
+                }
+            });
+            assert_eq!(checksum, expected * iterations as f64, "{name}/{phase}");
+            if !validate {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "family":"direct", "case":name, "mode":format!("{mode:?}"), "phase":phase,
+                        "sample":sample, "iterations":iterations, "ns":ns, "checksum":checksum,
+                        "bounds":[sr,sc,er,ec], "sheet_rows":sheet.nrows, "chunks":sheet.chunk_starts.len(),
+                    })
+                );
+            }
+        }
+    }
+}
+
+fn direct(validate: bool, samples: usize) {
+    for (chunk_rows, chunks) in [(32768, 1), (32768, 32), (256, 4096)] {
+        for tail in [false, true] {
+            let position = if tail { "tail" } else { "head" };
+            for mode in [Read::Numbers, Read::First] {
+                let expected = if matches!(mode, Read::First) {
+                    8.0
+                } else if tail {
+                    24.0
+                } else {
+                    16.0
+                };
+                direct_case(
+                    &format!("locality-{chunk_rows}-{chunks}-{position}"),
+                    || sparse(chunk_rows, chunks),
+                    |sheet| {
+                        let sr = if tail { sheet.nrows as usize - 8 } else { 0 };
+                        (sr, 0, sr + 7, 0)
+                    },
+                    mode,
+                    expected,
+                    validate,
+                    samples,
+                    128,
+                );
+            }
+        }
+    }
+    for chunk_rows in [32768, 1024] {
+        for mode in [Read::Sum, Read::Count] {
+            let expected = if matches!(mode, Read::Count) {
+                32768.0 * 8.0
+            } else {
+                32768.0 * 16.0
+            };
+            direct_case(
+                &format!("dense-{chunk_rows}-false"),
+                || dense(chunk_rows),
+                |_| (0, 0, 32767, 7),
+                mode,
+                expected,
+                validate,
+                samples,
+                8,
+            );
+        }
+    }
+    direct_case(
+        "sparse-gaps-true-wide-false",
+        || sparse(256, 4096),
+        |sheet| (0, 0, sheet.nrows as usize - 1, 0),
+        Read::Sum,
+        256.0 * 2.0 + 24.0,
+        validate,
+        samples,
+        4,
+    );
+}
+
+fn engine(validate: bool, samples: usize) {
+    for chunk_rows in [32768, 256] {
+        for sample in 0..samples {
+            let mut engine = Engine::new(
+                TestWorkbook::new(),
+                EvalConfig {
+                    enable_parallel: false,
+                    max_threads: Some(1),
+                    formula_plane_mode: FormulaPlaneMode::Off,
+                    arrow_storage_enabled: true,
+                    delta_overlay_enabled: true,
+                    write_formula_overlay_enabled: true,
+                    ..EvalConfig::default()
+                },
+            );
+            let mut ingest = engine.begin_bulk_ingest_arrow();
+            ingest.add_sheet("Source", 2, chunk_rows);
+            for row in 1..=32768 {
+                ingest
+                    .append_row(
+                        "Source",
+                        &[LiteralValue::Number(row as f64), LiteralValue::Number(2.0)],
+                    )
+                    .unwrap();
+            }
+            ingest.finish().unwrap();
+            for (row, formula) in ["=SUM(Source!A32761:A32768)", "=COUNT(Source!A32761:A32768)"]
+                .iter()
+                .enumerate()
+            {
+                engine
+                    .set_cell_formula("Results", row as u32 + 1, 1, parse(formula).unwrap())
+                    .unwrap();
+            }
+            assert_eq!(engine.baseline_stats().formula_plane_active_span_count, 0);
+            let mut computed = 0;
+            let ns = observe(validate, || {
+                computed = engine.evaluate_all().unwrap().computed_vertices;
+            });
+            assert_eq!(computed, 2);
+            let sum = (32761 + 32768) as f64 * 4.0;
+            assert_eq!(
+                engine.get_cell_value("Results", 1, 1),
+                Some(LiteralValue::Number(sum))
+            );
+            assert_eq!(
+                engine.get_cell_value("Results", 2, 1),
+                Some(LiteralValue::Number(8.0))
+            );
+            if !validate {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "family":"engine", "case":"sum-count", "phase":"cold", "chunk_rows":chunk_rows,
+                        "sample":sample, "iterations":1, "ns":ns, "checksum":sum + 8.0, "computed":computed,
+                    })
+                );
+            }
+        }
+    }
+}
+
+fn main() {
+    assert!(
+        !black_box(cfg!(test)),
+        "production corroboration must not enable cfg(test)"
+    );
+    let validate = std::env::args().skip(1).any(|arg| arg == "--validate");
+    let samples = if validate {
+        1
+    } else {
+        std::env::var("FZ_RANGES_SAMPLES")
+            .ok()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(7)
+    };
+    direct(validate, samples);
+    engine(validate, samples);
+    if validate {
+        println!("range production fixtures: validated (no timing)");
+    }
+}

--- a/crates/formualizer-eval/src/arrow_store/mod.rs
+++ b/crates/formualizer-eval/src/arrow_store/mod.rs
@@ -158,11 +158,18 @@ impl ColumnChunk {
     }
     #[inline]
     pub fn numbers_or_null(&self) -> Arc<Float64Array> {
+        #[cfg(test)]
+        crate::engine::range_view::range_work::record(|w| w.provider_requests[0] += 1);
         if let Some(a) = &self.numbers {
             return a.clone();
         }
         self.lazy_null_numbers
             .get_or_init(|| {
+                #[cfg(test)]
+                crate::engine::range_view::range_work::record(|w| {
+                    w.provider_builds[0] += 1;
+                    w.provider_slots[0] += self.len();
+                });
                 let arr = new_null_array(&DataType::Float64, self.len());
                 Arc::new(arr.as_any().downcast_ref::<Float64Array>().unwrap().clone())
             })
@@ -170,11 +177,18 @@ impl ColumnChunk {
     }
     #[inline]
     pub fn booleans_or_null(&self) -> Arc<BooleanArray> {
+        #[cfg(test)]
+        crate::engine::range_view::range_work::record(|w| w.provider_requests[1] += 1);
         if let Some(a) = &self.booleans {
             return a.clone();
         }
         self.lazy_null_booleans
             .get_or_init(|| {
+                #[cfg(test)]
+                crate::engine::range_view::range_work::record(|w| {
+                    w.provider_builds[1] += 1;
+                    w.provider_slots[1] += self.len();
+                });
                 let arr = new_null_array(&DataType::Boolean, self.len());
                 Arc::new(arr.as_any().downcast_ref::<BooleanArray>().unwrap().clone())
             })
@@ -182,11 +196,18 @@ impl ColumnChunk {
     }
     #[inline]
     pub fn errors_or_null(&self) -> Arc<UInt8Array> {
+        #[cfg(test)]
+        crate::engine::range_view::range_work::record(|w| w.provider_requests[2] += 1);
         if let Some(a) = &self.errors {
             return a.clone();
         }
         self.lazy_null_errors
             .get_or_init(|| {
+                #[cfg(test)]
+                crate::engine::range_view::range_work::record(|w| {
+                    w.provider_builds[2] += 1;
+                    w.provider_slots[2] += self.len();
+                });
                 let arr = new_null_array(&DataType::UInt8, self.len());
                 Arc::new(arr.as_any().downcast_ref::<UInt8Array>().unwrap().clone())
             })
@@ -194,11 +215,20 @@ impl ColumnChunk {
     }
     #[inline]
     pub fn text_or_null(&self) -> ArrayRef {
+        #[cfg(test)]
+        crate::engine::range_view::range_work::record(|w| w.provider_requests[3] += 1);
         if let Some(a) = &self.text {
             return a.clone();
         }
         self.lazy_null_text
-            .get_or_init(|| new_null_array(&DataType::Utf8, self.len()))
+            .get_or_init(|| {
+                #[cfg(test)]
+                crate::engine::range_view::range_work::record(|w| {
+                    w.provider_builds[3] += 1;
+                    w.provider_slots[3] += self.len();
+                });
+                new_null_array(&DataType::Utf8, self.len())
+            })
             .clone()
     }
 

--- a/crates/formualizer-eval/src/engine/range_view.rs
+++ b/crates/formualizer-eval/src/engine/range_view.rs
@@ -7,6 +7,49 @@ use arrow_schema::DataType;
 use formualizer_common::{CoercionPolicy, DateSystem, ExcelError, LiteralValue};
 use std::sync::Arc;
 
+#[cfg(test)]
+pub(crate) mod range_work {
+    use std::cell::Cell;
+
+    #[derive(Clone, Copy, Debug, Default, serde::Serialize)]
+    pub(crate) struct Work {
+        pub iterators: usize,
+        pub search_probes: usize,
+        pub candidates: usize,
+        pub segments: usize,
+        pub segment_rows: usize,
+        pub generic_columns: usize,
+        pub selector_searches: usize,
+        pub null_arrays: usize,
+        pub null_slots: usize,
+        pub provider_requests: [usize; 4],
+        pub provider_builds: [usize; 4],
+        pub provider_slots: [usize; 4],
+    }
+
+    thread_local! {
+        static WORK: Cell<Option<Work>> = const { Cell::new(None) };
+    }
+
+    pub(crate) fn begin() {
+        WORK.with(|work| work.set(Some(Work::default())));
+    }
+
+    pub(crate) fn take() -> Work {
+        WORK.with(|work| work.replace(None).unwrap_or_default())
+    }
+
+    #[inline]
+    pub(crate) fn record(f: impl FnOnce(&mut Work)) {
+        WORK.with(|work| {
+            if let Some(mut value) = work.get() {
+                f(&mut value);
+                work.set(Some(value));
+            }
+        });
+    }
+}
+
 #[derive(Clone)]
 pub enum RangeBacking<'a> {
     Borrowed(&'a arrow_store::ArrowSheet),
@@ -59,13 +102,20 @@ pub struct ChunkSlice {
     pub cols: Vec<ChunkCol>,
 }
 
-pub struct RowChunkIterator<'a> {
-    view: &'a RangeView<'a>,
-    current_chunk_idx: usize,
+struct RowSegment {
+    chunk_idx: usize,
+    chunk_offset: usize,
+    row_start: usize,
+    row_len: usize,
 }
 
-impl<'a> Iterator for RowChunkIterator<'a> {
-    type Item = Result<ChunkSlice, ExcelError>;
+struct RowSegmentIterator<'a> {
+    view: &'a RangeView<'a>,
+    chunks: Option<core::ops::Range<usize>>,
+}
+
+impl Iterator for RowSegmentIterator<'_> {
+    type Item = Result<RowSegment, ExcelError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self
@@ -78,38 +128,112 @@ impl<'a> Iterator for RowChunkIterator<'a> {
                 formualizer_common::ExcelErrorKind::Cancelled,
             )));
         }
-
         let sheet = self.view.sheet();
-        let chunk_starts = &sheet.chunk_starts;
+        let starts = &sheet.chunk_starts;
         let sheet_rows = sheet.nrows as usize;
         let row_end = self.view.er.min(sheet_rows.saturating_sub(1));
-
-        while self.current_chunk_idx < chunk_starts.len() {
-            let ci = self.current_chunk_idx;
-            let start = chunk_starts[ci];
-            self.current_chunk_idx += 1;
-
-            let end = if ci + 1 < chunk_starts.len() {
-                chunk_starts[ci + 1]
-            } else {
-                sheet_rows
-            };
+        let chunks = self.chunks.get_or_insert_with(|| {
+            // Match row coverage independently of logical column/zero-sized subview dimensions.
+            if sheet_rows == 0 || starts.is_empty() || self.view.sr > row_end {
+                return 0..0;
+            }
+            let first = starts
+                .partition_point(|&start| {
+                    #[cfg(test)]
+                    range_work::record(|w| w.search_probes += 1);
+                    start <= self.view.sr
+                })
+                .saturating_sub(1);
+            let end = starts.partition_point(|&start| {
+                #[cfg(test)]
+                range_work::record(|w| w.search_probes += 1);
+                start <= row_end
+            });
+            first..end
+        });
+        for ci in chunks.by_ref() {
+            #[cfg(test)]
+            range_work::record(|w| w.candidates += 1);
+            let start = starts[ci];
+            let end = starts.get(ci + 1).copied().unwrap_or(sheet_rows);
             let len = end.saturating_sub(start);
             if len == 0 {
                 continue;
             }
-            let chunk_end_abs = start + len - 1;
-            let is = start.max(self.view.sr);
-            let ie = chunk_end_abs.min(row_end);
-            if is > ie {
+            let lo = start.max(self.view.sr);
+            let hi = (start + len - 1).min(row_end);
+            if lo > hi {
                 continue;
             }
-            let seg_len = ie - is + 1;
-            let rel_off = is - start;
+            let row_len = hi - lo + 1;
+            #[cfg(test)]
+            range_work::record(|w| {
+                w.segments += 1;
+                w.segment_rows += row_len;
+            });
+            return Some(Ok(RowSegment {
+                chunk_idx: ci,
+                chunk_offset: lo - start,
+                row_start: lo - self.view.sr,
+                row_len,
+            }));
+        }
+        None
+    }
+}
 
-            let mut cols = Vec::with_capacity(self.view.cols);
-            for col_idx in self.view.sc..=self.view.ec {
-                if col_idx >= sheet.columns.len() {
+pub struct RowChunkIterator<'a> {
+    segments: RowSegmentIterator<'a>,
+}
+
+impl Iterator for RowChunkIterator<'_> {
+    type Item = Result<ChunkSlice, ExcelError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let segment = match self.segments.next()? {
+            Ok(segment) => segment,
+            Err(error) => return Some(Err(error)),
+        };
+        let view = self.segments.view;
+        let sheet = view.sheet();
+        let ci = segment.chunk_idx;
+        let rel_off = segment.chunk_offset;
+        let seg_len = segment.row_len;
+        let mut cols = Vec::with_capacity(view.cols);
+        for col_idx in view.sc..=view.ec {
+            #[cfg(test)]
+            range_work::record(|w| w.generic_columns += 1);
+            if col_idx >= sheet.columns.len() {
+                #[cfg(test)]
+                range_work::record(|w| {
+                    w.null_arrays += 4;
+                    w.null_slots += 4 * seg_len;
+                });
+                let numbers = Some(arrow_array::new_null_array(&DataType::Float64, seg_len));
+                let booleans = Some(arrow_array::new_null_array(&DataType::Boolean, seg_len));
+                let text = Some(arrow_array::new_null_array(&DataType::Utf8, seg_len));
+                let errors = Some(arrow_array::new_null_array(&DataType::UInt8, seg_len));
+                let type_tag: arrow_array::ArrayRef =
+                    Arc::new(arrow_array::UInt8Array::from(vec![
+                        arrow_store::TypeTag::Empty
+                            as u8;
+                        seg_len
+                    ]));
+                cols.push(ChunkCol {
+                    numbers,
+                    booleans,
+                    text,
+                    errors,
+                    type_tag,
+                });
+            } else {
+                let col = &sheet.columns[col_idx];
+                let Some(ch) = col.chunk(ci) else {
+                    #[cfg(test)]
+                    range_work::record(|w| {
+                        w.null_arrays += 4;
+                        w.null_slots += 4 * seg_len;
+                    });
                     let numbers = Some(arrow_array::new_null_array(&DataType::Float64, seg_len));
                     let booleans = Some(arrow_array::new_null_array(&DataType::Boolean, seg_len));
                     let text = Some(arrow_array::new_null_array(&DataType::Utf8, seg_len));
@@ -127,58 +251,33 @@ impl<'a> Iterator for RowChunkIterator<'a> {
                         errors,
                         type_tag,
                     });
-                } else {
-                    let col = &sheet.columns[col_idx];
-                    let Some(ch) = col.chunk(ci) else {
-                        let numbers =
-                            Some(arrow_array::new_null_array(&DataType::Float64, seg_len));
-                        let booleans =
-                            Some(arrow_array::new_null_array(&DataType::Boolean, seg_len));
-                        let text = Some(arrow_array::new_null_array(&DataType::Utf8, seg_len));
-                        let errors = Some(arrow_array::new_null_array(&DataType::UInt8, seg_len));
-                        let type_tag: arrow_array::ArrayRef =
-                            Arc::new(arrow_array::UInt8Array::from(vec![
-                                arrow_store::TypeTag::Empty
-                                    as u8;
-                                seg_len
-                            ]));
-                        cols.push(ChunkCol {
-                            numbers,
-                            booleans,
-                            text,
-                            errors,
-                            type_tag,
-                        });
-                        continue;
-                    };
+                    continue;
+                };
 
-                    let numbers_base: arrow_array::ArrayRef = ch.numbers_or_null();
-                    let booleans_base: arrow_array::ArrayRef = ch.booleans_or_null();
-                    let text_base: arrow_array::ArrayRef = ch.text_or_null();
-                    let errors_base: arrow_array::ArrayRef = ch.errors_or_null();
+                let numbers_base: arrow_array::ArrayRef = ch.numbers_or_null();
+                let booleans_base: arrow_array::ArrayRef = ch.booleans_or_null();
+                let text_base: arrow_array::ArrayRef = ch.text_or_null();
+                let errors_base: arrow_array::ArrayRef = ch.errors_or_null();
 
-                    let numbers = Some(numbers_base.slice(rel_off, seg_len));
-                    let booleans = Some(booleans_base.slice(rel_off, seg_len));
-                    let text = Some(text_base.slice(rel_off, seg_len));
-                    let errors = Some(errors_base.slice(rel_off, seg_len));
-                    let type_tag: arrow_array::ArrayRef =
-                        Arc::new(ch.type_tag.slice(rel_off, seg_len));
-                    cols.push(ChunkCol {
-                        numbers,
-                        booleans,
-                        text,
-                        errors,
-                        type_tag,
-                    });
-                }
+                let numbers = Some(numbers_base.slice(rel_off, seg_len));
+                let booleans = Some(booleans_base.slice(rel_off, seg_len));
+                let text = Some(text_base.slice(rel_off, seg_len));
+                let errors = Some(errors_base.slice(rel_off, seg_len));
+                let type_tag: arrow_array::ArrayRef = Arc::new(ch.type_tag.slice(rel_off, seg_len));
+                cols.push(ChunkCol {
+                    numbers,
+                    booleans,
+                    text,
+                    errors,
+                    type_tag,
+                });
             }
-            return Some(Ok(ChunkSlice {
-                row_start: is - self.view.sr,
-                row_len: seg_len,
-                cols,
-            }));
         }
-        None
+        Some(Ok(ChunkSlice {
+            row_start: segment.row_start,
+            row_len: seg_len,
+            cols,
+        }))
     }
 }
 
@@ -486,8 +585,16 @@ impl<'a> RangeView<'a> {
     /// Iterate overlapping chunks by row segment.
     pub fn iter_row_chunks(&self) -> RowChunkIterator<'_> {
         RowChunkIterator {
+            segments: self.iter_row_segments(),
+        }
+    }
+
+    fn iter_row_segments(&self) -> RowSegmentIterator<'_> {
+        #[cfg(test)]
+        range_work::record(|w| w.iterators += 1);
+        RowSegmentIterator {
             view: self,
-            current_chunk_idx: 0,
+            chunks: None,
         }
     }
 
@@ -639,56 +746,38 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<Arc<arrow_array::Float64Array>>), ExcelError>> + '_
     {
-        self.iter_row_chunks().map(move |res| {
-            let cs = res?;
-            let mut out_cols: Vec<Arc<arrow_array::Float64Array>> =
-                Vec::with_capacity(cs.cols.len());
+        self.iter_row_segments().map(move |res| {
+            let segment = res?;
+            let mut out_cols = Vec::with_capacity(self.cols);
             let sheet = self.sheet();
-            let chunk_starts = &sheet.chunk_starts;
-
-            for (local_c, col_idx) in (self.sc..=self.ec).enumerate() {
-                let base = cs.cols[local_c]
-                    .numbers
-                    .as_ref()
-                    .expect("numbers lane exists")
-                    .clone();
-                let base_fa = base
-                    .as_any()
-                    .downcast_ref::<arrow_array::Float64Array>()
-                    .unwrap()
-                    .clone();
-                let base_arc = Arc::new(base_fa);
-
-                // Identify chunk and overlay segment
-                let abs_seg_start = self.sr + cs.row_start;
-                let ch_idx = match chunk_starts.binary_search(&abs_seg_start) {
-                    Ok(i) => i,
-                    Err(0) => 0,
-                    Err(i) => i - 1,
-                };
-                if col_idx >= sheet.columns.len() {
-                    out_cols.push(base_arc);
-                    continue;
-                }
-                let col = &sheet.columns[col_idx];
-                let Some(ch) = col.chunk(ch_idx) else {
-                    out_cols.push(base_arc);
+            for col_idx in self.sc..=self.ec {
+                let Some(ch) = sheet
+                    .columns
+                    .get(col_idx)
+                    .and_then(|col| col.chunk(segment.chunk_idx))
+                else {
+                    #[cfg(test)]
+                    range_work::record(|w| {
+                        w.null_arrays += 1;
+                        w.null_slots += segment.row_len;
+                    });
+                    out_cols.push(Arc::new(arrow_array::Float64Array::new_null(
+                        segment.row_len,
+                    )));
                     continue;
                 };
-                let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
-                let seg_range = rel_off..(rel_off + cs.row_len);
+                let base = ch
+                    .numbers_or_null()
+                    .slice(segment.chunk_offset, segment.row_len);
+                let range = segment.chunk_offset..segment.chunk_offset + segment.row_len;
                 let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
-                if cascade.has_any_in_range(seg_range.clone()) {
-                    let base_fa = base
-                        .as_any()
-                        .downcast_ref::<arrow_array::Float64Array>()
-                        .unwrap();
-                    out_cols.push(cascade.select_numbers(seg_range, base_fa));
+                out_cols.push(if cascade.has_any_in_range(range.clone()) {
+                    cascade.select_numbers(range, &base)
                 } else {
-                    out_cols.push(base_arc);
-                }
+                    Arc::new(base)
+                });
             }
-            Ok((cs.row_start, cs.row_len, out_cols))
+            Ok((segment.row_start, segment.row_len, out_cols))
         })
     }
 
@@ -854,53 +943,36 @@ impl<'a> RangeView<'a> {
         &self,
     ) -> impl Iterator<Item = Result<(usize, usize, Vec<Arc<arrow_array::UInt8Array>>), ExcelError>> + '_
     {
-        self.iter_row_chunks().map(move |res| {
-            let cs = res?;
-            let mut out_cols: Vec<Arc<arrow_array::UInt8Array>> = Vec::with_capacity(cs.cols.len());
+        self.iter_row_segments().map(move |res| {
+            let segment = res?;
+            let mut out_cols = Vec::with_capacity(self.cols);
             let sheet = self.sheet();
-            let chunk_starts = &sheet.chunk_starts;
-
-            for (local_c, col_idx) in (self.sc..=self.ec).enumerate() {
-                let base = cs.cols[local_c]
-                    .errors
-                    .as_ref()
-                    .expect("errors lane exists")
-                    .clone();
-                let base_e = base
-                    .as_any()
-                    .downcast_ref::<arrow_array::UInt8Array>()
-                    .unwrap()
-                    .clone();
-                let base_arc: Arc<arrow_array::UInt8Array> = Arc::new(base_e);
-                let abs_seg_start = self.sr + cs.row_start;
-                let ch_idx = match chunk_starts.binary_search(&abs_seg_start) {
-                    Ok(i) => i,
-                    Err(0) => 0,
-                    Err(i) => i - 1,
-                };
-                if col_idx >= sheet.columns.len() {
-                    out_cols.push(base_arc);
-                    continue;
-                }
-                let col = &sheet.columns[col_idx];
-                let Some(ch) = col.chunk(ch_idx) else {
-                    out_cols.push(base_arc);
+            for col_idx in self.sc..=self.ec {
+                let Some(ch) = sheet
+                    .columns
+                    .get(col_idx)
+                    .and_then(|col| col.chunk(segment.chunk_idx))
+                else {
+                    #[cfg(test)]
+                    range_work::record(|w| {
+                        w.null_arrays += 1;
+                        w.null_slots += segment.row_len;
+                    });
+                    out_cols.push(Arc::new(arrow_array::UInt8Array::new_null(segment.row_len)));
                     continue;
                 };
-                let rel_off = (self.sr + cs.row_start) - chunk_starts[ch_idx];
-                let seg_range = rel_off..(rel_off + cs.row_len);
+                let base = ch
+                    .errors_or_null()
+                    .slice(segment.chunk_offset, segment.row_len);
+                let range = segment.chunk_offset..segment.chunk_offset + segment.row_len;
                 let cascade = arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
-                if cascade.has_any_in_range(seg_range.clone()) {
-                    let base_ea = base
-                        .as_any()
-                        .downcast_ref::<arrow_array::UInt8Array>()
-                        .unwrap();
-                    out_cols.push(cascade.select_errors(seg_range, base_ea));
+                out_cols.push(if cascade.has_any_in_range(range.clone()) {
+                    cascade.select_errors(range, &base)
                 } else {
-                    out_cols.push(base_arc);
-                }
+                    Arc::new(base)
+                });
             }
-            Ok((cs.row_start, cs.row_len, out_cols))
+            Ok((segment.row_start, segment.row_len, out_cols))
         })
     }
 
@@ -1353,5 +1425,443 @@ mod tests {
         };
 
         assert_eq!(error.kind, formualizer_common::ExcelErrorKind::Cancelled);
+    }
+}
+#[cfg(test)]
+mod bounded_projection_tests {
+    use super::*;
+    use crate::arrow_store::{ArrowSheet, OverlayFragment, OverlayValue};
+    use arrow_array::{Float64Array, UInt8Array};
+    use formualizer_common::ExcelErrorKind;
+
+    // Deliberately retain the exhaustive baseline intersection algorithm as an oracle.
+    fn segments(view: &RangeView<'_>) -> Vec<(usize, usize, usize, usize)> {
+        let sheet = view.sheet();
+        let mut out = Vec::new();
+        let row_end = view.er.min((sheet.nrows as usize).saturating_sub(1));
+        for (ci, &start) in sheet.chunk_starts.iter().enumerate() {
+            let end = sheet
+                .chunk_starts
+                .get(ci + 1)
+                .copied()
+                .unwrap_or(sheet.nrows as usize);
+            let len = end.saturating_sub(start);
+            if len == 0 {
+                continue;
+            }
+            let lo = start.max(view.sr);
+            let hi = (start + len - 1).min(row_end);
+            if lo <= hi {
+                out.push((ci, lo - start, lo - view.sr, hi - lo + 1));
+            }
+        }
+        out
+    }
+
+    fn assert_projection(view: &RangeView<'_>) {
+        let expected = segments(view);
+        let generic: Vec<_> = view.iter_row_chunks().map(Result::unwrap).collect();
+        assert_eq!(
+            generic
+                .iter()
+                .map(|s| (s.row_start, s.row_len))
+                .collect::<Vec<_>>(),
+            expected.iter().map(|s| (s.2, s.3)).collect::<Vec<_>>()
+        );
+        let numbers: Vec<_> = view.numbers_slices().map(Result::unwrap).collect();
+        let errors: Vec<_> = view.errors_slices().map(Result::unwrap).collect();
+        assert_eq!(numbers.len(), expected.len());
+        assert_eq!(errors.len(), expected.len());
+        for (seg, &(ci, offset, row_start, len)) in expected.iter().enumerate() {
+            assert_eq!((numbers[seg].0, numbers[seg].1), (row_start, len));
+            assert_eq!((errors[seg].0, errors[seg].1), (row_start, len));
+            let columns = (view.sc..=view.ec).count();
+            assert_eq!(generic[seg].cols.len(), columns);
+            assert_eq!(numbers[seg].2.len(), columns);
+            assert_eq!(errors[seg].2.len(), columns);
+            for (c, absolute) in (view.sc..=view.ec).enumerate() {
+                let (base_n, base_e) =
+                    match view.sheet().columns.get(absolute).and_then(|c| c.chunk(ci)) {
+                        Some(ch) => {
+                            // Access physical lanes directly, without the optimized cursor/providers.
+                            let n = ch
+                                .numbers
+                                .as_ref()
+                                .map(|a| a.slice(offset, len))
+                                .unwrap_or_else(|| Float64Array::new_null(len));
+                            let e = ch
+                                .errors
+                                .as_ref()
+                                .map(|a| a.slice(offset, len))
+                                .unwrap_or_else(|| UInt8Array::new_null(len));
+                            let cascade =
+                                arrow_store::OverlayCascade::new(&ch.overlay, &ch.computed_overlay);
+                            (
+                                cascade.select_numbers(offset..offset + len, &n),
+                                cascade.select_errors(offset..offset + len, &e),
+                            )
+                        }
+                        None => (
+                            Arc::new(Float64Array::new_null(len)),
+                            Arc::new(UInt8Array::new_null(len)),
+                        ),
+                    };
+                let actual_n = &numbers[seg].2[c];
+                let actual_e = &errors[seg].2[c];
+                assert_eq!(actual_n.len(), len);
+                assert_eq!(actual_e.len(), len);
+                for i in 0..len {
+                    assert_eq!(actual_n.is_null(i), base_n.is_null(i));
+                    assert_eq!(actual_e.is_null(i), base_e.is_null(i));
+                    if !base_n.is_null(i) {
+                        assert_eq!(actual_n.value(i).to_bits(), base_n.value(i).to_bits());
+                    }
+                    if !base_e.is_null(i) {
+                        assert_eq!(actual_e.value(i), base_e.value(i));
+                    }
+                }
+            }
+        }
+    }
+
+    fn fixture(chunk_rows: usize) -> ArrowSheet {
+        let mut ingest = IngestBuilder::new("S", 3, chunk_rows, DateSystem::Excel1900);
+        for row in 0..11 {
+            ingest
+                .append_row(&[
+                    LiteralValue::Number(row as f64),
+                    if row % 3 == 0 {
+                        LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div))
+                    } else {
+                        LiteralValue::Empty
+                    },
+                    LiteralValue::Text(format!("r{row}")),
+                ])
+                .unwrap();
+        }
+        let mut sheet = ingest.finish();
+        sheet.ensure_row_capacity(29);
+        for (row, value) in [
+            (1, OverlayValue::Empty),
+            (3, OverlayValue::Text(Arc::from("mask"))),
+            (
+                7,
+                OverlayValue::Error(arrow_store::map_error_code(ExcelErrorKind::Na)),
+            ),
+            (22, OverlayValue::Number(17.0)),
+            (28, OverlayValue::Pending),
+        ] {
+            let (ci, off) = sheet.chunk_of_row(row).unwrap();
+            let chunk = sheet.ensure_column_chunk_mut(0, ci).unwrap();
+            chunk.computed_overlay.set(off, OverlayValue::Number(99.0));
+            chunk.overlay.set(off, value);
+        }
+        for (row, user) in [(0, OverlayValue::Empty), (8, OverlayValue::Number(17.0))] {
+            let (ci, off) = sheet.chunk_of_row(row).unwrap();
+            let ch = sheet.ensure_column_chunk_mut(1, ci).unwrap();
+            ch.computed_overlay.set(
+                off,
+                OverlayValue::Error(arrow_store::map_error_code(ExcelErrorKind::Na)),
+            );
+            ch.overlay.set(off, user);
+        }
+        sheet
+    }
+
+    #[test]
+    fn range_projection_matches_independent_oracle_for_all_small_bounds() {
+        for chunk_rows in [1, 3, 8, 32] {
+            let sheet = fixture(chunk_rows);
+            for sr in 0..=31 {
+                for er in 0..=31 {
+                    for (sc, ec) in [(0, 0), (1, 2), (0, 4), (4, 5), (2, 1)] {
+                        assert_projection(&sheet.range_view(sr, sc, er, ec));
+                    }
+                }
+            }
+            let base = sheet.range_view(2, 1, 10, 2);
+            for rows in [0, 1, 9, 40] {
+                for cols in [0, 1, 4] {
+                    assert_projection(&base.sub_view(1, 1, rows, cols));
+                    assert_projection(&base.expand_to(rows, cols));
+                }
+            }
+        }
+        let empty = IngestBuilder::new("S", 1, 4, DateSystem::Excel1900).finish();
+        assert_projection(&empty.range_view(0, 0, 7, 3));
+    }
+
+    #[test]
+    fn range_projection_preserves_dense_run_and_partial_overlay_paths() {
+        for run in [false, true] {
+            let mut sheet = fixture(32);
+            let chunk = &mut sheet.columns[0].chunks[0];
+            chunk.overlay.clear();
+            chunk.computed_overlay.clear();
+            let values = vec![OverlayValue::Number(7.0); 29];
+            let fragment = if run {
+                OverlayFragment::run_range(0, values)
+            } else {
+                OverlayFragment::dense_range(0, values)
+            }
+            .unwrap();
+            chunk.computed_overlay.apply_fragment(fragment);
+            let view = sheet.range_view(2, 0, 9, 0);
+            arrow_store::reset_overlay_select_stats();
+            let numeric = view.numbers_slices().next().unwrap().unwrap();
+            assert_eq!(numeric.2[0].value(0), 7.0);
+            let stats = arrow_store::snapshot_overlay_select_stats();
+            assert_eq!(stats.zip_select_calls, 0);
+            assert_eq!(stats.direct_dense_slices, usize::from(!run));
+            assert_eq!(stats.direct_run_materializations, usize::from(run));
+            assert_projection(&view);
+            let chunk = &mut sheet.columns[0].chunks[0];
+            for (off, value) in [
+                (3, OverlayValue::Empty),
+                (4, OverlayValue::Pending),
+                (5, OverlayValue::DateTime(45000.25)),
+                (6, OverlayValue::Duration(0.5)),
+                (7, OverlayValue::Boolean(true)),
+                (
+                    8,
+                    OverlayValue::Error(arrow_store::map_error_code(ExcelErrorKind::Ref)),
+                ),
+                (9, OverlayValue::Text(Arc::from("not numeric"))),
+            ] {
+                chunk.overlay.set(off, value);
+            }
+            assert_projection(&sheet.range_view(2, 0, 10, 3));
+        }
+    }
+
+    #[test]
+    fn range_discovery_work_is_bounded_and_projection_is_lane_local() {
+        let mut ingest = IngestBuilder::new("S", 1, 256, DateSystem::Excel1900);
+        for _ in 0..256 {
+            ingest.append_row(&[LiteralValue::Number(1.0)]).unwrap();
+        }
+        let mut sheet = ingest.finish();
+        sheet.ensure_row_capacity(256 * 4096);
+        for start in [0, 256 * 2048 + 1, 256 * 4096 - 8, 256 * 4096 + 8] {
+            let view = sheet.range_view(start, 0, start + 7, 2);
+            range_work::begin();
+            let generic: Vec<_> = view.iter_row_chunks().collect();
+            let work = range_work::take();
+            assert_eq!(work.candidates, generic.len());
+            assert_eq!(work.segments, generic.len());
+            assert!(work.search_probes <= 32);
+            range_work::begin();
+            let _: Vec<_> = view.numbers_slices().collect();
+            let numeric = range_work::take();
+            assert_eq!(numeric.generic_columns, 0);
+            assert_eq!(numeric.selector_searches, 0);
+            assert_eq!(numeric.provider_requests[1..], [0, 0, 0]);
+            assert!(numeric.null_arrays <= 3);
+            range_work::begin();
+            let _: Vec<_> = view.errors_slices().collect();
+            let errors = range_work::take();
+            assert_eq!(errors.generic_columns, 0);
+            assert_eq!(errors.selector_searches, 0);
+            assert_eq!(errors.provider_requests[0], 0);
+            assert_eq!(errors.provider_requests[1], 0);
+            assert_eq!(errors.provider_requests[3], 0);
+        }
+        let view = sheet.range_view(0, 0, sheet.nrows as usize - 1, 0);
+        range_work::begin();
+        assert!(view.iter_row_chunks().next().unwrap().is_ok());
+        let work = range_work::take();
+        assert_eq!(work.candidates, 1);
+        assert_eq!(work.segments, 1);
+    }
+
+    #[test]
+    fn range_cold_numeric_does_not_initialize_unused_null_providers() {
+        let mut ingest = IngestBuilder::new("S", 1, 32768, DateSystem::Excel1900);
+        for _ in 0..32768 {
+            ingest.append_row(&[LiteralValue::Number(1.0)]).unwrap();
+        }
+        let sheet = ingest.finish();
+        let view = sheet.range_view(1, 0, 8, 0);
+        range_work::begin();
+        view.numbers_slices().next().unwrap().unwrap();
+        let numeric = range_work::take();
+        assert_eq!(numeric.provider_requests, [1, 0, 0, 0]);
+        assert_eq!(numeric.provider_builds, [0; 4]);
+        range_work::begin();
+        view.errors_slices().next().unwrap().unwrap();
+        let errors = range_work::take();
+        assert_eq!(errors.provider_requests, [0, 0, 1, 0]);
+        assert_eq!(errors.provider_builds, [0, 0, 1, 0]);
+        assert_eq!(errors.provider_slots, [0, 0, 32768, 0]);
+    }
+
+    #[test]
+    fn range_cancellation_keeps_empty_exhausted_and_between_segment_errors() {
+        let sheet = fixture(3);
+        for bounds in [(0, 0, 28, 0), (30, 0, 35, 0), (3, 0, 1, 0), (0, 2, 5, 1)] {
+            let token = CancelToken::new();
+            let view = sheet
+                .range_view(bounds.0, bounds.1, bounds.2, bounds.3)
+                .with_cancel_token(Some(token.clone()));
+            let mut generic = view.iter_row_chunks();
+            let mut numeric = view.numbers_slices();
+            let mut errors = view.errors_slices();
+            token.cancel();
+            for _ in 0..2 {
+                assert_eq!(
+                    generic.next().unwrap().err().unwrap().kind,
+                    ExcelErrorKind::Cancelled
+                );
+                assert_eq!(
+                    numeric.next().unwrap().err().unwrap().kind,
+                    ExcelErrorKind::Cancelled
+                );
+                assert_eq!(
+                    errors.next().unwrap().err().unwrap().kind,
+                    ExcelErrorKind::Cancelled
+                );
+            }
+        }
+        let token = CancelToken::new();
+        let view = sheet
+            .range_view(0, 0, 28, 0)
+            .with_cancel_token(Some(token.clone()));
+        let mut numeric = view.numbers_slices();
+        assert!(numeric.next().unwrap().is_ok());
+        token.cancel();
+        assert_eq!(
+            numeric.next().unwrap().err().unwrap().kind,
+            ExcelErrorKind::Cancelled
+        );
+        let token = CancelToken::new();
+        let view = sheet
+            .range_view(30, 0, 35, 0)
+            .with_cancel_token(Some(token.clone()));
+        let mut numeric = view.numbers_slices();
+        assert!(numeric.next().is_none());
+        token.cancel();
+        assert_eq!(
+            numeric.next().unwrap().err().unwrap().kind,
+            ExcelErrorKind::Cancelled
+        );
+    }
+
+    #[test]
+    fn range_projection_keeps_numeric_bits_and_engine_error_order() {
+        let values = [
+            0.0,
+            -0.0,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::from_bits(0x7ff8000000000001),
+        ];
+        let view = RangeView::from_owned_rows(
+            values
+                .iter()
+                .map(|n| vec![LiteralValue::Number(*n)])
+                .collect(),
+            DateSystem::Excel1900,
+        );
+        assert_projection(&view);
+        let slice = view.numbers_slices().next().unwrap().unwrap().2.remove(0);
+        for (i, n) in values.iter().enumerate() {
+            assert_eq!(slice.value(i).to_bits(), n.to_bits());
+        }
+        for chunk_rows in [1, 2] {
+            let mut engine = crate::engine::Engine::new(
+                crate::test_workbook::TestWorkbook::new(),
+                crate::engine::EvalConfig {
+                    arrow_storage_enabled: true,
+                    delta_overlay_enabled: true,
+                    write_formula_overlay_enabled: true,
+                    enable_parallel: false,
+                    ..Default::default()
+                },
+            );
+            let mut ingest = engine.begin_bulk_ingest_arrow();
+            ingest.add_sheet("Source", 2, chunk_rows);
+            ingest
+                .append_row(
+                    "Source",
+                    &[
+                        LiteralValue::Number(1.0),
+                        LiteralValue::Error(ExcelError::new(ExcelErrorKind::Na)),
+                    ],
+                )
+                .unwrap();
+            ingest
+                .append_row(
+                    "Source",
+                    &[
+                        LiteralValue::Error(ExcelError::new(ExcelErrorKind::Div)),
+                        LiteralValue::Number(2.0),
+                    ],
+                )
+                .unwrap();
+            ingest.finish().unwrap();
+            engine
+                .set_cell_formula(
+                    "Result",
+                    1,
+                    1,
+                    formualizer_parse::parser::parse("=SUM(Source!A1:B2)").unwrap(),
+                )
+                .unwrap();
+            engine.evaluate_all().unwrap();
+            let expected = if chunk_rows == 1 {
+                ExcelErrorKind::Na
+            } else {
+                ExcelErrorKind::Div
+            };
+            assert!(
+                matches!(engine.get_cell_value("Result", 1, 1), Some(LiteralValue::Error(e)) if e.kind == expected)
+            );
+        }
+    }
+
+    #[test]
+    fn range_arrays_outlive_owned_view_and_new_views_follow_structural_edits() {
+        let numbers = {
+            let view = RangeView::from_owned_rows(
+                vec![vec![LiteralValue::Number(-0.0)]],
+                DateSystem::Excel1900,
+            );
+            view.numbers_slices().next().unwrap().unwrap().2.remove(0)
+        };
+        assert_eq!(numbers.value(0).to_bits(), (-0.0f64).to_bits());
+        let errors = {
+            let view = RangeView::from_owned_rows(
+                vec![vec![LiteralValue::Error(ExcelError::new(
+                    ExcelErrorKind::Div,
+                ))]],
+                DateSystem::Excel1900,
+            );
+            view.errors_slices().next().unwrap().unwrap().2.remove(0)
+        };
+        assert_eq!(
+            errors.value(0),
+            arrow_store::map_error_code(ExcelErrorKind::Div)
+        );
+        let mut sheet = fixture(3);
+        let chunks_before: usize = sheet.columns.iter().map(|c| c.total_chunk_count()).sum();
+        assert_projection(&sheet.range_view(0, 0, 40, 4));
+        assert_eq!(
+            sheet
+                .columns
+                .iter()
+                .map(|c| c.total_chunk_count())
+                .sum::<usize>(),
+            chunks_before
+        );
+        sheet.insert_rows(4, 2);
+        assert_projection(&sheet.range_view(1, 0, 35, 4));
+        sheet.delete_rows(2, 1);
+        assert_projection(&sheet.range_view(0, 0, 35, 4));
+        sheet.ensure_row_capacity(50);
+        assert_projection(&sheet.range_view(0, 0, 55, 4));
+        sheet.insert_columns(1, 1);
+        assert_projection(&sheet.range_view(0, 0, 55, 4));
+        sheet.delete_columns(0, 1);
+        assert_projection(&sheet.range_view(0, 0, 55, 4));
     }
 }

--- a/crates/formualizer-eval/src/engine/tests/perf_ranges.rs
+++ b/crates/formualizer-eval/src/engine/tests/perf_ranges.rs
@@ -1,0 +1,394 @@
+//! Shared baseline/candidate fixtures. Timing runs require an exclusive resource window.
+use super::{config, dirty, measure};
+use crate::arrow_store::{ArrowSheet, IngestBuilder, OverlayValue};
+use crate::engine::range_view::{RangeView, range_work};
+use crate::engine::{Engine, FormulaPlaneMode};
+use crate::test_workbook::TestWorkbook;
+use arrow_array::Array;
+use formualizer_common::{DateSystem, LiteralValue};
+use formualizer_parse::parser::parse;
+use std::hint::black_box;
+
+#[derive(Clone, Copy, Debug)]
+enum Read {
+    Generic,
+    First,
+    Numbers,
+    Errors,
+    Sum,
+    Count,
+}
+
+fn read(view: &RangeView<'_>, mode: Read) -> f64 {
+    let mut out = 0.0;
+    match mode {
+        Read::Generic | Read::First => {
+            for item in view.iter_row_chunks() {
+                let item = item.unwrap();
+                out += item.row_len as f64;
+                black_box(&item.cols);
+                if matches!(mode, Read::First) {
+                    break;
+                }
+            }
+        }
+        Read::Numbers | Read::Count | Read::Sum => {
+            if matches!(mode, Read::Sum) {
+                out += read(view, Read::Errors);
+            }
+            for item in view.numbers_slices() {
+                let (_, _, cols) = item.unwrap();
+                for col in cols {
+                    out += if matches!(mode, Read::Count) {
+                        (col.len() - col.null_count()) as f64
+                    } else {
+                        arrow::compute::kernels::aggregate::sum(col.as_ref()).unwrap_or(0.0)
+                    };
+                }
+            }
+        }
+        Read::Errors => {
+            for item in view.errors_slices() {
+                let (_, _, cols) = item.unwrap();
+                for col in cols {
+                    out += (col.len() - col.null_count()) as f64;
+                }
+            }
+        }
+    }
+    black_box(out)
+}
+
+fn sparse(chunk_rows: usize, chunks: usize) -> ArrowSheet {
+    let mut ingest = IngestBuilder::new("Source", 2, chunk_rows, DateSystem::Excel1900);
+    for _ in 0..chunk_rows {
+        ingest
+            .append_row(&[LiteralValue::Number(2.0), LiteralValue::Empty])
+            .unwrap();
+    }
+    let mut sheet = ingest.finish();
+    sheet.ensure_row_capacity(chunk_rows * chunks);
+    let tail = sheet.nrows as usize - 8;
+    for row in tail..tail + 8 {
+        let (ci, off) = sheet.chunk_of_row(row).unwrap();
+        sheet
+            .ensure_column_chunk_mut(0, ci)
+            .unwrap()
+            .overlay
+            .set(off, OverlayValue::Number(3.0));
+    }
+    sheet
+}
+
+fn dense(chunk_rows: usize, mixed: bool) -> ArrowSheet {
+    let mut ingest = IngestBuilder::new("Source", 8, chunk_rows, DateSystem::Excel1900);
+    for row in 0..32768 {
+        let values: Vec<_> = (0..8)
+            .map(|col| {
+                if mixed && (row + col) % 3 == 0 {
+                    LiteralValue::Text("mixed".into())
+                } else {
+                    LiteralValue::Number(2.0)
+                }
+            })
+            .collect();
+        ingest.append_row(&values).unwrap();
+    }
+    ingest.finish()
+}
+
+fn scalar_oracle(view: &RangeView<'_>, mode: Read) -> f64 {
+    let sheet = view.sheet();
+    let mut total = 0.0;
+    for (ci, &start) in sheet.chunk_starts.iter().enumerate() {
+        let end = sheet
+            .chunk_starts
+            .get(ci + 1)
+            .copied()
+            .unwrap_or(sheet.nrows as usize);
+        let lo = start.max(view.start_row());
+        let hi = end.min(view.end_row().saturating_add(1));
+        if lo >= hi {
+            continue;
+        }
+        if matches!(mode, Read::Generic | Read::First) {
+            total += (hi - lo) as f64;
+            if matches!(mode, Read::First) {
+                break;
+            }
+            continue;
+        }
+        for r in lo..hi {
+            for c in 0..view.dims().1 {
+                match view.get_cell(r - view.start_row(), c) {
+                    LiteralValue::Number(n) if matches!(mode, Read::Numbers | Read::Sum) => {
+                        total += n
+                    }
+                    LiteralValue::Number(_) if matches!(mode, Read::Count) => total += 1.0,
+                    LiteralValue::Error(_) if matches!(mode, Read::Errors | Read::Sum) => {
+                        total += 1.0
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    total
+}
+
+fn observation(timed: bool, f: impl FnOnce()) -> (u128, usize, usize) {
+    if timed {
+        measure(f)
+    } else {
+        f();
+        (0, 0, 0)
+    }
+}
+
+fn direct_case(
+    name: &str,
+    make: impl Fn() -> ArrowSheet,
+    bounds: impl Fn(&ArrowSheet) -> (usize, usize, usize, usize),
+    mode: Read,
+    timed: bool,
+    samples: usize,
+    repeats: usize,
+) {
+    for sample in 0..samples {
+        let sheet = make();
+        let (sr, sc, er, ec) = bounds(&sheet);
+        let view = sheet.range_view(sr, sc, er, ec);
+        let expected = scalar_oracle(&view, mode);
+        for phase in ["cold", "warm"] {
+            let iterations = if phase == "cold" { 1 } else { repeats };
+            range_work::begin();
+            let mut answer = 0.0;
+            let measured = observation(timed, || {
+                for _ in 0..iterations {
+                    answer += read(black_box(&view), mode);
+                }
+            });
+            let work = range_work::take();
+            assert_eq!(
+                answer,
+                expected * iterations as f64,
+                "{name}/{mode:?}/{phase}"
+            );
+            if timed {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "family":"direct", "case":name, "mode":format!("{mode:?}"), "phase":phase,
+                        "sample":sample, "iterations":iterations, "ns":measured.0,
+                        "allocations":measured.1, "allocated_bytes":measured.2, "work":work,
+                        "bounds":[sr,sc,er,ec], "sheet_rows":sheet.nrows, "chunks":sheet.chunk_starts.len(),
+                        "physical_chunks":sheet.columns.iter().map(|c| c.total_chunk_count()).sum::<usize>()
+                    })
+                );
+            }
+        }
+    }
+}
+
+fn direct(timed: bool, samples: usize) {
+    for (chunk_rows, chunks) in [(32768, 1), (32768, 32), (256, 32), (256, 4096)] {
+        for position in ["head", "tail", "oob", "cross"] {
+            for mode in [Read::Generic, Read::First, Read::Numbers, Read::Errors] {
+                direct_case(
+                    &format!("locality-{chunk_rows}-{chunks}-{position}"),
+                    || sparse(chunk_rows, chunks),
+                    |sheet| {
+                        let start = match position {
+                            "head" => 0,
+                            "tail" => sheet.nrows as usize - 8,
+                            "cross" => chunk_rows - 4,
+                            _ => sheet.nrows as usize + 8,
+                        };
+                        (start, 0, start + 7, 0)
+                    },
+                    mode,
+                    timed,
+                    samples,
+                    if timed { 128 } else { 1 },
+                );
+            }
+        }
+    }
+    for (chunk_rows, mixed) in [(32768, false), (1024, false), (1024, true)] {
+        for mode in [Read::Numbers, Read::Sum, Read::Count] {
+            direct_case(
+                &format!("dense-{chunk_rows}-{mixed}"),
+                || dense(chunk_rows, mixed),
+                |_| (0, 0, 32767, 7),
+                mode,
+                timed,
+                samples,
+                if timed { 8 } else { 1 },
+            );
+        }
+    }
+    for gaps in [false, true] {
+        for wide in [false, true] {
+            direct_case(
+                &format!("sparse-gaps-{gaps}-wide-{wide}"),
+                || sparse(256, 4096),
+                |sheet| {
+                    (
+                        if gaps { 0 } else { sheet.nrows as usize - 8 },
+                        0,
+                        sheet.nrows as usize - 1,
+                        if wide { 7 } else { 0 },
+                    )
+                },
+                Read::Sum,
+                timed,
+                samples,
+                if timed { 4 } else { 1 },
+            );
+        }
+    }
+    for overlay in ["outside", "partial", "computed"] {
+        direct_case(
+            &format!("overlay-{overlay}"),
+            || {
+                let mut sheet = sparse(32768, 1);
+                let ch = &mut sheet.columns[0].chunks[0];
+                match overlay {
+                    "outside" => {
+                        ch.overlay.set(100, OverlayValue::Number(4.0));
+                    }
+                    "partial" => {
+                        ch.computed_overlay.set(2, OverlayValue::Number(9.0));
+                        ch.overlay.set(2, OverlayValue::Empty);
+                        ch.overlay.set(
+                            3,
+                            OverlayValue::Error(crate::arrow_store::map_error_code(
+                                formualizer_common::ExcelErrorKind::Div,
+                            )),
+                        );
+                    }
+                    _ => {
+                        for off in 0..8 {
+                            ch.computed_overlay.set(off, OverlayValue::Number(5.0));
+                        }
+                    }
+                }
+                sheet
+            },
+            |_| (0, 0, 7, 0),
+            Read::Sum,
+            timed,
+            samples,
+            if timed { 128 } else { 1 },
+        );
+    }
+}
+
+fn engine(timed: bool, samples: usize) {
+    for family in ["sum-count", "lookup"] {
+        for index_enabled in [false, true] {
+            for chunk_rows in [32768, 256] {
+                let mut cfg = config(FormulaPlaneMode::Off, 1);
+                if !index_enabled {
+                    cfg.lookup_index_cache_max_bytes = 0;
+                }
+                let mut engine = Engine::new(TestWorkbook::new(), cfg);
+                let mut ingest = engine.begin_bulk_ingest_arrow();
+                ingest.add_sheet("Source", 2, chunk_rows);
+                for row in 1..=32768 {
+                    ingest
+                        .append_row(
+                            "Source",
+                            &[LiteralValue::Number(row as f64), LiteralValue::Number(2.0)],
+                        )
+                        .unwrap();
+                }
+                ingest.finish().unwrap();
+                let formulas: &[&str] = if family == "sum-count" {
+                    &["=SUM(Source!A32761:A32768)", "=COUNT(Source!A32761:A32768)"]
+                } else {
+                    &[
+                        "=VLOOKUP(32705,Source!A32705:B32768,2,FALSE)",
+                        "=VLOOKUP(32768,Source!A32705:B32768,2,FALSE)",
+                        "=VLOOKUP(99999,Source!A32705:B32768,2,FALSE)",
+                    ]
+                };
+                for (row, formula) in formulas.iter().enumerate() {
+                    engine
+                        .set_cell_formula("Results", row as u32 + 1, 1, parse(formula).unwrap())
+                        .unwrap();
+                }
+                for sample in 0..samples.max(4) {
+                    dirty(&mut engine);
+                    range_work::begin();
+                    let measured = observation(timed, || {
+                        engine.evaluate_all().unwrap();
+                    });
+                    let work = range_work::take();
+                    if family == "sum-count" {
+                        for (row, expected) in [(1, (32761 + 32768) as f64 * 4.0), (2, 8.0)] {
+                            assert_eq!(
+                                engine.get_cell_value("Results", row, 1),
+                                Some(LiteralValue::Number(expected))
+                            );
+                        }
+                    } else {
+                        for row in 1..=2 {
+                            assert_eq!(
+                                engine.get_cell_value("Results", row, 1),
+                                Some(LiteralValue::Number(2.0))
+                            );
+                        }
+                        assert!(
+                            matches!(engine.get_cell_value("Results", 3, 1), Some(LiteralValue::Error(e)) if e.kind == formualizer_common::ExcelErrorKind::Na)
+                        );
+                        let report = engine.last_lookup_index_cache_report();
+                        if !index_enabled {
+                            assert_eq!(report.builds, 0);
+                            assert_eq!(report.hits, 0);
+                            assert!(work.segments >= 3);
+                        } else if sample >= 3 {
+                            assert!(report.hits >= 3);
+                            assert_eq!(work.segments, 0);
+                        }
+                    }
+                    if timed {
+                        let report = engine.last_lookup_index_cache_report();
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "family":"engine", "case":family, "index_enabled":index_enabled, "chunk_rows":chunk_rows,
+                                "sample":sample, "ns":measured.0, "allocations":measured.1,
+                                "allocated_bytes":measured.2, "work":work,
+                                "lookup_builds":report.builds, "lookup_hits":report.hits,
+                                "lookup_skipped_cap":report.skipped_cap,
+                            })
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn range_probe_fixtures_validate() {
+    direct(false, 1);
+    engine(false, 1);
+}
+
+#[test]
+#[ignore = "exclusive release measurement window required"]
+fn range_release_probe() {
+    let samples = std::env::var("FZ_RANGES_SAMPLES")
+        .ok()
+        .map(|s| s.parse().unwrap())
+        .unwrap_or(7);
+    let family = std::env::var("FZ_RANGES_FAMILY").unwrap_or_default();
+    if family.is_empty() || family == "direct" {
+        direct(true, samples);
+    }
+    if family.is_empty() || family == "engine" {
+        engine(true, samples);
+    }
+}

--- a/crates/formualizer-eval/src/engine/tests/perf_tranche.rs
+++ b/crates/formualizer-eval/src/engine/tests/perf_tranche.rs
@@ -1,4 +1,6 @@
 //! Standalone release probe: see benchmarks/perf-tranche-419-421.md.
+#[path = "perf_ranges.rs"]
+mod perf_ranges;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
 use std::hint::black_box;

--- a/public-api/formualizer-eval.txt
+++ b/public-api/formualizer-eval.txt
@@ -3750,9 +3750,9 @@ pub fn formualizer_eval::engine::range_view::RangeView<'a>::clone(&self) -> form
 impl<'a> core::fmt::Debug for formualizer_eval::engine::range_view::RangeView<'a>
 pub fn formualizer_eval::engine::range_view::RangeView<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct formualizer_eval::engine::range_view::RowChunkIterator<'a>
-impl<'a> core::iter::traits::iterator::Iterator for formualizer_eval::engine::range_view::RowChunkIterator<'a>
-pub type formualizer_eval::engine::range_view::RowChunkIterator<'a>::Item = core::result::Result<formualizer_eval::engine::range_view::ChunkSlice, formualizer_common::error::ExcelError>
-pub fn formualizer_eval::engine::range_view::RowChunkIterator<'a>::next(&mut self) -> core::option::Option<Self::Item>
+impl core::iter::traits::iterator::Iterator for formualizer_eval::engine::range_view::RowChunkIterator<'_>
+pub type formualizer_eval::engine::range_view::RowChunkIterator<'_>::Item = core::result::Result<formualizer_eval::engine::range_view::ChunkSlice, formualizer_common::error::ExcelError>
+pub fn formualizer_eval::engine::range_view::RowChunkIterator<'_>::next(&mut self) -> core::option::Option<Self::Item>
 pub mod formualizer_eval::engine::resource_ledger
 pub enum formualizer_eval::engine::resource_ledger::DiskScratchPolicy
 pub formualizer_eval::engine::resource_ledger::DiskScratchPolicy::MemoryOnly


### PR DESCRIPTION
## Summary

Advances #422 with a private bounded chunk cursor and numeric/error-only projection. Public `ChunkSlice` fields, row/column order, overlap, cancellation, and overlay behavior are preserved. No lookup semantics, FormulaPlane defaults, scheduler, used-extent policy, or global cache changes.

This is a measured subset, not a whole-column or general workbook speedup. Other typed lanes retain the generic adapter; sparse gaps are still traversed, and #414 remains open.

## Evidence

The inspected [report](https://github.com/PSU3D0/formualizer/blob/f44d89023436282bb8c4cfc5ec8aacecc9926bdc/benchmarks/perf-ranges-422.md), counter-free example, baseline/A source patches and summarizer are included. Raw captures, binaries and archives are not committed.

Balanced release comparisons used an exclusive build-free window, separate Cargo targets, Rust 1.93.0 and a shared Ryzen 9 3900XT host. Counter-free warm medians include:

| Fixture | Baseline | Fixed |
| --- | ---: | ---: |
| Eight-row numeric tail, default 32 chunks | 1.613 us | 1.188 us |
| Dense 32768 × 8 SUM-like traversal, default chunking | 68.030 us | 51.445 us |
| Same dense data, fragmented chunking | 270.096 us | 89.705 us |
| Million-row sparse full-span SUM-like traversal | 12.054 ms | 1.469 ms |

Direct SUM-like traversal is not general builtin SUM. Actual Engine SUM/COUNT first-evaluation results are reported separately. Each distribution has 14 fixture batches from two process runs; dispersion, cold-state limits and shared-host noise are disclosed.

There is a small accepted generic head-only regression: approximately 34 ns / 9% in the fragmented control, with smaller/default-layout effects noisier. No claim that every consumer improves.

## Validation

- Seven independent segmentation/projection, overlay, cancellation, sparse/structural/lifetime and bit/error-order regressions pass.
- Debug eval/workbook: 3,065 passed, 17 ignored.
- Release eval: 2,914 passed, 16 ignored, excluding the separately baseline-reproduced `test_scalar_arena_float_overflow` missing-panic failure.
- Targeted Clippy, formatting and staged diff checks pass.
- Independent Astra implementation/evidence review: no scoped blocker; parent verified frozen source hashes and reran the public summarizer against retained captures.

Future performance work does not automatically enlarge the frozen 0.9.0 release candidate. CI on this PR remains the integration gate.
