### PR TITLE
fix(release): align version fixtures and publisher toolchains

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.93.0
 
       - name: Publish parser/common crates
         env:
@@ -347,7 +347,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.93.0
 
       - name: Publish product crates
         env:

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -28,6 +28,20 @@ POLICY_FIXTURE_FILES = (
     "bindings/wasm/Cargo.toml",
 )
 
+WORKBOOK_WORKSPACE_VERSION = str(
+    tomllib.loads((release_preflight.ROOT / "Cargo.toml").read_text(encoding="utf-8"))[
+        "workspace"
+    ]["dependencies"]["formualizer-workbook"]["version"]
+)
+
+
+def workbook_workspace_dependency(extra: str = "") -> str:
+    return (
+        "formualizer-workbook = { version = "
+        f'"{WORKBOOK_WORKSPACE_VERSION}", path = "crates/formualizer-workbook"'
+        f"{extra} }}"
+    )
+
 
 def copy_policy_fixture(destination: Path) -> None:
     for relative in POLICY_FIXTURE_FILES:
@@ -288,8 +302,8 @@ class ReleasePreflightTests(unittest.TestCase):
             r"cffi-native.*system-clock.*uncovered",
             (
                 "Cargo.toml",
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook", default-features = false }',
+                workbook_workspace_dependency(),
+                workbook_workspace_dependency(", default-features = false"),
             ),
         )
 
@@ -302,8 +316,10 @@ class ReleasePreflightTests(unittest.TestCase):
             mutate_file(
                 root,
                 "Cargo.toml",
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook", default-features = false, features = ["system-clock"] }',
+                workbook_workspace_dependency(),
+                workbook_workspace_dependency(
+                    ', default-features = false, features = ["system-clock"]'
+                ),
             )
             release_preflight.validate_binding_value_feature_policy(root)
 
@@ -312,8 +328,8 @@ class ReleasePreflightTests(unittest.TestCase):
             r"member default-features override",
             (
                 "Cargo.toml",
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook", default-features = false }',
+                workbook_workspace_dependency(),
+                workbook_workspace_dependency(", default-features = false"),
             ),
             (
                 "crates/formualizer-cffi/Cargo.toml",
@@ -473,8 +489,10 @@ class ReleasePreflightTests(unittest.TestCase):
             r"alternate semantic dependency 'clock-workbook'.*formualizer-workbook",
             (
                 "Cargo.toml",
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }',
-                'formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }\nclock-workbook = { package = "formualizer-workbook", version = "0.8.4", path = "crates/formualizer-workbook" }',
+                workbook_workspace_dependency(),
+                workbook_workspace_dependency()
+                + "\nclock-workbook = { package = \"formualizer-workbook\", version = "
+                + f'"{WORKBOOK_WORKSPACE_VERSION}", path = "crates/formualizer-workbook" }}',
             ),
             (
                 "bindings/python/Cargo.toml",


### PR DESCRIPTION
## Summary

Preparing 0.9.0 exposed four release-policy fixture failures: their exact workbook-dependency anchors embedded `0.8.4`. Derive only that version from the same workspace manifest copied into the fixture, preserving declaration shape and semantic mutations. No checker policy or assertion is relaxed.

Also select Rust 1.93.0 in the parser/common and product Cargo publisher jobs, matching their verify jobs instead of switching to floating stable after preflight. Triggers, dependency gates, permissions and publishing commands are unchanged. This does not trigger or authorize publication.

## Independent validation

- All 44 tests pass on both unchanged 0.8.4/3.1.0 and provisional 0.9.0/3.1.1 sources with the identical test correction.
- A separate observer verifies all four dynamic anchors actually mutate the intended declaration; a missing-anchor negative control still fails. All 41 unittest/mock assertions and 24 negative-policy error patterns remain unchanged.
- YAML parsing and structural comparison confirm exactly the two intended toolchain selections changed. `actionlint` is unavailable locally; fresh PR CI remains required.

Local preflight commands must explicitly set `RUSTUP_TOOLCHAIN=1.93.0`: the script's internal toolchain constant pins its registry-tool installer, not every unqualified Cargo call.

The separate native/npm compiler consistency review remains a pre-product-publication follow-up. Pyodide retains its intentional xbuildenv-derived custom toolchain; the independent spec publisher is untouched. Only the user may authorize any eventual tag or registry publication.
