### PR TITLE
chore(release): prepare 0.9.0 and parser SDK 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Formualizer will be documented in this file.
 
 ## Unreleased
 
+## [0.9.0] - 2026-09-06
+
+### Highlights
+
+- Improved lookup, reference-returning conditional, LET/LAMBDA, and temporal-value compatibility.
+- Fixed stale results after structural, named-symbol, logged, and atomic edits, with broader FormulaPlane parity coverage.
+- Reduced repeated criteria work, registry locking, range traversal, and schedule copying; exactly converged nonvolatile cycles can remain clean between recalculations.
+- Added Python workbook clock control, hardened parser and binding error paths, and corrected release package contents.
+
+### Compatibility notes
+
+- Rust callers constructing or matching `RangeKey::OpenRect` must use its four independent optional axis bounds instead of the former two optional coordinates. (#371)
+- Review temporal egress and runtime XLSX source selection below when upgrading. The `mmap` feature is now a compatibility no-op; mapping is an explicit runtime choice.
+- Product crates and Python/npm bindings move to **0.9.0**; common/parse move together to **3.1.1**. `sheetport-spec` remains **0.3.1** and the internal C ABI crate remains **0.1.0**.
+
 ### Changed
 
 - **Exactly converged circular cells are no longer re-run on every recalc.** Under `CyclePolicy::Iterate` the engine redirtied every iterating SCC at the end of each recalc, so every circular cell in a workbook was re-evaluated on every recalculation, like Excel. An SCC is now retained clean across recalcs when the recalc that iterated it stopped because every member reproduced its previous value exactly — `|Δ| == 0` for numbers, identity for text, booleans and errors, and never a NaN identity — before the `max_iterations` cap, with no volatile and no dynamic-reference (`INDIRECT`/`OFFSET`) member. Such an SCC is a fixed point of its own inputs, so re-running it with the same inputs cannot change a value: it runs again only when the dirty graph reaches a member (a precedent edit, a formula change, a structural edit, a name rebinding) or when a config knob that can change its result changes between recalcs (cycle policy or tolerance, date system, workbook seed, volatile level, deterministic mode, range-expansion limits) or when a function that a member calls is registered or replaced in the function registry. Tolerance-only convergence (`|Δ| < max_change` but non-zero), capped SCCs (including the `max_iterations: 1` accumulator contract) and volatile cycles keep re-running every recalc, exactly as before. Retention is unconditional (there is no knob): it changes only the work done, never a value, and retained SCCs are invalidated by the same machinery that invalidates every other formula. `CycleTelemetry::reused_sccs` and `CycleTelemetry::reused_scc_members` count the retained SCCs served without a re-run in a request, and `EngineBaselineStats::retained_scc_members` reports the retained population. Measured in release on 78 ring SCCs of 120 members each (9,360 circular cells) plus three downstream column families: a no-change recalc goes 70 ms -> 0.3 ms, an unrelated-cell edit 84 ms -> 0.9 ms, and an edit feeding one SCC goes 72 ms -> 2.6 ms with exactly one SCC re-run (two passes), on identical checksums. (#368)
@@ -23,14 +38,24 @@ All notable changes to Formualizer will be documented in this file.
 - Computed temporals are numeric during evaluation (`ISNUMBER`/`TYPE` now match Excel). Native scalar, range, table, Python, and SheetPort egress materializes date/time values from the cell's effective format; callers can opt into uniform raw serials. A known datetime class preserves midnight datetimes, while calamine's code-lossy date-ish signal can only classify pure fractions as time, day-plus-fraction serials as datetime, and integers as date.
 - Arrow dependencies upgraded 58.2 → 59.2 across `formualizer-eval` (`arrow`, `arrow-array`, `arrow-buffer`, `arrow-schema`, `arrow-select`, `arrow-cast`). No API or behaviour change; full suite green on the pinned surface, native and wasm32.
 
-- **Parser/SDK track `parse-v3.1.0`.** `formualizer-common` gains the number-format carrier introduced by the format channel work (`NumberFormat`, `FormatClass`, `numfmt::builtin_code`) and is published as 3.1.0; `formualizer-parse` moves to 3.1.0 with no source change so the two crates keep their documented shared version. Product crates now pin `formualizer-parse = "3.1.0"`. `scripts/release-preflight.py` asserts that the two parser-track manifests agree, and that a product-track preflight only passes once the pinned parser-track version is already on crates.io; previously the product preflight staged the workspace archives locally, passed, and left `cargo publish` to fail against the real registry.
+- **Parser/SDK track `parse-v3.1.1`.** The previously published 3.1.0 track introduced `NumberFormat`, `FormatClass`, and `numfmt::builtin_code`. This release advances both parser-track crates to 3.1.1 for parser hardening and package-content corrections; product crates now pin `formualizer-parse = "3.1.1"`. Release preflight requires matching common/parse versions and actual registry availability before the product track can publish. (#439, #444)
 - Pyodide wheel documentation now reflects distribution reality: native wheels are on PyPI, while Pyodide wheels are built and smoke-tested and retained as the `wheels-pyodide` Actions artifact for download or self-hosting from a compatible wheel URL.
 
 ### Performance
 
+- Bounded range traversal to relevant row segments and projected numeric/error lanes without repeatedly materializing unrelated values. Preserved order, overlays, ownership and cancellation behavior. Synthetic results and the small generic-head regression are documented in the benchmark report; these are not universal workbook speedup claims. (#436)
+- Shared immutable cached legacy schedules instead of deep-copying nested vectors on eligible requests. Cache eligibility and target routing are unchanged. Synthetic same-chain edit/recalculation medians improved, with shared-host attribution limits and a small alternating-case regression retained in the report. (#441)
+
 - **Reduced criteria, registry, and exact-lookup overhead.** Criteria masks are memoized per invocation, predicate, and column with a conservative 1 MiB admission charge; ordinary registry hits take a read lock and clone only the current function handle; exact indexes are reclaimed at exclusive Engine snapshot-mutation boundaries with retained-payload admission accounting. Matching rules are unchanged; tranche probes show less repeated mask work and fewer direct-registry allocations, while no-edit lookup recalculation reuses the index. (#431)
 
 ### Fixed
+
+- Resolved LET/LAMBDA locals before workbook named-range lookup in range-consuming arguments, so expressions such as `LET(r,A1:A3,SUM(r))` work and local names consistently shadow workbook names. (#339)
+- Preserved selected references through `IF`, `IFS`, and `CHOOSE`, allowing compositions such as `OFFSET(IF(TRUE,A1,B1),2,0)`. `IFERROR` and `IFNA` remain value-returning. (#369)
+- Propagated `IF` condition errors unchanged without evaluating either arm. (#372)
+- Made bounded single-cell `INDEX` selection read only the selected cell, avoiding phantom cycles under runtime cycle detection with bulk ingest. Static-cycle behavior and other INDEX shapes remain unchanged. (#370)
+- Preserved independent row/column bounds in open ranges, fixed zero-column plan labels, and handled wholly unbounded range dependencies without dropping coverage. (#371, #377)
+- Treated an omitted `XLOOKUP` fallback as absent rather than numeric zero, and kept exact text needles from matching numeric cells. (#340)
 
 - Logged formula/topology edits, atomic commits, and undo/redo now invalidate cached schedules and retained plans according to the replayed operation. Partial replay failures invalidate before returning; existing-cell value-only edits preserve eligible schedule hits while clearing lookup snapshots. (#435)
 
@@ -58,9 +83,20 @@ All notable changes to Formualizer will be documented in this file.
 
   Symbol vertices now hold a `SymbolAddr` in an address space disjoint from the grid's, and the structures keyed by position — the cell index, the per-sheet range index, and the iteration that drives every structural edit — accept a `GridAddr`, which a symbol cannot produce. `NameScope` is now purely lookup metadata and no longer decides where a vertex lives. Evaluation results are unchanged; a name's scope, resolution and dirty propagation all behave exactly as before.
 
+### Python bindings
+
+- Added `Workbook.set_deterministic_clock` to pin time on an existing workbook for its next recalculation, including deterministic embedding and Pyodide use. (#341)
+- Accepted `NImpl` and `Error` in `LiteralValue.error`, allowing all canonical error kinds to round-trip. (#354)
+- Replaced panicking AST/Token conversions and a Sheet cache-lock unwrap with Python error propagation while preserving callback reentrancy guards. (#404)
+
+### Packaging
+
+- Included canonical project license texts in Rust, Python, and npm package payloads. Python's declared license remains MIT; shipping both repository texts does not change that declaration. The published `sheetport-spec` 0.3.1 payload is unchanged. (#444)
+- Pinned native Rust/package release builds to Rust 1.93.0; Pyodide retains its xbuildenv-derived toolchain. Made release-preflight fixtures independent of the product version. (#442, #444)
+
 ### Security and hardening
 
-- Bounded parser recursion so excessively nested formulas return a parser error instead of exhausting the stack, with accepted-boundary coverage for 64 nested calls and parentheses. The limit counts parser frames rather than Excel nesting levels; recursive destruction of very long flat ASTs remains a separate known limitation (#411). Original recursion guard contributed by @chiliec. (#408)
+- Bounded parser recursion to 72 parser frames so excessively nested formulas return a parser error instead of exhausting the stack, with accepted-boundary coverage for 64 nested calls and parentheses. The limit counts parser frames rather than Excel nesting levels; recursive destruction of very long flat ASTs remains a separate known limitation (#411). Original recursion guard contributed by @chiliec. (#408)
 - Release preflight now fails closed when declared binding feature profiles drift from the canonical value-feature policy; Pyodide's explicit `system-clock` opt-out remains the only approved exception. (#433)
 
 - Bumped the docs site to Next.js `16.2.11`, clearing nine npm advisories affecting `next` `16.2.6` (four high: GHSA-89xv-2m56-2m9x, GHSA-p9j2-gv94-2wf4, GHSA-6gpp-xcg3-4w24, GHSA-m99w-x7hq-7vfj). The docs site's `bun.lock` was removed; `pnpm-lock.yaml` is the only lockfile the site builds and deploys from.
@@ -68,6 +104,10 @@ All notable changes to Formualizer will be documented in this file.
 ### Known limitations
 
 - Workbook undo can drop a dependent formula edge after writing a referenced empty cell (#301), leave a retained formula AST and dependency edge referring to different rows after undoing a logged row insertion (#303), truncate the changelog and lose the undone operation's audit record (#367), or leave an evaluated formula written to a fresh cell in place (#412). Long flat, left-associative chains can overflow the stack during recursive AST drop even when parsing returns `Ok` (#411).
+
+### Contributors
+
+Thanks to @Ocean82, @chiliec, and @tommy230 for contributed fixes, parser hardening, and independently captured lookup compatibility cases and reruns. The integration preserves original authorship. (#438, #439)
 
 ## [0.8.4] - 2026-08-14
 
@@ -535,7 +575,8 @@ All notable changes to Formualizer will be documented in this file.
 
 - Incomplete product release due to partial publication during the release workflow. Superseded by `0.5.1`.
 
-[Unreleased]: https://github.com/PSU3D0/formualizer/compare/v0.8.4...HEAD
+[Unreleased]: https://github.com/PSU3D0/formualizer/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/PSU3D0/formualizer/compare/v0.8.4...v0.9.0
 [0.8.4]: https://github.com/PSU3D0/formualizer/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/PSU3D0/formualizer/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/PSU3D0/formualizer/compare/v0.8.1...v0.8.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "formualizer-common",
  "formualizer-eval",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-common"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-eval"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-macros"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "formualizer-common",
  "proc-macro2",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-parse"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "formualizer-common",
  "once_cell",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-python"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "formualizer",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-sheetport"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "formualizer-common",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-wasm"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "formualizer-workbook"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ documentation = "https://docs.rs/formualizer"
 
 [workspace.dependencies]
 
-formualizer-common = { version = "3.1.0", path = "crates/formualizer-common" }
-formualizer-macros = { version = "0.8.4", path = "crates/formualizer-macros" }
-formualizer-parse = { version = "3.1.0", path = "crates/formualizer-parse" }
-formualizer-eval = { version = "0.8.4", path = "crates/formualizer-eval" }
-formualizer-workbook = { version = "0.8.4", path = "crates/formualizer-workbook" }
+formualizer-common = { version = "3.1.1", path = "crates/formualizer-common" }
+formualizer-macros = { version = "0.9.0", path = "crates/formualizer-macros" }
+formualizer-parse = { version = "3.1.1", path = "crates/formualizer-parse" }
+formualizer-eval = { version = "0.9.0", path = "crates/formualizer-eval" }
+formualizer-workbook = { version = "0.9.0", path = "crates/formualizer-workbook" }
 
 chrono = { version = "0.4.41", default-features = false, features = ["std"] }
 serde = "1.0.228"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-python"
-version = "0.8.4"
+version = "0.9.0"
 publish = false
 edition = "2024"
 homepage = "https://github.com/PSU3D0/formualizer"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "formualizer"
-version = "0.8.4"
+version = "0.9.0"
 description = "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks at native speed"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "formualizer"
-version = "0.8.4"
+version = "0.9.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-wasm"
-version = "0.8.4"
+version = "0.9.0"
 publish = false
 edition = "2024"
 authors = ["Formualizer Contributors"]

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formualizer",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks in the browser. 320+ functions, Arrow-powered.",
   "homepage": "https://github.com/psu3d0/formualizer",
   "type": "module",

--- a/crates/formualizer-common/Cargo.toml
+++ b/crates/formualizer-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-common"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 description = "Core value, reference, and error types shared across the Formualizer parser and engine"
 homepage.workspace = true

--- a/crates/formualizer-eval/Cargo.toml
+++ b/crates/formualizer-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-eval"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 description = "High-performance Arrow-backed Excel formula engine with dependency graph and incremental recalculation"
 homepage.workspace = true

--- a/crates/formualizer-macros/Cargo.toml
+++ b/crates/formualizer-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-macros"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 description = "Proc macros for authoring Formualizer built-ins (caps, schemas, and validation)"
 homepage.workspace = true

--- a/crates/formualizer-parse/Cargo.toml
+++ b/crates/formualizer-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-parse"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 description = "High-performance Excel/OpenFormula tokenizer + parser with a stable AST surface"
 homepage.workspace = true

--- a/crates/formualizer-sheetport/Cargo.toml
+++ b/crates/formualizer-sheetport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-sheetport"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 description = "SheetPort runtime: bind manifests to workbooks, validate IO, and run sessions deterministically"
 homepage.workspace = true
@@ -26,10 +26,10 @@ benchmark_internal = []
 
 [dependencies]
 sheetport-spec = { path = "../sheetport-spec", version = "0.3.1" }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.8.4", default-features = false }
-formualizer-common = { path = "../formualizer-common", version = "3.1.0" }
-formualizer-parse = { path = "../formualizer-parse", version = "3.1.0" }
-formualizer-eval = { path = "../formualizer-eval", version = "0.8.4", default-features = false }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.9.0", default-features = false }
+formualizer-common = { path = "../formualizer-common", version = "3.1.1" }
+formualizer-parse = { path = "../formualizer-parse", version = "3.1.1" }
+formualizer-eval = { path = "../formualizer-eval", version = "0.9.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -44,5 +44,5 @@ chrono = { workspace = true }
 chrono = { workspace = true }
 formualizer-testkit = { path = "../formualizer-testkit" }
 tempfile = { workspace = true }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.8.4", features = ["umya_integration"] }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.9.0", features = ["umya_integration"] }
 umya-spreadsheet = "=2.3.2"

--- a/crates/formualizer-workbook/Cargo.toml
+++ b/crates/formualizer-workbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer-workbook"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 description = "Ergonomic workbook API over the Formualizer engine (sheets, loaders, staging, undo/redo)"
 homepage.workspace = true
@@ -14,7 +14,7 @@ categories = ["data-structures", "mathematics"]
 [dependencies]
 formualizer-parse = { workspace = true }
 formualizer-common = { workspace = true }
-formualizer-eval = { path = "../formualizer-eval", version = "0.8.4", default-features = false }
+formualizer-eval = { path = "../formualizer-eval", version = "0.9.0", default-features = false }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
@@ -88,7 +88,7 @@ wasmtime = { version = "43.0.2", optional = true }
 memmap2 = { version = "0.9", optional = true }
 
 [dev-dependencies]
-formualizer-eval = { path = "../formualizer-eval", version = "0.8.4", default-features = false, features = ["test-support"] }
+formualizer-eval = { path = "../formualizer-eval", version = "0.9.0", default-features = false, features = ["test-support"] }
 wasm-encoder = "0.240"
 formualizer-testkit = { path = "../formualizer-testkit" }
 tempfile = { workspace = true }

--- a/crates/formualizer/Cargo.toml
+++ b/crates/formualizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formualizer"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 description = "Embeddable spreadsheet engine — parse, evaluate & mutate Excel workbooks from Rust"
 homepage.workspace = true
@@ -63,9 +63,9 @@ portable-wasm = ["eval", "workbook", "sheetport", "parse", "common"]
 wasm-js = ["portable-wasm", "system-clock", "js-runtime"]
 
 [dependencies]
-formualizer-common = { path = "../formualizer-common", version = "3.1.0", optional = true }
-formualizer-parse = { path = "../formualizer-parse", version = "3.1.0", optional = true }
-formualizer-eval = { path = "../formualizer-eval", version = "0.8.4", optional = true, default-features = false }
-formualizer-workbook = { path = "../formualizer-workbook", version = "0.8.4", optional = true, default-features = false }
-formualizer-sheetport = { path = "../formualizer-sheetport", version = "0.8.4", optional = true, default-features = false }
+formualizer-common = { path = "../formualizer-common", version = "3.1.1", optional = true }
+formualizer-parse = { path = "../formualizer-parse", version = "3.1.1", optional = true }
+formualizer-eval = { path = "../formualizer-eval", version = "0.9.0", optional = true, default-features = false }
+formualizer-workbook = { path = "../formualizer-workbook", version = "0.9.0", optional = true, default-features = false }
+formualizer-sheetport = { path = "../formualizer-sheetport", version = "0.9.0", optional = true, default-features = false }
 sheetport-spec = { path = "../sheetport-spec", version = "0.3.1", optional = true }


### PR DESCRIPTION
## Release scope

Prepare 0.9.0 from all cleaned main, including the range/schedule optimizations, attributed lookup completion #438 with the corrected X-function blank rule, and parser hardening #439. Cleanup #446 is retained; no native validation framework is reintroduced.

- Product crates and Python/npm bindings: 0.9.0.
- Common/parser SDK pair: 3.1.1; publish this prerequisite track before the product track.
- sheetport-spec remains 0.3.1 and the internal C ABI crate remains 0.1.0.
- Cargo.lock changes only local package versions; third-party dependency versions/checksums are unchanged.
- Dated September 6 changelog includes user-facing compatibility, reference/lookup/temporal fixes, Python features, performance work, packaging, attribution and known limitations. Historical release entries are unchanged.

## Validation and publication

Independent read-only review of the complete 15-file release diff passes. Version-independent preflight fixtures and real parser-track packaging/verification pass; fresh integrated native wheel/sdist builds have completed. Remaining installed-artifact checks and exact current CI must pass before the authorized publication sequence.

The owner explicitly authorized integration now and release of all cleaned main. Publication will use the existing release workflow: parse-v3.1.1 first, verify actual registry propagation, then genuine product preflight and v0.9.0. This PR itself does not tag or publish. No same-version drift waiver or registry substitute is used.
